### PR TITLE
chore(deps): resolve dependabot PRs #66-#70

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,16 @@
 			"dependencies": {
 				"pinia": "^2.1.7",
 				"vue": "^3.4.0",
-				"vue-i18n": "^9.9.0",
+				"vue-i18n": "^11.4.0",
 				"vue-router": "^4.3.0"
 			},
 			"devDependencies": {
 				"@eslint/js": "^10.0.1",
-				"@types/node": "^22.0.0",
+				"@types/node": "^25.6.0",
 				"@vitejs/plugin-vue": "^5.0.4",
-				"@vitest/coverage-v8": "^3.0.0",
+				"@vitest/coverage-v8": "^4.1.5",
 				"@vue/test-utils": "^2.4.4",
-				"@vue/tsconfig": "^0.5.1",
+				"@vue/tsconfig": "^0.9.1",
 				"eslint": "^10.3.0",
 				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-vue": "^10.9.0",
@@ -31,22 +31,8 @@
 				"typescript": "^5.8.0",
 				"typescript-eslint": "^8.59.1",
 				"vite": "^6.0.0",
-				"vitest": "^3.0.0",
-				"vue-tsc": "^2.0.0"
-			}
-		},
-		"node_modules/@ampproject/remapping": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.24"
-			},
-			"engines": {
-				"node": ">=6.0.0"
+				"vitest": "^4.1.5",
+				"vue-tsc": "^3.2.7"
 			}
 		},
 		"node_modules/@asamuzakjp/css-color": {
@@ -1003,13 +989,30 @@
 			}
 		},
 		"node_modules/@intlify/core-base": {
-			"version": "9.14.5",
-			"resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.14.5.tgz",
-			"integrity": "sha512-5ah5FqZG4pOoHjkvs8mjtv+gPKYU0zCISaYNjBNNqYiaITxW8ZtVih3GS/oTOqN8d9/mDLyrjD46GBApNxmlsA==",
+			"version": "11.4.0",
+			"resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.4.0.tgz",
+			"integrity": "sha512-nlxFOnmjJgVkL1PsuSMagyh3qIHTwc2KlO2R3qQQV1ydrcwh1XpM7opWUGqvGaLlktttopDzbLBpr/k5tvbNmA==",
 			"license": "MIT",
 			"dependencies": {
-				"@intlify/message-compiler": "9.14.5",
-				"@intlify/shared": "9.14.5"
+				"@intlify/devtools-types": "11.4.0",
+				"@intlify/message-compiler": "11.4.0",
+				"@intlify/shared": "11.4.0"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/kazupon"
+			}
+		},
+		"node_modules/@intlify/devtools-types": {
+			"version": "11.4.0",
+			"resolved": "https://registry.npmjs.org/@intlify/devtools-types/-/devtools-types-11.4.0.tgz",
+			"integrity": "sha512-LtQ04kG8/2Nv6AbuINpkjODuhKHdd+MGLlXKW3I0GTCeDsDIBZUot82nnyK7D6+qersF08FqSvoN/eGPcL3c7Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@intlify/core-base": "11.4.0",
+				"@intlify/shared": "11.4.0"
 			},
 			"engines": {
 				"node": ">= 16"
@@ -1019,12 +1022,12 @@
 			}
 		},
 		"node_modules/@intlify/message-compiler": {
-			"version": "9.14.5",
-			"resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.14.5.tgz",
-			"integrity": "sha512-IHzgEu61/YIpQV5Pc3aRWScDcnFKWvQA9kigcINcCBXN8mbW+vk9SK+lDxA6STzKQsVJxUPg9ACC52pKKo3SVQ==",
+			"version": "11.4.0",
+			"resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.4.0.tgz",
+			"integrity": "sha512-v455gVZqMb0er63Wd/akX8DXTnwSubgrgQaRigLB60V3xpnq3B99oPvGXW+N4G/5QFt8Ls84FJ8qHJUVnRCs1A==",
 			"license": "MIT",
 			"dependencies": {
-				"@intlify/shared": "9.14.5",
+				"@intlify/shared": "11.4.0",
 				"source-map-js": "^1.0.2"
 			},
 			"engines": {
@@ -1035,9 +1038,9 @@
 			}
 		},
 		"node_modules/@intlify/shared": {
-			"version": "9.14.5",
-			"resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.14.5.tgz",
-			"integrity": "sha512-9gB+E53BYuAEMhbCAxVgG38EZrk59sxBtv3jSizNL2hEWlgjBjAw1AwpLHtNaeda12pe6W20OGEa0TwuMSRbyQ==",
+			"version": "11.4.0",
+			"resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.4.0.tgz",
+			"integrity": "sha512-r9qUeLeO0TMZmUZ+mXS6IGQ6xwzZJaVMK6j4CdoA3eQP8xp3JtCfwkZ30gB4+knlN40pmBdDXgx85SWhMCzHng==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 16"
@@ -1062,27 +1065,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/@istanbuljs/schema": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
-			"integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.5.0",
-				"@jridgewell/trace-mapping": "^0.3.24"
 			}
 		},
 		"node_modules/@jridgewell/resolve-uri": {
@@ -1537,6 +1519,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/chai": {
 			"version": "5.2.3",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1597,13 +1586,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "22.19.17",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
-			"integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+			"version": "25.6.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~6.21.0"
+				"undici-types": "~7.19.0"
 			}
 		},
 		"node_modules/@types/tern": {
@@ -1868,32 +1857,29 @@
 			}
 		},
 		"node_modules/@vitest/coverage-v8": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
