### PR TITLE
docs: add AGENTS.md + .codex recipes for agent contributors (#118)

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,18 @@
+# `.codex/` recipes
+
+Short, mechanical step-by-step recipes for automated and AI agents working in this repository. Each recipe is self-contained, idempotent where possible, and assumes the agent has already read [`AGENTS.md`](../AGENTS.md).
+
+| Recipe | When to use |
+|---|---|
+| [`pre-pr-gate.md`](./pre-pr-gate.md) | Before opening or updating any PR. |
+| [`open-pr.md`](./open-pr.md) | Opening a fresh PR against `develop`. |
+| [`address-review.md`](./address-review.md) | After a reviewer (human or bot) has submitted feedback. |
+| [`branch-hygiene.md`](./branch-hygiene.md) | After a PR has been merged or abandoned. |
+
+Recipes are intentionally narrow. If the situation does not match the preconditions in a recipe, fall back to the general workflow described in [`AGENTS.md`](../AGENTS.md) and ask the human maintainer rather than improvising a destructive action.
+
+Conventions used inside recipes:
+
+- Shell snippets are POSIX `sh`-compatible unless explicitly marked `bash` or `pwsh`.
+- `<owner>` and `<repo>` are the GitHub coordinates for the active repository (`Luis85/specorator` for the canonical Specorator project). `<n>` is a PR number.
+- Long-running steps that can be safely backgrounded are noted as such; otherwise treat each step as blocking.

--- a/.codex/address-review.md
+++ b/.codex/address-review.md
@@ -28,7 +28,7 @@ gh pr view <n> --json reviews --jq '.reviews[] | {
 }'
 
 # Inline file-line comments (the actual technical feedback)
-gh api repos/<owner>/<repo>/pulls/<n>/comments --jq '.[] | {
+gh api --paginate repos/<owner>/<repo>/pulls/<n>/comments --jq '.[] | {
   path,
   line,
   commit: .commit_id,
@@ -36,6 +36,8 @@ gh api repos/<owner>/<repo>/pulls/<n>/comments --jq '.[] | {
   body: (.body[0:600])
 }'
 ```
+
+`--paginate` is required: without it, `gh api` returns only the first page (30 comments by default) and a long-running review thread on the PR will silently lose later comments. The `--jq` filter is applied per page, so pagination still produces a single concatenated stream of records.
 
 If the inline endpoint returns a non-empty array, treat each entry as real review feedback that must be resolved before merge.
 
@@ -83,7 +85,7 @@ Before squash-merging, re-run step 1. If new comments appeared on the latest com
 ```sh
 # Final check
 gh pr view <n> --json mergeable,mergeStateStatus,statusCheckRollup
