### PR TITLE
Add Dependabot config and security policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,57 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    groups:
+      dev-tooling:
+        patterns:
+          - "@eslint/*"
+          - "eslint*"
+          - "prettier*"
+          - "typescript*"
+          - "vue-tsc"
+          - "typedoc*"
+          - "globals"
+        update-types:
+          - minor
+          - patch
+      vite-vitest:
+        patterns:
+          - "vite*"
+          - "@vitejs/*"
+          - "vitest*"
+          - "@vitest/*"
+        update-types:
+          - minor
+          - patch
+      vue:
+        patterns:
+          - "vue*"
+          - "@vue/*"
+          - "pinia"
+          - "vue-i18n"
+          - "vue-router"
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest release of Specorator receives security fixes.
+Pre-release versions (e.g. `v0.x.x-alpha`) are not supported for security patches.
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Report vulnerabilities privately via [GitHub Security Advisories](https://github.com/Luis85/specorator/security/advisories/new).
+
+Include as much detail as possible:
+
+- a description of the vulnerability and its potential impact;
+- steps to reproduce or a proof-of-concept;
+- affected versions;
+- any suggested mitigations if known.
+
+You can expect an acknowledgement within **5 business days** and a resolution timeline within **30 days** for confirmed vulnerabilities, depending on severity and complexity.


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` — weekly Dependabot updates for npm packages and GitHub Actions
- Adds `SECURITY.md` — directs reporters to GitHub Security Advisories and sets acknowledgement/resolution SLAs

Closes #9

## Dependabot configuration details

**npm** (weekly, Mondays):
- Packages grouped into three batches to keep PR noise low: `vue` ecosystem, `vite`/`vitest`, and dev tooling (ESLint, Prettier, TypeScript, TypeDoc)
- Major version bumps open individual PRs so they can be reviewed separately
- Capped at 5 open PRs; all tagged `dependencies`

**GitHub Actions** (weekly, Mondays):
- Keeps `actions/checkout`, `actions/setup-node`, and `softprops/action-gh-release` pinned versions current
- Tagged `dependencies` + `ci`

## Security policy

`SECURITY.md` covers:
- supported versions (latest release only)
- private reporting via GitHub Security Advisories
- acknowledgement within 5 business days, resolution within 30 days for confirmed issues

## Test plan

- [ ] Confirm Dependabot appears under the repository's Security tab after merge
- [ ] Verify a weekly run opens grouped PRs for npm and individual PRs for GitHub Actions
- [ ] Confirm `SECURITY.md` is surfaced by GitHub as the repo's security policy

https://claude.ai/code/session_01Uozvx6pofAuMrXKJuABP8n

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uozvx6pofAuMrXKJuABP8n)_