### PR TITLE
chore(ci): supply-chain hardening (#121)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Audit production dependencies
+        run: npm audit --audit-level=high --omit=dev
+
       - name: Typecheck
         run: npm run typecheck
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,29 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [develop, demo, main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: dep-review-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Review pull-request dependency changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure
+          deny-licenses: AGPL-1.0-only, AGPL-1.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later, GPL-2.0-only, GPL-2.0-or-later, GPL-3.0-only, GPL-3.0-or-later

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,51 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '23 4 * * 1'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
+        with:
+          sarif_file: results.sarif

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -1,0 +1,89 @@
+---
+title: Supply-chain hardening policy
+doc_type: policy
+status: active
+owner: maintainers
+last_reviewed: 2026-05-02
+---
+
+# Supply-chain hardening policy
+
+This document records the controls Specorator applies to its dependency graph and CI/CD surface, plus the manual review expectations that sit on top of those controls.
+
+## Goals
+
+- Detect known-vulnerable dependencies before they reach `develop`.
+- Prevent silent introduction of copyleft (GPL/AGPL) licenses incompatible with this project's MIT license.
+- Make every third-party CI step auditable to a specific commit.
+- Surface project-level supply-chain hygiene metrics (Scorecard) over time.
+
+## Automated controls
+
+### `npm audit` on every CI run
+
+`.github/workflows/ci.yml` runs `npm audit --audit-level=high --omit=dev` after `npm ci` in the verify job.
+
+- **Threshold:** `high`. CI fails on any `high` or `critical` advisory in production dependencies.
+- **Scope:** `--omit=dev` limits the gate to runtime dependencies. Dev-dependency advisories are surfaced by Dependabot but do not block CI on their own.
+- **Rationale:** Treating every moderate dev-tool advisory as a release blocker leads to rubber-stamping. The high-severity production threshold is the point at which a release should not ship without a deliberate decision.
+
+### `actions/dependency-review-action` on pull requests
+
+`.github/workflows/dependency-review.yml` runs on every pull request targeting `develop`, `demo`, or `main`.
+
+- Fails the PR check if the diff introduces any dependency with a `high` or `critical` advisory.
+- Fails the PR check if the diff introduces any GPL-family license (`GPL-2.0`, `GPL-3.0`, `AGPL-1.0`, `AGPL-3.0`, in `-only` and `-or-later` variants).
+- Posts a summary comment on the PR when it fails so the author can see the offending package without digging through logs.
+
+### OpenSSF Scorecard
+
+`.github/workflows/scorecard.yml` runs weekly (Mondays 04:23 UTC), on push to `main`, and on branch-protection-rule changes.
+
+- Publishes results to the OpenSSF public Scorecard registry (`publish_results: true`).
+- Uploads SARIF to GitHub code-scanning so findings appear in the Security tab.
+- Treated as observability, not a merge gate. Use Scorecard output to drive policy changes; do not block ordinary feature work on Scorecard regressions.
+
+### Action pinning
+
+All third-party actions are pinned to a 40-character commit SHA with the human-readable tag preserved as a comment, for example:
+
+```yaml
+uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+```
+
+`actionlint` (run in CI) catches malformed workflow files. PRs that introduce a `uses:` line without a SHA must be revised before merge.
+
+## Manual review expectations
+
+### Dependency bumps
+
+- Dependabot opens PRs for npm and GitHub Actions updates. The `dependabot-auto-merge` workflow auto-merges patch updates and minor dev-dependency updates after CI passes.
+- Major-version bumps and any production-dependency minor bump require a human review before merge.
+- Reviewer responsibilities, in order:
+  1. Confirm the upstream changelog and release notes are visible from the PR.
+  2. Confirm the action SHA in the diff matches the upstream tag's commit.
+  3. Confirm CI is green, including the dependency-review job.
+  4. Apply the same `develop → main` flow as any other change — never merge dependency PRs directly to `main`.
+
+### New runtime dependencies
+
+When a PR adds a new runtime dependency (`dependencies` in `package.json`, not `devDependencies`):
+
+- The PR description must state why the dependency is preferred over a hand-rolled implementation or an existing dependency in the tree.
+- The reviewer confirms the package's license is MIT, Apache-2.0, BSD-2/3, ISC, or another permissive license. GPL-family licenses are blocked at CI; the reviewer is the second line for ambiguous licenses (e.g. dual-licensed packages).
+- The reviewer checks the package's age, weekly downloads, and last-release recency on npm. New, low-traffic packages get extra scrutiny, especially if they have transitive dependencies.
+
+### Workflow / action changes
+
+- Any new `uses:` line must be pinned to a SHA in the same PR that introduces it. CI does not enforce this directly today; reviewers do.
+- Granting a workflow `write` permission requires an explicit comment in the PR explaining what is written and why a `read` token is insufficient.
+
+## Threat model assumptions
+
+- The project trusts GitHub-hosted runners and GitHub's identity layer. Compromise of GitHub itself is out of scope.
+- The project does not assume Dependabot's auto-merge path is sufficient for security patches alone — the `npm audit` gate exists so that a production-severity advisory cannot slip through a Dependabot PR that races ahead of advisory publication.
+- The project assumes contributors are honest but fallible. Controls focus on accidental introduction of vulnerable or unsafely-licensed code rather than on resisting a determined insider.
+
+## Review cadence
+
+This policy is reviewed at every `main` release tag. Update `last_reviewed` in the front matter and commit the change as part of the release PR.


### PR DESCRIPTION
## Summary

Closes #121. Adds the four controls listed in the acceptance criteria.

- `npm audit --audit-level=high --omit=dev` in the CI verify job
- New `dependency-review.yml` workflow: blocks high+ vulnerabilities and GPL/AGPL licenses on PRs to `develop`, `demo`, `main`
- New `scorecard.yml` workflow: weekly cron + push to `main` + branch-protection-rule, publishes results and uploads SARIF to code-scanning
- New `docs/security/supply-chain.md` policy doc covering thresholds, manual review expectations, and the SHA-pinning rule (#94 already pinned the existing actions)

All new third-party actions pinned to commit SHA with `# vX.Y.Z` comment.

## Verification

- `actionlint` (v1.7.12, Windows binary) passed locally on the three changed workflow files
- `npm audit --audit-level=high --omit=dev` exits 0 on current `develop` (zero advisories at any severity)
- No source code changes — typecheck/lint/test gate not relevant

## Test plan

- [ ] CI workflow lint job passes on this PR
- [ ] CI verify job runs the new `npm audit` step and passes
- [ ] Dependency Review job runs on this PR and passes (no new deps in the diff)
- [ ] Scorecard workflow becomes visible in the Actions tab and can be triggered via `workflow_dispatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)