-gh api repos/<owner>/<repo>/pulls/<n>/comments --jq 'length'
+gh api --paginate repos/<owner>/<repo>/pulls/<n>/comments --jq '.[]' | jq -s 'length'
 ```
 
 If `mergeStateStatus` is `CLEAN`, all checks SUCCESS, and every inline comment has been addressed, proceed to merge per [`open-pr.md`](./open-pr.md) §5.

--- a/.codex/address-review.md
+++ b/.codex/address-review.md
@@ -1,0 +1,95 @@
+# Recipe: Address review feedback
+
+Use after a reviewer (human or bot — Codex, dependabot, etc.) has posted feedback on an open PR.
+
+## Why this recipe exists
+
+Reviews on this repository can include both a top-level summary body and inline file-line comments. They are returned by **different gh API endpoints**. A common failure mode is to query only the summary, see boilerplate text, and squash-merge while real feedback sits unaddressed in the inline comments.
+
+The rule: **inspect both endpoints before you merge**.
+
+## Preconditions
+
+- The PR is open.
+- At least one reviewer has posted feedback (or a bot has finished its scan).
+
+## Steps
+
+### 1. Fetch both endpoints
+
+```sh
+# Top-level review summaries (state, summary body, who reviewed)
+gh pr view <n> --json reviews --jq '.reviews[] | {
+  author: .author.login,
+  state,
+  commit: .commit.oid,
+  submittedAt,
+  body: (.body[0:400])
+}'
+
+# Inline file-line comments (the actual technical feedback)
+gh api repos/<owner>/<repo>/pulls/<n>/comments --jq '.[] | {
+  path,
+  line,
+  commit: .commit_id,
+  submittedAt: .created_at,
+  body: (.body[0:600])
+}'
+```
+
+If the inline endpoint returns a non-empty array, treat each entry as real review feedback that must be resolved before merge.
+
+### 2. Reconcile each comment with the current head
+
+For each inline comment, compare its `commit_id` to the PR's current head SHA:
+
+```sh
+gh pr view <n> --json headRefOid --jq .headRefOid
+```
+
+Three cases:
+
+| `commit_id` vs head | Meaning | Action |
+|---|---|---|
+| Equal to head | Reviewer saw the latest code. | Address the feedback. |
+| Older than head, line content unchanged | Feedback still applies. | Address. |
+| Older than head, line content changed | The new code may already resolve, partially resolve, or sidestep the feedback. | Read the new line and decide. Do not assume it's resolved without reading. |
+
+Note: GitHub may reposition stale inline comments to the latest commit when the line content survives. The `commit_id` may show as the current head even though no fresh review happened. Use `submittedAt` from the matching `reviews` entry to confirm whether a real re-review occurred.
+
+### 3. Address the feedback
+
+Each inline comment must end up in one of three states before merge:
+
+1. **Fixed in code** — the simplest path. Push the fix, let CI re-run.
+2. **Justified in a reply** — when the reviewer's premise is wrong or the trade-off is intentional. Reply on the inline thread with the reasoning. Do not delete the comment. The maintainer decides whether the justification is acceptable.
+3. **Explicitly waived by a human maintainer** — only the human owner of the change can waive. Bots cannot waive their own feedback; you cannot waive on the maintainer's behalf.
+
+When pushing a code fix, use a commit message that names the comment you are addressing:
+
+```
+chore(ci): strip CRLF before SHA-suffix match
+
+Address Codex P2 inline review on PR #125 (commit d5941b1).
+<short why, short how>
+```
+
+This makes the audit trail readable when someone scans `git log` later.
+
+### 4. Verify before merge
+
+Before squash-merging, re-run step 1. If new comments appeared on the latest commit, repeat the loop. Do not merge while any inline comment is unresolved.
+
+```sh
+# Final check
+gh pr view <n> --json mergeable,mergeStateStatus,statusCheckRollup
+gh api repos/<owner>/<repo>/pulls/<n>/comments --jq 'length'
+```
+
+If `mergeStateStatus` is `CLEAN`, all checks SUCCESS, and every inline comment has been addressed, proceed to merge per [`open-pr.md`](./open-pr.md) §5.
+
+## Failure handling
+
+- **Reviewer comment is a false positive** (a regression Codex flagged that does not exist). Verify against the actual code path with file:line citations. Reply with the verification on the inline thread. Do not silently ignore. The PR description or follow-up commit should record that the claim was investigated and dismissed, in case future readers see the same comment.
+- **Reviewer requests scope expansion that is out of scope for the PR.** Open a follow-up issue, link it from a reply on the inline thread, and proceed with the merge — the original PR's acceptance criteria are the contract.
+- **A reviewer keeps posting new findings on every push** (true for many automated reviewers). This is normal. Address each finding in turn. The PR is ready when the latest push receives no new actionable feedback (Codex typically reacts with 👍 or stays silent on a clean review).

--- a/.codex/branch-hygiene.md
+++ b/.codex/branch-hygiene.md
@@ -1,0 +1,79 @@
+# Recipe: Branch hygiene after merge
+
+Use after a PR has been merged (or explicitly abandoned) to clean up local and remote state.
+
+## Preconditions
+
+- The PR is in `MERGED` or `CLOSED` state.
+- You are *not* currently on the merged branch in any active worktree (the branch you are checked out on cannot be deleted).
+
+## Steps
+
+### 1. Confirm the PR's final state
+
+```sh
+gh pr view <n> --json state,mergeCommit,mergedAt
+```
+
+Only proceed when `state` is `MERGED` or `CLOSED`. If the PR is still `OPEN`, stop — branch deletion would orphan the work.
+
+### 2. Delete the remote branch (if not already deleted)
+
+`gh pr merge --delete-branch` removes the remote branch automatically. If that step was skipped or failed, delete manually:
+
+```sh
+git push origin --delete <branch-name>
+```
+
+If the response says the branch does not exist on the remote, the merge step already cleaned it. Continue.
+
+### 3. Remove the local worktree
+
+If you used a worktree for the branch:
+
+```sh
+git worktree remove <path-to-worktree>
+```
+
+If `git worktree remove` reports `Permission denied` (Windows often holds file locks via running editors, dev servers, or watch processes), close the holding process and retry. As a last resort:
+
+```sh
+rm -rf <path-to-worktree>   # POSIX
+# or
+Remove-Item -Recurse -Force <path-to-worktree>   # PowerShell
+
+git worktree prune
+```
+
+`git worktree prune` clears the orphaned registration left behind when the directory is removed out-of-band.
+
+### 4. Delete the local branch
+
+```sh
+git branch -D <branch-name>
+```
+
+`-D` is required when the branch was squash-merged (the branch SHA is not an ancestor of the squash commit, so `-d` will refuse).
+
+### 5. Sync `develop`
+
+```sh
+git fetch origin develop --prune
+```
+
+`--prune` removes stale remote-tracking branches that were deleted on the server.
+
+### 6. Verify state
+
+```sh
+git worktree list
+git branch --list '<type>/*'
+```
+
+Neither command should show the just-merged branch.
+
+## Failure handling
+
+- **`git worktree remove` keeps failing** even after closing the editor. Identify the locking process with `lsof <path>` (POSIX) or `handle.exe <path>` (Windows). Common culprits: a watch-mode test runner (`vitest --watch`), a dev server (`npm run dev`), an IDE indexer.
+- **The branch was force-pushed and `gh pr merge --delete-branch` failed silently.** The remote branch may still exist with newer commits than the merged squash captured. Inspect with `git ls-remote origin '<type>/*'`. If the remote head is the same as the merged head, delete; if it has unexpected commits, stop and ask the maintainer — there may be unsynced work.
+- **You cannot delete the local branch because it is checked out somewhere.** Run `git worktree list` to find the holding worktree and clean it up first.

--- a/.codex/open-pr.md
+++ b/.codex/open-pr.md
@@ -26,7 +26,7 @@ gh pr create \
   --base develop \
   --head <branch-name> \
   --title "<type>(<scope>): <imperative summary>" \
-  --body-file <(cat <<'EOF'
+  --body "$(cat <<'EOF'
 ## Summary
 
 <one short paragraph: what changed, why>
@@ -42,8 +42,10 @@ Closes #<issue-number>
 - [ ] CI passes
 - [ ] <feature-specific manual check, if applicable>
 EOF
-)
+)"
 ```
