### PR TITLE
Add contribution guide, P3.express initiation package, and GitHub workspace config

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Specorator is an Obsidian plugin and companion app for spec-driven, agentic soft
 | [docs/contributing.md](docs/contributing.md)                               | Labels, milestones, branch naming, and merge policy   |
 | [docs/traceability.md](docs/traceability.md)                               | Requirements traceability index and ID conventions    |
 | [docs/glossary.md](docs/glossary.md)                                       | Product terminology baseline                          |
+| [docs/github-workspace.md](docs/github-workspace.md)                       | GitHub Project board, views, fields, and admin setup  |
+| [docs/initiation.md](docs/initiation.md)                                   | P3.express initiation package and go/no-go decision   |
 
 ## Project tracking
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Specorator is an Obsidian plugin and companion app for spec-driven, agentic soft
 | [docs/prd.md](docs/prd.md)                                                 | v1 and v2.0 product requirements documents            |
 | [docs/roadmap-v1.md](docs/roadmap-v1.md)                                   | Phased delivery plan for v1 alpha                     |
 | [docs/process/requirements-intake.md](docs/process/requirements-intake.md) | Intake-first requirements and design workflow         |
+| [docs/contributing.md](docs/contributing.md)                               | Labels, milestones, branch naming, and merge policy   |
+| [docs/traceability.md](docs/traceability.md)                               | Requirements traceability index and ID conventions    |
+| [docs/glossary.md](docs/glossary.md)                                       | Product terminology baseline                          |
 
 ## Project tracking
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -101,7 +101,7 @@ Milestones map to the phases in [docs/roadmap-v1.md](./roadmap-v1.md).
 | **Phase 3 — Plugin Shell** | Vue scaffold, browser runtime, bridge API, toolchain, test harness |
 | **v1 Alpha** | Feature delivery: template install, workflow navigator, artifact creation |
 
