### PR TITLE
ci: auto-merge dependabot PRs for patches and dev-dep minors

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,34 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge dependabot patches
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"
+
+      - name: Enable auto-merge for minor dev-dependency updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-minor' && steps.metadata.outputs.dependency-type == 'direct:development'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary

Adds `dependabot-auto-merge.yml` that fires on every PR event, runs only for `dependabot[bot]`, inspects update type via `dependabot/fetch-metadata@v2`, and calls `gh pr merge --auto --squash` for:

- Any `version-update:semver-patch` (production or dev)
- `version-update:semver-minor` of `direct:development` dependencies

Auto-merge only completes once required ruleset checks pass (CI green + no force-push), so the existing `develop` branch ruleset still gates the merge. Major upgrades and minor production-dep upgrades stay manual.

Repo-level `allow_auto_merge` was flipped to `true` via the REST API as a prerequisite.

## Test plan

- [ ] CI passes (incl. actionlint)
- [ ] After merge, next Dependabot patch PR auto-merges once CI is green
- [ ] Dependabot major-bump PR is NOT auto-merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)