### PR TITLE
ci: add main source guard workflow (#78)

### DIFF
--- a/.github/workflows/main-source-guard.yml
+++ b/.github/workflows/main-source-guard.yml
@@ -1,0 +1,19 @@
+name: Main source guard
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  guard:
+    name: Verify PR source is develop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject non-develop source
+        if: github.head_ref != 'develop'
+        run: |
+          echo "::error::PRs to main must come from 'develop' (got '${{ github.head_ref }}')"
+          exit 1
+      - name: Confirm develop source
+        if: github.head_ref == 'develop'
+        run: echo "OK: PR source is develop"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/main-source-guard.yml`: required check on PRs to `main` that fails unless `head_ref == develop`.
- Enforces release-source rule from #78 at workflow layer (rulesets cannot natively restrict merge sources).
- Status check name `Verify PR source is develop` will be required by the upcoming `main` branch ruleset.

## Test plan

- [ ] CI passes on this branch
- [ ] After merge, opening any non-`develop` PR to `main` fails with the guard error
- [ ] PR `develop` → `main` passes the guard step

🤖 Generated with [Claude Code](https://claude.com/claude-code)