-Assign issues to their milestone during triage. Phase 0 and Phase 1 issues must reach "complete or explicitly deferred" before Phase 3 and Phase 4 implementation work is considered ready.
+Assign issues to their milestone during triage. Phase 0 and Phase 1 issues must reach "complete or explicitly deferred" before Phase 3 begins. Phase 2 must also be at sufficient completion before Phase 3 is considered ready. Phase 4 begins only after Phase 3 is complete. See [docs/roadmap-v1.md](./roadmap-v1.md) for the full prerequisite chain.
 
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,296 @@
+---
+title: "Specorator contribution guide"
+doc_type: process
+status: draft
+owner: engineering
+last_updated: 2026-05-01
+references:
+  - docs/local-development.md
+  - docs/roadmap-v1.md
+  - docs/process/requirements-intake.md
+---
+
+# Contributing to Specorator
+
+**Related issues:** [#4](https://github.com/Luis85/specorator/issues/4) · [#7](https://github.com/Luis85/specorator/issues/7)
+
+This guide covers the GitHub workflow for Specorator: how issues are filed and triaged, how labels and milestones are used, how branches are named, and what is expected before a PR is merged.
+
+For local development setup, see [docs/local-development.md](./local-development.md).
+
+---
+
+## 1. Opening Issues
+
+### Issue templates
+
+Use the provided templates when filing new issues. Blank issues are disabled.
+
+| Template | When to use |
+|---|---|
+| **Feature request** | Proposing a new capability or enhancement |
+| **Bug report** | Reporting unexpected behavior in the plugin |
+| **Task** | Concrete setup, engineering, documentation, or maintenance work |
+| **Architecture / design decision** | A decision that needs to be explored and recorded |
+| **Requirement intake** | A new product or engineering requirement entering the triage process |
+| **Design intake** | A design or UX concern entering the triage process |
+
+Before opening a feature request, read the [product vision](./product-vision.md) and check the [roadmap](./roadmap-v1.md) to confirm the idea fits the current phase.
+
+### Intake-first for requirements and design
+
+New requirements and significant design decisions go through a structured intake process before implementation begins. See [docs/process/requirements-intake.md](./process/requirements-intake.md) for the triage and promotion steps.
+
+---
+
+## 2. Labels
+
+Labels are applied by maintainers during triage. Use them when opening an issue only if the template pre-populates them.
+
+### Type labels
+
+| Label | Meaning |
+|---|---|
+| `enhancement` | New capability or improvement |
+| `bug` | Defect or unexpected behavior |
+| `documentation` | Documentation-only work |
+| `architecture` | Architecture decision or constraint |
+
+### Domain labels
+
+| Label | Meaning |
+|---|---|
+| `setup` | Repository, tooling, CI, or GitHub configuration work |
+| `github` | GitHub-specific setup (templates, labels, Actions, branch protection) |
+| `product` | Product direction, PRDs, use cases, or roadmap work |
+| `planning` | Project or milestone planning |
+| `pages` | GitHub Pages product page |
+| `ux-research` | UX research, personas, or design inputs |
+| `testing` | Test harness, coverage, or verification |
+| `traceability` | Requirements traceability or ID conventions |
+
+### Process labels
+
+| Label | Meaning |
+|---|---|
+| `p3-express` | P3.express governance and initiation activities |
+| `project-management` | Cross-cutting project management tasks |
+| `governance` | Decisions, policies, or approval gates |
+
+### Standard GitHub labels
+
+| Label | Meaning |
+|---|---|
+| `good first issue` | Suitable for new contributors |
+| `help wanted` | Input or contribution welcome |
+| `wontfix` | Out of scope; will not be addressed |
+| `duplicate` | Covered by another issue |
+| `invalid` | Not a valid issue for this repo |
+
+---
+
+## 3. Milestones
+
+Milestones map to the phases in [docs/roadmap-v1.md](./roadmap-v1.md).
+
+| Milestone | Scope |
+|---|---|
+| **Phase 0 — Initiation** | P3.express governance, go/no-go gate, project setup |
+| **Phase 1 — Repo Foundation** | README, license, CI, release workflow, branch protection, issue workflow |
+| **Phase 2 — Product Setup** | PRDs, use cases, design brief, architecture inputs, traceability, glossary |
+| **Phase 3 — Plugin Shell** | Vue scaffold, browser runtime, bridge API, toolchain, test harness |
+| **v1 Alpha** | Feature delivery: template install, workflow navigator, artifact creation |
+
+Assign issues to their milestone during triage. Phase 0 and Phase 1 issues must reach "complete or explicitly deferred" before Phase 3 and Phase 4 implementation work is considered ready.
+
+---
+
+## 4. Issue Lifecycle
+
+```
+New issue filed
+    │
+    ▼
+Triage (maintainer)
+  • Assign label(s) and milestone
+  • Link to parent objective issue if applicable
+  • Mark "wontfix" or "duplicate" if out of scope
+    │
+    ▼
+Ready for work
+  • Issue has clear acceptance criteria
+  • For requirements/design: intake process complete (see requirements-intake.md)
+    │
+    ▼
+In progress
+  • Assignee creates a branch (see §5)
+  • PR opened referencing the issue
+    │
+    ▼
+Review
+  • CI must pass
+  • PR description includes verification steps
+    │
+    ▼
+Merged → issue closed automatically via "Closes #NNN" in PR
+```
+
+Issues without acceptance criteria should not move to "In progress". If the scope is unclear, resolve it in the issue comments before branching.
+
+---
+
+## 5. Branches
+
+### Naming convention
+
+```
+<type>/<short-description>
+```
+
+| Type | When to use |
+|---|---|
+| `feature/` | New plugin capability |
+| `fix/` | Bug fix |
+| `docs/` | Documentation-only change |
+| `chore/` | Tooling, CI, dependency, or configuration change |
+| `refactor/` | Code restructuring with no functional change |
+
+**Examples:**
+
+```
+feature/template-installation-service
+fix/navigator-empty-state-crash
+docs/contributing-guide
+chore/update-vitest-to-3
+```
+
+Keep the description short (3–5 words, kebab-case). Do not include issue numbers in branch names; link the issue in the PR instead.
+
+### Branch rules
+
+- Branch from `main` for all new work.
+- Never commit directly to `main`.
+- Delete merged branches; do not accumulate stale branches.
+
+---
+
+## 6. Commits
+
+Write commit messages in the imperative present tense: "Add template installation service", not "Added" or "Adds".
+
+**Format:**
+
+```
+<short summary (≤72 characters)>
+
+<optional body: why this change, not what — keep it under 5 lines>
+```
+
+**Scope prefixes** (optional but helpful for larger changes):
+
+```
+feat: add template installation service
+fix: prevent navigator crash on empty vault
+docs: add requirements traceability index
+chore: update vitest to 3.1
+refactor: extract bridge event handlers
+test: add unit tests for overwrite detection
+```
+
+Keep commits focused. A commit that does two unrelated things should be two commits.
+
+---
+
+## 7. Pull Requests
+
+### Before opening a PR
+
+Run the full pre-PR verification locally:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test
+npm run build
+```
+
+All checks must pass. See [docs/local-development.md](./local-development.md) for the full verification workflow.
+
+### PR description
+
+Use the PR template. It asks for:
+
+- A summary and `Closes #NNN` link.
+- A list of key changes.
+- Verification steps performed.
+- Screenshots or test vault notes for UI or vault-content changes.
+- Known risks or follow-up items.
+
+### Review
+
+For this repository at its current size, a PR can be self-merged if CI passes and no review has been requested. When a review is requested, wait for approval before merging.
+
+### Merge policy
+
+**Use squash merge.** This keeps `main` history linear and readable — one squashed commit per feature or fix, not the full branch history.
+
+The squash commit message should follow the same format as §6: a clear summary line and optional body explaining the why.
+
+Do not use merge commits or rebase-and-merge unless there is a specific reason (e.g., preserving co-author attribution).
+
+---
+
+## 8. Branch Protection for `main`
+
+The following settings should be applied to `main` by a repository admin. These settings cannot be configured through the codebase — they require manual action in **Settings → Branches → Add branch ruleset**.
+
+### Required settings
+
+| Setting | Value |
+|---|---|
+| Require a pull request before merging | Enabled |
+| Require status checks to pass before merging | Enabled |
+| Required status check | `Install, typecheck, lint, test, and build` |
+| Require branches to be up to date before merging | Enabled |
+| Block force pushes | Enabled |
+| Restrict deletions | Enabled |
+
+### Optional (recommended once team grows)
+
+| Setting | Value |
+|---|---|
+| Require approvals | 1 (when working in a team) |
+| Dismiss stale pull request approvals when new commits are pushed | Enabled |
+
+### Rationale
+
+These settings ensure:
+- No code lands on `main` without CI passing.
+- `main` always builds cleanly.
+- History cannot be rewritten by force pushes.
+- Direct commits to `main` are prevented, keeping the PR-based review flow intact.
+
+The required check name (`Install, typecheck, lint, test, and build`) matches the job name in `.github/workflows/ci.yml`.
+
+---
+
+## 9. CI and Checks
+
+The CI workflow (`.github/workflows/ci.yml`) runs on every push and PR and executes:
+
+1. `npm ci` — install dependencies
+2. `npm run typecheck` — TypeScript strict-mode check
+3. `npm run lint` — ESLint
+4. `npm run test` — Vitest unit tests
+5. `npm run build` — Vite production build
+
+All steps must pass for the check to succeed. Dependabot keeps dependencies current; security alerts are configured in `.github/dependabot.yml`.
+
+---
+
+## Related
+
+- [docs/local-development.md](./local-development.md) — setup, commands, and test vault instructions
+- [docs/roadmap-v1.md](./roadmap-v1.md) — current phase and priorities
+- [docs/process/requirements-intake.md](./process/requirements-intake.md) — intake workflow for new requirements
+- [docs/traceability.md](./traceability.md) — requirements ID conventions

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -212,6 +212,8 @@ npm run lint
 npm run typecheck
 npm run test
 npm run build
+npm run build:web
+npm run docs:api
 ```
 
 All checks must pass. See [docs/local-development.md](./local-development.md) for the full verification workflow.
@@ -276,13 +278,15 @@ The required check name (`Install, typecheck, lint, test, and build`) matches th
 
 ## 9. CI and Checks
 
-The CI workflow (`.github/workflows/ci.yml`) runs on every push and PR and executes:
+The CI workflow (`.github/workflows/ci.yml`) runs on pushes to `main` and on pull requests targeting `main`. It does **not** run on feature-branch pushes — run the checks locally before opening a PR. Steps:
 
 1. `npm ci` — install dependencies
 2. `npm run typecheck` — TypeScript strict-mode check
 3. `npm run lint` — ESLint
 4. `npm run test` — Vitest unit tests
-5. `npm run build` — Vite production build
+5. `npm run build` — Vite plugin build
+6. `npm run build:web` — standalone UI build
+7. `npm run docs:api` — TypeDoc API docs generation
 
 All steps must pass for the check to succeed. Dependabot keeps dependencies current; security alerts are configured in `.github/dependabot.yml`.
 

--- a/docs/github-workspace.md
+++ b/docs/github-workspace.md
@@ -1,0 +1,244 @@
+---
+title: "Specorator GitHub workspace configuration"
+doc_type: governance
+status: draft
+owner: engineering
+last_updated: 2026-05-02
+references:
+  - docs/contributing.md
+  - docs/roadmap-v1.md
+  - docs/initiation.md
+---
+
+# GitHub Workspace Configuration
+
+**Related issues:** [#44](https://github.com/Luis85/specorator/issues/44)  
+**Admin instructions:** Settings that cannot be configured through the codebase are marked **[admin action required]** with exact values.
+
+This document specifies which GitHub repository features to enable, the GitHub Project board structure, project views and fields, and how issues, milestones, labels, PRs, releases, and views work together.
+
+---
+
+## 1. Repository Features
+
+Apply these settings in **Settings → General** and **Settings → Features**.
+
+| Feature | Setting | Rationale |
+|---|---|---|
+| Issues | **Enabled** | Primary work tracking mechanism |
+| Pull requests | **Enabled** | All changes land via PR |
+| Projects | **Enabled** | Phase-level and cross-cutting views |
+| Discussions | **Disabled for now** | No community yet; re-evaluate post v1 alpha |
+| Wiki | **Disabled** | Documentation lives in `docs/` under version control |
+| GitHub Pages | **Enabled** | Product page (issue #22) will be hosted here |
+| Sponsorships | Owner's preference | No requirement either way |
+| Preserve this repository | Owner's preference | — |
+
+**[admin action required]** Apply the above in Settings → General → Features.
+
+### Security and dependency features
+
+| Feature | Setting |
+|---|---|
+| Dependency graph | Enabled (auto) |
+| Dependabot alerts | Enabled |
+| Dependabot security updates | Enabled |
+| Dependabot version updates | Configured via `.github/dependabot.yml` |
+| Secret scanning | Enabled |
+| Push protection | Enabled |
+| Code scanning | Evaluate after Phase 4 — not required for v1 alpha |
+
+**[admin action required]** Verify in Settings → Security → Code security and analysis.
+
+---
+
+## 2. Branch Protection
+
+Full specification is in [docs/contributing.md §8](./contributing.md#8-branch-protection-for-main). Summary:
+
+**[admin action required]** In **Settings → Branches → Add branch ruleset**, apply:
+
+| Setting | Value |
+|---|---|
+| Target branch | `main` |
+| Require a pull request before merging | ✓ |
+| Required status check | `Install, typecheck, lint, test, and build` |
+| Require branches to be up to date | ✓ |
+| Block force pushes | ✓ |
+| Restrict deletions | ✓ |
+
+---
+
+## 3. Labels
+
+Verify the following labels exist in **Issues → Labels**. Create any that are missing.
+
+**[admin action required]** Create missing labels with the colours below. Exact hex values can be adjusted for accessibility; the names and descriptions must match.
+
+### Type labels
+
+| Label | Colour | Description |
+|---|---|---|
+| `enhancement` | `#a2eeef` | New capability or improvement |
+| `bug` | `#d73a4a` | Defect or unexpected behavior |
+| `documentation` | `#0075ca` | Documentation-only work |
+| `architecture` | `#e4e669` | Architecture decision or constraint |
+
+### Domain labels
+
+| Label | Colour | Description |
+|---|---|---|
+| `setup` | `#bfd4f2` | Repository, tooling, or CI configuration |
+| `github` | `#0e8a16` | GitHub-specific setup |
+| `product` | `#c2e0c6` | Product direction, PRDs, use cases |
+| `planning` | `#f9d0c4` | Project or milestone planning |
+| `pages` | `#1d76db` | GitHub Pages product page |
+| `ux-research` | `#fbca04` | UX research, personas, or design inputs |
+| `testing` | `#b60205` | Test harness, coverage, or verification |
+| `traceability` | `#5319e7` | Requirements traceability or ID conventions |
+
+### Process labels
+
+| Label | Colour | Description |
+|---|---|---|
+| `p3-express` | `#e99695` | P3.express governance activities |
+| `project-management` | `#c5def5` | Cross-cutting project management |
+| `governance` | `#eeeeee` | Policies, decisions, and approval gates |
+
+### Standard GitHub labels
+
+Keep the defaults: `good first issue`, `help wanted`, `wontfix`, `duplicate`, `invalid`.
+
+---
+
+## 4. Milestones
+
+Verify the following milestones exist in **Issues → Milestones**. Create any that are missing.
+
+**[admin action required]** Create missing milestones:
+
+| Milestone | Description |
+|---|---|
+| Phase 0 — Initiation | P3.express governance, go/no-go gate, project setup |
+| Phase 1 — Repo Foundation | README, license, CI, release, branch protection, contributing guide |
+| Phase 2 — Product Setup | PRDs, use cases, design, traceability, glossary |
+| Phase 3 — Plugin Shell | Vue scaffold, bridge API, test harness, TypeDoc |
+| v1 Alpha | Feature delivery: template install, navigator, artifact creation |
+
+No due dates required at this stage. Add dates when Phase 4 planning is complete.
+
+---
+
+## 5. GitHub Project Board
+
+### Decision
+
+**Use one GitHub Project board** named **Specorator** to provide cross-cutting views that the flat issue list cannot. A single board with multiple views is simpler to maintain than several boards for a solo project.
+
+**[admin action required]** Create the project in **github.com/users/Luis85/projects → New project → Board** or **Table** layout. Link it to the `Luis85/specorator` repository.
+
+### Project Fields
+
+Define these custom fields on the project:
+
+| Field | Type | Values / Notes |
+|---|---|---|
+| Status | Single select | `No status`, `Backlog`, `Ready`, `In progress`, `In review`, `Done`, `Deferred` |
+| Priority | Single select | `P0 — Critical`, `P1 — High`, `P2 — Normal`, `P3 — Low` |
+| Phase / milestone | Single select | mirrors the five milestones above |
+| Product perspective | Single select | `Product`, `Engineering`, `Design`, `QA`, `Release`, `Documentation`, `Governance` |
+| Risk level | Single select | `Low`, `Medium`, `High` |
+| Blocked | Checkbox | True when waiting on an external dependency or decision |
+
+The built-in `Milestone` and `Assignee` fields from the repository can be reused; create the above as additional custom fields.
+
+### Project Views
+
+Create the following views as **Table** or **Board** layout:
+
+| View | Filter / group | Purpose |
+|---|---|---|
+| **All active** | Status ≠ Done, Status ≠ Deferred | Default entry point — everything in flight |
+| **Phase 0 — Initiation** | Phase = Phase 0 | Governance and go/no-go checklist |
+| **Phase 1 — Repo Foundation** | Phase = Phase 1 | Repo and tooling setup progress |
+| **Phase 2 — Product Setup** | Phase = Phase 2 | PRDs, use cases, and product artifacts |
+| **Phase 3 — Plugin Shell** | Phase = Phase 3 | Plugin architecture and toolchain |
+| **v1 Alpha delivery** | Phase = v1 Alpha | Feature delivery — primary execution view |
+| **v2.0 planning** | Label = `enhancement`, `architecture` | Long-horizon planning for companion app |
+| **Risks and follow-up** | Risk level = High OR Medium | Standing risks from the initiation register |
+| **Decision gates** | Label = `governance`, `architecture` | Decisions and approval gates to resolve |
+| **By perspective** | Group by: Product perspective | Multi-role view for product, engineering, QA, etc. |
+
+---
+
+## 6. How the Pieces Fit Together
+
+This section summarises how issues, milestones, labels, PRs, releases, and project views compose into a coherent workflow.
+
+### Issues
+
+- Every piece of work has an issue.
+- Issues use a template; blank issues are disabled.
+- Labels express type + domain; milestone expresses phase.
+- New requirements and design decisions go through the intake process before implementation (see [docs/process/requirements-intake.md](./process/requirements-intake.md)).
+- Objective / tracking issues (#1, #2, #11, #24, #47) stay open until all child issues are resolved.
+
+### Pull Requests
+
+- Every change lands via a PR that closes at least one issue (`Closes #NNN`).
+- CI must pass before merge.
+- Squash merge keeps `main` history linear.
+- The PR template prompts for verification steps and screenshots for UI changes.
+
+### Milestones
+
+- Each issue belongs to exactly one milestone.
+- A milestone is "complete" when all its issues are closed or explicitly deferred.
+- Phase 4 (v1 Alpha milestone) is the active execution milestone.
+
+### Releases
+
+- Releases are created from `main` after all v1 Alpha milestone issues are closed.
+- The release workflow (`.github/workflows/release.yml`) packages `main.js` and `manifest.json` as release assets.
+- Release tags follow `v{major}.{minor}.{patch}` (e.g., `v0.1.0` for first alpha).
+- Pre-release tags (`v0.1.0-alpha.1`) trigger pre-release packaging.
+- See `docs/marketplace-readiness.md` for the Obsidian marketplace submission checklist.
+
+### Project Views as the Planning Surface
+
+The GitHub Project board is the primary planning surface, not the issue list:
+- **All active** view is the daily driver.
+- **v1 Alpha delivery** view tracks Phase 4 progress.
+- **Risks and follow-up** view surfaces blockers and risks from the initiation register.
+- **Decision gates** view tracks open architecture and governance decisions.
+
+---
+
+## 7. GitHub Pages Setup
+
+**[admin action required]** When the product page (issue #22) is implemented:
+
+1. Go to **Settings → Pages**.
+2. Set Source to **Deploy from a branch** or **GitHub Actions** (preferred for a Vite-built site).
+3. If branch-based: set branch to `gh-pages`, folder to `/ (root)`.
+4. If Actions-based: the deploy workflow handles publishing; no manual branch selection needed.
+5. The product page URL will be `https://luis85.github.io/specorator/`.
+6. Link the URL from the README once live.
+
+---
+
+## 8. Manual Admin Actions Summary
+
+All items requiring admin access to the GitHub repository settings:
+
+| # | Action | Location |
+|---|---|---|
+| 1 | Enable/disable repository features per §1 | Settings → General → Features |
+| 2 | Verify security features per §1 | Settings → Security |
+| 3 | Add branch ruleset for `main` per §2 | Settings → Branches |
+| 4 | Create missing labels per §3 | Issues → Labels |
+| 5 | Create missing milestones per §4 | Issues → Milestones |
+| 6 | Create GitHub Project board per §5 | github.com/users/Luis85/projects |
+| 7 | Add custom fields and views to the board | Project settings |
+| 8 | Link project to `Luis85/specorator` repository | Project settings → Linked repositories |
+| 9 | Configure GitHub Pages when product page is ready | Settings → Pages |

--- a/docs/github-workspace.md
+++ b/docs/github-workspace.md
@@ -210,7 +210,7 @@ This section summarises how issues, milestones, labels, PRs, releases, and proje
 ### Releases
 
 - Releases are created from `main` after all v1 Alpha milestone issues are closed.
-- The release workflow (`.github/workflows/release.yml`) packages `main.js` and `manifest.json` as release assets.
+- The release workflow (`.github/workflows/release.yml`) packages `main.js`, `manifest.json`, and `styles.css` as release assets.
 - Release tags follow `v{major}.{minor}.{patch}` (e.g., `v0.1.0` for first alpha).
 - Pre-release tags (`v0.1.0-alpha.1`) trigger pre-release packaging.
 - See `docs/marketplace-readiness.md` for the Obsidian marketplace submission checklist.

--- a/docs/github-workspace.md
+++ b/docs/github-workspace.md
@@ -84,6 +84,17 @@ Verify the following labels exist in **Issues → Labels**. Create any that are 
 | `documentation` | `#0075ca` | Documentation-only work |
 | `architecture` | `#e4e669` | Architecture decision or constraint |
 
+### Intake labels
+
+These labels are auto-applied by the issue form templates (`01-design-intake.yml`, `02-requirement-intake.yml`) and must exist for the intake flow to work correctly.
+
+| Label | Colour | Description |
+|---|---|---|
+| `requirements` | `#d4c5f9` | Requirement intake item |
+| `design` | `#fef2c0` | Design intake item |
+| `intake` | `#c5def5` | New item in the intake queue |
+| `needs-triage` | `#e4e669` | Awaiting triage and milestone assignment |
+
 ### Domain labels
 
 | Label | Colour | Description |

--- a/docs/initiation.md
+++ b/docs/initiation.md
@@ -1,0 +1,229 @@
+---
+title: "Specorator project initiation package"
+doc_type: governance
+status: complete
+owner: product
+last_updated: 2026-05-02
+references:
+  - docs/roadmap-v1.md
+  - docs/product-vision.md
+  - docs/prd.md
+  - docs/contributing.md
+---
+
+# Project Initiation Package — Specorator
+
+**Related issues:** [#50](https://github.com/Luis85/specorator/issues/50) (consolidated checklist) · #34–#43 (detailed P3.express activities, kept for reference)  
+**Roadmap:** [docs/roadmap-v1.md](./roadmap-v1.md)  
+**Format:** Lightweight P3.express initiation, adapted for a solo/small-team project context
+
+This document records the initiation decisions that gate Phase 1 (Repository Foundation) and Phase 2 (Product Setup). Because Phases 1–3 were executed concurrently with initiation, several decisions are recorded retrospectively. All are now affirmed for the record.
+
+---
+
+## A01–A03: Roles
+
+### Sponsor
+
+**Luis Mendez** (`@Luis85`) — project owner, decision authority, and funder. Accountable for project justification, scope changes, and go/no-go authority.
+
+*For a sole-contributor project the sponsor and project manager are the same person. This is recorded as a risk in §A06.*
+
+### Project Manager / Coordinator
+
+**Luis Mendez** (`@Luis85`) — responsible for issue hygiene, milestone health, risk follow-up, and release cadence.
+
+### Key Role Mapping
+
+| Role | Holder | Gap / risk |
+|---|---|---|
+| Product | Luis Mendez | Sole contributor; no independent product review |
+| Engineering | Luis Mendez | Sole contributor |
+| Design | Luis Mendez | Wireframes produced; no dedicated designer |
+| QA | Luis Mendez | Automated CI + manual vault testing; no independent tester |
+| Documentation | Luis Mendez | — |
+| Release | Luis Mendez | Sideload only in v1; marketplace submission TBD |
+
+**Open gaps treated as risks:** all roles held by one person. Mitigated by structured intake process, written requirements, and CI quality gates. Contributor recruitment is a Phase 4 consideration.
+
+---
+
+## A04: Project Description
+
+**Purpose and expected benefits**
+
+Specorator gives individual contributors and small teams an approachable way to follow a spec-driven, agentic development workflow inside Obsidian — the tool they are likely already using. It removes the friction of managing workflow artifacts, quality gates, and decision records through the file system alone.
+
+Expected benefits:
+- Faster onboarding to the `agentic-workflow` methodology.
+- Consistent, auditable workflow artifacts stored as plain Markdown in the vault.
+- A foundation for v2.0 agentic coworker assistance without depending on AI to make it useful.
+
+**v1 scope summary**
+
+Template installation, workflow navigation UI, artifact creation, and the agent-interaction placeholder. Full scope in [docs/prd.md § v1 Alpha PRD](./prd.md).
+
+**v2.0 scope summary**
+
+Companion app with `agentonomous`-powered agentic coworkers. Full scope in [docs/prd.md § v2.0 PRD](./prd.md) and [issue #23](https://github.com/Luis85/specorator/issues/23).
+
+**Expected duration and cadence**
+
+- v1 alpha: iterative, milestone-driven, no fixed deadline. Phases 1–3 substantially complete as of May 2026.
+- Phase 4 (feature delivery) in active planning.
+- No externally committed release date for v1 alpha.
+
+**Requirements and quality expectations**
+
+Requirements are maintained in [docs/prd.md](./prd.md) with stable IDs (`V1-FR-NNN`, `V1-NFR-NNN`, etc.) and traced in [docs/traceability.md](./traceability.md). Quality is enforced through CI (lint, typecheck, test, build) and vault acceptance testing.
+
+**In-scope / out-of-scope**
+
+In scope for v1: see PRD §3.1 Goals.  
+Explicitly out of scope for v1: see PRD §3.2 Non-Goals.
+
+**Stakeholder list**
+
+| Stakeholder | Interest |
+|---|---|
+| Plugin users | Installable plugin that makes the agentic workflow accessible in Obsidian |
+| `agentic-workflow` users | Seamless integration with the methodology they already follow |
+| Contributors | Clear codebase, documented workflow, and a roadmap to contribute to |
+| `agentonomous` project | v1 bridge API designed as a clean integration point for v2.0 |
+
+---
+
+## A05: Deliverables Map and Milestones
+
+**Deliverables map** aligned with [docs/roadmap-v1.md](./roadmap-v1.md):
+
+| Phase | Key deliverables | Status |
+|---|---|---|
+| 0 — Initiation | Initiation package (this doc), GitHub workspace config, go/no-go decision | Complete |
+| 1 — Repo Foundation | README, license, CI, release workflow, branch policy, contributing guide | Complete |
+| 2 — Product Setup | Product vision, PRDs, use cases, design brief, architecture input, traceability, glossary, product page brief | Complete |
+| 3 — Plugin Shell | Vue scaffold, browser runtime, bridge API, test harness, TypeDoc, marketplace checklist | Complete |
+| 4 — v1 Alpha | Template installation, workflow navigator, artifact creation, agent placeholder, update model | In progress |
+
+**GitHub milestones** (all five required; verify existence in repository Settings → Milestones):
+
+| Milestone | Scope |
+|---|---|
+| Phase 0 — Initiation | P3.express governance and project setup |
+| Phase 1 — Repo Foundation | Repository and tooling foundation |
+| Phase 2 — Product Setup | PRDs, use cases, and product artifacts |
+| Phase 3 — Plugin Shell | Plugin architecture and Vue shell |
+| v1 Alpha | Feature delivery and first usable release |
+
+Issues are assigned to their milestone. The roadmap progress tracker is [issue #47](https://github.com/Luis85/specorator/issues/47).
+
+---
+
+## A06: Follow-up Register
+
+**Register structure decision:** GitHub issues are the primary register for tracked risks and follow-up items. This section records standing risks and assumptions; create a dedicated issue for any that require active management.
+
+### Standing Risks
+
+| ID | Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|---|
+| RISK-001 | Sole-contributor risk — Luis Mendez is unavailable, ill, or changes focus | Medium | High | All decisions and requirements are documented; any contributor can pick up from the roadmap and docs |
+| RISK-002 | `agentonomous` API instability — the v2.0 integration contract is not yet stable | Medium | Medium | v1 bridge API (#16) designed as an extension point, not a hard dependency; v2.0 integration is deferred |
+| RISK-003 | Obsidian marketplace submission timeline — marketplace review may delay public release | Low | Medium | v1 alpha distributed via sideloading; marketplace submission is not on the critical path |
+| RISK-004 | `agentic-workflow` release format undefined — template installation design blocked without a stable package format | Medium | High | Resolve via issue #26 / open question V1-OQ-001 before Phase 4 template installation work begins |
+| RISK-005 | Plugin bundle size — Vite build may exceed Obsidian marketplace size guidance | Low | Medium | Monitor in CI from Phase 3 onward (V1-NFR-004) |
+
+### Assumptions
+
+- The `agentic-workflow` template will be available as a versioned release (Git tag, npm package, or downloadable archive) by the time Phase 4 template installation work begins.
+- Obsidian's community plugin API will remain stable enough for the v1 alpha scope.
+- v1 alpha does not require marketplace submission to be considered done; sideloading is acceptable.
+- No external team members or contributors are expected until after v1 alpha ships.
+
+### Open Decisions
+
+Open questions are tracked in the PRD with IDs `V1-OQ-NNN`. See [docs/prd.md §11](./prd.md#11-open-questions). Resolve each before the relevant Phase 4 implementation task begins.
+
+### Review Cadence
+
+Solo project. Self-review at each phase boundary:
+- Review risk register and open questions at the start of Phase 4.
+- Update this document when risks are resolved or new ones are identified.
+- No fixed meeting cadence; issue hygiene is the primary coordination mechanism.
+
+---
+
+## A07: Self-Review — Initiation Readiness Assessment
+
+*Solo project self-review, conducted in lieu of peer review.*
+
+**Assessment date:** May 2026
+
+| Check | Status | Notes |
+|---|---|---|
+| Sponsor and PM identified | ✓ | Sole contributor fills both roles |
+| Key roles mapped with gaps noted | ✓ | See §A01–A03 |
+| Project description written | ✓ | See §A04 |
+| Deliverables map aligned with roadmap | ✓ | See §A05 and roadmap-v1.md |
+| GitHub milestones exist | ✓ | Verify via repository settings |
+| Follow-up register seeded with initial risks | ✓ | See §A06 |
+| Assumptions documented | ✓ | See §A06 |
+| Critical unknowns tracked | ✓ | Open questions in PRD §11 |
+| Phases 1–3 substantially complete | ✓ | Per roadmap issue #47 |
+
+**Gaps / critical unknowns requiring resolution before Phase 4:**
+- V1-OQ-001 — `agentic-workflow` package format must be decided before template installation begins.
+- RISK-004 — same dependency; owner to resolve in coordination with `agentic-workflow` planning.
+
+---
+
+## A08: Go / No-Go Decision
+
+**Decision: GO**
+
+**Date:** May 2026  
+**Decision owner:** Luis Mendez (`@Luis85`)
+
+**Rationale:** Phases 1–3 are substantially complete. Product requirements, use cases, architecture, and design artifacts are documented. The plugin shell is verified by CI. Phase 4 feature delivery is the logical next step.
+
+**Conditions:**
+- V1-OQ-001 (`agentic-workflow` package format) must be resolved before Phase 4 template installation work begins. Owner: `@Luis85`.
+
+**Phase 1 and Phase 2 execution status:** Authorised and substantially complete.  
+**Phase 4 execution:** Authorised to begin, with the condition above named.
+
+---
+
+## A09: Kickoff
+
+*Async kickoff, recorded in this document.*
+
+**Date:** May 2026  
+**Participants:** Luis Mendez (sole contributor)
+
+**Summary confirmed:**
+
+- **Scope:** v1 alpha as described in the PRD and roadmap.
+- **Roles:** Owner fills all roles; see §A01–A03.
+- **GitHub workflow:** PRs to `main`, squash merge, CI required. See [docs/contributing.md](./contributing.md).
+- **Key risks:** See §A06.
+- **Next actions:**
+  1. Resolve V1-OQ-001 (template package format) — required before Phase 4 template installation.
+  2. Configure GitHub Project board per [docs/github-workspace.md](./github-workspace.md) (issue #44).
+  3. Begin Phase 4 feature delivery (issue #1).
+
+---
+
+## A10: Startup Communication
+
+**Draft prepared:** The product page content brief ([docs/product-page-brief.md](./product-page-brief.md)) provides the structured content for the public startup communication.
+
+**Publication channel decision:** GitHub Pages product page (issue #22) is the primary external communication channel. The README serves as the in-repo entry point.
+
+**Communication covers:**
+- Why Specorator exists and the problem it solves.
+- v1 goal and current status.
+- v2.0 direction with `agentonomous`.
+- How to get started and how to contribute.
+
+**Status:** Content brief complete; implementation pending issue #22.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -130,7 +130,7 @@ Keep the test vault empty of personal content. The plugin may write files during
 
 ## Verifying plugin behavior before opening a PR
 
-1. Run the full verification gate: `npm run typecheck && npm run lint && npm run test && npm run build`
+1. Run the full verification gate: `npm run typecheck && npm run lint && npm run test && npm run build && npm run build:web && npm run docs:api`
 2. Confirm the plugin loads in Obsidian without errors (check **Settings → Community plugins** and the developer console with `Ctrl+Shift+I` / `Cmd+Option+I`).
 3. Open the Specorator panel and confirm the UI renders correctly.
 4. Exercise the specific code path changed by your PR and confirm it works as expected.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -57,7 +57,7 @@ npm ci
 Run the full verification gate before opening a pull request:
 
 ```sh
-npm run typecheck && npm run lint && npm run test && npm run build
+npm run typecheck && npm run lint && npm run test && npm run build && npm run build:web && npm run docs:api
 ```
 
 ## Build output


### PR DESCRIPTION
## Summary

- **docs/contributing.md** (closes #4, closes #7): label taxonomy, milestone-to-phase mapping, issue lifecycle, branch naming convention, commit format, squash merge policy, and exact branch protection settings for `main`
- **docs/initiation.md** (closes #50): P3.express A01–A10 initiation package for a solo project — role assignments, project description, deliverables map, risk register (RISK-001–005), assumptions, self-review readiness assessment, go/no-go decision (**GO**), async kickoff notes, and startup communication plan
- **docs/github-workspace.md** (closes #44): GitHub workspace config spec — repository features, branch protection, full label taxonomy (including intake labels used by issue form templates), milestone definitions, GitHub Project board (one board, eight views, six custom fields), how issues/PRs/milestones/releases compose, GitHub Pages setup, and a consolidated admin action checklist (9 items)
- **README.md**: documentation table extended with all four new docs

## Review feedback addressed

| Thread | File | Fix |
|---|---|---|
| Include all required checks in pre-PR verification | `docs/contributing.md` | Added `npm run build:web` and `npm run docs:api` to pre-PR command block |
| Align CI trigger description with actual workflow scope | `docs/contributing.md` | Corrected to "pushes to `main` and PRs targeting `main`" with note that feature-branch pushes don't trigger CI |
| Include issue-form labels in required label inventory | `docs/github-workspace.md` | Added "Intake labels" section with `requirements`, `design`, `intake`, `needs-triage` |
| Correct the referenced full verification workflow | `docs/local-development.md` | Extended pre-PR gate command to include `build:web` and `docs:api` |
| Gate Phase 3/4 work on Phase 2 completion | `docs/contributing.md` | Corrected milestone readiness rule to match roadmap: Phase 2 must be complete before Phase 3; Phase 4 only after Phase 3 |
| Harmonize duplicated full-verification instructions | `docs/local-development.md` | Extended duplicate gate command at line 133 to match the updated primary command |

## Test plan

- [ ] Review `docs/contributing.md` — verify label list, CI command list, and milestone prerequisites match repo reality
- [ ] Review `docs/github-workspace.md` — verify all label names match existing labels; verify CI check name matches `.github/workflows/ci.yml`
- [ ] Review `docs/local-development.md` — verify both pre-PR gate commands are consistent and complete
- [ ] Apply the 9 admin actions in `github-workspace.md §8` to the live repository settings

https://claude.ai/code/session_01VxPQAQnpZLGS6zPgwfLMTu