-			"integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+			"integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@ampproject/remapping": "^2.3.0",
 				"@bcoe/v8-coverage": "^1.0.2",
-				"ast-v8-to-istanbul": "^0.3.3",
-				"debug": "^4.4.1",
+				"@vitest/utils": "4.1.5",
+				"ast-v8-to-istanbul": "^1.0.0",
 				"istanbul-lib-coverage": "^3.2.2",
 				"istanbul-lib-report": "^3.0.1",
-				"istanbul-lib-source-maps": "^5.0.6",
-				"istanbul-reports": "^3.1.7",
-				"magic-string": "^0.30.17",
-				"magicast": "^0.3.5",
-				"std-env": "^3.9.0",
-				"test-exclude": "^7.0.1",
-				"tinyrainbow": "^2.0.0"
+				"istanbul-reports": "^3.2.0",
+				"magicast": "^0.5.2",
+				"obug": "^2.1.1",
+				"std-env": "^4.0.0-rc.1",
+				"tinyrainbow": "^3.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"@vitest/browser": "3.2.4",
-				"vitest": "3.2.4"
+				"@vitest/browser": "4.1.5",
+				"vitest": "4.1.5"
 			},
 			"peerDependenciesMeta": {
 				"@vitest/browser": {
@@ -1902,39 +1888,40 @@
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-			"integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+			"integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "3.2.4",
-				"@vitest/utils": "3.2.4",
-				"chai": "^5.2.0",
-				"tinyrainbow": "^2.0.0"
+				"@vitest/spy": "4.1.5",
+				"@vitest/utils": "4.1.5",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-			"integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+			"integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "3.2.4",
+				"@vitest/spy": "4.1.5",
 				"estree-walker": "^3.0.3",
-				"magic-string": "^0.30.17"
+				"magic-string": "^0.30.21"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
 				"msw": "^2.4.9",
-				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"msw": {
@@ -1956,42 +1943,42 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-			"integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+			"integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tinyrainbow": "^2.0.0"
+				"tinyrainbow": "^3.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-			"integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+			"integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "3.2.4",
-				"pathe": "^2.0.3",
-				"strip-literal": "^3.0.0"
+				"@vitest/utils": "4.1.5",
+				"pathe": "^2.0.3"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-			"integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+			"integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "3.2.4",
-				"magic-string": "^0.30.17",
+				"@vitest/pretty-format": "4.1.5",
+				"@vitest/utils": "4.1.5",
+				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -1999,58 +1986,55 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-			"integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+			"integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"tinyspy": "^4.0.3"
-			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-			"integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+			"integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "3.2.4",
-				"loupe": "^3.1.4",
-				"tinyrainbow": "^2.0.0"
+				"@vitest/pretty-format": "4.1.5",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@volar/language-core": {
-			"version": "2.4.15",
-			"resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.15.tgz",
-			"integrity": "sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==",
+			"version": "2.4.28",
+			"resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+			"integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@volar/source-map": "2.4.15"
+				"@volar/source-map": "2.4.28"
 			}
 		},
 		"node_modules/@volar/source-map": {
-			"version": "2.4.15",
-			"resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.15.tgz",
-			"integrity": "sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg==",
+			"version": "2.4.28",
+			"resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+			"integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@volar/typescript": {
-			"version": "2.4.15",
-			"resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.15.tgz",
-			"integrity": "sha512-2aZ8i0cqPGjXb4BhkMsPYDkkuc2ZQ6yOpqwAuNwUoncELqoy5fRgOQtLR9gB0g902iS0NAkvpIzs27geVyVdPg==",
+			"version": "2.4.28",
+			"resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+			"integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@volar/language-core": "2.4.15",
+				"@volar/language-core": "2.4.28",
 				"path-browserify": "^1.0.1",
 				"vscode-uri": "^3.0.8"
 			}
@@ -2105,17 +2089,6 @@
 				"@vue/shared": "3.5.33"
 			}
 		},
