### PR TITLE
ci: recreate PR source guard with fresh workflow id

### DIFF
--- a/.github/workflows/pr-source-guard.yml
+++ b/.github/workflows/pr-source-guard.yml
@@ -1,14 +1,8 @@
-name: Main source guard
+name: PR source guard
 
 on:
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - edited
-    branches:
-      - main
+    branches: [main]
 
 jobs:
   guard:


### PR DESCRIPTION
## Summary

GitHub cached broken metadata for the original `main-source-guard.yml` (workflow_id 270063975): API returned the file path as `name` instead of `Main source guard`, and push events generated phantom failed run records with empty `jobs[]`. Disable/enable did not refresh the cache.

Rename to `pr-source-guard.yml` to allocate a fresh workflow_id with clean metadata. Job name `Verify PR source is develop` is unchanged so the existing `main` ruleset required-status-check stays valid.

## Test plan

- [ ] CI passes on this branch
- [ ] After merge, push to `develop` produces NO new run for `pr-source-guard.yml`
- [ ] New workflow's metadata `name` field returns `PR source guard` not the path
- [ ] Old workflow_id 270063975 stops receiving runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)