### PR TITLE
docs: expand README and product vision; add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,43 @@
+name: Bug report
+description: Report a defect or unexpected behavior
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the unexpected behavior clearly.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What was expected?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open Obsidian with the plugin enabled.
+        2. ...
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: "Obsidian version · Plugin version · OS"
+      placeholder: "Obsidian 1.x · Specorator 0.x · macOS 14"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, vault structure notes, or anything else that helps.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Product vision
+    url: https://github.com/Luis85/specorator/blob/main/docs/product-vision.md
+    about: Read the product north star before opening a feature request.
+  - name: Roadmap
+    url: https://github.com/Luis85/specorator/blob/main/docs/roadmap-v1.md
+    about: Check the roadmap to see what phase is active before filing a task.

--- a/.github/ISSUE_TEMPLATE/decision.yml
+++ b/.github/ISSUE_TEMPLATE/decision.yml
@@ -1,0 +1,37 @@
+name: Architecture / design decision
+description: A decision that needs to be made, explored, and recorded
+labels: ["architecture"]
+body:
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why does this decision need to be made? What forces or constraints drive it?
+    validations:
+      required: true
+
+  - type: textarea
+    id: options
+    attributes:
+      label: Options considered
+      description: List the realistic options with a brief summary of trade-offs for each.
+    validations:
+      required: true
+
+  - type: textarea
+    id: decision
+    attributes:
+      label: Decision
+      description: Leave blank until decided. Record the chosen option and the rationale here.
+
+  - type: textarea
+    id: consequences
+    attributes:
+      label: Consequences
+      description: What does this decision enable, block, defer, or constrain?
+
+  - type: textarea
+    id: related
+    attributes:
+      label: Related
+      description: Link to related issues, PRDs, or upstream decisions.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,33 @@
+name: Feature request
+description: Propose a new capability or enhancement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem does this solve? Who is affected, and when does it happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the feature and how it should work.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How will we know this is done? Use checkable items where possible.
+    validations:
+      required: true
+
+  - type: textarea
+    id: related
+    attributes:
+      label: Related
+      description: Link to related planning issues, PRDs, use cases, or ADRs.

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,30 @@
+name: Task
+description: A concrete setup, engineering, documentation, or maintenance task
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What does this task accomplish and why does it matter now?
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What is in scope? What is explicitly out of scope?
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Checkable conditions that define done.
+    validations:
+      required: true
+
+  - type: textarea
+    id: related
+    attributes:
+      label: Related
+      description: Link to related issues, PRDs, or ADRs.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## Summary
+
+<!-- What does this PR do? Link the issue it closes with "Closes #NNN". -->
+
+Closes #
+
+## Changes
+
+<!-- List the key changes. Keep it focused on what reviewers need to understand. -->
+
+-
+
+## Verification
+
+<!-- How did you verify this works? Check all that apply. -->
+
+- [ ] Runs locally (documented verification command)
+- [ ] Plugin loads in an Obsidian test vault (if plugin code changed)
+- [ ] UI runs in browser mode (if UI code changed)
+- [ ] Lint passes
+- [ ] Typecheck passes
+- [ ] Tests pass
+
+## Screenshots or test vault notes
+
+<!-- For UI or vault-content changes, add screenshots or describe what you observed. -->
+
+## Risks or follow-up
+
+<!-- Known issues, deferred work, or things reviewers should watch for. -->

--- a/README.md
+++ b/README.md
@@ -1,5 +1,51 @@
 # Specorator
 
-Specorator is an Obsidian-centered workflow product for spec-driven, agentic software development.
+Specorator is an Obsidian plugin and companion app for spec-driven, agentic software development. It guides users through a structured workflow — from idea to release — keeping all artifacts as editable Markdown inside the vault.
 