-		"node_modules/@vue/compiler-vue2": {
-			"version": "2.7.16",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
-			"integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"de-indent": "^1.0.2",
-				"he": "^1.2.0"
-			}
-		},
 		"node_modules/@vue/devtools-api": {
 			"version": "6.6.4",
 			"resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
@@ -2123,61 +2096,19 @@
 			"license": "MIT"
 		},
 		"node_modules/@vue/language-core": {
-			"version": "2.2.12",
-			"resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.12.tgz",
-			"integrity": "sha512-IsGljWbKGU1MZpBPN+BvPAdr55YPkj2nB/TBNGNC32Vy2qLG25DYu/NBN2vNtZqdRbTRjaoYrahLrToim2NanA==",
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.2.7.tgz",
+			"integrity": "sha512-Gn4q/tRxbpVGLEuARQ43p3YELlNAFgRUVCgW9U5Cr+5q4vfD2bWDWpl3ABbJMXUt5xlE1dF8dkigg2aUq7JYYw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@volar/language-core": "2.4.15",
+				"@volar/language-core": "2.4.28",
 				"@vue/compiler-dom": "^3.5.0",
-				"@vue/compiler-vue2": "^2.7.16",
 				"@vue/shared": "^3.5.0",
-				"alien-signals": "^1.0.3",
-				"minimatch": "^9.0.3",
+				"alien-signals": "^3.1.2",
 				"muggle-string": "^0.4.1",
-				"path-browserify": "^1.0.1"
-			},
-			"peerDependencies": {
-				"typescript": "*"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@vue/language-core/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@vue/language-core/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/@vue/language-core/node_modules/minimatch": {
-			"version": "9.0.9",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+				"path-browserify": "^1.0.1",
+				"picomatch": "^4.0.4"
 			}
 		},
 		"node_modules/@vue/reactivity": {
@@ -2252,11 +2183,23 @@
 			}
 		},
 		"node_modules/@vue/tsconfig": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.5.1.tgz",
-			"integrity": "sha512-VcZK7MvpjuTPx2w6blwnwZAu5/LgBUtejFOi3pPGQFXQN5Ela03FUtd2Qtg4yWGGissVL0dr6Ro1LfOFh+PCuQ==",
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.9.1.tgz",
+			"integrity": "sha512-buvjm+9NzLCJL29KY1j1991YYJ5e6275OiK+G4jtmfIb+z4POywbdm0wXusT9adVWqe0xqg70TbI7+mRx4uU9w==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peerDependencies": {
+				"typescript": ">= 5.8",
+				"vue": "^3.4.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				},
+				"vue": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/abbrev": {
 			"version": "2.0.0",
@@ -2309,9 +2252,9 @@
 			}
 		},
 		"node_modules/alien-signals": {
-			"version": "1.0.13",
-			"resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-1.0.13.tgz",
-			"integrity": "sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.1.2.tgz",
+			"integrity": "sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2359,9 +2302,9 @@
 			}
 		},
 		"node_modules/ast-v8-to-istanbul": {
-			"version": "0.3.12",
-			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
-			"integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+			"integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2420,41 +2363,14 @@
 				"node": "18 || 20 || >=22"
 			}
 		},
-		"node_modules/cac": {
-			"version": "6.7.14",
-			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/chai": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-			"integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"assertion-error": "^2.0.1",
-				"check-error": "^2.1.1",
-				"deep-eql": "^5.0.1",
-				"loupe": "^3.1.0",
-				"pathval": "^2.0.0"
-			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/check-error": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-			"integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16"
 			}
 		},
 		"node_modules/color-convert": {
@@ -2497,6 +2413,13 @@
 				"ini": "^1.3.4",
 				"proto-list": "~1.2.1"
 			}
+		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/crelt": {
 			"version": "1.0.6",
@@ -2568,13 +2491,6 @@
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
-		"node_modules/de-indent": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-			"integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/debug": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2599,16 +2515,6 @@
 			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/deep-eql": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
 		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
@@ -2696,9 +2602,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3186,16 +3092,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/he": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"he": "bin/he"
-			}
-		},
 		"node_modules/html-encoding-sniffer": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -3310,21 +3206,6 @@
 				"istanbul-lib-coverage": "^3.0.0",
 				"make-dir": "^4.0.0",
 				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/istanbul-lib-source-maps": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
