### PR TITLE
Fix CSS leakage from Specorator UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,13 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Specorator — Standalone Dev</title>
-    <style>
-      *, *::before, *::after { box-sizing: border-box; }
-      body { margin: 0; font-family: system-ui, -apple-system, sans-serif; background: #1e1e2e; color: #cdd6f4; }
-    </style>
   </head>
   <body>
-    <div id="app"></div>
+    <div id="app" class="specorator-root"></div>
     <script type="module" src="/src/ui/main.ts"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
 				"globals": "^17.6.0",
 				"jsdom": "^29.1.1",
 				"obsidian": "^1.12.3",
+				"postcss": "^8.5.13",
 				"prettier": "^3.8.3",
 				"typedoc": "^0.28.19",
 				"typescript": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"globals": "^17.6.0",
 		"jsdom": "^29.1.1",
 		"obsidian": "^1.12.3",
+		"postcss": "^8.5.13",
 		"prettier": "^3.8.3",
 		"typedoc": "^0.28.19",
 		"typescript": "^6.0.3",

--- a/src/plugin/SpecoratorView.ts
+++ b/src/plugin/SpecoratorView.ts
@@ -29,6 +29,7 @@ export class SpecoratorView extends ItemView {
     container.empty()
 
     const mountPoint = container.createEl('div', {
+      cls: 'specorator-root',
       attr: { id: 'specorator-root', style: 'height:100%;overflow:auto;' },
     })
 

--- a/src/ui/App.vue
+++ b/src/ui/App.vue
@@ -51,11 +51,16 @@ onUnmounted(() => {
 </template>
 
 <style>
-/* Global reset — safe in both Obsidian and standalone mode. */
-* { box-sizing: border-box; }
+/* Scope shared reset to the plugin mount root so Obsidian host UI is untouched. */
+.specorator-root,
+.specorator-root *,
+.specorator-root *::before,
+.specorator-root *::after {
+  box-sizing: border-box;
+}
 </style>
 
-<!-- Standalone-only styles injected by main.ts via a <style> tag on #app.
+<!-- Standalone-only variables are imported by main.ts and scoped to .specorator-root.
      In Obsidian, the theme provides these variables; we must NOT set them
      on :root or body as that would override the entire Obsidian UI. -->
 

--- a/src/ui/components/common/AppToast.vue
+++ b/src/ui/components/common/AppToast.vue
@@ -5,18 +5,16 @@ const store = useNotificationStore()
 </script>
 
 <template>
-  <Teleport to="body">
-    <div class="sp-toast-container" aria-live="polite" aria-atomic="false">
-      <div
-        v-for="notice in store.notices"
-        :key="notice.id"
-        class="sp-toast"
-        role="status"
-      >
-        {{ notice.message }}
-      </div>
+  <div class="sp-toast-container" aria-live="polite" aria-atomic="false">
+    <div
+      v-for="notice in store.notices"
+      :key="notice.id"
+      class="sp-toast"
+      role="status"
+    >
+      {{ notice.message }}
     </div>
-  </Teleport>
+  </div>
 </template>
 
 <style scoped>

--- a/src/ui/main.ts
+++ b/src/ui/main.ts
@@ -17,10 +17,13 @@ import { MockBridge } from '@/infrastructure/mock/MockBridge'
 import { DEV_FIXTURES } from '@/infrastructure/mock/fixtures'
 
 const bridge = import.meta.env.PROD ? new LocalStorageBridge() : new MockBridge(DEV_FIXTURES)
+const mountPoint = document.querySelector('#app')
+
+mountPoint?.classList.add('specorator-root')
 
 const app = createApp(App)
 app.use(createPinia())
 app.use(router)
 app.use(i18n)
 app.provide(BRIDGE_KEY, bridge)
-app.mount('#app')
+app.mount(mountPoint ?? '#app')

--- a/src/ui/standalone.css
+++ b/src/ui/standalone.css
@@ -3,7 +3,7 @@
  * These variables are provided by the Obsidian theme at runtime;
  * scoping them here prevents them from overriding the real Obsidian UI.
  */
-#app {
+.specorator-root {
 	--background-primary: #1e1e2e;
 	--background-secondary: #181825;
 	--background-modifier-border: #313244;

--- a/src/ui/standalone.css
+++ b/src/ui/standalone.css
@@ -14,6 +14,8 @@
 	--text-on-accent: #1e1e2e;
 	--interactive-accent: #cba6f7;
 
+	position: fixed;
+	inset: 0;
 	height: 100vh;
 	overflow: hidden;
 	font-family: system-ui, -apple-system, sans-serif;

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 
-.sp-badge[data-v-a85a8ac3] {
+.specorator-root :where(.sp-badge[data-v-a85a8ac3]) {
   display: inline-block;
   padding: 0.1rem 0.5rem;
   border-radius: 9999px;
@@ -8,16 +8,16 @@
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
-.sp-badge--draft[data-v-a85a8ac3]    { background: var(--background-modifier-border); color: var(--text-muted);
+.specorator-root :where(.sp-badge--draft[data-v-a85a8ac3])    { background: var(--background-modifier-border); color: var(--text-muted);
 }
-.sp-badge--active[data-v-a85a8ac3]   { background: #1a4731; color: #4ade80;
+.specorator-root :where(.sp-badge--active[data-v-a85a8ac3])   { background: #1a4731; color: #4ade80;
 }
-.sp-badge--archived[data-v-a85a8ac3] { background: #1e2a3a; color: #60a5fa;
+.specorator-root :where(.sp-badge--archived[data-v-a85a8ac3]) { background: #1e2a3a; color: #60a5fa;
 }
-.sp-badge--abandoned[data-v-a85a8ac3] { background: #2a1a1a; color: #f87171;
+.specorator-root :where(.sp-badge--abandoned[data-v-a85a8ac3]) { background: #2a1a1a; color: #f87171;
 }
 
-.sp-btn[data-v-09ae60a2] {
+.specorator-root :where(.sp-btn[data-v-09ae60a2]) {
   display: inline-flex;
   align-items: center;
   gap: 0.375rem;
@@ -29,39 +29,39 @@
   transition: background 0.15s, opacity 0.15s;
   white-space: nowrap;
 }
-.sp-btn[data-v-09ae60a2]:disabled { opacity: 0.5; cursor: not-allowed;
+.specorator-root :where(.sp-btn[data-v-09ae60a2]:disabled) { opacity: 0.5; cursor: not-allowed;
 }
-.sp-btn--sm[data-v-09ae60a2] { padding: 0.25rem 0.625rem; font-size: 0.8rem;
+.specorator-root :where(.sp-btn--sm[data-v-09ae60a2]) { padding: 0.25rem 0.625rem; font-size: 0.8rem;
 }
-.sp-btn--md[data-v-09ae60a2] { padding: 0.4rem 0.875rem;
+.specorator-root :where(.sp-btn--md[data-v-09ae60a2]) { padding: 0.4rem 0.875rem;
 }
-.sp-btn--primary[data-v-09ae60a2] {
+.specorator-root :where(.sp-btn--primary[data-v-09ae60a2]) {
   background: var(--interactive-accent);
   color: var(--text-on-accent);
   border-color: var(--interactive-accent);
 }
-.sp-btn--primary[data-v-09ae60a2]:hover:not(:disabled) { opacity: 0.88;
+.specorator-root :where(.sp-btn--primary[data-v-09ae60a2]:hover:not(:disabled)) { opacity: 0.88;
 }
-.sp-btn--secondary[data-v-09ae60a2] {
+.specorator-root :where(.sp-btn--secondary[data-v-09ae60a2]) {
   background: var(--background-modifier-border);
   color: var(--text-normal);
 }
-.sp-btn--secondary[data-v-09ae60a2]:hover:not(:disabled) { background: var(--background-modifier-hover);
+.specorator-root :where(.sp-btn--secondary[data-v-09ae60a2]:hover:not(:disabled)) { background: var(--background-modifier-hover);
 }
-.sp-btn--ghost[data-v-09ae60a2] {
+.specorator-root :where(.sp-btn--ghost[data-v-09ae60a2]) {
   background: transparent;
   color: var(--text-muted);
 }
-.sp-btn--ghost[data-v-09ae60a2]:hover:not(:disabled) { background: var(--background-modifier-hover); color: var(--text-normal);
+.specorator-root :where(.sp-btn--ghost[data-v-09ae60a2]:hover:not(:disabled)) { background: var(--background-modifier-hover); color: var(--text-normal);
 }
-.sp-btn--danger[data-v-09ae60a2] {
+.specorator-root :where(.sp-btn--danger[data-v-09ae60a2]) {
   background: transparent;
   color: var(--text-error);
   border-color: var(--text-error);
 }
-.sp-btn--danger[data-v-09ae60a2]:hover:not(:disabled) { background: var(--text-error); color: #fff;
+.specorator-root :where(.sp-btn--danger[data-v-09ae60a2]:hover:not(:disabled)) { background: var(--text-error); color: #fff;
 }
-.sp-btn__spinner[data-v-09ae60a2] {
+.specorator-root :where(.sp-btn__spinner[data-v-09ae60a2]) {
   width: 0.875rem;
   height: 0.875rem;
   border: 2px solid currentColor;
@@ -74,7 +74,7 @@ to { transform: rotate(360deg);
 }
 }
 
-.sp-feature-card[data-v-a707630d] {
+.specorator-root :where(.sp-feature-card[data-v-abdcd6a9]) {
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
   border-radius: 8px;
@@ -83,13 +83,13 @@ to { transform: rotate(360deg);
   flex-direction: column;
   gap: 0.625rem;
 }
-.sp-feature-card__header[data-v-a707630d] {
+.specorator-root :where(.sp-feature-card__header[data-v-abdcd6a9]) {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
 }
-.sp-feature-card__title[data-v-a707630d] {
+.specorator-root :where(.sp-feature-card__title[data-v-abdcd6a9]) {
   margin: 0;
   font-size: 0.9375rem;
   font-weight: 600;
@@ -100,34 +100,34 @@ to { transform: rotate(360deg);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.sp-feature-card__progress[data-v-a707630d] {
+.specorator-root :where(.sp-feature-card__progress[data-v-abdcd6a9]) {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
 }
-.sp-progress-bar[data-v-a707630d] {
+.specorator-root :where(.sp-progress-bar[data-v-abdcd6a9]) {
   height: 4px;
   background: var(--background-modifier-border);
   border-radius: 9999px;
   overflow: hidden;
 }
-.sp-progress-bar__fill[data-v-a707630d] {
+.specorator-root :where(.sp-progress-bar__fill[data-v-abdcd6a9]) {
   height: 100%;
   background: var(--interactive-accent);
   border-radius: 9999px;
   transition: width 0.3s ease;
 }
-.sp-feature-card__step-label[data-v-a707630d] {
+.specorator-root :where(.sp-feature-card__step-label[data-v-abdcd6a9]) {
   font-size: 0.75rem;
   color: var(--text-muted);
 }
-.sp-feature-card__actions[data-v-a707630d] {
+.specorator-root :where(.sp-feature-card__actions[data-v-abdcd6a9]) {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
 }
 
-.sp-create-form[data-v-0313fa2c] {
+.specorator-root :where(.sp-create-form[data-v-b07dc06e]) {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -136,14 +136,14 @@ to { transform: rotate(360deg);
   border: 1px solid var(--interactive-accent);
   border-radius: 8px;
 }
-.sp-create-form__label[data-v-0313fa2c] {
+.specorator-root :where(.sp-create-form__label[data-v-b07dc06e]) {
   font-size: 0.8125rem;
   font-weight: 600;
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
-.sp-create-form__input[data-v-0313fa2c] {
+.specorator-root :where(.sp-create-form__input[data-v-b07dc06e]) {
   background: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
   border-radius: 6px;
@@ -153,117 +153,117 @@ to { transform: rotate(360deg);
   outline: none;
   width: 100%;
 }
-.sp-create-form__input[data-v-0313fa2c]:focus {
+.specorator-root :where(.sp-create-form__input[data-v-b07dc06e]:focus) {
   border-color: var(--interactive-accent);
 }
-.sp-create-form__actions[data-v-0313fa2c] {
+.specorator-root :where(.sp-create-form__actions[data-v-b07dc06e]) {
   display: flex;
   gap: 0.5rem;
   margin-top: 0.25rem;
 }
 
-.sp-home[data-v-75727a3a] {
+.specorator-root :where(.sp-home[data-v-89ffe986]) {
   padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
 }
-.sp-home__header[data-v-75727a3a] { display: flex; align-items: flex-start; justify-content: space-between;
+.specorator-root :where(.sp-home__header[data-v-89ffe986]) { display: flex; align-items: flex-start; justify-content: space-between;
 }
-.sp-home__title[data-v-75727a3a] { margin: 0; font-size: 1.25rem; font-weight: 700; color: var(--text-normal);
+.specorator-root :where(.sp-home__title[data-v-89ffe986]) { margin: 0; font-size: 1.25rem; font-weight: 700; color: var(--text-normal);
 }
-.sp-home__subtitle[data-v-75727a3a] { margin: 0.25rem 0 0; font-size: 0.875rem; color: var(--text-muted);
+.specorator-root :where(.sp-home__subtitle[data-v-89ffe986]) { margin: 0.25rem 0 0; font-size: 0.875rem; color: var(--text-muted);
 }
-.sp-home__section[data-v-75727a3a] { display: flex; flex-direction: column; gap: 0.75rem;
+.specorator-root :where(.sp-home__section[data-v-89ffe986]) { display: flex; flex-direction: column; gap: 0.75rem;
 }
-.sp-home__section-header[data-v-75727a3a] { display: flex; align-items: center; justify-content: space-between;
+.specorator-root :where(.sp-home__section-header[data-v-89ffe986]) { display: flex; align-items: center; justify-content: space-between;
 }
-.sp-home__section-title[data-v-75727a3a] { margin: 0; font-size: 0.875rem; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em;
+.specorator-root :where(.sp-home__section-title[data-v-89ffe986]) { margin: 0; font-size: 0.875rem; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em;
 }
-.sp-home__cards[data-v-75727a3a] { display: flex; flex-direction: column; gap: 0.625rem;
+.specorator-root :where(.sp-home__cards[data-v-89ffe986]) { display: flex; flex-direction: column; gap: 0.625rem;
 }
-.sp-home__meta[data-v-75727a3a] { color: var(--text-muted); font-size: 0.875rem; margin: 0;
+.specorator-root :where(.sp-home__meta[data-v-89ffe986]) { color: var(--text-muted); font-size: 0.875rem; margin: 0;
 }
-.sp-home__error[data-v-75727a3a] { color: var(--text-error); font-size: 0.875rem; margin: 0;
+.specorator-root :where(.sp-home__error[data-v-89ffe986]) { color: var(--text-error); font-size: 0.875rem; margin: 0;
 }
-.sp-home__nav[data-v-75727a3a] { display: flex; gap: 0.5rem;
+.specorator-root :where(.sp-home__nav[data-v-89ffe986]) { display: flex; gap: 0.5rem;
 }
 
-.sp-features[data-v-5c986872] {
+.specorator-root :where(.sp-features[data-v-109961bb]) {
   padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
-.sp-features__header[data-v-5c986872] {
+.specorator-root :where(.sp-features__header[data-v-109961bb]) {
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
-.sp-features__title[data-v-5c986872] {
+.specorator-root :where(.sp-features__title[data-v-109961bb]) {
   margin: 0;
   font-size: 1.1rem;
   font-weight: 700;
   color: var(--text-normal);
 }
-.sp-features__list[data-v-5c986872] {
+.specorator-root :where(.sp-features__list[data-v-109961bb]) {
   display: flex;
   flex-direction: column;
   gap: 0.625rem;
 }
-.sp-features__meta[data-v-5c986872],
-.sp-features__empty[data-v-5c986872] {
+.specorator-root :where(.sp-features__meta[data-v-109961bb]),
+.specorator-root :where(.sp-features__empty[data-v-109961bb]) {
   color: var(--text-muted);
   font-size: 0.875rem;
   margin: 0;
   line-height: 1.6;
 }
-.sp-features__empty-hint[data-v-5c986872] {
+.specorator-root :where(.sp-features__empty-hint[data-v-109961bb]) {
   font-size: 0.8125rem;
   opacity: 0.7;
 }
-.sp-features__error[data-v-5c986872] {
+.specorator-root :where(.sp-features__error[data-v-109961bb]) {
   color: var(--text-error);
   font-size: 0.875rem;
   margin: 0;
 }
 
-.sp-settings[data-v-b10aa702] {
+.specorator-root :where(.sp-settings[data-v-b10aa702]) {
   padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
 }
-.sp-settings__title[data-v-b10aa702] {
+.specorator-root :where(.sp-settings__title[data-v-b10aa702]) {
   margin: 0;
   font-size: 1.1rem;
   font-weight: 700;
   color: var(--text-normal);
 }
-.sp-settings__fields[data-v-b10aa702] {
+.specorator-root :where(.sp-settings__fields[data-v-b10aa702]) {
   display: flex;
   flex-direction: column;
   gap: 0.875rem;
 }
-.sp-settings__field[data-v-b10aa702] {
+.specorator-root :where(.sp-settings__field[data-v-b10aa702]) {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
 }
-.sp-settings__field--inline[data-v-b10aa702] {
+.specorator-root :where(.sp-settings__field--inline[data-v-b10aa702]) {
   flex-direction: row;
   align-items: center;
   gap: 0.5rem;
 }
-.sp-settings__label[data-v-b10aa702] {
+.specorator-root :where(.sp-settings__label[data-v-b10aa702]) {
   font-size: 0.8125rem;
   font-weight: 600;
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
-.sp-settings__input[data-v-b10aa702],
-.sp-settings__select[data-v-b10aa702] {
+.specorator-root :where(.sp-settings__input[data-v-b10aa702]),
+.specorator-root :where(.sp-settings__select[data-v-b10aa702]) {
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
   border-radius: 6px;
@@ -272,33 +272,33 @@ to { transform: rotate(360deg);
   padding: 0.375rem 0.625rem;
   outline: none;
 }
-.sp-settings__input[data-v-b10aa702]:focus,
-.sp-settings__select[data-v-b10aa702]:focus {
+.specorator-root :where(.sp-settings__input[data-v-b10aa702]:focus),
+.specorator-root :where(.sp-settings__select[data-v-b10aa702]:focus) {
   border-color: var(--interactive-accent);
 }
-.sp-settings__footer[data-v-b10aa702] {
+.specorator-root :where(.sp-settings__footer[data-v-b10aa702]) {
   display: flex;
   align-items: center;
   gap: 0.75rem;
 }
-.sp-settings__saved[data-v-b10aa702] {
+.specorator-root :where(.sp-settings__saved[data-v-b10aa702]) {
   font-size: 0.875rem;
   color: #4ade80;
 }
 
-.sp-file-view[data-v-51498423] {
+.specorator-root :where(.sp-file-view[data-v-95874630]) {
   padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 1rem;
   height: 100%;
 }
-.sp-file-view__header[data-v-51498423] {
+.specorator-root :where(.sp-file-view__header[data-v-95874630]) {
   display: flex;
   align-items: center;
   gap: 0.75rem;
 }
-.sp-file-view__path[data-v-51498423] {
+.specorator-root :where(.sp-file-view__path[data-v-95874630]) {
   flex: 1;
   margin: 0;
   font-size: 0.875rem;
@@ -308,11 +308,11 @@ to { transform: rotate(360deg);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.sp-file-view__not-found[data-v-51498423] {
+.specorator-root :where(.sp-file-view__not-found[data-v-95874630]) {
   color: var(--text-muted);
   font-size: 0.875rem;
 }
-.sp-file-view__content[data-v-51498423] {
+.specorator-root :where(.sp-file-view__content[data-v-95874630]) {
   flex: 1;
   margin: 0;
   padding: 1rem;
@@ -327,13 +327,13 @@ to { transform: rotate(360deg);
   word-break: break-all;
   color: var(--text-normal);
 }
-.sp-file-view__loading[data-v-51498423] {
+.specorator-root :where(.sp-file-view__loading[data-v-95874630]) {
   color: var(--text-muted);
   font-size: 0.875rem;
   margin: 0;
 }
 
-.sp-toast-container[data-v-ef1ee9c4] {
+.specorator-root :where(.sp-toast-container[data-v-6b8812bc]) {
   position: fixed;
   bottom: 1.5rem;
   right: 1.5rem;
@@ -343,7 +343,7 @@ to { transform: rotate(360deg);
   z-index: 9999;
   pointer-events: none;
 }
-.sp-toast[data-v-ef1ee9c4] {
+.specorator-root :where(.sp-toast[data-v-6b8812bc]) {
   background: var(--background-secondary);
   color: var(--text-normal);
   border: 1px solid var(--background-modifier-border);
@@ -353,26 +353,30 @@ to { transform: rotate(360deg);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
   max-width: 20rem;
   word-break: break-word;
-  animation: sp-toast-in-ef1ee9c4 0.2s ease-out;
+  animation: sp-toast-in-6b8812bc 0.2s ease-out;
 }
-@keyframes sp-toast-in-ef1ee9c4 {
+@keyframes sp-toast-in-6b8812bc {
 from { opacity: 0; transform: translateY(0.5rem);
 }
 to   { opacity: 1; transform: translateY(0);
 }
 }
 
-/* Global reset — safe in both Obsidian and standalone mode. */
-* { box-sizing: border-box;
+/* Scope shared reset to the plugin mount root so Obsidian host UI is untouched. */
+.specorator-root,
+.specorator-root *,
+.specorator-root *::before,
+.specorator-root *::after {
+  box-sizing: border-box;
 }
 
-.sp-app[data-v-48f1a503] {
+.specorator-root :where(.sp-app[data-v-884c0b35]) {
   display: flex;
   flex-direction: column;
   height: 100vh;
   overflow: hidden;
 }
-.sp-nav[data-v-48f1a503] {
+.specorator-root :where(.sp-nav[data-v-884c0b35]) {
   display: flex;
   gap: 0;
   border-bottom: 1px solid var(--background-modifier-border);
@@ -380,7 +384,7 @@ to   { opacity: 1; transform: translateY(0);
   padding: 0 0.5rem;
   flex-shrink: 0;
 }
-.sp-nav__link[data-v-48f1a503] {
+.specorator-root :where(.sp-nav__link[data-v-884c0b35]) {
   padding: 0.5rem 0.875rem;
   font-size: 0.8125rem;
   font-weight: 500;
@@ -389,14 +393,15 @@ to   { opacity: 1; transform: translateY(0);
   border-bottom: 2px solid transparent;
   transition: color 0.15s, border-color 0.15s;
 }
-.sp-nav__link[data-v-48f1a503]:hover {
+.specorator-root :where(.sp-nav__link[data-v-884c0b35]:hover) {
   color: var(--text-normal);
 }
-.sp-nav__link--active[data-v-48f1a503] {
+.specorator-root :where(.sp-nav__link--active[data-v-884c0b35]) {
   color: var(--text-normal);
   border-bottom-color: var(--interactive-accent);
 }
-.sp-main[data-v-48f1a503] {
+.specorator-root :where(.sp-main[data-v-884c0b35]) {
   flex: 1;
   overflow-y: auto;
 }
+/*$vite$:1*/

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,9 @@
 import { builtinModules } from 'module';
 import { resolve } from 'path';
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin as VitePlugin } from 'vite';
 import vue from '@vitejs/plugin-vue';
+import { parse } from 'postcss';
+import type { AtRule, Rule } from 'postcss';
 
 const OBSIDIAN_EXTERNALS = [
 	'obsidian',
@@ -25,12 +27,54 @@ const ALL_EXTERNALS = [
 	...builtinModules.map((m) => `node:${m}`),
 ];
 
+function scopeSelector(selector: string): string {
+	const trimmedSelector = selector.trim();
+
+	if (trimmedSelector.startsWith('.specorator-root')) {
+		return trimmedSelector;
+	}
+
+	return `.specorator-root :where(${trimmedSelector})`;
+}
+
+function parentAtRule(rule: Rule): AtRule | undefined {
+	return rule.parent?.type === 'atrule' ? (rule.parent as AtRule) : undefined;
+}
+
+function scopeBuiltCss(): VitePlugin {
+	return {
+		name: 'specorator-scope-css',
+		enforce: 'post',
+		generateBundle(_, bundle) {
+			for (const asset of Object.values(bundle)) {
+				if (asset.type !== 'asset' || !asset.fileName.endsWith('.css')) {
+					continue;
+				}
+
+				const root = parse(String(asset.source));
+
+				root.walkRules((rule) => {
+					const atRule = parentAtRule(rule);
+
+					if (atRule?.name.endsWith('keyframes')) {
+						return;
+					}
+
+					rule.selectors = rule.selectors.map(scopeSelector);
+				});
+
+				asset.source = root.toString();
+			}
+		},
+	};
+}
+
 export default defineConfig(({ mode }) => {
 	const alias = { '@': resolve(__dirname, 'src') };
 
 	if (mode === 'plugin') {
 		return {
-			plugins: [vue()],
+			plugins: [vue(), scopeBuiltCss()],
 			resolve: { alias },
 			build: {
 				lib: {
@@ -57,7 +101,7 @@ export default defineConfig(({ mode }) => {
 
 	// Standalone dev / browser build
 	return {
-		plugins: [vue()],
+		plugins: [vue(), scopeBuiltCss()],
 		resolve: { alias },
 		build: {
 			outDir: 'dist-standalone',


### PR DESCRIPTION
## Summary
- Add a stable `.specorator-root` class to the Obsidian and standalone mount roots.
- Scope the shared reset and standalone variables to the plugin root.
- Keep toast UI inside the plugin tree instead of teleporting to `body`.
- Add a Vite bundle CSS scoping step so emitted app CSS selectors are rooted in `.specorator-root`.

Closes #116.

## Verification
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`
- `npm run build:web`
- `git diff --check`
- Custom PostCSS assertion: all non-keyframe selectors in `styles.css` start with `.specorator-root`