### PR TITLE
fix: resolve open bugs #111 and #114 (MockBridge.openFile no-op, failed create clears form)

### DIFF
--- a/src/infrastructure/mock/MockBridge.ts
+++ b/src/infrastructure/mock/MockBridge.ts
@@ -10,6 +10,7 @@ export class MockBridge implements IBridge {
   private readonly folders = new Set<string>()
   private settings: PluginSettings = { ...DEFAULT_SETTINGS }
   private readonly noticeLog: Array<{ message: string; durationMs: number }> = []
+  private openedFile: string | null = null
 
   constructor(initialFiles: Record<string, string> = {}) {
     for (const [path, content] of Object.entries(initialFiles)) {
@@ -64,8 +65,8 @@ export class MockBridge implements IBridge {
     this.folders.add(path)
   }
 
-  async openFile(_path: string): Promise<void> {
-    // No-op in standalone mode
+  async openFile(path: string): Promise<void> {
+    this.openedFile = path
   }
 
   showNotice(message: string, durationMs = 4000): void {
@@ -85,6 +86,10 @@ export class MockBridge implements IBridge {
 
   getNotices(): Array<{ message: string; durationMs: number }> {
     return [...this.noticeLog]
+  }
+
+  getOpenedFile(): string | null {
+    return this.openedFile
   }
 
   getAllFiles(): Record<string, string> {

--- a/src/infrastructure/mock/__tests__/MockBridge.spec.ts
+++ b/src/infrastructure/mock/__tests__/MockBridge.spec.ts
@@ -32,4 +32,11 @@ describe('MockBridge', () => {
     bridge.showNotice('Hello world')
     expect(bridge.getNotices()[0].message).toBe('Hello world')
   })
+
+  it('tracks the last opened file', async () => {
+    const bridge = new MockBridge()
+    expect(bridge.getOpenedFile()).toBeNull()
+    await bridge.openFile('specs/my-feature/workflow-state.md')
+    expect(bridge.getOpenedFile()).toBe('specs/my-feature/workflow-state.md')
+  })
 })

--- a/src/ui/components/feature/CreateFeatureForm.vue
+++ b/src/ui/components/feature/CreateFeatureForm.vue
@@ -3,8 +3,11 @@ import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import AppButton from '../common/AppButton.vue'
 
+const props = defineProps<{
+  submitHandler: (payload: { title: string; area?: string }) => Promise<boolean>
+}>()
+
 const emit = defineEmits<{
-  submit: [payload: { title: string; area?: string }]
   cancel: []
 }>()
 
@@ -19,9 +22,11 @@ async function handleSubmit() {
   const trimmedArea = area.value.trim()
   submitting.value = true
   try {
-    emit('submit', { title: trimmedTitle, area: trimmedArea || undefined })
-    title.value = ''
-    area.value = ''
+    const succeeded = await props.submitHandler({ title: trimmedTitle, area: trimmedArea || undefined })
+    if (succeeded) {
+      title.value = ''
+      area.value = ''
+    }
   } finally {
     submitting.value = false
   }

--- a/src/ui/components/feature/CreateFeatureForm.vue
+++ b/src/ui/components/feature/CreateFeatureForm.vue
@@ -17,6 +17,7 @@ const area = ref('')
 const submitting = ref(false)
 
 async function handleSubmit() {
+  if (submitting.value) return
   const trimmedTitle = title.value.trim()
   if (!trimmedTitle) return
   const trimmedArea = area.value.trim()

--- a/src/ui/components/feature/__tests__/CreateFeatureForm.spec.ts
+++ b/src/ui/components/feature/__tests__/CreateFeatureForm.spec.ts
@@ -34,6 +34,22 @@ describe('CreateFeatureForm', () => {
     expect((wrapper.find('#feature-title').element as HTMLInputElement).value).toBe('My Feature')
   })
 
+  it('ignores re-entrant submits while a submit is in flight', async () => {
+    let resolve!: (v: boolean) => void
+    const handler = vi.fn(() => new Promise<boolean>((r) => { resolve = r }))
+    const wrapper = mountForm(handler)
+
+    await wrapper.find('#feature-title').setValue('My Feature')
+    // First submit — handler is now in flight
+    await wrapper.find('form').trigger('submit')
+    // Second submit while first is still pending
+    await wrapper.find('form').trigger('submit')
+    resolve(true)
+    await flushPromises()
+
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
   it('emits cancel when the cancel button is clicked', async () => {
     const wrapper = mountForm(vi.fn())
 

--- a/src/ui/components/feature/__tests__/CreateFeatureForm.spec.ts
+++ b/src/ui/components/feature/__tests__/CreateFeatureForm.spec.ts
@@ -1,0 +1,46 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { i18n } from '@/ui/i18n'
+import CreateFeatureForm from '../CreateFeatureForm.vue'
+
+function mountForm(submitHandler: (payload: { title: string; area?: string }) => Promise<boolean>) {
+  return mount(CreateFeatureForm, {
+    props: { submitHandler },
+    global: { plugins: [i18n] },
+  })
+}
+
+describe('CreateFeatureForm', () => {
+  it('clears inputs after a successful submit', async () => {
+    const handler = vi.fn().mockResolvedValue(true)
+    const wrapper = mountForm(handler)
+
+    await wrapper.find('#feature-title').setValue('My Feature')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(handler).toHaveBeenCalledWith({ title: 'My Feature', area: undefined })
+    expect((wrapper.find('#feature-title').element as HTMLInputElement).value).toBe('')
+  })
+
+  it('retains inputs after a failed submit', async () => {
+    const handler = vi.fn().mockResolvedValue(false)
+    const wrapper = mountForm(handler)
+
+    await wrapper.find('#feature-title').setValue('My Feature')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect((wrapper.find('#feature-title').element as HTMLInputElement).value).toBe('My Feature')
+  })
+
+  it('emits cancel when the cancel button is clicked', async () => {
+    const wrapper = mountForm(vi.fn())
+
+    const buttons = wrapper.findAll('button')
+    const cancelButton = buttons.find((b) => b.attributes('type') === 'button')
+    await cancelButton!.trigger('click')
+
+    expect(wrapper.emitted('cancel')).toBeTruthy()
+  })
+})

--- a/src/ui/views/FeaturesView.vue
+++ b/src/ui/views/FeaturesView.vue
@@ -15,9 +15,13 @@ const showCreateForm = ref(false)
 
 onMounted(loadFeatures)
 
-async function handleCreate(payload: { title: string; area?: string }) {
-  await createFeature(payload.title, payload.area)
-  showCreateForm.value = false
+async function handleCreate(payload: { title: string; area?: string }): Promise<boolean> {
+  const result = await createFeature(payload.title, payload.area)
+  if (result) {
+    showCreateForm.value = false
+    return true
+  }
+  return false
 }
 
 async function handleOpen(featureId: string) {
@@ -39,7 +43,7 @@ async function handleOpen(featureId: string) {
 
     <CreateFeatureForm
       v-if="showCreateForm"
-      @submit="handleCreate"
+      :submit-handler="handleCreate"
       @cancel="showCreateForm = false"
     />
 

--- a/src/ui/views/HomeView.vue
+++ b/src/ui/views/HomeView.vue
@@ -16,9 +16,13 @@ const showCreateForm = ref(false)
 
 onMounted(loadFeatures)
 
-async function handleCreate(payload: { title: string; area?: string }) {
-  await createFeature(payload.title, payload.area)
-  showCreateForm.value = false
+async function handleCreate(payload: { title: string; area?: string }): Promise<boolean> {
+  const result = await createFeature(payload.title, payload.area)
+  if (result) {
+    showCreateForm.value = false
+    return true
+  }
+  return false
 }
 
 async function handleOpen(featureId: string) {
@@ -48,7 +52,7 @@ async function handleOpen(featureId: string) {
 
       <CreateFeatureForm
         v-if="showCreateForm"
-        @submit="handleCreate"
+        :submit-handler="handleCreate"
         @cancel="showCreateForm = false"
       />
 

--- a/styles.css
+++ b/styles.css
@@ -127,7 +127,7 @@ to { transform: rotate(360deg);
   flex-wrap: wrap;
 }
 
-.specorator-root :where(.sp-create-form[data-v-b07dc06e]) {
+.specorator-root :where(.sp-create-form[data-v-dda9ef54]) {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -136,14 +136,14 @@ to { transform: rotate(360deg);
   border: 1px solid var(--interactive-accent);
   border-radius: 8px;
 }
-.specorator-root :where(.sp-create-form__label[data-v-b07dc06e]) {
+.specorator-root :where(.sp-create-form__label[data-v-dda9ef54]) {
   font-size: 0.8125rem;
   font-weight: 600;
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
-.specorator-root :where(.sp-create-form__input[data-v-b07dc06e]) {
+.specorator-root :where(.sp-create-form__input[data-v-dda9ef54]) {
   background: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
   border-radius: 6px;
@@ -153,76 +153,76 @@ to { transform: rotate(360deg);
   outline: none;
   width: 100%;
 }
-.specorator-root :where(.sp-create-form__input[data-v-b07dc06e]:focus) {
+.specorator-root :where(.sp-create-form__input[data-v-dda9ef54]:focus) {
   border-color: var(--interactive-accent);
 }
-.specorator-root :where(.sp-create-form__actions[data-v-b07dc06e]) {
+.specorator-root :where(.sp-create-form__actions[data-v-dda9ef54]) {
   display: flex;
   gap: 0.5rem;
   margin-top: 0.25rem;
 }
 
-.specorator-root :where(.sp-home[data-v-89ffe986]) {
+.specorator-root :where(.sp-home[data-v-39731351]) {
   padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
 }
-.specorator-root :where(.sp-home__header[data-v-89ffe986]) { display: flex; align-items: flex-start; justify-content: space-between;
+.specorator-root :where(.sp-home__header[data-v-39731351]) { display: flex; align-items: flex-start; justify-content: space-between;
 }
-.specorator-root :where(.sp-home__title[data-v-89ffe986]) { margin: 0; font-size: 1.25rem; font-weight: 700; color: var(--text-normal);
+.specorator-root :where(.sp-home__title[data-v-39731351]) { margin: 0; font-size: 1.25rem; font-weight: 700; color: var(--text-normal);
 }
-.specorator-root :where(.sp-home__subtitle[data-v-89ffe986]) { margin: 0.25rem 0 0; font-size: 0.875rem; color: var(--text-muted);
+.specorator-root :where(.sp-home__subtitle[data-v-39731351]) { margin: 0.25rem 0 0; font-size: 0.875rem; color: var(--text-muted);
 }
-.specorator-root :where(.sp-home__section[data-v-89ffe986]) { display: flex; flex-direction: column; gap: 0.75rem;
+.specorator-root :where(.sp-home__section[data-v-39731351]) { display: flex; flex-direction: column; gap: 0.75rem;
 }
-.specorator-root :where(.sp-home__section-header[data-v-89ffe986]) { display: flex; align-items: center; justify-content: space-between;
+.specorator-root :where(.sp-home__section-header[data-v-39731351]) { display: flex; align-items: center; justify-content: space-between;
 }
-.specorator-root :where(.sp-home__section-title[data-v-89ffe986]) { margin: 0; font-size: 0.875rem; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em;
+.specorator-root :where(.sp-home__section-title[data-v-39731351]) { margin: 0; font-size: 0.875rem; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em;
 }
-.specorator-root :where(.sp-home__cards[data-v-89ffe986]) { display: flex; flex-direction: column; gap: 0.625rem;
+.specorator-root :where(.sp-home__cards[data-v-39731351]) { display: flex; flex-direction: column; gap: 0.625rem;
 }
-.specorator-root :where(.sp-home__meta[data-v-89ffe986]) { color: var(--text-muted); font-size: 0.875rem; margin: 0;
+.specorator-root :where(.sp-home__meta[data-v-39731351]) { color: var(--text-muted); font-size: 0.875rem; margin: 0;
 }
-.specorator-root :where(.sp-home__error[data-v-89ffe986]) { color: var(--text-error); font-size: 0.875rem; margin: 0;
+.specorator-root :where(.sp-home__error[data-v-39731351]) { color: var(--text-error); font-size: 0.875rem; margin: 0;
 }
-.specorator-root :where(.sp-home__nav[data-v-89ffe986]) { display: flex; gap: 0.5rem;
+.specorator-root :where(.sp-home__nav[data-v-39731351]) { display: flex; gap: 0.5rem;
 }
 
-.specorator-root :where(.sp-features[data-v-109961bb]) {
+.specorator-root :where(.sp-features[data-v-caff02d4]) {
   padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
-.specorator-root :where(.sp-features__header[data-v-109961bb]) {
+.specorator-root :where(.sp-features__header[data-v-caff02d4]) {
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
-.specorator-root :where(.sp-features__title[data-v-109961bb]) {
+.specorator-root :where(.sp-features__title[data-v-caff02d4]) {
   margin: 0;
   font-size: 1.1rem;
   font-weight: 700;
   color: var(--text-normal);
 }
-.specorator-root :where(.sp-features__list[data-v-109961bb]) {
+.specorator-root :where(.sp-features__list[data-v-caff02d4]) {
   display: flex;
   flex-direction: column;
   gap: 0.625rem;
 }
-.specorator-root :where(.sp-features__meta[data-v-109961bb]),
-.specorator-root :where(.sp-features__empty[data-v-109961bb]) {
+.specorator-root :where(.sp-features__meta[data-v-caff02d4]),
+.specorator-root :where(.sp-features__empty[data-v-caff02d4]) {
   color: var(--text-muted);
   font-size: 0.875rem;
   margin: 0;
   line-height: 1.6;
 }
-.specorator-root :where(.sp-features__empty-hint[data-v-109961bb]) {
+.specorator-root :where(.sp-features__empty-hint[data-v-caff02d4]) {
   font-size: 0.8125rem;
   opacity: 0.7;
 }
-.specorator-root :where(.sp-features__error[data-v-109961bb]) {
+.specorator-root :where(.sp-features__error[data-v-caff02d4]) {
   color: var(--text-error);
   font-size: 0.875rem;
   margin: 0;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **#111 MockBridge.openFile() is a no-op**: `openFile()` now records the last opened path in memory, making the open-file flow testable and exercisable in `npm run dev`. A `getOpenedFile()` test helper was added alongside a test asserting the call updates state.
- **#114 Failed feature creation clears input and closes form**: The `submit` emit was replaced with a `submitHandler` function prop so `CreateFeatureForm` can await the outcome. Inputs are only cleared on success; the form stays open on failure. Both `HomeView` and `FeaturesView` updated accordingly. Component tests cover both the success and failure branches.

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run test` passes (67 tests, +4 new)
- [ ] `npm run build` passes
- [ ] `npm run build:web` passes
- [ ] Manual: create a feature with a duplicate slug → form stays open with inputs retained
- [ ] Manual: `npm run dev` → clicking open on a feature no longer silently no-ops (MockBridge records the path)

Closes #111
Closes #114

https://claude.ai/code/session_01QNphEzGk2YsXn27NcKEf9M
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNphEzGk2YsXn27NcKEf9M)_