-			"integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.23",
-				"debug": "^4.1.1",
-				"istanbul-lib-coverage": "^3.0.0"
 			},
 			"engines": {
 				"node": ">=10"
@@ -3521,13 +3402,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/loupe": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-			"integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/lru-cache": {
 			"version": "11.3.5",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
@@ -3555,15 +3429,15 @@
 			}
 		},
 		"node_modules/magicast": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
-			"integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+			"integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.25.4",
-				"@babel/types": "^7.25.4",
-				"source-map-js": "^1.2.0"
+				"@babel/parser": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"source-map-js": "^1.2.1"
 			}
 		},
 		"node_modules/make-dir": {
@@ -3746,6 +3620,17 @@
 				"@codemirror/view": "6.38.6"
 			}
 		},
+		"node_modules/obug": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT"
+		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3886,16 +3771,6 @@
 			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/pathval": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-			"integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 14.16"
-			}
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
@@ -4174,9 +4049,9 @@
 			"license": "MIT"
 		},
 		"node_modules/std-env": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4284,26 +4159,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/strip-literal": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-			"integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"js-tokens": "^9.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
-			}
-		},
-		"node_modules/strip-literal/node_modules/js-tokens": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-			"integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/style-mod": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
@@ -4332,21 +4187,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/test-exclude": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
-			"integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@istanbuljs/schema": "^0.1.2",
-				"glob": "^10.4.1",
-				"minimatch": "^10.2.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/tinybench": {
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -4355,11 +4195,14 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-			"integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+			"integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.16",
@@ -4378,30 +4221,10 @@
 				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
-		"node_modules/tinypool": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-			"integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.0.0 || >=20.0.0"
-			}
-		},
 		"node_modules/tinyrainbow": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-			"integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/tinyspy": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-			"integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4560,9 +4383,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"version": "7.19.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4658,89 +4481,80 @@
 				}
 			}
 		},
-		"node_modules/vite-node": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-			"integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cac": "^6.7.14",
-				"debug": "^4.4.1",
-				"es-module-lexer": "^1.7.0",
-				"pathe": "^2.0.3",
-				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-			},
-			"bin": {
-				"vite-node": "vite-node.mjs"
-			},
-			"engines": {
-				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
 		"node_modules/vitest": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-			"integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+			"integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/chai": "^5.2.2",
-				"@vitest/expect": "3.2.4",
-				"@vitest/mocker": "3.2.4",
-				"@vitest/pretty-format": "^3.2.4",
-				"@vitest/runner": "3.2.4",
-				"@vitest/snapshot": "3.2.4",
-				"@vitest/spy": "3.2.4",
-				"@vitest/utils": "3.2.4",
-				"chai": "^5.2.0",
-				"debug": "^4.4.1",
-				"expect-type": "^1.2.1",
-				"magic-string": "^0.30.17",
+				"@vitest/expect": "4.1.5",
+				"@vitest/mocker": "4.1.5",
+				"@vitest/pretty-format": "4.1.5",
+				"@vitest/runner": "4.1.5",
+				"@vitest/snapshot": "4.1.5",
+				"@vitest/spy": "4.1.5",
+				"@vitest/utils": "4.1.5",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
 				"pathe": "^2.0.3",
-				"picomatch": "^4.0.2",
-				"std-env": "^3.9.0",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
 				"tinybench": "^2.9.0",
-				"tinyexec": "^0.3.2",
-				"tinyglobby": "^0.2.14",
-				"tinypool": "^1.1.1",
-				"tinyrainbow": "^2.0.0",
-				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-				"vite-node": "3.2.4",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
 				"why-is-node-running": "^2.3.0"
 			},
 			"bin": {
 				"vitest": "vitest.mjs"
 			},
 			"engines": {
-				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
 				"@edge-runtime/vm": "*",
-				"@types/debug": "^4.1.12",
-				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-				"@vitest/browser": "3.2.4",
-				"@vitest/ui": "3.2.4",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.5",
+				"@vitest/browser-preview": "4.1.5",
+				"@vitest/browser-webdriverio": "4.1.5",
+				"@vitest/coverage-istanbul": "4.1.5",
+				"@vitest/coverage-v8": "4.1.5",
+				"@vitest/ui": "4.1.5",
 				"happy-dom": "*",
-				"jsdom": "*"
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@edge-runtime/vm": {
 					"optional": true
 				},
-				"@types/debug": {
+				"@opentelemetry/api": {
 					"optional": true
 				},
 				"@types/node": {
 					"optional": true
 				},
-				"@vitest/browser": {
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
 					"optional": true
 				},
 				"@vitest/ui": {
@@ -4751,6 +4565,9 @@
 				},
 				"jsdom": {
 					"optional": true
+				},
+				"vite": {
+					"optional": false
 				}
 			}
 		},
