### PR TITLE
ci: workflow hygiene — concurrency, permissions, timeouts, gitignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,18 @@ on:
   pull_request:
     branches: [develop, demo, main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   workflow-lint:
     name: Lint workflow files (actionlint)
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -23,6 +31,7 @@ jobs:
     name: Verify PR source is develop
     if: github.event_name == 'pull_request' && github.base_ref == 'main'
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - name: Reject non-develop source
         if: github.head_ref != 'develop'
@@ -39,6 +48,7 @@ jobs:
   verify:
     name: Install, typecheck, lint, test, and build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -46,6 +47,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,15 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Build and publish release
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ Thumbs.db
 
 # Generated API docs (run `npm run docs:api` to regenerate)
 docs/api/
+
+# Local agent state (Claude Code, etc.)
+.claude/
+.worktrees/


### PR DESCRIPTION
## Summary

Bundle of small workflow improvements:

**`ci.yml`**
- Top-level `permissions: contents: read` (least-privilege; default token is broad)
- `concurrency` group keyed by ref; `cancel-in-progress` only on PR events so develop/main pushes never cancel each other
- `timeout-minutes` on all jobs (was 360 default): workflow-lint=5, guard=2, verify=15

**`pages.yml`**: `timeout-minutes` on build (10) and deploy (5)

**`release.yml`**: `concurrency` group with `cancel-in-progress: false` so concurrent release tags never abort each other; `timeout-minutes: 15`

**`.gitignore`**: add `.claude/` and `.worktrees/` (local agent state)

## Test plan

- [ ] CI passes (incl. actionlint)
- [ ] Pushing two commits to this PR in quick succession cancels the older run
- [ ] Push to develop after merge does NOT cancel a still-running develop CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)