+
+`$(...)` and here-documents are POSIX; the previous draft used `<(...)` process substitution, which is a bash-only feature and would fail under `dash` or another strict POSIX shell.
 
 Title rules:
 

--- a/.codex/open-pr.md
+++ b/.codex/open-pr.md
@@ -67,14 +67,17 @@ CI status:
 gh pr view <n> --json statusCheckRollup,mergeStateStatus
 ```
 
-Required checks for `develop`:
+The repository ruleset on `develop` enforces exactly one required status check by name:
 
-- `Install, typecheck, lint, test, and build`
-- `Lint workflow files (actionlint)`
-- `Verify third-party actions are SHA-pinned` (in the same job as actionlint)
-- `Review pull-request dependency changes`
+- `Install, typecheck, lint, test, and build` — the `verify` job in `.github/workflows/ci.yml`
 
-If any required check fails, fetch the failing log:
+Several other checks must also pass for the merge UI to allow a squash. They are not enforced by the ruleset, so a failure is reported as `UNSTABLE` rather than `BLOCKED`, but the PR should not be merged while any of them is failing:
+
+- `Lint workflow files (actionlint)` — runs `actionlint` and the SHA-pin enforcement step
+- `Review pull-request dependency changes` — `actions/dependency-review-action`
+- `GitGuardian Security Checks`
+
+If any of these fails, fetch the failing log:
 
 ```sh
 gh run view --log-failed --job=<job-id>

--- a/.codex/open-pr.md
+++ b/.codex/open-pr.md
@@ -1,0 +1,108 @@
+# Recipe: Open a pull request
+
+Use after [`pre-pr-gate.md`](./pre-pr-gate.md) has passed and the branch is rooted in `origin/develop`.
+
+## Preconditions
+
+- All pre-PR gates pass.
+- The working tree is clean (`git status --short` empty).
+- The branch follows the `<type>/<short-kebab>` naming convention (`feature/...`, `fix/...`, `chore/...`, `docs/...`, `refactor/...`).
+- An issue exists that this PR will close, or the change is trivial enough that a standalone PR is acceptable per [`docs/contributing.md`](../docs/contributing.md).
+
+## Steps
+
+### 1. Push the branch
+
+```sh
+git push -u origin <branch-name>
+```
+
+If the branch already tracks `origin`, `git push` alone is sufficient.
+
+### 2. Open the PR with `gh`
+
+```sh
+gh pr create \
+  --base develop \
+  --head <branch-name> \
+  --title "<type>(<scope>): <imperative summary>" \
+  --body-file <(cat <<'EOF'
+## Summary
+
+<one short paragraph: what changed, why>
+
+Closes #<issue-number>
+
+## Verification
+
+<bulleted list of what you ran locally — typecheck, lint, test, build, build:web, docs:api, plus any conditional gates>
+
+## Test plan
+
+- [ ] CI passes
+- [ ] <feature-specific manual check, if applicable>
+EOF
+)
+```
+
+Title rules:
+
+- Imperative present tense (`add`, not `added` / `adds`).
+- ≤72 characters total.
+- Optional `<type>(<scope>):` prefix matching the branch type (`feat`, `fix`, `chore`, `docs`, `refactor`, `test`).
+
+Body rules:
+
+- Always include `Closes #<n>` if an issue exists. GitHub auto-closes the issue when the PR merges.
+- The verification section lists the *commands you actually ran*, not the commands you intended to run. If you skipped a step, say so and why.
+- The test plan is checked off by reviewers as they validate the PR; leave it actionable.
+
+### 3. Wait for CI
+
+CI status:
+
+```sh
+gh pr view <n> --json statusCheckRollup,mergeStateStatus
+```
+
+Required checks for `develop`:
+
+- `Install, typecheck, lint, test, and build`
+- `Lint workflow files (actionlint)`
+- `Verify third-party actions are SHA-pinned` (in the same job as actionlint)
+- `Review pull-request dependency changes`
+
+If any required check fails, fetch the failing log:
+
+```sh
+gh run view --log-failed --job=<job-id>
+```
+
+Fix the underlying issue; do not retry without changes.
+
+### 4. Wait for review
+
+Automated review (Codex) typically posts within 3–5 minutes of the latest push. Check both endpoints:
+
+```sh
+gh pr view <n> --json reviews
+gh api repos/<owner>/<repo>/pulls/<n>/comments
+```
+
+Inline comments live on the second endpoint and are easy to miss if you only query the first. Address every inline comment before merging — see [`address-review.md`](./address-review.md).
+
+### 5. Merge
+
+After all required checks are SUCCESS, all inline comments are addressed, and the maintainer (human or auto-merge policy) has signaled approval:
+
+```sh
+gh pr merge <n> --squash --delete-branch
+```
+
+`--delete-branch` removes the remote branch after merge. Local cleanup is described in [`branch-hygiene.md`](./branch-hygiene.md).
+
+## Failure handling
+
+- **`gh pr create` reports an existing PR.** A previous attempt opened one. Update the existing PR (`gh pr view`) instead of opening a duplicate.
+- **CI reports `BLOCKED`.** Inspect `mergeStateStatus`. Common causes: a required check is missing or queued, the branch is `BEHIND` `develop`, or branch protection requires conversation resolution. Address each cause specifically; do not retry blindly.
+- **Auto-merge fails to delete the branch** because a worktree still references it. Run [`branch-hygiene.md`](./branch-hygiene.md) and retry the delete.