@@ -4841,14 +4658,14 @@
 			}
 		},
 		"node_modules/vue-i18n": {
-			"version": "9.14.5",
-			"resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.14.5.tgz",
-			"integrity": "sha512-0jQ9Em3ymWngyiIkj0+c/k7WgaPO+TNzjKSNq9BvBQaKJECqn9cd9fL4tkDhB5G1QBskGl9YxxbDAhgbFtpe2g==",
-			"deprecated": "v9 and v10 no longer supported. please migrate to v11. about maintenance status, see https://vue-i18n.intlify.dev/guide/maintenance.html",
+			"version": "11.4.0",
+			"resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.4.0.tgz",
+			"integrity": "sha512-gxLVtcwdvOgwKSzkdb7nHKlW0N85A6aDNmHLnq6V+3w2/BXy/os5l71P7TIlgIQTxX0zJjiz89iImoHi51GieQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@intlify/core-base": "9.14.5",
-				"@intlify/shared": "9.14.5",
+				"@intlify/core-base": "11.4.0",
+				"@intlify/devtools-types": "11.4.0",
+				"@intlify/shared": "11.4.0",
 				"@vue/devtools-api": "^6.5.0"
 			},
 			"engines": {
@@ -4877,14 +4694,14 @@
 			}
 		},
 		"node_modules/vue-tsc": {
-			"version": "2.2.12",
-			"resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.12.tgz",
-			"integrity": "sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==",
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.2.7.tgz",
+			"integrity": "sha512-zc1tL3HoQni1zGTGrwBVRQb7rGP5SWdu/m4rGB6JcnAC5MT5LFZIxF7Y+EJEnt4hGF23d60rXH7gRjHGb5KQQQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@volar/typescript": "2.4.15",
-				"@vue/language-core": "2.2.12"
+				"@volar/typescript": "2.4.28",
+				"@vue/language-core": "3.2.7"
 			},
 			"bin": {
 				"vue-tsc": "bin/vue-tsc.js"

--- a/package.json
+++ b/package.json
@@ -23,16 +23,16 @@
 	"dependencies": {
 		"pinia": "^2.1.7",
 		"vue": "^3.4.0",
-		"vue-i18n": "^9.9.0",
+		"vue-i18n": "^11.4.0",
 		"vue-router": "^4.3.0"
 	},
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",
-		"@types/node": "^22.0.0",
+		"@types/node": "^25.6.0",
 		"@vitejs/plugin-vue": "^5.0.4",
-		"@vitest/coverage-v8": "^3.0.0",
+		"@vitest/coverage-v8": "^4.1.5",
 		"@vue/test-utils": "^2.4.4",
-		"@vue/tsconfig": "^0.5.1",
+		"@vue/tsconfig": "^0.9.1",
 		"eslint": "^10.3.0",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-vue": "^10.9.0",
@@ -44,7 +44,7 @@
 		"typescript": "^5.8.0",
 		"typescript-eslint": "^8.59.1",
 		"vite": "^6.0.0",
-		"vitest": "^3.0.0",
-		"vue-tsc": "^2.0.0"
+		"vitest": "^4.1.5",
+		"vue-tsc": "^3.2.7"
 	}
 }


### PR DESCRIPTION
Consolidates 5 open Dependabot PRs (#66, #67, #68, #69, #70) into a single update. All changes were applied together, `npm install` was run to regenerate the lockfile, and all 53 tests pass.

## Changes

| Package | From | To | PR |
|---|---|---|---|
| `vue-i18n` | `^9.9.0` | `^11.4.0` | #70 — also removes deprecation warning |
| `vue-tsc` | `^2.0.0` | `^3.2.7` | #69 |
| `@types/node` | `^22.0.0` | `^25.6.0` | #68 |
| `@vitest/coverage-v8` | `^3.0.0` | `^4.1.5` | #67 |
| `@vue/tsconfig` | `^0.5.1` | `^0.9.1` | #66 |
| `vitest` | `^3.0.0` | `^4.1.5` | (peer dep of `@vitest/coverage-v8@4.1.5`) |

> Note: `vitest` was also bumped to `^4.1.5` because `@vitest/coverage-v8@4.1.5` requires exactly `vitest@4.1.5` as a peer dependency.

## Test plan
- [x] `npm install` completes without errors
- [x] `npm test` — 53/53 tests pass

https://claude.ai/code/session_01DV8ZzVjeDf3kBJ2xZ2t5vv

---
_Generated by [Claude Code](https://claude.ai/code/session_01DV8ZzVjeDf3kBJ2xZ2t5vv)_