### PR TITLE
feat(#19): add TypeDoc generation for public plugin shell APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,6 @@ jobs:
 
       - name: Build (standalone UI)
         run: npm run build:web
+
+      - name: Generate API docs
+        run: npm run docs:api

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ Thumbs.db
 
 # Obsidian local settings (not plugin source)
 .obsidian/
+
+# Generated API docs (run `npm run docs:api` to regenerate)
+docs/api/

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
 				"jsdom": "^29.1.1",
 				"obsidian": "latest",
 				"prettier": "^3.8.3",
+				"typedoc": "^0.28.19",
 				"typescript": "^5.8.0",
 				"typescript-eslint": "^8.59.1",
 				"vite": "^6.0.0",
@@ -921,6 +922,20 @@
 				}
 			}
 		},
+		"node_modules/@gerrit0/mini-shiki": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
+			"integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/engine-oniguruma": "^3.23.0",
+				"@shikijs/langs": "^3.23.0",
+				"@shikijs/themes": "^3.23.0",
+				"@shikijs/types": "^3.23.0",
+				"@shikijs/vscode-textmate": "^10.0.2"
+			}
+		},
 		"node_modules/@humanfs/core": {
 			"version": "0.19.2",
 			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1473,6 +1488,55 @@
 				"win32"
 			]
 		},
+		"node_modules/@shikijs/engine-oniguruma": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+			"integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "3.23.0",
+				"@shikijs/vscode-textmate": "^10.0.2"
+			}
+		},
+		"node_modules/@shikijs/langs": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+			"integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "3.23.0"
+			}
+		},
+		"node_modules/@shikijs/themes": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+			"integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "3.23.0"
+			}
+		},
+		"node_modules/@shikijs/types": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+			"integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			}
+		},
+		"node_modules/@shikijs/vscode-textmate": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+			"integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/chai": {
 			"version": "5.2.3",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1515,6 +1579,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/hast": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+			"integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "*"
+			}
+		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1541,6 +1615,13 @@
 			"dependencies": {
 				"@types/estree": "*"
 			}
+		},
+		"node_modules/@types/unist": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "8.59.1",
@@ -2259,6 +2340,13 @@
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
+		},
+		"node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true,
+			"license": "Python-2.0"
 		},
 		"node_modules/assertion-error": {
 			"version": "2.0.1",
@@ -3407,6 +3495,16 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/linkify-it": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"uc.micro": "^2.0.0"
+			}
+		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3439,6 +3537,13 @@
 			"engines": {
 				"node": "20 || >=22"
 			}
+		},
+		"node_modules/lunr": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
@@ -3477,12 +3582,50 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/markdown-it": {
+			"version": "14.1.1",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+			"integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1",
+				"entities": "^4.4.0",
+				"linkify-it": "^5.0.0",
+				"mdurl": "^2.0.0",
+				"punycode.js": "^2.3.1",
+				"uc.micro": "^2.1.0"
+			},
+			"bin": {
+				"markdown-it": "bin/markdown-it.mjs"
+			}
+		},
+		"node_modules/markdown-it/node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
 		"node_modules/mdn-data": {
 			"version": "2.27.1",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
 			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
 			"dev": true,
 			"license": "CC0-1.0"
+		},
+		"node_modules/mdurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/minimatch": {
 			"version": "10.2.5",
@@ -3874,6 +4017,16 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/punycode.js": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4327,6 +4480,30 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/typedoc": {
+			"version": "0.28.19",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.19.tgz",
+			"integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@gerrit0/mini-shiki": "^3.23.0",
+				"lunr": "^2.3.9",
+				"markdown-it": "^14.1.1",
+				"minimatch": "^10.2.5",
+				"yaml": "^2.8.3"
+			},
+			"bin": {
+				"typedoc": "bin/typedoc"
+			},
+			"engines": {
+				"node": ">= 18",
+				"pnpm": ">= 10"
+			},
+			"peerDependencies": {
+				"typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
+			}
+		},
 		"node_modules/typescript": {
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -4364,6 +4541,13 @@
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
+		},
+		"node_modules/uc.micro": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/undici": {
 			"version": "7.25.0",
@@ -4932,6 +5116,22 @@
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/yaml": {
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"build:web": "vue-tsc --noEmit && vite build",
-		"test:coverage": "vitest run --coverage"
+		"test:coverage": "vitest run --coverage",
+		"docs:api": "typedoc"
 	},
 	"dependencies": {
 		"pinia": "^2.1.7",
@@ -39,6 +40,7 @@
 		"jsdom": "^29.1.1",
 		"obsidian": "latest",
 		"prettier": "^3.8.3",
+		"typedoc": "^0.28.19",
 		"typescript": "^5.8.0",
 		"typescript-eslint": "^8.59.1",
 		"vite": "^6.0.0",

--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": false
+  },
+  "include": [
+    "src/infrastructure/bridge/**/*.ts",
+    "src/domain/**/*.ts",
+    "src/application/**/*.ts"
+  ],
+  "exclude": [
+    "**/*.spec.ts"
+  ]
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://typedoc.app/schema.json",
+  "entryPoints": [
+    "src/infrastructure/bridge/IBridge.ts",
+    "src/infrastructure/bridge/BridgeKey.ts",
+    "src/domain",
+    "src/application"
+  ],
+  "entryPointStrategy": "expand",
+  "out": "docs/api",
+  "tsconfig": "tsconfig.typedoc.json",
+  "excludePrivate": true,
+  "excludeInternal": true,
+  "excludeExternals": true,
+  "exclude": ["**/*.spec.ts", "**/__tests__/**"],
+  "readme": "none",
+  "name": "Specorator API",
+  "githubPages": false
+}


### PR DESCRIPTION
## Summary

- Install `typedoc` 0.28 as a dev dependency
- Add `typedoc.json` targeting the bridge, domain, and application layers as entry points (excludes Vue UI and test specs)
- Add `tsconfig.typedoc.json` so TypeDoc resolves only pure-TypeScript source without needing Vue file type declarations
- Add `docs:api` script to `package.json`
- Wire a **Generate API docs** step into CI — failures here catch broken public API types/comments
- Exclude `docs/api/` from git (generated artifact; regenerate with `npm run docs:api`)

## Covered entry points

| Layer | Path |
|---|---|
| Bridge interface | `src/infrastructure/bridge/IBridge.ts` |
| Bridge injection key | `src/infrastructure/bridge/BridgeKey.ts` |
| Domain | `src/domain/**` |
| Application | `src/application/**` |

## Test plan

- [ ] `npm run docs:api` runs without errors from a clean checkout
- [ ] `docs/api/index.html` is generated and shows `IBridge`, domain types, and use cases
- [ ] CI step passes on this branch

## Related

Closes #19

https://claude.ai/code/session_01JQzrjs9nChXRhQpu3jYg8d

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQzrjs9nChXRhQpu3jYg8d)_