### PR TITLE
[codex] Open browser for dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"description": "Spec-driven, agentic software development workflow inside Obsidian.",
 	"main": "main.js",
 	"scripts": {
-		"dev": "vite",
+		"dev": "vite --open",
 		"dev:plugin": "vite build --watch --mode plugin",
 		"build": "vue-tsc --noEmit && vite build --mode plugin",
 		"typecheck": "vue-tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
 	"description": "Spec-driven, agentic software development workflow inside Obsidian.",
 	"main": "main.js",
 	"scripts": {
-		"dev": "vite --open",
+		"dev": "vite",
+		"dev:open": "vite --open",
 		"dev:plugin": "vite build --watch --mode plugin",
 		"build": "vue-tsc --noEmit && vite build --mode plugin",
 		"typecheck": "vue-tsc --noEmit",


### PR DESCRIPTION
## Summary

- Keep `npm run dev` headless-safe by leaving it as plain `vite`.
- Add `npm run dev:open` for local development sessions that should launch the standalone UI in the default browser.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test`
- `git diff --check`
- Earlier startup smoke: `npm run dev -- --host 127.0.0.1` returned HTTP 200 at `http://127.0.0.1:5173/`.