--- a/.codex/open-pr.md
+++ b/.codex/open-pr.md
@@ -91,7 +91,7 @@ Automated review (Codex) typically posts within 3–5 minutes of the latest push
 
 ```sh
 gh pr view <n> --json reviews
-gh api repos/<owner>/<repo>/pulls/<n>/comments
+gh api --paginate repos/<owner>/<repo>/pulls/<n>/comments
 ```
 
 Inline comments live on the second endpoint and are easy to miss if you only query the first. Address every inline comment before merging — see [`address-review.md`](./address-review.md).

--- a/.codex/pre-pr-gate.md
+++ b/.codex/pre-pr-gate.md
@@ -48,8 +48,8 @@ If commits from `origin/develop` are missing from your branch, merge or rebase b
 ## Failure handling
 
 - **A check fails consistently in one environment but passes in another.** Treat the failing environment as authoritative — that is what CI will see. Do not "fix" by suppressing in the failing environment.
-- **A check fails for an unrelated reason** (e.g. a TypeDoc warning surfaced by a dependency update). Fix it in the same PR if it's small; otherwise file a separate issue and skip *only* that step with a recorded justification in the PR description. Never silently skip.
-- **You believe the gate itself is wrong.** File an issue, propose the fix in a separate PR, and merge that PR before merging the work that needs the change.
+- **A check fails for a reason that looks unrelated to your change** (e.g. a TypeDoc warning surfaced by a dependency update). Fix it in the same PR if it's small. If the fix is large enough to deserve its own PR, stop here, open a separate PR for the prerequisite fix, get it merged, then come back to your work. Never bypass the gate or push a PR with a known-failing pre-PR check — `AGENTS.md` §3 forbids it without exception.
+- **You believe the gate itself is wrong.** Same approach as above: file an issue, propose the fix in a separate PR, and merge that PR before merging the work that needs the change.
 
 ## Output
 

--- a/.codex/pre-pr-gate.md
+++ b/.codex/pre-pr-gate.md
@@ -1,0 +1,56 @@
+# Recipe: Pre-PR verification gate
+
+Run this before pushing a branch you intend to open or update a PR with. CI re-runs the same checks; failing locally first shortens the loop.
+
+## Preconditions
+
+- You are on the feature branch (`git status` shows the branch you expect).
+- `npm ci` has been run in this checkout at least once since the last `package-lock.json` change.
+- You have not bypassed any prior gate with `--no-verify` or similar.
+
+## Steps
+
+### 1. Run the standard verification chain
+
+```sh
+npm run typecheck && npm run lint && npm run test && npm run build && npm run build:web && npm run docs:api
+```
+
+All six steps must succeed in order. If any step fails, fix the underlying issue and re-run from the start — do not skip steps that previously passed; later changes may regress them.
+
+### 2. Run the conditional gates
+
+| Condition | Additional gate |
+|---|---|
+| You changed any file under `.github/workflows/` | Run `actionlint` against the changed file(s) and confirm every `uses:` reference is pinned to a 40-character commit SHA. |
+| You added or upgraded a `dependencies` entry in `package.json` | `npm audit --audit-level=high --omit=dev` — must exit zero. |
+| You changed Vue or browser-side code under `src/ui/` | `npm run dev` and exercise the affected feature in a browser. Type-checks alone do not validate runtime behaviour. |
+| You changed plugin-side code under `src/plugin/` or `src/infrastructure/obsidian/` | Build with `npm run build` and load the resulting `main.js` in an Obsidian test vault if the change is non-trivial. |
+
+### 3. Confirm the working tree is clean
+
+```sh
+git status --short
+git diff --check
+```
+
+`git diff --check` rejects whitespace errors that ESLint and Prettier may not catch (e.g. trailing whitespace inside code fences in markdown).
+
+### 4. Confirm the branch is rooted in `develop`
+
+```sh
+git fetch origin develop
+git log --oneline origin/develop ^HEAD | head -5
+```
+
+If commits from `origin/develop` are missing from your branch, merge or rebase before pushing — the repository's required-status-checks rule blocks merge of branches that are behind `develop`.
+
+## Failure handling
+
+- **A check fails consistently in one environment but passes in another.** Treat the failing environment as authoritative — that is what CI will see. Do not "fix" by suppressing in the failing environment.
+- **A check fails for an unrelated reason** (e.g. a TypeDoc warning surfaced by a dependency update). Fix it in the same PR if it's small; otherwise file a separate issue and skip *only* that step with a recorded justification in the PR description. Never silently skip.
+- **You believe the gate itself is wrong.** File an issue, propose the fix in a separate PR, and merge that PR before merging the work that needs the change.
+
+## Output
+
+When all gates pass you should see exit-zero from every command and a clean `git status`. Only then proceed to [`open-pr.md`](./open-pr.md) (for a new PR) or push the update (for an existing PR).

