### PR TITLE
feat: add design & requirement intake templates and frontmatter requirements workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-design-intake.yml
+++ b/.github/ISSUE_TEMPLATE/01-design-intake.yml
@@ -1,0 +1,46 @@
+name: "Design intake"
+description: "Capture design-level problem framing, options, and decision pressure."
+title: "design: <concise design problem>"
+labels: ["design", "intake", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this issue when a workflow or UX decision needs explicit design treatment.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What user or workflow problem are we solving?
+      placeholder: "Who is blocked, and why?"
+    validations:
+      required: true
+  - type: textarea
+    id: outcomes
+    attributes:
+      label: Intended outcomes
+      description: What should be measurably better when this is complete?
+      placeholder: "Examples: reduced onboarding friction, clearer stage transitions"
+    validations:
+      required: true
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints and non-goals
+      description: What boundaries must the design respect?
+    validations:
+      required: true
+  - type: textarea
+    id: options
+    attributes:
+      label: Candidate approaches
+      description: List options considered, including at least one rejected path.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance signals
+      description: How will maintainers decide this design is good enough to implement?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/02-requirement-intake.yml
+++ b/.github/ISSUE_TEMPLATE/02-requirement-intake.yml
@@ -1,0 +1,54 @@
+name: "Requirement intake"
+description: "Propose a new requirement that should become a frontmatter requirement note."
+title: "req: <requirement summary>"
+labels: ["requirements", "intake", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this issue to propose a requirement before implementation starts.
+        A merged requirement should be represented by a file in `requirements/intake/`.
+  - type: input
+    id: requirement_id
+    attributes:
+      label: Proposed requirement ID
+      description: Format `REQ-XXXX` where `XXXX` is zero-padded numeric.
+      placeholder: "REQ-0001"
+    validations:
+      required: true
+  - type: textarea
+    id: user_need
+    attributes:
+      label: User need
+      description: Who needs this and what outcome do they need?
+    validations:
+      required: true
+  - type: textarea
+    id: requirement_statement
+    attributes:
+      label: Requirement statement
+      description: Write a testable requirement using SHALL language.
+      placeholder: "The system SHALL ..."
+    validations:
+      required: true
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Rationale
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: Bullet list of objective pass/fail criteria.
+    validations:
+      required: true
+  - type: input
+    id: related_design
+    attributes:
+      label: Related design intake issue
+      description: Link to design intake issue when applicable.
+      placeholder: "#123"
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Specorator is an Obsidian plugin and companion app for spec-driven, agentic soft
 |----------|---------|
 | [docs/product-vision.md](docs/product-vision.md) | Product north star, principles, and v1/v2.0 direction |
 | [docs/roadmap-v1.md](docs/roadmap-v1.md) | Phased delivery plan for v1 alpha |
+| [docs/process/requirements-intake.md](docs/process/requirements-intake.md) | Intake-first requirements and design workflow |
 
 ## Project tracking
 
@@ -43,7 +44,13 @@ The planned stack: Obsidian community plugin · Vue 3 · Vue Router · Pinia 2 �
 
 ## Contributing
 
-Issues and pull requests are welcome. See the [roadmap](docs/roadmap-v1.md) for current priorities. Issue templates are available for feature requests, bug reports, tasks, and architecture decisions.
+Issues and pull requests are welcome. See the [roadmap](docs/roadmap-v1.md) for current priorities.
+
+**Intake-first workflow:** new requirements and design decisions go through a structured intake process before implementation begins.
+
+- Open a **Requirement intake** or **Design intake** issue using the provided templates.
+- Add a requirement draft under `requirements/intake/` using `REQ-0000-template.md`.
+- Follow `docs/process/requirements-intake.md` for triage and promotion steps.
 
 ## Related repositories
 

--- a/docs/process/requirements-intake.md
+++ b/docs/process/requirements-intake.md
@@ -1,0 +1,29 @@
+# Requirements Intake Workflow
+
+This repository uses frontmatter-backed Markdown files in `requirements/intake/` as the durable intake artifact for new requirements.
+
+## Flow
+
+1. Open a **Requirement intake** issue with a proposed `REQ-XXXX` identifier.
+2. (Optional) Open a **Design intake** issue first when the requirement implies non-trivial UX or workflow decisions.
+3. Create a draft PR that adds a requirement file copied from `requirements/intake/REQ-0000-template.md`.
+4. Link both intake issues in the PR template.
+5. Move status from `proposed` to `accepted` only after triage consensus.
+
+## File conventions
+
+- One requirement per file: `requirements/intake/REQ-XXXX-<slug>.md`
+- Required frontmatter keys: `id`, `status`, `summary`, `source_issue`, `statement`, `acceptance_criteria`, `traceability`.
+- Use `statement` with explicit SHALL wording.
+- `acceptance_criteria` must be objective and testable.
+
+## Triaging GitHub issues in order
+
+To process issues predictably:
+
+1. Sort by oldest first.
+2. Confirm each issue is one of: design intake, requirement intake, implementation task, or maintenance.
+3. Convert under-specified issues into intake issues before implementation.
+4. Reject or close issues missing a clear user need or testable outcome.
+
+A future automation can validate required frontmatter keys and ID format.

--- a/requirements/intake/REQ-0000-template.md
+++ b/requirements/intake/REQ-0000-template.md
@@ -1,0 +1,30 @@
+---
+id: REQ-0000
+status: proposed
+summary: "<concise requirement summary>"
+owner: "<github-handle-or-team>"
+created: 2026-05-01
+last_updated: 2026-05-01
+source_issue: "#<requirement-intake-issue>"
+related_design: "#<design-intake-issue-or-empty>"
+tags: [requirements, intake]
+priority: medium
+risk: medium
+verification:
+  - "<test-or-check-1>"
+  - "<test-or-check-2>"
+statement: "The system SHALL ..."
+rationale: "<why this matters>"
+acceptance_criteria:
+  - "<objective criterion 1>"
+  - "<objective criterion 2>"
+traceability:
+  upstream:
+    - "<product-vision-section-or-issue-link>"
+  downstream:
+    - "<design-doc-link-or-task-link>"
+---
+
+## Notes
+
+Capture clarifications, assumptions, and open questions.


### PR DESCRIPTION
## Summary

- Add GitHub issue templates for **design intake** (`.github/ISSUE_TEMPLATE/01-design-intake.yml`) and **requirement intake** (`.github/ISSUE_TEMPLATE/02-requirement-intake.yml`) to enforce structured submissions before implementation begins.
- Add `requirements/intake/REQ-0000-template.md` as the canonical frontmatter template for new requirement files.
- Add `docs/process/requirements-intake.md` describing the intake-first flow, file conventions, and issue triage order.
- Update `README.md` with intake-first contributing guidance and a docs table entry.

## Resolves

Supersedes #46 (had merge conflicts and a placeholder URL in `config.yml`). All improvements from that PR are incorporated here with conflicts resolved against main.

**Fixes from PR review:**
- Placeholder `https://github.com/OWNER/REPO/...` URL in `config.yml` — already corrected on `main` in PR #49; this branch is rebased on top of that fix.

## Validation

- [ ] `rg --files .github/ISSUE_TEMPLATE` lists all five templates
- [ ] `cat docs/process/requirements-intake.md` shows full flow
- [ ] `cat requirements/intake/REQ-0000-template.md` shows valid YAML frontmatter

https://claude.ai/code/session_01AG61QrgmSnXmLCWte4AJXV

---
_Generated by [Claude Code](https://claude.ai/code/session_01AG61QrgmSnXmLCWte4AJXV)_