### PR TITLE
chore(ci): enforce SHA pinning for third-party actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,10 @@ jobs:
           violations=$(awk '
             /^[[:space:]]*-?[[:space:]]*uses:/ {
               ref = $0
+              sub(/\r$/, "", ref)
               sub(/^[^:]*:[[:space:]]*/, "", ref)
               sub(/[[:space:]]*#.*$/, "", ref)
+              sub(/[[:space:]]+$/, "", ref)
               gsub(/^["\x27]+|["\x27]+$/, "", ref)
               if (ref ~ /^\.\//) next
               if (ref ~ /^docker:\/\//) next

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          violations=$(grep -nE '^[[:space:]]*-?[[:space:]]*uses:' .github/workflows/*.yml \
+          mapfile -t files < <(find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) | sort)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No workflow files found under .github/workflows."
+            exit 0
+          fi
+          violations=$(grep -nE '^[[:space:]]*-?[[:space:]]*uses:' "${files[@]}" \
             | grep -vE 'uses:[[:space:]]*\./' \
             | grep -vE 'uses:[[:space:]]*docker://' \
             | grep -vE 'uses:[[:space:]]*[^@[:space:]]+@[0-9a-f]{40}([[:space:]]|$)' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,17 @@ jobs:
             echo "No workflow files found under .github/workflows."
             exit 0
           fi
-          violations=$(grep -nE '^[[:space:]]*-?[[:space:]]*uses:' "${files[@]}" \
-            | grep -vE 'uses:[[:space:]]*\./' \
-            | grep -vE 'uses:[[:space:]]*docker://' \
-            | grep -vE 'uses:[[:space:]]*[^@[:space:]]+@[0-9a-f]{40}([[:space:]]|$)' \
-            || true)
+          violations=$(awk '
+            /^[[:space:]]*-?[[:space:]]*uses:/ {
+              ref = $0
+              sub(/^[^:]*:[[:space:]]*/, "", ref)
+              sub(/[[:space:]]*#.*$/, "", ref)
+              gsub(/^["\x27]+|["\x27]+$/, "", ref)
+              if (ref ~ /^\.\//) next
+              if (ref ~ /^docker:\/\//) next
+              if (ref !~ /@[0-9a-f]{40}$/) print FILENAME ":" FNR ": " $0
+            }
+          ' "${files[@]}")
           if [ -n "$violations" ]; then
             echo "::error::Unpinned actions found — every 'uses:' must reference a 40-character commit SHA (see docs/security/supply-chain.md)."
             echo "$violations"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,21 @@ jobs:
           bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
       - name: Run actionlint
         run: ./actionlint -color
+      - name: Verify third-party actions are SHA-pinned
+        shell: bash
+        run: |
+          set -euo pipefail
+          violations=$(grep -nE '^[[:space:]]*-?[[:space:]]*uses:' .github/workflows/*.yml \
+            | grep -vE 'uses:[[:space:]]*\./' \
+            | grep -vE 'uses:[[:space:]]*docker://' \
+            | grep -vE 'uses:[[:space:]]*[^@[:space:]]+@[0-9a-f]{40}([[:space:]]|$)' \
+            || true)
+          if [ -n "$violations" ]; then
+            echo "::error::Unpinned actions found — every 'uses:' must reference a 40-character commit SHA (see docs/security/supply-chain.md)."
+            echo "$violations"
+            exit 1
+          fi
+          echo "All third-party actions are SHA-pinned."
 
   guard:
     name: Verify PR source is develop

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -54,7 +54,7 @@ uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 Two CI checks back this rule:
 
 - `actionlint` validates workflow YAML syntax and expression types.
-- A dedicated `Verify third-party actions are SHA-pinned` step in the `workflow-lint` job greps every `uses:` line in `.github/workflows/*.yml` and fails the build if any reference is not pinned to a 40-character commit SHA. Local composite actions (`./...`) and `docker://` references are exempt.
+- A dedicated `Verify third-party actions are SHA-pinned` step in the `workflow-lint` job greps every `uses:` line across both `.yml` and `.yaml` files under `.github/workflows/` and fails the build if any reference is not pinned to a 40-character commit SHA. Local composite actions (`./...`) and `docker://` references are exempt.
 
 A PR that introduces an unpinned `uses:` line cannot merge until the SHA is supplied.
 

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -51,7 +51,12 @@ All third-party actions are pinned to a 40-character commit SHA with the human-r
 uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 ```
 
-`actionlint` (run in CI) catches malformed workflow files. PRs that introduce a `uses:` line without a SHA must be revised before merge.
+Two CI checks back this rule:
+
+- `actionlint` validates workflow YAML syntax and expression types.
+- A dedicated `Verify third-party actions are SHA-pinned` step in the `workflow-lint` job greps every `uses:` line in `.github/workflows/*.yml` and fails the build if any reference is not pinned to a 40-character commit SHA. Local composite actions (`./...`) and `docker://` references are exempt.
+
+A PR that introduces an unpinned `uses:` line cannot merge until the SHA is supplied.
 
 ## Manual review expectations
 


### PR DESCRIPTION
## Summary

Follow-up to PR #124. Addresses Codex's P2 inline feedback on `docs/security/supply-chain.md`: the merged doc claimed CI enforced SHA pinning, but the only workflow check (`actionlint`) validates syntax/expressions, not pinning.

- New step in the `workflow-lint` job: greps every `uses:` line in `.github/workflows/*.yml` and fails the build on any reference not pinned to a 40-character commit SHA.
- Local composite actions (`./...`) and `docker://` references are exempt.
- Doc updated to describe the actual two-check enforcement (`actionlint` for syntax, dedicated grep step for pinning).

## Verification

- Local pin-check passes against current `develop` (17 `uses:` lines, all SHA-pinned).
- Local pin-check correctly rejects synthetic `@v4` and `@main` test entries while accepting `@<40-hex>`, `./local`, and `docker://...`.
- `actionlint` v1.7.12 passes locally on the edited `ci.yml`.
- No source changes; verify gate not relevant.

## Test plan

- [ ] CI workflow-lint job runs the new step and reports "All third-party actions are SHA-pinned."
- [ ] Verify step fails the build if a future PR introduces an unpinned `uses:` line (covered by local synthetic test, will be re-confirmed the first time someone tries it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)