--- a/.codex/pre-pr-gate.md
+++ b/.codex/pre-pr-gate.md
@@ -13,17 +13,22 @@ Run this before pushing a branch you intend to open or update a PR with. CI re-r
 ### 1. Run the standard verification chain
 
 ```sh
-npm run typecheck && npm run lint && npm run test && npm run build && npm run build:web && npm run docs:api
+npm audit --audit-level=high --omit=dev \
+  && npm run typecheck \
+  && npm run lint \
+  && npm run test \
+  && npm run build \
+  && npm run build:web \
+  && npm run docs:api
 ```
 
-All six steps must succeed in order. If any step fails, fix the underlying issue and re-run from the start — do not skip steps that previously passed; later changes may regress them.
+All seven steps must succeed in order. `npm audit` runs first because the `verify` job in `.github/workflows/ci.yml` runs it unconditionally on every CI run; matching that locally avoids a slow round-trip if a `high`/`critical` advisory was published since the last install. If any step fails, fix the underlying issue and re-run from the start — do not skip steps that previously passed; later changes may regress them.
 
 ### 2. Run the conditional gates
 
 | Condition | Additional gate |
 |---|---|
 | You changed any file under `.github/workflows/` | Run `actionlint` against the changed file(s) and confirm every `uses:` reference is pinned to a 40-character commit SHA. |
-| You added or upgraded a `dependencies` entry in `package.json` | `npm audit --audit-level=high --omit=dev` — must exit zero. |
 | You changed Vue or browser-side code under `src/ui/` | `npm run dev` and exercise the affected feature in a browser. Type-checks alone do not validate runtime behaviour. |
 | You changed plugin-side code under `src/plugin/` or `src/infrastructure/obsidian/` | Build with `npm run build` and load the resulting `main.js` in an Obsidian test vault if the change is non-trivial. |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,7 @@ Reviews on this repository can include both a top-level summary body and inline 
 A common failure mode is to query only the review summary (e.g. `gh pr view <n> --json reviews`) and miss inline comments that contain the substantive feedback. Inline comments live on a different endpoint:
 
 ```sh
-gh api repos/<owner>/<repo>/pulls/<n>/comments
+gh api --paginate repos/<owner>/<repo>/pulls/<n>/comments
 ```
 
 Rules:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,179 @@
