### PR TITLE
Add requirements traceability index, product glossary, and product page content brief

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,204 @@
+---
+title: "Specorator product glossary"
+doc_type: glossary
+status: draft
+owner: product
+last_updated: 2026-05-01
+references:
+  - docs/product-vision.md
+  - docs/prd.md
+  - docs/design/USE_CASES.md
+  - docs/design/DESIGN_BRIEF.md
+---
+
+# Product Glossary
+
+**Related issues:** [#32](https://github.com/Luis85/specorator/issues/32)  
+**Source documents:** [Product Vision](./product-vision.md) · [PRD](./prd.md) · [Use Case Catalogue](./design/USE_CASES.md) · [Design Brief](./design/DESIGN_BRIEF.md)
+
+This glossary defines terms used across product, design, engineering, documentation, and user-facing communication for Specorator. Terms distinguish v1 current capabilities from v2.0 planned direction. Ambiguous terms are flagged.
+
+---
+
+## Core Product Terms
+
+### Specorator
+
+The Obsidian plugin described in this repository. In v1, Specorator installs the `agentic-workflow` template into a vault, provides workflow navigation, and enables artifact creation from inside Obsidian. In v2.0, Specorator becomes a companion app offering a team of agentic coworkers powered by `agentonomous`.
+
+The name is a portmanteau of *spec* and *decorator* — it layers workflow structure onto a vault without owning the underlying content.
+
+### companion app
+
+v2.0 framing. A Specorator instance with active `agentonomous` integration that gives the user a team of agentic coworkers inside Obsidian. The companion app assists with producing, reviewing, and improving workflow outputs while the user stays focused on the vault. **Not available in v1.**
+
+### agentic coworker
+
+v2.0 framing. A purpose-built agent (defined in `agentonomous`) that appears as a named, role-specific helper in the Specorator UI. Examples: Spec Writer, Design Reviewer, Decision Recorder, Task Planner. Coworkers propose outputs; the user reviews, edits, and accepts or rejects them. **Not available in v1.**
+
+---
+
+## Workflow Terms
+
+### workflow stage
+
+A named phase in the `agentic-workflow` methodology through which a feature or project progresses (e.g., Define, Design, Build, Verify). The plugin surfaces the active stage in the navigator and shows expected next artifacts for that stage.
+
+### artifact
+
+A Markdown file produced or managed through the workflow. Artifacts are stored in the vault as plain files that remain useful and editable without the plugin. Examples: feature specs, decision notes, open questions, task lists, gate check records.
+
+### workflow state
+
+The current status of a feature or project as derived from vault Markdown content — which stage the feature is in, which artifacts are present, which gates have been crossed. Workflow state is read from the vault, not from plugin-private storage.
+
+### template installation
+
+The process of writing the `agentic-workflow` template's required files and folder structure into an Obsidian vault. The plugin checks for existing files before writing and requires explicit user confirmation before overwriting any file.
+
+### gate
+
+A quality checkpoint between workflow stages. The plugin can check whether required artifacts are present and surface the result before the user crosses to the next stage. Gates are enforced with configurable strictness (see `UC-09`–`UC-13`).
+
+### gate check
+
+A specific check performed at a gate — for example, verifying that a spec file exists and has the required frontmatter fields. Gate checks can pass, fail, or be overridden.
+
+### scaffold / project scaffold
+
+The initial set of folders and template files created when a user starts a new feature or project through the plugin. The scaffold follows `agentic-workflow` conventions and produces plain Markdown artifacts.
+
+### feature
+
+A unit of work tracked through the workflow. A feature has a name, a slug-based folder, a set of step files, and a `_meta.md` state file. Features can be active, archived, or abandoned.
+
+### step file
+
+One of the 11 structured Markdown files within a feature folder, each corresponding to a workflow stage. Step files are created from templates at feature creation and are editable at any time.
+
+### open question (OQ)
+
+A documented uncertainty or decision point logged during a feature's workflow. Open questions can be resolved by the builder or a peer, or escalated to a decision note. They are tracked as Markdown artifacts in the vault.
+
+### decision note
+
+A structured Markdown record of a decision made during the workflow, including the options considered, rationale, and outcome. Decision notes are the primary form of ADR (Architecture Decision Record) in the Specorator workflow.
+
+### house rule / constitution
+
+A set of team- or project-specific rules written in Markdown and referenced at gate checks. A constitution violation surfaces during a gate review and must be resolved or overridden before the user can advance.
+
+---
+
+## UI Terms
+
+### cockpit
+
+The primary Specorator panel inside Obsidian. In v1, the cockpit shows the active feature, current stage, expected artifacts, and available next actions. In v2.0, the cockpit is extended with an agentic coworker assistance area. **The cockpit is the navigator view referenced in the PRD.**
+
+### workflow navigator
+
+The v1 sidebar or panel view that exposes workflow state: active project, current stage, next required artifacts, and controls for opening or creating workflow files. Implemented with Vue 3 in an isolated browser runtime.
+
+### empty state
+
+The cockpit display when no template is installed or no features exist in the vault. The empty state provides a clear call-to-action to begin template installation or create a first feature.
+
+### coach
+
+v1 UX term for inline contextual guidance shown in the cockpit to orient the user at each step (e.g., "Start with the vision — what are you building and why?"). Not a live AI; static guidance text.
+
+### re-entry context
+
+An optional cockpit mode that shows a summary of recent vault activity when the user returns after a configurable absence threshold (default 24 h). Helps restore context without manual navigation.
+
+### feature switcher
+
+A UI control in the cockpit that lets the user move between multiple active features without leaving the navigator.
+
+---
+
+## Technical Terms
+
+### bridge API
+
+The typed interface between the Obsidian plugin host and the Vue 3 UI, implemented in v1 as `src/bridge/`. The bridge decouples the UI from direct Obsidian API calls so the Vue panel can run both inside Obsidian and standalone in a browser. See [issue #16](https://github.com/Luis85/specorator/issues/16).
+
+### browser mode
+
+A development and testing mode in which the Vue 3 UI runs directly in a desktop browser without Obsidian. Browser mode uses mock implementations of the bridge API. See `V1-NFR-005`.
+
+### Obsidian mode
+
+Production mode in which the plugin runs inside Obsidian's desktop app, using the real vault file system, Obsidian API, and bridge implementation.
+
+### isolated browser runtime
+
+The technical approach used to host the Vue 3 UI inside the Obsidian plugin without giving it direct access to Node.js or Obsidian internals. The runtime provides a controlled environment where the UI communicates with the plugin host exclusively through the bridge API.
+
+### plugin settings / data.json
+
+Obsidian's mechanism for persisting plugin state (`loadData`/`saveData`). Specorator stores the installed template version, user preferences, and other per-vault settings here. Not the primary representation of workflow state — that is derived from vault Markdown.
+
+### sideloading
+
+Installing the plugin manually by placing compiled `main.js` and `manifest.json` in the vault's `.obsidian/plugins/specorator/` directory, without going through the Obsidian community marketplace. v1 alpha is distributed via sideloading.
+
+---
+
+## Ecosystem Terms
+
+### agentic-workflow
+
+The upstream methodology repository (`Luis85/agentic-workflow`) that defines the workflow stages, artifacts, templates, traceability conventions, and quality gates that Specorator implements. Specorator consumes released versions of `agentic-workflow` template packages as the source of truth for template content.
+
+### agentonomous
+
+The upstream agent orchestration library (`Luis85/agentonomous`) that will power v2.0 agentic coworker interactions. In v1, the plugin is designed to leave clean extension points for `agentonomous` without depending on it. **Not integrated in v1.**
+
+### agent run
+
+v2.0 term. A single execution of an agentic coworker flow in `agentonomous`, triggered by a user action in the Specorator UI. Agent runs produce proposed outputs that the user reviews before acceptance. **Not available in v1.**
+
+### proposed output
+
+v2.0 term. A coworker-generated artifact, patch, or suggestion presented to the user in the Specorator UI for review, editing, acceptance, or rejection. Proposed outputs do not become durable vault artifacts until the user accepts them. **Not available in v1.**
+
+### accepted output
+
+v2.0 term. A proposed output that the user has reviewed and accepted, after which it is written to the vault as a standard Markdown artifact. **Not available in v1.**
+
+### vault context
+
+The set of vault files or folders that the user explicitly permits an agentic coworker to read during an agent run. Users select vault context; coworkers do not have unrestricted vault access. **v2.0 concept; not applicable in v1.**
+
+---
+
+## Scope Boundaries
+
+These terms flag areas where v1 and v2.0 differ significantly. Use precise language to avoid misleading users or contributors.
+
+| Term | v1 status | v2.0 status |
+|------|-----------|-------------|
+| companion app | Not applicable | Core product framing |
+| agentic coworker | Placeholder UI area only | Active coworker interactions |
+| agent run | Not implemented | Orchestrated via `agentonomous` |
+| proposed output | Not implemented | Generated by coworkers |
+| accepted output | Not implemented | Applied to vault after user review |
+| vault context | Not applicable | User-selected per agent run |
+| `agentonomous` integration | Extension point only | Full integration |
+
+---
+
+## Ambiguous or Overloaded Terms
+
+These terms have multiple possible meanings in the Specorator context and should be used carefully.
+
+| Term | Ambiguity | Resolution |
+|------|-----------|------------|
+| **workflow** | Can refer to the `agentic-workflow` methodology, a specific feature's workflow path, or a GitHub Actions workflow. | Use "the workflow methodology" (methodology), "feature workflow" (per-feature path), or "CI workflow" (GitHub Actions). |
+| **template** | Can mean the `agentic-workflow` template package or an individual step-file template. | Use "`agentic-workflow` template" (the full package) or "step template" / "artifact template" (individual file). |
+| **plugin** | Can mean the Specorator Obsidian plugin specifically or Obsidian plugins generally. | Use "the Specorator plugin" or "the plugin" (Specorator context); "an Obsidian plugin" (generic). |
+| **stage** | Sometimes used interchangeably with "step". | Prefer "stage" for workflow phases (Define, Design, Build, Verify) and "step" for the 11 numbered step files within a feature. |
+| **state** | Can mean workflow state (derived from vault) or plugin settings state. | Use "workflow state" (vault-derived) and "plugin settings" or "plugin data" (stored config). |
+| **agent** | Overloaded across engineering (agents as processes), `agentonomous` (agents as coworker definitions), and general AI usage. | Use "agentic coworker" for user-facing references to v2.0 assistants; "agent" alone is ambiguous. |

--- a/docs/product-page-brief.md
+++ b/docs/product-page-brief.md
@@ -1,0 +1,237 @@
+---
+title: "Specorator product page content brief"
+doc_type: content-brief
+status: draft
+owner: product
+last_updated: 2026-05-01
+references:
+  - docs/product-vision.md
+  - docs/prd.md
+  - docs/design/USE_CASES.md
+  - docs/glossary.md
+---
+
+# Product Page Content Brief
+
+**Related issues:** [#33](https://github.com/Luis85/specorator/issues/33) · [#22](https://github.com/Luis85/specorator/issues/22)  
+**Implements:** GitHub Pages product page for `Luis85/specorator`  
+**Source documents:** [Product Vision](./product-vision.md) · [PRD](./prd.md) · [Use Cases](./design/USE_CASES.md) · [Glossary](./glossary.md)
+
+This brief provides all the structure, copy boundaries, and content decisions needed to implement issue #22 (the GitHub Pages product page). Work from this brief rather than from individual issue descriptions.
+
+---
+
+## 1. Purpose and Audience
+
+### Target Audience
+
+| Audience | Goal on the page |
+|---|---|
+| **Curious user** | Understand what Specorator is, whether it helps their workflow, how to get started |
+| **Obsidian user already using `agentic-workflow`** | See how the plugin automates their current manual steps and makes the methodology accessible inside Obsidian |
+| **Potential contributor** | Find out how to get involved, run the project locally, and understand where development is heading |
+| **Evaluator / researcher** | Quickly grasp the product's purpose, scope, and relationship to upstream repos |
+
+### Primary Message
+
+> Specorator is an Obsidian plugin that turns the `agentic-workflow` methodology into an approachable, guided experience inside your vault. It installs the workflow, navigates your active work, and helps you build better software with discipline — without requiring a heavy process tool.
+
+### Secondary Message
+
+> In v2.0, Specorator becomes a companion app powered by `agentonomous`, giving you a team of agentic coworkers that assist with drafting, reviewing, and improving your workflow outputs while you stay focused on the vault.
+
+---
+
+## 2. Content Sections
+
+### Section 1 — Hero
+
+**Heading (suggested):** *Specorator — structured software work, inside Obsidian*
+
+**Subheading:** *Install the workflow. Navigate your active work. Build with discipline.*
+
+**Body:** 2–3 sentences maximum. Establish what Specorator is and who it is for. Do not mention `agentonomous` here — keep the hero focused on the v1 value.
+
+**CTA:** Two buttons:
+- Primary: "Get started" → links to quick-start / local-dev section
+- Secondary: "View on GitHub" → links to `Luis85/specorator`
+
+**Copy constraint:** Do not claim agent capabilities in the hero. v1 is a workflow tool, not an AI product.
+
+---
+
+### Section 2 — What problem does it solve?
+
+Speak to the target persona (the Focused Builder from the Design Brief): someone who suspects discipline would help them but finds orthodox process daunting.
+
+**Key points to cover:**
+- AI coding tools make it easy to generate code, but not easy to generate *good* software.
+- Without structure, decisions get lost, specs diverge from code, and features don't finish cleanly.
+- The discipline (requirements, decision records, quality gates) exists but is buried in enterprise tooling.
+- Specorator is a plugin-sized, jargon-softened version: it makes the next right action obvious.
+
+**Copy constraint:** One short paragraph or a tight 3-point list. Do not expand into methodology detail here.
+
+---
+
+### Section 3 — How does it work? (v1 capabilities)
+
+Explain the three core v1 workflows with short, concrete descriptions. Use past-present tense: what the user *does*, not what the product *will do*.
+
+**Template installation**
+> Install a supported version of the `agentic-workflow` template into your vault with one command. Specorator checks for existing files and asks before overwriting anything.
+
+**Workflow navigation**
+> Open the cockpit to see your active feature, current stage, and the next artifact you need to create. Commands open workflow files directly in Obsidian — no file-system browsing required.
+
+**Artifact creation**
+> Create a new feature scaffold from the plugin UI. All outputs are plain Markdown in your vault — readable and editable with or without the plugin installed.
+
+**Copy constraint:** Do not list v2.0 coworker capabilities in this section. Flag them clearly as "coming in v2.0" if mentioned at all.
+
+---
+
+### Section 4 — How does it relate to `agentic-workflow`?
+
+Short explanation of the three-layer relationship:
+
+| Layer | Role |
+|---|---|
+| `agentic-workflow` | The methodology — workflow stages, artifacts, templates, quality gates. Specorator consumes released versions. |
+| Specorator | The Obsidian plugin — installs, navigates, and surfaces the methodology from inside the vault. |
+| `agentonomous` | The agent orchestration engine — powers v2.0 agentic coworkers. Not used in v1. |
+
+Link to `Luis85/agentic-workflow` repository.
+
+**Copy constraint:** Do not imply that `agentonomous` is part of v1. Reference it only as the v2.0 direction.
+
+---
+
+### Section 5 — What's available now? (v1 status)
+
+Be honest about v1 alpha status. Do not overstate stability.
+
+**What works:**
+- Plugin scaffold and build toolchain
+- Isolated browser runtime for the Vue 3 UI
+- Typed Obsidian-to-UI bridge API
+- CI and dependency automation
+- Local development documentation
+
+**In active development:**
+- Template installation service
+- Workflow navigator UI
+- Artifact creation commands
+
+**Copy constraint:** Only list items that are actually built or in flight. Do not list items as "available" that are still in planning.
+
+---
+
+### Section 6 — v2.0 direction (companion app)
+
+One short section on the v2.0 vision. Frame it as a roadmap direction, not a current feature.
+
+**Heading:** *Where we're going: agentic coworkers in your vault*
+
+**Body:** 2–3 sentences. In v2.0, Specorator becomes a companion app powered by `agentonomous`. Users get a team of purpose-built agentic coworkers — Spec Writer, Design Reviewer, Decision Recorder, Task Planner — that assist with producing workflow outputs while the user retains full control over what gets accepted and written to the vault.
+
+**CTA:** "Follow v2.0 planning →" → links to [issue #23](https://github.com/Luis85/specorator/issues/23)
+
+**Copy constraint:** Use "v2.0" or "coming in v2.0" consistently. Do not use "coming soon" without version context.
+
+---
+
+### Section 7 — Quick start / get started
+
+The practical entry point for users who want to try the plugin.
+
+**Steps (draft — update when installation is available):**
+
+1. Clone the repository: `git clone https://github.com/Luis85/specorator`
+2. Install dependencies: `npm install`
+3. Run in browser mode: `npm run dev` → opens at `http://localhost:5173`
+4. Build for Obsidian sideloading: `npm run build`
+5. Copy `main.js` and `manifest.json` to `.obsidian/plugins/specorator/` in your vault
+
+**Note:** Link to [local development docs](./local-development.md) for the full setup guide.
+
+**Copy constraint:** Do not describe marketplace installation until the plugin is submitted. Use "sideloading" and link to the local-dev docs.
+
+---
+
+### Section 8 — Contributor path
+
+For developers who want to work on the plugin.
+
+**What to link:**
+- [Local development documentation](./local-development.md)
+- [Obsidian marketplace readiness checklist](./marketplace-readiness.md)
+- [Roadmap](./roadmap-v1.md)
+- [Open issues](https://github.com/Luis85/specorator/issues)
+- [CONTRIBUTING guide] (create when issue #4 is fully resolved)
+
+**Short paragraph:** Specorator is an open development project. Contributions to the plugin shell, bridge API, UI, and documentation are welcome. Read the local development guide to set up the test vault and run the CI checks locally.
+
+---
+
+### Section 9 — Footer / links
+
+| Link | Target |
+|---|---|
+| GitHub repository | `https://github.com/Luis85/specorator` |
+| `agentic-workflow` | `https://github.com/Luis85/agentic-workflow` |
+| `agentonomous` | `https://github.com/Luis85/agentonomous` |
+| v1 alpha planning | Issue #1 |
+| v2.0 planning | Issue #23 |
+| Roadmap | `docs/roadmap-v1.md` |
+
+---
+
+## 3. Copy Boundaries
+
+These rules prevent the page from overpromising capabilities that are not yet built.
+
+| Rule | Rationale |
+|---|---|
+| Never describe coworkers, agent runs, or proposed outputs as current features. | These are v2.0 capabilities. Claiming them in v1 creates false expectations. |
+| Never use "AI" to describe v1 without qualification. | v1 has no live AI integration. The coach text is static guidance, not generated content. |
+| Always distinguish "v1" from "v2.0" when describing roadmap items. | Users should know what they can try now vs. what is planned. |
+| Always link to an issue or doc for any claim about upcoming capabilities. | Keeps the page accountable and avoids vague promises. |
+| Do not describe sideloading as "installing from the Obsidian marketplace" until submission. | The plugin has not been submitted. Sideloading is a manual process. |
+
+---
+
+## 4. Page Structure Summary
+
+```
+1. Hero — what it is, primary CTA
+2. Problem — why structured workflow matters
+3. How it works — three v1 capabilities
+4. Ecosystem — relationship to agentic-workflow and agentonomous
+5. Current status — what's built vs. in progress
+6. v2.0 direction — companion app roadmap
+7. Get started — quick-start steps
+8. Contribute — contributor path
+9. Footer links
+```
+
+---
+
+## 5. Hosting Notes
+
+- Host via GitHub Pages on `Luis85/specorator` (configure in repository Settings → Pages).
+- Source: `docs/` directory on `main` branch, or a dedicated `gh-pages` branch — decide before implementation.
+- Link the page URL from the README `<p>` tag / shields row once live.
+- Update this brief alongside meaningful product or status changes; do not let it drift from the actual plugin state.
+
+---
+
+## 6. Update Cadence
+
+| Trigger | Section(s) to review |
+|---|---|
+| Template installation shipped | Section 5 (current status), Section 7 (quick start steps) |
+| Marketplace submission | Section 7 (update from sideloading to marketplace install) |
+| v2.0 integration begins | Section 6, Section 4 (ecosystem table) |
+| New contributor docs added | Section 8 (contributor path links) |
+| New `agentic-workflow` release consumed | Section 3, Section 7 |

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -1,0 +1,275 @@
+---
+title: "Specorator requirements traceability index"
+doc_type: traceability
+status: draft
+owner: product
+last_updated: 2026-05-01
+references:
+  - docs/product-vision.md
+  - docs/prd.md
+  - docs/design/USE_CASES.md
+  - docs/design/DESIGN_BRIEF.md
+---
+
+# Requirements Traceability Index
+
+**Related issues:** [#31](https://github.com/Luis85/specorator/issues/31)  
+**Source documents:** [Product Vision](./product-vision.md) · [PRD](./prd.md) · [Use Case Catalogue](./design/USE_CASES.md)
+
+This index provides stable traceability from product vision themes through requirements, use cases, engineering tasks, and acceptance criteria. Add new rows as requirements, use cases, or engineering issues are created.
+
+---
+
+## ID Conventions
+
+| Prefix | Domain | Example |
+|--------|--------|---------|
+| `V1-FR-NNN` | v1 functional requirement | `V1-FR-001` |
+| `V1-NFR-NNN` | v1 non-functional requirement | `V1-NFR-001` |
+| `V1-UX-NNN` | v1 UX requirement | `V1-UX-001` |
+| `V1-DA-NNN` | v1 data / artifact requirement | `V1-DA-001` |
+| `V1-AC-NNN` | v1 acceptance criterion | `V1-AC-001` |
+| `V1-OQ-NNN` | v1 open question | `V1-OQ-001` |
+| `REQ-V2-NNN` | v2.0 requirement | `REQ-V2-001` |
+| `UC-NNN` | use case | `UC-01` |
+| `SC-V1-NNN` | v1 scenario | `SC-V1-01` |
+| `TEST-NNN` | verification / test scenario | `TEST-001` |
+| `ARCH-NNN` | architecture concern | `ARCH-001` |
+
+All IDs are stable once assigned. Retired IDs are marked `[retired]` rather than deleted.
+
+---
+
+## 1. Vision Themes → Requirements
+
+These map the five product vision themes from [`docs/product-vision.md`](./product-vision.md) to the requirement groups that implement them.
+
+| Vision theme | Requirements |
+|---|---|
+| Template installation — users can install the `agentic-workflow` template into their vault | V1-FR-010–016, V1-DA-001–005, V1-AC-002–004 |
+| Workflow navigation — users can see and navigate active workflow state | V1-FR-020–026, V1-UX-003, V1-UX-007, V1-AC-005 |
+| Artifact creation — users can create and open workflow artifacts | V1-FR-030–034, V1-DA-001–003, V1-AC-006–007 |
+| Agent-ready extension point — v1 shell anticipates v2.0 agentic coworkers | V1-FR-040–043, V1-AC-008 |
+| Developer and contributor experience — contributors can run and extend the plugin locally | V1-NFR-005–007, V1-AC-009–010 |
+
+---
+
+## 2. Requirements → Use Cases
+
+### 2.1 Plugin Installation and Bootstrapping
+
+| Requirement | Description | Use cases | Engineering issue |
+|---|---|---|---|
+| V1-FR-001 | Sideload installation path | — | Phase 1 (#5) |
+| V1-FR-002 | Load without error in a fresh vault | UC-01, UC-02 | Phase 4 |
+| V1-FR-003 | Register Obsidian command for navigator | UC-02 | Phase 4 |
+| V1-FR-004 | Persist settings via `loadData`/`saveData` | UC-02, UC-32–34 | Phase 4 |
+| V1-FR-005 | Record installed template version in settings | UC-02 | Phase 4 |
+
+### 2.2 Template Installation
+
+| Requirement | Description | Use cases | Engineering issue |
+|---|---|---|---|
+| V1-FR-010 | Select template version | — | Phase 4 |
+| V1-FR-011 | Install template files and folder structure | UC-01 | Phase 4 |
+| V1-FR-012 | Detect existing files before writing | SC-V1-05 | Phase 4 |
+| V1-FR-013 | Prompt user before overwriting | SC-V1-05 | Phase 4 |
+| V1-FR-014 | Never overwrite without explicit confirmation | SC-V1-05, UC-02 | Phase 4 |
+| V1-FR-015 | Report success or failure with skipped files | — | Phase 4 |
+| V1-FR-016 | Use released template versions, not unpublished state | — | Phase 4 |
+
+### 2.3 Workflow Navigation UI
+
+| Requirement | Description | Use cases | Engineering issue |
+|---|---|---|---|
+| V1-FR-020 | Sidebar/panel view (Vue 3) | UC-02 | #14, Phase 4 |
+| V1-FR-021 | Display installed template version | UC-02 | Phase 4 |
+| V1-FR-022 | Display active project or feature name | UC-02, UC-08 | Phase 4 |
+| V1-FR-023 | Display current workflow stage | UC-02, UC-03 | Phase 4 |
+| V1-FR-024 | List expected next artifacts or actions | UC-03, UC-09 | Phase 4 |
+| V1-FR-025 | Commands to open key workflow files | UC-04, UC-19 | Phase 4 |
+| V1-FR-026 | Language and patterns extensible for v2.0 | — | #16, Phase 4 |
+
+### 2.4 Artifact Creation
+
+| Requirement | Description | Use cases | Engineering issue |
+|---|---|---|---|
+| V1-FR-030 | Create project or workflow scaffold from plugin | UC-01 | Phase 4 |
+| V1-FR-031 | Follow template conventions for scaffolded artifacts | UC-01 | Phase 4 |
+| V1-FR-032 | All artifacts written as plain Markdown | UC-01, UC-14, UC-18 | Phase 4 |
+| V1-FR-033 | Artifacts editable outside the plugin | UC-35 | Phase 4 |
+| V1-FR-034 | No plugin-private artifact storage | — | Phase 4 |
+
+### 2.5 Agent Interaction Placeholder
+
+| Requirement | Description | Use cases | Engineering issue |
+|---|---|---|---|
+| V1-FR-040 | Reserved UI area for future agent coworkers | — | #16, Phase 4 |
+| V1-FR-041 | Placeholder defines v2.0 data shapes | — | Phase 4 |
+| V1-FR-042 | Documentation identifies agent capabilities deferred to v2.0 | — | #23 |
+| V1-FR-043 | Architecture does not block `agentonomous` integration | — | #12, #16 |
+
+### 2.6 Update Model Placeholder
+
+| Requirement | Description | Use cases | Engineering issue |
+|---|---|---|---|
+| V1-FR-050 | Record installed template version (see V1-FR-005) | — | Phase 4 |
+| V1-FR-051 | Document update model for future releases | — | Phase 4 |
+| V1-FR-052 | Full migration support is deferred; version recording only | — | — |
+
+### 2.7 Non-Functional Requirements
+
+| Requirement | Category | Use cases | Engineering issue |
+|---|---|---|---|
+| V1-NFR-001 | Performance — navigator renders within 500 ms | UC-02 | Phase 4 |
+| V1-NFR-002 | Reliability — partial installation failures surfaced | SC-V1-05 | Phase 4 |
+| V1-NFR-003 | Compatibility — Obsidian desktop (Win/macOS/Linux) | — | #5 |
+| V1-NFR-004 | Build size — within marketplace guidance | — | #6, #8 |
+| V1-NFR-005 | Browser runtime — Vue UI runnable standalone | — | #14, #15 |
+| V1-NFR-006 | Test coverage — Vitest for acceptance-critical paths | — | #18 |
+| V1-NFR-007 | Type safety — TypeScript strict mode, no `any` in public API | — | #17 |
+| V1-NFR-008 | Local-first — fully offline capable | — | Phase 4 |
+
+### 2.8 UX Requirements
+
+| Requirement | Description | Use cases | Engineering issue |
+|---|---|---|---|
+| V1-UX-001 | Reach installation in two interactions | UC-01 | Phase 4 |
+| V1-UX-002 | Confirm before every destructive action | SC-V1-05, UC-23–25 | Phase 4 |
+| V1-UX-003 | Helpful empty state when no template installed | UC-02 A1 | Phase 4 |
+| V1-UX-004 | Error messages describe failure and next step | UC-10, UC-36 | Phase 4 |
+| V1-UX-005 | UI language accessible without prior methodology knowledge | UC-39 | Phase 4 |
+| V1-UX-006 | Obsidian native UI conventions for out-of-panel interactions | UC-01, UC-23 | Phase 4 |
+| V1-UX-007 | Navigator dismissable and re-openable without losing context | UC-02, UC-26 | Phase 4 |
+
+### 2.9 Data and Artifact Requirements
+
+| Requirement | Description | Engineering issue |
+|---|---|---|
+| V1-DA-001 | All artifacts as Markdown in vault file system | Phase 4 |
+| V1-DA-002 | Settings stored via Obsidian plugin data API | Phase 4 |
+| V1-DA-003 | No secondary database or hidden index | Phase 4 |
+| V1-DA-004 | Workflow state derived from vault Markdown | Phase 4 |
+| V1-DA-005 | Template version recorded for future comparison | Phase 4 |
+
+---
+
+## 3. Use Cases → Requirements
+
+| Use case | Domain | Requirements covered |
+|---|---|---|
+| UC-01 Create a new feature | Feature lifecycle | V1-FR-002, V1-FR-030–032, V1-UX-001 |
+| UC-02 Open the cockpit and restore context | Feature lifecycle | V1-FR-003–005, V1-FR-020–024, V1-UX-003, V1-UX-007 |
+| UC-03 Hand off a step | Feature lifecycle | V1-FR-023–025 |
+| UC-04 Skip a step | Feature lifecycle | V1-FR-025 |
+| UC-05 Close a feature | Feature lifecycle | V1-FR-004, V1-DA-001 |
+| UC-06 Abandon a feature | Feature lifecycle | V1-UX-002 |
+| UC-07 Re-open an archived feature | Feature lifecycle | V1-FR-004 |
+| UC-08 Switch between features | Feature lifecycle | V1-FR-022 |
+| UC-09 Approach and enter a gate | Gate review | V1-FR-024 |
+| UC-10 Fix a failing gate check | Gate review | V1-UX-004 |
+| UC-11 Cross a gate | Gate review | V1-FR-023 |
+| UC-12 Override a failing gate check | Gate review | V1-UX-002 |
+| UC-13 Re-run gate checks manually | Gate review | V1-FR-025 |
+| UC-14 Write an open question | Open questions | V1-FR-032, V1-DA-001 |
+| UC-15 View all open questions for a feature | Open questions | V1-FR-025 |
+| UC-16 Resolve an open question | Open questions | V1-DA-001 |
+| UC-17 Escalate an open question to a decision note | Open questions | V1-FR-025, V1-DA-001 |
+| UC-18 Log a decision note | Decision notes | V1-FR-032, V1-DA-001 |
+| UC-19 View decision notes linked to a feature | Decision notes | V1-FR-025 |
+| UC-20 Write the first house rule | Constitution | V1-FR-032, V1-DA-001 |
+| UC-21 Add a house rule mid-project | Constitution | V1-DA-001 |
+| UC-22 Handle a constitution violation at the gate | Constitution | V1-FR-024, V1-UX-004 |
+| UC-23 Undo the last action | Recovery | V1-UX-002 |
+| UC-24 Revert a feature to an earlier snapshot | Recovery | V1-UX-002 |
+| UC-25 Revert a single step file | Recovery | V1-UX-002 |
+| UC-26 Recover from spatial disorientation | Recovery | V1-FR-022–024, V1-UX-007 |
+| UC-27 Enable team mode on a vault | Team mode | V1-FR-004 |
+| UC-28 Request peer gate sign-off | Team mode | V1-FR-024 |
+| UC-29 Peer resolves an open question | Team mode | V1-DA-001 |
+| UC-30 Peer escalates an open question | Team mode | V1-DA-001 |
+| UC-31 Resolve a sync conflict | Team mode | V1-NFR-002 |
+| UC-32 Configure gate strictness | Settings | V1-FR-004 |
+| UC-33 Configure vault folder paths | Settings | V1-FR-004 |
+| UC-34 Configure team mode and committers | Settings | V1-FR-004 |
+| UC-35 Export a feature spec | Utility | V1-FR-033 |
+| UC-36 Run vault diagnostics | Utility | V1-UX-004 |
+| UC-37 Copy an error report | Utility | V1-UX-004 |
+| UC-38 View the feature timeline | Utility | V1-FR-025 |
+| UC-39 Access help for a jargon term | Utility | V1-UX-005 |
+
+---
+
+## 4. Acceptance Criteria → Requirements and Use Cases
+
+| Criterion | Description | Requirements | Use cases |
+|---|---|---|---|
+| V1-AC-001 | User can install or sideload plugin | V1-FR-001 | SC-V1-01 |
+| V1-AC-002 | User can initialize vault with template | V1-FR-010–016 | UC-01, SC-V1-01 |
+| V1-AC-003 | Existing files detected and protected | V1-FR-012–014 | SC-V1-05 |
+| V1-AC-004 | Installed template version recorded | V1-FR-005, V1-FR-050 | SC-V1-02 |
+| V1-AC-005 | User can open workflow files from plugin | V1-FR-025 | SC-V1-04, UC-04 |
+| V1-AC-006 | User can create at least one project scaffold | V1-FR-030–032 | SC-V1-03, UC-01 |
+| V1-AC-007 | All generated artifacts are plain Markdown | V1-FR-032–033, V1-DA-001 | — |
+| V1-AC-008 | Shell documents v2.0 extension point | V1-FR-042–043 | — |
+| V1-AC-009 | External contributor can run locally | V1-NFR-005–006 | SC-V1-06 |
+| V1-AC-010 | All CI checks pass on `main` | V1-NFR-004, V1-NFR-006–007 | — |
+
+---
+
+## 5. Architecture Concerns
+
+| ID | Concern | Requirement link | Related issue |
+|---|---|---|---|
+| ARCH-001 | Isolated browser runtime boundary — Vue UI must run in both Obsidian and standalone browser | V1-NFR-005 | #15 |
+| ARCH-002 | Obsidian-to-UI bridge API contract — typed, stable, mockable | V1-FR-026, V1-FR-041 | #16 |
+| ARCH-003 | `agentonomous` integration extension point — no design choices that block v2.0 | V1-FR-043 | #23 |
+| ARCH-004 | Vault-first state — workflow state derived from Markdown, not plugin-private storage | V1-DA-003–004 | — |
+| ARCH-005 | Template source boundary — released versions only, not repo HEAD | V1-FR-016 | — |
+
+---
+
+## 6. Test and Verification Scenarios
+
+These supplement the acceptance criteria with specific verification checkpoints. Expand as test harness matures.
+
+| ID | Scenario | Requirement | Type |
+|---|---|---|---|
+| TEST-001 | Plugin loads without error in a fresh Obsidian vault | V1-FR-002, V1-AC-001 | Manual / integration |
+| TEST-002 | Template installation creates all required files and folders | V1-FR-011, V1-AC-002 | Unit / integration |
+| TEST-003 | Installation aborts without user confirmation when existing files detected | V1-FR-013–014, V1-AC-003 | Unit |
+| TEST-004 | Installed template version recorded in plugin settings | V1-FR-005, V1-AC-004 | Unit |
+| TEST-005 | Workflow navigator renders within 500 ms with 500 vault files | V1-NFR-001 | Performance |
+| TEST-006 | Plugin bundle size within Obsidian marketplace limits | V1-NFR-004 | Build check (CI) |
+| TEST-007 | Vue UI runs standalone in browser without Obsidian | V1-NFR-005 | Manual / integration |
+| TEST-008 | All Vitest unit tests pass with no type errors | V1-NFR-006–007, V1-AC-010 | Automated (CI) |
+| TEST-009 | User can create a new project scaffold through plugin UI | V1-FR-030, V1-AC-006 | Manual |
+| TEST-010 | Generated artifacts are readable Markdown outside Obsidian | V1-FR-032–033, V1-AC-007 | Manual |
+| TEST-011 | Navigator empty state shown when no template is installed | V1-UX-003 | Manual |
+| TEST-012 | Navigator dismissable and reopens without losing session context | V1-UX-007 | Manual |
+
+---
+
+## 7. v2.0 Requirements Placeholder
+
+v2.0 requirements are tracked in [issue #23](https://github.com/Luis85/specorator/issues/23) and the [v2.0 PRD section of docs/prd.md](./prd.md#v20-prd--companion-app-with-agentic-coworkers). Stable `REQ-V2-NNN` IDs will be assigned here as v2.0 planning matures.
+
+| ID | Description | v2.0 PRD section |
+|---|---|---|
+| REQ-V2-001 | `agentonomous` integration runtime boundary decision | §1 Architecture and compatibility review |
+| REQ-V2-002 | Agent coworker model and UI representation | §2 Agent coworker model |
+| REQ-V2-003 | Typed Specorator-to-agentonomous service interface | §3 Agent runtime bridge |
+| REQ-V2-004 | Workflow-stage assistance with pause/resume/refine | §4 Workflow-stage assistance |
+| REQ-V2-005 | Vault context and permission model | §5 Vault context and permissions |
+| REQ-V2-006 | Agent output review and artifact acceptance | §6 Agent output review |
+| REQ-V2-007 | Observability and run diagnostics | §7 Observability and diagnostics |
+
+---
+
+## Maintenance Notes
+
+- Add new requirements to the source PRD first, then cross-reference here.
+- Use cases are the primary source for UC-NNN IDs; see [USE_CASES.md](./design/USE_CASES.md).
+- ARCH-NNN concerns should be decided in ADRs under `docs/adr/`; link ADR file once created.
+- TEST-NNN scenarios should map to Vitest test files once implementation begins.
+- Close open questions (V1-OQ-NNN) in the PRD and record the decision in an ADR.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **docs/traceability.md** — requirements traceability index (closes #31): maps vision themes → PRD requirements → use cases → engineering issues → acceptance criteria and test scenarios; defines stable ID conventions (`V1-FR`, `V1-NFR`, `V1-UX`, `V1-DA`, `V1-AC`, `UC`, `TEST`, `ARCH`, `REQ-V2`)
- **docs/glossary.md** — product glossary (closes #32): terminology baseline covering core product, workflow, UI, technical, and ecosystem terms; disambiguates overloaded terms and explicitly marks v2.0-only concepts
- **docs/product-page-brief.md** — product page content brief (closes #33): structured content brief for the GitHub Pages product page (#22) with section-by-section copy guidance, copy boundary rules, hosting notes, and update cadence

## Test plan

- [ ] Review `docs/traceability.md` — verify ID conventions match those used in `docs/prd.md` and `docs/design/USE_CASES.md`
- [ ] Review `docs/glossary.md` — verify v1 vs. v2.0 scope boundaries are clear and no current capabilities are misrepresented
- [ ] Review `docs/product-page-brief.md` — verify copy constraints prevent overpromising v2.0 features, and that all linked issues/docs exist

https://claude.ai/code/session_01VxPQAQnpZLGS6zPgwfLMTu
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxPQAQnpZLGS6zPgwfLMTu)_