### PR TITLE
[codex] Fix terminal feature progress display

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
 		"lint:fix": "eslint . --fix",
 		"format": "prettier --write .",
 		"format:check": "prettier --check .",
-		"test": "vitest run",
-		"test:watch": "vitest",
+		"test": "vitest run --configLoader runner",
+		"test:watch": "vitest --configLoader runner",
 		"build:web": "vue-tsc --noEmit && vite build",
-		"test:coverage": "vitest run --coverage",
+		"test:coverage": "vitest run --configLoader runner --coverage",
 		"docs:api": "typedoc",
 		"version": "node version-bump.js && git add manifest.json versions.json"
 	},

--- a/src/ui/components/feature/FeatureCard.vue
+++ b/src/ui/components/feature/FeatureCard.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import AppBadge from '../common/AppBadge.vue'
 import AppButton from '../common/AppButton.vue'
 import type { FeatureDto } from '@/ui/types/FeatureDto'
 import { FEATURE_STEP_COUNT } from '@/domain/feature/FeatureStep'
 
-defineProps<{ feature: FeatureDto }>()
+const props = defineProps<{ feature: FeatureDto }>()
 
 const emit = defineEmits<{
   activate: [id: string]
@@ -13,6 +14,11 @@ const emit = defineEmits<{
 }>()
 
 const stepCount = FEATURE_STEP_COUNT
+const displayedStep = computed(() => Math.min(Math.max(props.feature.currentStep, 1), stepCount))
+const isComplete = computed(() => props.feature.currentStep > stepCount)
+const showProgress = computed(() => props.feature.status !== 'draft')
+const completedSteps = computed(() => (isComplete.value ? stepCount : displayedStep.value - 1))
+const progressWidth = computed(() => `${(completedSteps.value / stepCount) * 100}%`)
 </script>
 
 <template>
@@ -22,15 +28,24 @@ const stepCount = FEATURE_STEP_COUNT
       <AppBadge :status="feature.status" />
     </header>
 
-    <div v-if="feature.status === 'active'" class="sp-feature-card__progress">
+    <div v-if="showProgress" class="sp-feature-card__progress">
       <div class="sp-progress-bar">
         <div
           class="sp-progress-bar__fill"
-          :style="{ width: `${((feature.currentStep - 1) / stepCount) * 100}%` }"
+          :style="{ width: progressWidth }"
         />
       </div>
-      <span class="sp-feature-card__step-label">
-        {{ $t('feature.stepProgress', { current: feature.currentStep, total: stepCount }) }}
+      <span v-if="feature.status === 'archived'" class="sp-feature-card__step-label">
+        {{ $t('feature.status.archived') }}
+      </span>
+      <span v-else-if="feature.status === 'abandoned'" class="sp-feature-card__step-label">
+        {{ $t('feature.status.abandoned') }}
+      </span>
+      <span v-else-if="isComplete" class="sp-feature-card__step-label">
+        {{ $t('feature.complete') }}
+      </span>
+      <span v-else class="sp-feature-card__step-label">
+        {{ $t('feature.stepProgress', { current: displayedStep, total: stepCount }) }}
       </span>
     </div>
 

--- a/src/ui/components/feature/__tests__/FeatureCard.spec.ts
+++ b/src/ui/components/feature/__tests__/FeatureCard.spec.ts
@@ -1,0 +1,74 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { i18n } from '@/ui/i18n'
+import type { FeatureDto } from '@/ui/types/FeatureDto'
+import FeatureCard from '../FeatureCard.vue'
+
+function makeFeature(overrides: Partial<FeatureDto> = {}): FeatureDto {
+  return {
+    id: 'feature-1',
+    slug: 'feature-1',
+    title: 'Feature 1',
+    status: 'active',
+    currentStep: 1,
+    createdAt: '2026-05-02T00:00:00.000Z',
+    updatedAt: '2026-05-02T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function mountCard(feature: FeatureDto) {
+  return mount(FeatureCard, {
+    props: { feature },
+    global: {
+      plugins: [i18n],
+    },
+  })
+}
+
+describe('FeatureCard', () => {
+  it('renders idea-stage progress', () => {
+    const wrapper = mountCard(makeFeature({ currentStep: 1 }))
+
+    expect(wrapper.text()).toContain('Step 1 of 12')
+    expect(wrapper.find('.sp-progress-bar__fill').attributes('style')).toContain('width: 0%;')
+  })
+
+  it('renders mid-stage progress', () => {
+    const wrapper = mountCard(makeFeature({ currentStep: 7 }))
+
+    expect(wrapper.text()).toContain('Step 7 of 12')
+    expect(wrapper.find('.sp-progress-bar__fill').attributes('style')).toContain('width: 50%;')
+  })
+
+  it('renders final-stage progress without exceeding the total', () => {
+    const wrapper = mountCard(makeFeature({ currentStep: 12 }))
+
+    expect(wrapper.text()).toContain('Step 12 of 12')
+    expect(wrapper.find('.sp-progress-bar__fill').attributes('style')).toContain(
+      'width: 91.66666666666666%;',
+    )
+  })
+
+  it('renders complete instead of an out-of-range step', () => {
+    const wrapper = mountCard(makeFeature({ currentStep: 13 }))
+
+    expect(wrapper.text()).toContain('Complete')
+    expect(wrapper.text()).not.toContain('Step 13 of 12')
+    expect(wrapper.find('.sp-progress-bar__fill').attributes('style')).toContain('width: 100%;')
+  })
+
+  it('renders archived terminal state without step progress text', () => {
+    const wrapper = mountCard(makeFeature({ status: 'archived', currentStep: 13 }))
+
+    expect(wrapper.text()).toContain('Archived')
+    expect(wrapper.text()).not.toContain('Step 13 of 12')
+  })
+
+  it('renders abandoned terminal state without step progress text', () => {
+    const wrapper = mountCard(makeFeature({ status: 'abandoned', currentStep: 13 }))
+
+    expect(wrapper.text()).toContain('Abandoned')
+    expect(wrapper.text()).not.toContain('Step 13 of 12')
+  })
+})

--- a/src/ui/i18n/locales/de.ts
+++ b/src/ui/i18n/locales/de.ts
@@ -38,6 +38,7 @@ export default {
       retrospective: 'Retrospektive',
     },
     stepProgress: 'Schritt {current} von {total}',
+    complete: 'Abgeschlossen',
     actions: {
       activate: 'Feature starten',
       archive: 'Archivieren',

--- a/src/ui/i18n/locales/en.ts
+++ b/src/ui/i18n/locales/en.ts
@@ -38,6 +38,7 @@ export default {
       retrospective: 'Retrospective',
     },
     stepProgress: 'Step {current} of {total}',
+    complete: 'Complete',
     actions: {
       activate: 'Start Feature',
       archive: 'Archive',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vitest/config'
 import vue from '@vitejs/plugin-vue'
+import { fileURLToPath } from 'node:url'
 import { resolve } from 'path'
+
+const projectRoot = fileURLToPath(new URL('.', import.meta.url))
 
 export default defineConfig({
   plugins: [vue()],
@@ -16,6 +19,6 @@ export default defineConfig({
     },
   },
   resolve: {
-    alias: { '@': resolve(__dirname, 'src') },
+    alias: { '@': resolve(projectRoot, 'src') },
   },
 })


### PR DESCRIPTION
## Summary

Fixes #115.

- Clamp the feature-card progress display so active lifecycle boundary states no longer render out-of-range labels like `Step 13 of 12`.
- Render distinct terminal labels for completed, archived, and abandoned feature cards.
- Add component coverage for idea, mid-stage, final-stage, completed, archived, and abandoned states.
- Use Vite/Vitest's runner config loader in test scripts so nested Git worktrees do not emit parent-checkout `tsconfig` warnings.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test`
- `git diff --check`