+# AGENTS.md
+
+Operating manual for automated and AI agents (Codex, Claude Code, dependabot operators, scripted tools) contributing to Specorator. Human contributors should read [`docs/contributing.md`](./docs/contributing.md) instead — that document is authoritative for triage, labels, milestones, and merge policy. This file is the agent-facing surface: short, mechanical, optimised for non-human readers.
+
+If a rule here disagrees with `docs/contributing.md`, the human guide wins; open a PR to reconcile the two rather than acting on the divergence.
+
+---
+
+## 1. Environment
+
+- **Runtime:** Node.js LTS (matches `lts/*` in `.github/workflows/ci.yml`).
+- **Package manager:** `npm` only. Do not invoke `yarn`, `pnpm`, or `bun`.
+- **Working directory:** project root unless a recipe says otherwise.
+- **Git remote:** `origin` is the canonical Specorator repository.
+
+If a tool needs Node version pinning, read `lts/*` from CI rather than hardcoding a number — the CI workflow is the source of truth.
+
+---
+
+## 2. Commands you will use
+
+| Purpose | Command |
+|---|---|
+| Type-check TS + Vue | `npm run typecheck` |
+| Lint | `npm run lint` |
+| Format check | `npm run format:check` |
+| Tests (single pass) | `npm run test` |
+| Plugin build | `npm run build` |
+| Standalone UI build | `npm run build:web` |
+| API docs | `npm run docs:api` |
+| Single test file | `npx vitest run <path>` |
+
+---
+
+## 3. Pre-PR verification gate
+
+Run all of the following before opening or updating a PR. CI re-runs them, but failing locally first wastes a slower cycle.
+
+```sh
+npm run typecheck && npm run lint && npm run test && npm run build && npm run build:web && npm run docs:api
+```
+
+Additional gates depending on what changed:
+
+- **Workflow file changed** (`.github/workflows/*.{yml,yaml}`): run `actionlint` locally and confirm every `uses:` reference is pinned to a 40-character commit SHA. CI enforces both, but the local pass shortens the loop. See [`docs/security/supply-chain.md`](./docs/security/supply-chain.md).
+- **Production dependency added or upgraded** (`package.json` `dependencies`): run `npm audit --audit-level=high --omit=dev`. CI fails on `high`/`critical` advisories in production deps.
+- **Vue/UI changed**: build the standalone UI (`npm run build:web`) and load it in a browser. Type-checks alone do not validate runtime behaviour.
+
+If any gate fails, fix the underlying issue. Do not bypass with `--no-verify`, `--ignore-scripts`, `if: false`, or by deleting the failing step. If the gate itself is wrong, file an issue and propose the fix in a separate PR before merging the work that needs the bypass.
+
+The full recipe lives in [`.codex/pre-pr-gate.md`](./.codex/pre-pr-gate.md).
+
+---
+
+## 4. Branching model
+
+| Branch | Role | Direct pushes |
+|---|---|---|
+| `develop` | Integration branch. All feature branches cut from here and merge back here. | Never (PR-only) |
+| `demo` | Preview branch. GitHub Pages deploys from here. | PR from `develop` only |
+| `main` | Stable release gate. Tagging `main` HEAD triggers the Obsidian release. | PR from `develop` only |
+
+Rules:
+
+- **Cut every branch from `develop`**, never from `main` or `demo`.
+- **Open every PR against `develop`** unless explicitly publishing a preview or cutting a release.
+- **Branch name**: `<type>/<short-kebab>` where `<type>` is one of `feature`, `fix`, `docs`, `chore`, `refactor`. Three to five words; do not embed issue numbers.
+- **Squash-merge only.** No merge commits, no rebase-and-merge, unless explicitly requested by a maintainer.
+- **Delete the branch after merge** (remote and any local worktree). See [`.codex/branch-hygiene.md`](./.codex/branch-hygiene.md).
+
+The full branching reference is [`docs/contributing.md`](./docs/contributing.md) §5.
+
+---
+
+## 5. Spec-first gate (Phase 4 features)
+
+A Phase 4 feature implementation branch may not be opened until the feature has:
+
+1. `specs/{slug}/idea.md` accepted by the PM role.
+2. `specs/{slug}/workflow-state.md` at the correct stage using the ADR-005 schema.
+3. Requirements accepted (or an explicit PM sign-off to proceed from idea directly).
+
+If any of those three are missing, stop and prompt the human maintainer rather than proceeding. See [`CONSTITUTION.md`](./CONSTITUTION.md) §3 and [`decisions/DEC-001-adopt-agentic-workflow-for-repo.md`](./decisions/DEC-001-adopt-agentic-workflow-for-repo.md).
+
+This gate does not apply to chore, docs, refactor, or infrastructure work.
+
+---
+
+## 6. The end-to-end loop
+
+```
+┌──────────────────────────┐
+│ 1. Read the issue        │
+│    accept the scope      │
+└──────────┬───────────────┘
+           ▼
+┌──────────────────────────┐
+│ 2. Cut a worktree off    │
+│    origin/develop        │
+└──────────┬───────────────┘
+           ▼
+┌──────────────────────────┐
+│ 3. Implement the change  │
+│    keep commits focused  │
+└──────────┬───────────────┘
+           ▼
+┌──────────────────────────┐
+│ 4. Run pre-PR gate (§3)  │
+└──────────┬───────────────┘
+           ▼
+┌──────────────────────────┐
+│ 5. Push branch           │
+│    open PR → develop     │
+└──────────┬───────────────┘
+           ▼
+┌──────────────────────────┐
+│ 6. Watch CI + reviews    │
+│    address feedback      │
+└──────────┬───────────────┘
+           ▼
+┌──────────────────────────┐
+│ 7. Squash-merge          │
+│    delete branch         │
+└──────────────────────────┘
+```
+
+Step-by-step recipes:
+
+- Open a PR: [`.codex/open-pr.md`](./.codex/open-pr.md)
+- Run the pre-PR gate: [`.codex/pre-pr-gate.md`](./.codex/pre-pr-gate.md)
+- Address review feedback: [`.codex/address-review.md`](./.codex/address-review.md)
+- Branch hygiene after merge: [`.codex/branch-hygiene.md`](./.codex/branch-hygiene.md)
+
+---
+
+## 7. Handling review feedback
+
+Reviews on this repository can include both a top-level summary body and inline file-line comments. **Both must be inspected before merge.**
+
+A common failure mode is to query only the review summary (e.g. `gh pr view <n> --json reviews`) and miss inline comments that contain the substantive feedback. Inline comments live on a different endpoint:
+
+```sh
+gh api repos/<owner>/<repo>/pulls/<n>/comments
+```
+
+Rules:
+
+- Do not squash-merge while any inline comment is unaddressed.
+- An inline comment is "addressed" only if (a) the underlying issue is fixed in code, (b) it is responded to with a justification that the human maintainer accepts, or (c) the maintainer explicitly waives it.
+- Cross-reference each comment's `commit_id` against the PR's current head SHA. A comment on a stale commit may still apply if the line content survives unchanged.
+- After force-pushes or rebases, GitHub may reposition stale inline comments to the latest commit. Do not interpret that as a re-review — check the `pulls/.../reviews` endpoint for the actual review timestamps.
+
+Full recipe: [`.codex/address-review.md`](./.codex/address-review.md).
+
+---
+
+## 8. What you must not do
+
+- Push directly to `develop`, `demo`, or `main`.
+- Tag a release from any branch other than `main`.
+- Force-push to a shared branch.
+- Skip hooks or signing (`--no-verify`, `--no-gpg-sign`) unless a human explicitly asks for it.
+- Amend or rebase commits that have been pushed to a shared branch.
+- Add a runtime dependency without recording the rationale in the PR description (license, maintenance, why-not-existing).
+- Add a `uses:` line to a workflow without a 40-character commit SHA.
+- Re-export, rename, or leave dead code "for backwards compatibility" inside this repo. Delete it.
+
+---
+
+## 9. Where else to look
+
+| Document | What it covers |
+|---|---|
+| [`CLAUDE.md`](./CLAUDE.md) | Claude-Code-specific repository guide (architecture, paths, conventions). Read first. |
+| [`docs/contributing.md`](./docs/contributing.md) | Human-oriented contribution guide. Authoritative for triage, labels, milestones, merge policy. |
+| [`CONSTITUTION.md`](./CONSTITUTION.md) | Non-negotiable working agreement. |
+| [`docs/security/supply-chain.md`](./docs/security/supply-chain.md) | Supply-chain hardening policy (audit, dep-review, Scorecard, SHA-pinning). |
+| [`docs/local-development.md`](./docs/local-development.md) | Local dev environment setup. |
+| [`decisions/`](./decisions/) | Architectural decision records. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,13 +37,20 @@ If a tool needs Node version pinning, read `lts/*` from CI rather than hardcodin
 Run all of the following before opening or updating a PR. CI re-runs them, but failing locally first wastes a slower cycle.
 
 ```sh
-npm run typecheck && npm run lint && npm run test && npm run build && npm run build:web && npm run docs:api
+npm audit --audit-level=high --omit=dev \
+  && npm run typecheck \
+  && npm run lint \
+  && npm run test \
+  && npm run build \
+  && npm run build:web \
+  && npm run docs:api
 ```
