### PR TITLE
fix: address open review issues from PR #55

### DIFF
--- a/src/infrastructure/localstorage/LocalStorageBridge.ts
+++ b/src/infrastructure/localstorage/LocalStorageBridge.ts
@@ -43,7 +43,7 @@ export class LocalStorageBridge implements IBridge {
         const relative = filePath.slice(parent.endsWith('/') ? parent.length : parent.length + 1)
         const slash = relative.indexOf('/')
         if (slash !== -1) {
-          folders.add(parent + '/' + relative.slice(0, slash))
+          folders.add(relative.slice(0, slash))
         }
       }
     }

--- a/src/infrastructure/localstorage/__tests__/LocalStorageBridge.spec.ts
+++ b/src/infrastructure/localstorage/__tests__/LocalStorageBridge.spec.ts
@@ -48,8 +48,8 @@ describe('LocalStorageBridge', () => {
       await bridge.writeFile('features/dark-mode/_meta.md', '')
       await bridge.writeFile('features/search/_meta.md', '')
       const folders = await bridge.listFolders('features')
-      expect(folders).toContain('features/dark-mode')
-      expect(folders).toContain('features/search')
+      expect(folders).toContain('dark-mode')
+      expect(folders).toContain('search')
     })
 
     it('createFolder is a no-op and does not throw', async () => {

--- a/src/ui/composables/useSettings.ts
+++ b/src/ui/composables/useSettings.ts
@@ -1,3 +1,4 @@
+import { storeToRefs } from 'pinia'
 import { useBridge } from './useBridge'
 import { useSettingsStore } from '../stores/settingsStore'
 import { setLocale } from '../i18n'
@@ -7,6 +8,7 @@ import type { PluginSettings } from '@/infrastructure/bridge/IBridge'
 export function useSettings() {
   const bridge = useBridge()
   const store = useSettingsStore()
+  const { settings, loading } = storeToRefs(store)
 
   async function loadSettings(): Promise<void> {
     store.setLoading(true)
@@ -26,8 +28,8 @@ export function useSettings() {
   }
 
   return {
-    settings: store.settings,
-    loading: store.loading,
+    settings,
+    loading,
     loadSettings,
     saveSettings,
   }

--- a/src/ui/views/HomeView.vue
+++ b/src/ui/views/HomeView.vue
@@ -6,9 +6,11 @@ import FeatureCard from '../components/feature/FeatureCard.vue'
 import CreateFeatureForm from '../components/feature/CreateFeatureForm.vue'
 import AppButton from '../components/common/AppButton.vue'
 import { useFeatures } from '../composables/useFeatures'
+import { useBridge } from '../composables/useBridge'
 
 const { t } = useI18n()
 const router = useRouter()
+const bridge = useBridge()
 const { activeItems, loading, error, loadFeatures, createFeature, activateFeature, archiveFeature } = useFeatures()
 const showCreateForm = ref(false)
 
@@ -17,6 +19,13 @@ onMounted(loadFeatures)
 async function handleCreate(title: string) {
   await createFeature(title)
   showCreateForm.value = false
+}
+
+async function handleOpen(featureId: string) {
+  const feature = activeItems.value.find((f) => f.id === featureId)
+  if (!feature) return
+  const settings = await bridge.getSettings()
+  await bridge.openFile(`${settings.featuresFolder}/${feature.slug}/_meta.md`)
 }
 </script>
 
@@ -56,7 +65,7 @@ async function handleCreate(title: string) {
           :feature="feature"
           @activate="activateFeature"
           @archive="archiveFeature"
-          @open="router.push({ name: 'features', query: { open: $event } })"
+          @open="handleOpen"
         />
       </div>
     </section>

--- a/src/ui/views/SettingsView.vue
+++ b/src/ui/views/SettingsView.vue
@@ -16,7 +16,7 @@ onMounted(loadSettings)
 async function handleSave() {
   saving.value = true
   try {
-    await saveSettings({ ...settings })
+    await saveSettings({ ...settings.value })
     saved.value = true
     setTimeout(() => { saved.value = false }, 2500)
   } finally {
@@ -25,7 +25,7 @@ async function handleSave() {
 }
 
 function update<K extends keyof PluginSettings>(key: K, value: PluginSettings[K]) {
-  ;(settings as Record<string, unknown>)[key] = value
+  settings.value = { ...settings.value, [key]: value }
 }
 </script>
 


### PR DESCRIPTION
## Summary

Follow-up to #55 — fixes the three unresolved review threads left open after merge.

- **P1 `useSettings` reactivity** (`src/ui/composables/useSettings.ts`): `settings` and `loading` were returned as plain (snapshot) values. Now uses `storeToRefs` so consumers stay reactive when the store is updated by `loadSettings`.
- **P1 `LocalStorageBridge.listFolders` double-prefix** (`src/infrastructure/localstorage/LocalStorageBridge.ts`): `listFolders()` was returning full paths (`features/dark-mode`) but `FeatureRepository.findAll()` already prepends `settings.featuresFolder`, causing lookups like `features/features/dark-mode/_meta.md` that silently returned nothing. Now returns child names only (`dark-mode`).
- **P2 `HomeView` dead Open action** (`src/ui/views/HomeView.vue`): The `@open` handler was navigating to the Features route with a `?open=` query parameter that nothing consumed. Now calls `bridge.openFile` directly, matching the working handler in `FeaturesView`.

`SettingsView.vue` was also updated to access `settings.value` after the reactivity fix.

## Test plan

- [ ] `npm test` → 38 tests pass
- [ ] `npm run typecheck` → zero errors
- [ ] In dev (`npm run dev`): clicking **Open** on a Home card opens the feature file
- [ ] In GitHub Pages build: persisted features appear after page refresh (listFolders fix)
- [ ] Settings changes persist correctly across save/reload cycles

https://claude.ai/code/session_016u23vqzbn1kico6QbTDtVi

---
_Generated by [Claude Code](https://claude.ai/code/session_016u23vqzbn1kico6QbTDtVi)_