### PR TITLE
Add release and packaging workflow for Obsidian plugin artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and publish release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test
+
+      - name: Build plugin
+        run: npm run build
+
+      - name: Verify manifest version matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          MANIFEST_VERSION="$(node -p "require('./manifest.json').version")"
+          if [ "$TAG_VERSION" != "$MANIFEST_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match manifest.json version ($MANIFEST_VERSION)"
+            exit 1
+          fi
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            manifest.json
+            main.js
+            styles.css
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-') }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` triggered on semver tags (`v*.*.*`)
- Runs the full CI gate (typecheck, lint, test) before producing artifacts
- Verifies the pushed tag version matches `manifest.json` to prevent mismatched releases
- Builds the plugin and attaches `manifest.json`, `main.js`, and `styles.css` to a GitHub Release
- Tags containing a hyphen (e.g. `v0.1.0-alpha.1`) are automatically marked as pre-releases

Closes #8

## Versioning policy

Tags must follow semver: `vMAJOR.MINOR.PATCH` (e.g. `v0.1.0`).  
The `manifest.json` `version` field must be updated to match the tag before pushing — the workflow will fail and block the release if they diverge.  
Pre-release tags use a hyphen suffix, e.g. `v0.1.0-alpha.1`.

## Test plan

- [ ] Push a tag `v0.0.1` (after updating `manifest.json` to `0.0.1`) and verify the release is created with the three artifacts attached
- [ ] Push a tag whose version does not match `manifest.json` and verify the workflow fails at the version-check step
- [ ] Push a pre-release tag like `v0.1.0-alpha.1` and verify the release is marked as pre-release

https://claude.ai/code/session_01Uozvx6pofAuMrXKJuABP8n

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uozvx6pofAuMrXKJuABP8n)_