+
+`npm audit` is part of the standard chain because the CI `verify` job runs it unconditionally on every PR. Matching that locally catches advisories that were published since your last install.
 
 Additional gates depending on what changed:
 
 - **Workflow file changed** (`.github/workflows/*.{yml,yaml}`): run `actionlint` locally and confirm every `uses:` reference is pinned to a 40-character commit SHA. CI enforces both, but the local pass shortens the loop. See [`docs/security/supply-chain.md`](./docs/security/supply-chain.md).
-- **Production dependency added or upgraded** (`package.json` `dependencies`): run `npm audit --audit-level=high --omit=dev`. CI fails on `high`/`critical` advisories in production deps.
 - **Vue/UI changed**: build the standalone UI (`npm run build:web`) and load it in a browser. Type-checks alone do not validate runtime behaviour.
 
 If any gate fails, fix the underlying issue. Do not bypass with `--no-verify`, `--ignore-scripts`, `if: false`, or by deleting the failing step. If the gate itself is wrong, file an issue and propose the fix in a separate PR before merging the work that needs the bypass.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -3,12 +3,14 @@ title: "Specorator contribution guide"
 doc_type: process
 status: active
 owner: engineering
-last_updated: 2026-05-02
+last_updated: 2026-05-03
 references:
   - docs/local-development.md
   - docs/roadmap-v1.md
   - docs/process/requirements-intake.md
   - CONSTITUTION.md
+  - AGENTS.md
+  - .codex/
 ---
 
 # Contributing to Specorator
@@ -17,8 +19,9 @@ references:
 
 This guide covers the GitHub workflow for Specorator: how issues are filed and triaged, how labels and milestones are used, how branches are named, and what is expected before a PR is merged.
 
-For local development setup, see [docs/local-development.md](./local-development.md).
-For the non-negotiable working agreement, see [CONSTITUTION.md](../CONSTITUTION.md).
+- For local development setup, see [docs/local-development.md](./local-development.md).
+- For the non-negotiable working agreement, see [CONSTITUTION.md](../CONSTITUTION.md).
+- For automated and AI-agent contributors (Codex, Claude Code, scripted tooling), the operating manual is [`AGENTS.md`](../AGENTS.md) at the repo root, with mechanical step-by-step recipes in [`.codex/`](../.codex/). Humans should still read this guide first.
 
 ---
 
@@ -310,17 +313,35 @@ The required check name (`Install, typecheck, lint, test, and build`) matches th
 
 ## 9. CI and Checks
 
-The CI workflow (`.github/workflows/ci.yml`) runs on pushes to `develop`, `demo`, and `main`, and on pull requests targeting any of those three branches. It does **not** run on raw feature-branch pushes — run the checks locally before opening a PR. Steps:
+The CI workflow (`.github/workflows/ci.yml`) runs on pushes to `develop`, `demo`, and `main`, and on pull requests targeting any of those three branches. It does **not** run on raw feature-branch pushes — run the checks locally before opening a PR.
+
+### `verify` job
 
 1. `npm ci` — install dependencies