-The long-term product direction is captured in [docs/product-vision.md](docs/product-vision.md). The core idea: users should be able to run, inspect, and maintain the full workflow from an approachable interface, while the underlying vault quality tooling remains usable without requiring an LLM integration.
+**Current status:** Planning and setup phase. No installable plugin exists yet.
+
+## What it does
+
+**v1 alpha** establishes the plugin foundation:
+
+- Installs and manages the [`agentic-workflow`](https://github.com/Luis85/agentic-workflow) template inside an Obsidian vault.
+- Provides a workflow cockpit: active stage, required artifacts, next actions, and quality checks.
+- Keeps all generated content as plain Markdown — readable and usable without the plugin.
+
+**v2.0** adds a companion-app experience:
+
+- Integrates [`agentonomous`](https://github.com/Luis85/agentonomous) to provide a team of agentic coworkers that assist with drafting, review, and workflow progression.
+- Users stay focused on their vault; they decide what context agents can see, what they propose, and what becomes a durable artifact.
+
+## Documentation
+
+| Document | Purpose |
+|----------|---------|
+| [docs/product-vision.md](docs/product-vision.md) | Product north star, principles, and v1/v2.0 direction |
+| [docs/roadmap-v1.md](docs/roadmap-v1.md) | Phased delivery plan for v1 alpha |
+
+## Project tracking
+
+| Issue | Purpose |
+|-------|---------|
+| [#47 — Roadmap progress tracker](https://github.com/Luis85/specorator/issues/47) | Phase-by-phase checklist |
+| [#1 — v1 alpha planning](https://github.com/Luis85/specorator/issues/1) | v1 feature scope and acceptance criteria |
+| [#23 — v2.0 planning](https://github.com/Luis85/specorator/issues/23) | Companion-app and agentonomous direction |
+| [#2 — Repo setup objective](https://github.com/Luis85/specorator/issues/2) | Repository and GitHub foundation work |
+| [#11 — Plugin shell objective](https://github.com/Luis85/specorator/issues/11) | Plugin architecture and toolchain |
+| [#24 — Product setup objective](https://github.com/Luis85/specorator/issues/24) | PRDs, use cases, and product artifacts |
+
+## Development
+
+> Full setup documentation is in progress ([#10](https://github.com/Luis85/specorator/issues/10)). This section will expand once the plugin scaffold ([#5](https://github.com/Luis85/specorator/issues/5)) and CI ([#6](https://github.com/Luis85/specorator/issues/6)) are in place.
+
+The planned stack: Obsidian community plugin · Vue 3 · Vue Router · Pinia 2 · TypeScript 6 · Vite · Vitest · ESLint · TypeDoc.
+
+## Contributing
+
+Issues and pull requests are welcome. See the [roadmap](docs/roadmap-v1.md) for current priorities. Issue templates are available for feature requests, bug reports, tasks, and architecture decisions.
+
+## Related repositories
+
+- [`agentic-workflow`](https://github.com/Luis85/agentic-workflow) — workflow methodology, templates, and quality gates. [Upstream planning issue](https://github.com/Luis85/agentic-workflow/issues/96).
+- [`agentonomous`](https://github.com/Luis85/agentonomous) — agent orchestration engine used in v2.0.

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -10,6 +10,35 @@ LLM integrations can accelerate drafting and review, but they are not the produc
 
 Specorator helps teams move from idea to release through visible, auditable workflow stages while preserving the vault as the durable source of truth.
 
+## v1 Alpha — Foundation
+
+The v1 alpha establishes the plugin foundation and proves the end-to-end loop:
+
+1. Select or use a supported released [`agentic-workflow`](https://github.com/Luis85/agentic-workflow) template version.
+2. Install the required workflow files into an Obsidian vault with overwrite protection.
+3. Show the current workflow state, active project or feature, and available process steps.
+4. Let the user create or open workflow artifacts in Obsidian.
+5. Preserve all outputs as plain Markdown files that remain useful without the plugin.
+6. Leave a documented, clean extension point for the v2.0 agent coworker experience.
+
+v1 does not implement agent orchestration. It is the stable scaffold on which v2.0 is built.
+
+## v2.0 — Companion App with Agentic Coworkers
+
+v2.0 turns Specorator into an Obsidian companion app that gives the user a team of agentic coworkers through an easy-to-use interface, powered by [`agentonomous`](https://github.com/Luis85/agentonomous).
+
+The user stays focused on their vault and the work within it. Specorator guides them through the workflow, understands their input, helps formulate and improve outputs, and coordinates agentic coworkers that can assist with analysis, planning, drafting, review, and workflow-state progression.
+
+The plugin goes out of its way to reduce process friction, but it must not take control away from the user. The user decides:
+
+- where assistance is wanted;
+- what vault context is shared with agents;
+- which agent suggestions are accepted;
+- what gets edited;
+- when outputs become durable workflow artifacts.
+
+Agent outputs are always proposed, never silently applied.
+
 ## Target Users
 
 - Solo builders who want a guided path from rough idea to implemented feature.
@@ -25,6 +54,7 @@ Specorator helps teams move from idea to release through visible, auditable work
 - **Inspectable state.** Users can see the active stage, required artifacts, quality gates, blockers, and next actions.
 - **Deterministic upkeep.** Validation, linting, traceability checks, scaffolders, and repair helpers are exposed as normal plugin capabilities.
 - **Human-owned decisions.** The interface surfaces choices and risks, but the user remains responsible for intent, priority, and acceptance.
+- **User-controlled agents.** In v2.0, agents propose; the user decides. Context shared with agents is explicit and revocable.
 
 ## Core Experience
 
@@ -36,7 +66,7 @@ The first-class experience is a workflow cockpit inside Obsidian:
 - Runs local scripts and checks from plugin controls.
 - Displays validation results with direct links to affected notes.
 - Tracks requirements, tasks, tests, decisions, and release artifacts.
-- Offers optional LLM-assisted drafting or critique when configured.
+- In v2.0: offers agentic coworkers that assist with drafting, review, and stage progression under explicit user control.
 
 ## Required Tooling Surface
 
@@ -52,6 +82,14 @@ The plugin should make these capabilities available without requiring chat-based
 - Repair guidance for missing or inconsistent artifacts.
 - Export or handoff summaries for pull requests, releases, and reviews.
 
+## Relationship to Upstream Projects
+
+| Project | Role |
+|---------|------|
+| [`agentic-workflow`](https://github.com/Luis85/agentic-workflow) | Workflow methodology, stage model, templates, traceability conventions, and quality gates. Released versions are the source of truth for what high-quality workflow outputs look like. |
+| [`agentonomous`](https://github.com/Luis85/agentonomous) | Agent orchestration engine for v2.0. Provides agent definitions, coworker concepts, routing, handoffs, run state, and tool abstractions. |
+| Specorator | Obsidian plugin lifecycle, user interface, vault access, permission boundaries, and the bridge between the user's vault and upstream capabilities. |
+
 ## Non-Goals
 
 - Replacing Obsidian as the editing environment.
@@ -59,6 +97,9 @@ The plugin should make these capabilities available without requiring chat-based
 - Hiding workflow artifacts behind opaque plugin state.
 - Automating human approval gates.
 - Turning the workflow into a generic project management board detached from specs.
+- Giving agents unrestricted vault access by default.
+- Automatically accepting or applying agent outputs without user approval.
+- Implementing a separate orchestration engine inside Specorator (agentonomous owns that).
 
 ## Success Signals
 
@@ -67,11 +108,15 @@ The plugin should make these capabilities available without requiring chat-based
 - The same workflow artifacts remain readable and usable as Markdown files.
 - LLM-disabled usage remains productive for scaffolding, validation, upkeep, and review preparation.
 - Advanced users can still use scripts and command-line tools directly when they prefer.
+- In v2.0: a user can ask a coworker for help at a workflow stage, review the proposed output, and accept or reject it — without leaving Obsidian or losing control of their vault.
 
-## Near-Term Product Questions
+## Open Questions
 
 - Which workflow stages must be supported in the first usable plugin slice?
 - Which existing scripts should become plugin commands first?
 - What vault health checks are mandatory before any LLM-assisted workflow is added?
 - How should plugin state be stored so Markdown remains the source of truth?
 - What does a minimal but useful traceability dashboard need to show?
+- What is the right runtime boundary for agentonomous inside an Obsidian plugin — direct import, local service process, or CLI bridge?
+- Which agentic coworkers should be available first in v2.0?
+- How should long-running or interrupted agent runs be resumed?


### PR DESCRIPTION
## Summary

Three self-contained improvements from the post-roadmap cleanup review.

### README (`README.md`)
Replaces the 5-line stub with a structured landing page that covers v1/v2.0 direction, links to the vision and roadmap docs, project tracking issues (#47, #1, #2, #11, #24), planned stack, contributing guidance, and related repositories. Closes part of #3.

### Product vision (`docs/product-vision.md`)
Adds the missing content called out in #25:
- v1 alpha outcome section (the foundation, no agent orchestration)
- v2.0 companion-app section (agentonomous integration model, user-control principles, what agents may and may not do)
- Upstream project relationship table (agentic-workflow / agentonomous / Specorator roles)
- `User-controlled agents` principle added to the principles list
- Expanded non-goals covering v2.0 agent behaviour
- Expanded success signals including a v2.0 coworker scenario
- Additional open questions for the agentonomous runtime boundary

Closes #25.

### Issue and PR templates (`.github/`)
- `feature.yml` — feature request with problem statement, proposed solution, acceptance criteria, related links
- `bug.yml` — bug report with steps to reproduce, expected behaviour, environment
- `task.yml` — setup/engineering/docs task with goal, scope, acceptance criteria
- `decision.yml` — architecture / design decision with context, options, decision, consequences
- `config.yml` — disables blank issues; links to vision and roadmap docs as contact links
- `PULL_REQUEST_TEMPLATE.md` — summary, changes, verification checklist, screenshots/vault notes, risks

Addresses #4.

## Test plan

- [ ] README renders correctly on the repo landing page
- [ ] `docs/product-vision.md` covers v1 and v2.0 direction; all issue references resolve
- [ ] Issue templates appear when opening a new issue on GitHub
- [ ] PR template pre-fills when opening a new PR
- [ ] No existing files removed or broken

https://claude.ai/code/session_01U5BotdemPi55FjQbXUTmW1

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5BotdemPi55FjQbXUTmW1)_