### PR TITLE
ci: bump action versions and clean up source guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: npm

--- a/.github/workflows/main-source-guard.yml
+++ b/.github/workflows/main-source-guard.yml
@@ -2,7 +2,13 @@ name: Main source guard
 
 on:
   pull_request:
-    branches: [main]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+    branches:
+      - main
 
 jobs:
   guard:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,11 +18,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: lts/*
           cache: npm
 
       - name: Install dependencies
@@ -39,7 +39,7 @@ jobs:
           cp site/index.html _site/index.html
           cp -r dist-standalone/. _site/app/
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
@@ -52,4 +52,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -30,7 +30,7 @@ jobs:
           fi
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: npm


### PR DESCRIPTION
## Summary

- Bump pinned action versions to current majors (Node.js 20 deprecation, June 2026):
  - `actions/checkout` v4 → v6
  - `actions/setup-node` v4 → v6
  - `actions/upload-pages-artifact` v3 → v5
  - `actions/deploy-pages` v4 → v5
- `pages.yml`: pinned `node-version: 20` → `lts/*` (matches `ci.yml` / `release.yml`)
- Rewrite `main-source-guard.yml`: previous registration produced phantom failed runs on push events (workflow API returned filename as `name` instead of `Main source guard`, indicating GitHub had cached a broken record). Restructured trigger to force re-registration.

## Test plan

- [ ] CI passes on this branch with new action versions
- [ ] After merge, push to `develop` does NOT produce a phantom `main-source-guard` failed run
- [ ] Required-status-check name `Verify PR source is develop` still recognised by `main` ruleset (verify on next PR develop → main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)