### PR TITLE
release(demo): publish Pages site (product page + /app/)

### DIFF
--- a/.github/workflows/main-source-guard.yml
+++ b/.github/workflows/main-source-guard.yml
@@ -1,0 +1,19 @@
+name: Main source guard
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  guard:
+    name: Verify PR source is develop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject non-develop source
+        if: github.head_ref != 'develop'
+        run: |
+          echo "::error::PRs to main must come from 'develop' (got '${{ github.head_ref }}')"
+          exit 1
+      - name: Confirm develop source
+        if: github.head_ref == 'develop'
+        run: echo "OK: PR source is develop"


### PR DESCRIPTION
## Summary

First deploy via new branching model. `pages.yml` now triggers on push to `demo` (not `main`).

Brings `demo` to current `develop` HEAD so GitHub Pages publishes:
- Product page at `/`
- Standalone plugin UI at `/app/`

## Test plan

- [ ] Pages workflow triggers on merge
- [ ] `https://luis85.github.io/specorator/` serves product page
- [ ] `https://luis85.github.io/specorator/app/` serves standalone UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)