### PR TITLE
[codex] Fix file route path encoding

### DIFF
--- a/src/ui/App.vue
+++ b/src/ui/App.vue
@@ -16,7 +16,7 @@ function onNotice(e: Event) {
 
 function onOpenFile(e: Event) {
   const { path } = (e as CustomEvent<{ path: string }>).detail
-  router.push({ name: 'file', params: { encodedPath: encodeURIComponent(path) } })
+  router.push({ name: 'file', params: { filePath: path } })
 }
 
 onMounted(() => {

--- a/src/ui/router/__tests__/fileRoute.spec.ts
+++ b/src/ui/router/__tests__/fileRoute.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { router } from '../index'
+import { normalizeFileRoutePath } from '../fileRoute'
 
 describe('file route encoding', () => {
   it('round-trips a raw path with spaces, unicode, and slash separators', () => {
@@ -13,5 +14,11 @@ describe('file route encoding', () => {
     expect(resolved.href).not.toContain('%25')
     expect(matched.name).toBe('file')
     expect(matched.params.filePath).toBe(filePath)
+  })
+
+  it('normalizes legacy double-encoded file route paths', () => {
+    const legacyRouteParam = 'specs%2FÜber%20cool%20feature%2Ftest%20plan.md'
+
+    expect(normalizeFileRoutePath(legacyRouteParam)).toBe('specs/Über cool feature/test plan.md')
   })
 })

--- a/src/ui/router/__tests__/fileRoute.spec.ts
+++ b/src/ui/router/__tests__/fileRoute.spec.ts
@@ -21,4 +21,12 @@ describe('file route encoding', () => {
 
     expect(normalizeFileRoutePath(legacyRouteParam)).toBe('specs/Über cool feature/test plan.md')
   })
+
+  it('normalizes legacy single-segment file route paths', () => {
+    expect(normalizeFileRoutePath('My%20Note.md')).toBe('My Note.md')
+  })
+
+  it('preserves percent-like literals in current slash-containing paths', () => {
+    expect(normalizeFileRoutePath('docs/100%2Fready.md')).toBe('docs/100%2Fready.md')
+  })
 })

--- a/src/ui/router/__tests__/fileRoute.spec.ts
+++ b/src/ui/router/__tests__/fileRoute.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { router } from '../index'
+
+describe('file route encoding', () => {
+  it('round-trips a raw path with spaces, unicode, and slash separators', () => {
+    const filePath = 'specs/Über cool feature/test plan.md'
+
+    const resolved = router.resolve({ name: 'file', params: { filePath } })
+    const matched = router.resolve(resolved.fullPath)
+
+    expect(resolved.href).toContain('%C3%9Cber%20cool%20feature')
+    expect(resolved.href).toContain('test%20plan.md')
+    expect(resolved.href).not.toContain('%25')
+    expect(matched.name).toBe('file')
+    expect(matched.params.filePath).toBe(filePath)
+  })
+})

--- a/src/ui/router/fileRoute.ts
+++ b/src/ui/router/fileRoute.ts
@@ -1,0 +1,11 @@
+const LEGACY_ENCODED_SEPARATOR = /%2f/i
+
+export function normalizeFileRoutePath(filePath: string): string {
+  if (!LEGACY_ENCODED_SEPARATOR.test(filePath)) return filePath
+
+  try {
+    return decodeURIComponent(filePath)
+  } catch {
+    return filePath
+  }
+}

--- a/src/ui/router/fileRoute.ts
+++ b/src/ui/router/fileRoute.ts
@@ -1,7 +1,7 @@
-const LEGACY_ENCODED_SEPARATOR = /%2f/i
+const ENCODED_OCTET = /%[0-9a-f]{2}/i
 
 export function normalizeFileRoutePath(filePath: string): string {
-  if (!LEGACY_ENCODED_SEPARATOR.test(filePath)) return filePath
+  if (filePath.includes('/') || !ENCODED_OCTET.test(filePath)) return filePath
 
   try {
     return decodeURIComponent(filePath)

--- a/src/ui/router/index.ts
+++ b/src/ui/router/index.ts
@@ -10,6 +10,6 @@ export const router = createRouter({
     { path: '/', name: 'home', component: HomeView },
     { path: '/features', name: 'features', component: FeaturesView },
     { path: '/settings', name: 'settings', component: SettingsView },
-    { path: '/file/:encodedPath', name: 'file', component: FileView },
+    { path: '/file/:filePath(.*)', name: 'file', component: FileView },
   ],
 })

--- a/src/ui/views/FileView.vue
+++ b/src/ui/views/FileView.vue
@@ -10,7 +10,7 @@ const route = useRoute()
 const router = useRouter()
 const bridge = useBridge()
 
-const filePath = decodeURIComponent(route.params.encodedPath as string)
+const filePath = route.params.filePath as string
 const content = ref<string | null>(null)
 const notFound = ref(false)
 const copied = ref(false)

--- a/src/ui/views/FileView.vue
+++ b/src/ui/views/FileView.vue
@@ -4,13 +4,14 @@ import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import AppButton from '../components/common/AppButton.vue'
 import { useBridge } from '../composables/useBridge'
+import { normalizeFileRoutePath } from '../router/fileRoute'
 
 const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const bridge = useBridge()
 
-const filePath = route.params.filePath as string
+const filePath = normalizeFileRoutePath(route.params.filePath as string)
 const content = ref<string | null>(null)
 const notFound = ref(false)
 const copied = ref(false)


### PR DESCRIPTION
## Summary

Fixes #112.

- Stop pre-encoding file paths before passing them to Vue Router.
- Rename the route param to `filePath` and allow slash-containing paths with a catch-all route segment.
- Stop decoding route params manually in `FileView`, since Vue Router returns decoded params.
- Preserve compatibility for legacy double-encoded file URLs by decoding legacy fully encoded params that still contain percent escapes after Vue Router's first decode.
- Avoid second-decoding current slash-containing paths, preserving literal percent-like filename text such as `%2F`.
- Add route regression tests for spaces, Unicode, slash separators, no `%25` double-encoding, legacy double-encoded URLs, root-level legacy URLs, and literal `%2F` path text.

## Validation

- `npm test -- --run src/ui/router/__tests__/fileRoute.spec.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `git diff --check`