### PR TITLE
Add design & requirement intake templates and frontmatter-based requirements workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-design-intake.yml
+++ b/.github/ISSUE_TEMPLATE/01-design-intake.yml
@@ -1,0 +1,46 @@
+name: "Design intake"
+description: "Capture design-level problem framing, options, and decision pressure."
+title: "design: <concise design problem>"
+labels: ["design", "intake", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this issue when a workflow or UX decision needs explicit design treatment.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What user or workflow problem are we solving?
+      placeholder: "Who is blocked, and why?"
+    validations:
+      required: true
+  - type: textarea
+    id: outcomes
+    attributes:
+      label: Intended outcomes
+      description: What should be measurably better when this is complete?
+      placeholder: "Examples: reduced onboarding friction, clearer stage transitions"
+    validations:
+      required: true
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints and non-goals
+      description: What boundaries must the design respect?
+    validations:
+      required: true
+  - type: textarea
+    id: options
+    attributes:
+      label: Candidate approaches
+      description: List options considered, including at least one rejected path.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance signals
+      description: How will maintainers decide this design is good enough to implement?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/02-requirement-intake.yml
+++ b/.github/ISSUE_TEMPLATE/02-requirement-intake.yml
@@ -1,0 +1,54 @@
+name: "Requirement intake"
+description: "Propose a new requirement that should become a frontmatter requirement note."
+title: "req: <requirement summary>"
+labels: ["requirements", "intake", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this issue to propose a requirement before implementation starts.
+        A merged requirement should be represented by a file in `requirements/intake/`.
+  - type: input
+    id: requirement_id
+    attributes:
+      label: Proposed requirement ID
+      description: Format `REQ-XXXX` where `XXXX` is zero-padded numeric.
+      placeholder: "REQ-0001"
+    validations:
+      required: true
+  - type: textarea
+    id: user_need
+    attributes:
+      label: User need
+      description: Who needs this and what outcome do they need?
+    validations:
+      required: true
+  - type: textarea
+    id: requirement_statement
+    attributes:
+      label: Requirement statement
+      description: Write a testable requirement using SHALL language.
+      placeholder: "The system SHALL ..."
+    validations:
+      required: true
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Rationale
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: Bullet list of objective pass/fail criteria.
+    validations:
+      required: true
+  - type: input
+    id: related_design
+    attributes:
+      label: Related design intake issue
+      description: Link to design intake issue when applicable.
+      placeholder: "#123"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Product vision
+    url: https://github.com/OWNER/REPO/blob/main/docs/product-vision.md
+    about: Review the project vision before opening a new issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- What changed and why? -->
+
+## Linked intake
+
+- Design intake issue: <!-- #123 or N/A -->
+- Requirement intake issue: <!-- #124 or N/A -->
+
+## Requirement frontmatter updates
+
+<!-- List files added/updated in requirements/intake -->
+
+- [ ] Added or updated requirement frontmatter files under `requirements/intake/`
+- [ ] Validated IDs and traceability links in each requirement file
+
+## Validation
+
+<!-- Commands or checks run -->
+

--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@
 Specorator is an Obsidian-centered workflow product for spec-driven, agentic software development.
 
 The long-term product direction is captured in [docs/product-vision.md](docs/product-vision.md). The core idea: users should be able to run, inspect, and maintain the full workflow from an approachable interface, while the underlying vault quality tooling remains usable without requiring an LLM integration.
+
+## Intake-first planning
+
+The repository includes GitHub issue templates for design and requirement intake, plus a draft PR workflow for frontmatter-based requirement files.
+
+- Start with `.github/ISSUE_TEMPLATE/02-requirement-intake.yml` for new requirements.
+- Add requirement drafts under `requirements/intake/` using `REQ-0000-template.md`.
+- Follow `docs/process/requirements-intake.md` for triage and promotion.

--- a/docs/process/requirements-intake.md
+++ b/docs/process/requirements-intake.md
@@ -1,0 +1,29 @@
+# Requirements Intake Workflow
+
+This repository uses frontmatter-backed Markdown files in `requirements/intake/` as the durable intake artifact for new requirements.
+
+## Flow
+
+1. Open a **Requirement intake** issue with a proposed `REQ-XXXX` identifier.
+2. (Optional) Open a **Design intake** issue first when the requirement implies non-trivial UX or workflow decisions.
+3. Create a draft PR that adds a requirement file copied from `requirements/intake/REQ-0000-template.md`.
+4. Link both intake issues in the PR template.
+5. Move status from `proposed` to `accepted` only after triage consensus.
+
+## File conventions
+
+- One requirement per file: `requirements/intake/REQ-XXXX-<slug>.md`
+- Required frontmatter keys: `id`, `status`, `summary`, `source_issue`, `statement`, `acceptance_criteria`, `traceability`.
+- Use `statement` with explicit SHALL wording.
+- `acceptance_criteria` must be objective and testable.
+
+## Triaging GitHub issues in order
+
+To process issues predictably:
+
+1. Sort by oldest first.
+2. Confirm each issue is one of: design intake, requirement intake, implementation task, or maintenance.
+3. Convert under-specified issues into intake issues before implementation.
+4. Reject or close issues missing a clear user need or testable outcome.
+
+A future automation can validate required frontmatter keys and ID format.

--- a/requirements/intake/REQ-0000-template.md
+++ b/requirements/intake/REQ-0000-template.md
@@ -1,0 +1,30 @@
+---
+id: REQ-0000
+status: proposed
+summary: "<concise requirement summary>"
+owner: "<github-handle-or-team>"
+created: 2026-05-01
+last_updated: 2026-05-01
+source_issue: "#<requirement-intake-issue>"
+related_design: "#<design-intake-issue-or-empty>"
+tags: [requirements, intake]
+priority: medium
+risk: medium
+verification:
+  - "<test-or-check-1>"
+  - "<test-or-check-2>"
+statement: "The system SHALL ..."
+rationale: "<why this matters>"
+acceptance_criteria:
+  - "<objective criterion 1>"
+  - "<objective criterion 2>"
+traceability:
+  upstream:
+    - "<product-vision-section-or-issue-link>"
+  downstream:
+    - "<design-doc-link-or-task-link>"
+---
+
+## Notes
+
+Capture clarifications, assumptions, and open questions.


### PR DESCRIPTION
### Motivation

- Provide a repeatable, intake-first path to triage GitHub issues so design work and requirements are captured before implementation begins.
- Surface a draft-PR-as-intake pattern by storing requirement proposals as frontmatter-backed Markdown files to improve traceability and enable later automation.

### Description

- Add GitHub issue templates for design intake (`.github/ISSUE_TEMPLATE/01-design-intake.yml`) and requirement intake (`.github/ISSUE_TEMPLATE/02-requirement-intake.yml`) to enforce structured submissions. 
- Add `.github/ISSUE_TEMPLATE/config.yml` to disable blank issues and point contributors to the product vision. 
- Add a PR template (`.github/PULL_REQUEST_TEMPLATE.md`) that asks for linked intake issues and lists requirement frontmatter validation checks. 
- Add a requirement frontmatter draft (`requirements/intake/REQ-0000-template.md`) and documentation (`docs/process/requirements-intake.md`) describing the flow and file conventions, and update `README.md` with intake-first guidance. 

---

**Closing in favour of #51**, which resolves the merge conflicts against main and fixes the placeholder URL flagged in the review comment.