-2. `npm run typecheck` — TypeScript strict-mode check
-3. `npm run lint` — ESLint
-4. `npm run test` — Vitest unit tests
-5. `npm run build` — Vite plugin build
-6. `npm run build:web` — standalone UI build
-7. `npm run docs:api` — TypeDoc API docs generation
+2. `npm audit --audit-level=high --omit=dev` — fail on `high`/`critical` advisories in production dependencies
+3. `npm run typecheck` — TypeScript strict-mode check
+4. `npm run lint` — ESLint
+5. `npm run test` — Vitest unit tests
+6. `npm run build` — Vite plugin build
+7. `npm run build:web` — standalone UI build
+8. `npm run docs:api` — TypeDoc API docs generation
 
-All steps must pass for the check to succeed. Dependabot keeps dependencies current; security alerts are configured in `.github/dependabot.yml`.
+### `workflow-lint` job
+
+1. `actionlint` — validates workflow YAML syntax and expression types
+2. SHA-pin check — fails the build if any `uses:` reference in `.github/workflows/*.{yml,yaml}` is not pinned to a 40-character commit SHA
+
+### Pull-request-only jobs
+
+- `Review pull-request dependency changes` (`actions/dependency-review-action`) — fails on `high`+ vulnerabilities or GPL-family licenses introduced by the diff.
+
+### Scheduled jobs
+
+- `OpenSSF Scorecard` runs weekly, on push to `main`, and on branch-protection-rule changes; results publish to the OpenSSF registry and SARIF uploads to code-scanning.
+
+### Supply-chain policy
+
+The full supply-chain hardening policy — thresholds, manual review expectations, and the SHA-pinning rule — lives in [docs/security/supply-chain.md](./security/supply-chain.md). Dependabot keeps dependencies current; auto-merge for patch and dev-minor updates is configured in `.github/workflows/dependabot-auto-merge.yml`.
 
 ---
 
@@ -330,3 +351,6 @@ All steps must pass for the check to succeed. Dependabot keeps dependencies curr
 - [docs/roadmap-v1.md](./roadmap-v1.md) — current phase and priorities
 - [docs/process/requirements-intake.md](./process/requirements-intake.md) — intake workflow for new requirements
 - [docs/traceability.md](./traceability.md) — requirements ID conventions
+- [docs/security/supply-chain.md](./security/supply-chain.md) — supply-chain hardening policy
+- [AGENTS.md](../AGENTS.md) — operating manual for automated and AI-agent contributors
+- [.codex/](../.codex/) — mechanical step-by-step recipes paired with `AGENTS.md`

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -243,15 +243,16 @@ Keep commits focused. A commit that does two unrelated things should be two comm
 Run the full pre-PR verification locally:
 
 ```bash
-npm run lint
+npm audit --audit-level=high --omit=dev
 npm run typecheck
+npm run lint
 npm run test
 npm run build
 npm run build:web
 npm run docs:api
 ```
 
-All checks must pass. See [docs/local-development.md](./local-development.md) for the full verification workflow.
+`npm audit` is included because CI's `verify` job runs it unconditionally on every PR (see §9). All checks must pass. See [docs/local-development.md](./local-development.md) for the full verification workflow and [.codex/pre-pr-gate.md](../.codex/pre-pr-gate.md) for the agent-oriented version of the same chain.
 
 ### PR description
 


### PR DESCRIPTION
## Summary

Closes #118. Documents the contributor workflow for automated and AI-agent contributors and refreshes `docs/contributing.md` to match the CI surface as it stands after #124 and #125.

- **`AGENTS.md`** (new, root) — operating manual: environment, commands, pre-PR gate, branching, spec-first gate, end-to-end loop, review-feedback handling rule, what-not-to-do, and pointers to deeper docs.
- **`.codex/`** (new) — mechanical step-by-step recipes:
  - `README.md` — index
  - `pre-pr-gate.md` — full local verification chain + conditional gates
  - `open-pr.md` — push, `gh pr create`, watch CI, merge
  - `address-review.md` — fetch inline comments separately from review summary, reconcile vs head SHA, address before merge
  - `branch-hygiene.md` — post-merge cleanup, worktree teardown, prune
- **`docs/contributing.md`** — cross-references `AGENTS.md` and `.codex/` near the top; rewrites §9 (CI and Checks) to reflect the post-#124/#125 workflow (`npm audit`, dependency-review, OpenSSF Scorecard, SHA-pin enforcement step, supply-chain policy link); adds related-docs entries.

## Verification

- All cross-references resolve to existing files (`CONSTITUTION.md`, `CLAUDE.md`, `decisions/DEC-001-...`, `docs/security/supply-chain.md`, etc.).
- `docs/` is in `.prettierignore`, so prettier does not touch `docs/contributing.md`. Root-level `AGENTS.md` and `.codex/*.md` are not in `.prettierignore` but the project does not run `format:check` in CI.
- No source changes, no workflow changes.

## Test plan

- [ ] CI passes (verify, workflow-lint, dependency-review)
- [ ] Reviewer spot-checks one recipe end-to-end against the actual repo state
- [ ] Reviewer confirms the §9 CI description matches `.github/workflows/ci.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)