### PR TITLE
chore: align settings surface with PluginSettings model (#117)

### DIFF
--- a/src/plugin/settings.ts
+++ b/src/plugin/settings.ts
@@ -20,13 +20,26 @@ export class SpecoratorSettingTab extends PluginSettingTab {
     containerEl.createEl('h2', { text: 'Specorator' })
 
     new Setting(containerEl)
+      .setName('Language')
+      .setDesc('Display language for the Specorator panel.')
+      .addDropdown((dd) =>
+        dd
+          .addOption('en', 'English')
+          .addOption('de', 'Deutsch')
+          .setValue(this.plugin.settings.locale)
+          .onChange(async (value) => {
+            await this.plugin.updateSettings({ locale: value })
+          }),
+      )
+
+    new Setting(containerEl)
       .setName('Specs folder')
       .setDesc('Vault folder where spec directories are created (agentic-workflow convention: specs).')
       .addText((text) =>
         text
           .setValue(this.plugin.settings.specsFolder)
           .onChange(async (value) => {
-            await this.plugin.updateSettings({ specsFolder: value.trim() || 'specs' })
+            await this.plugin.updateSettings({ specsFolder: value.trim() || DEFAULT_SETTINGS.specsFolder })
           }),
       )
 
@@ -37,7 +50,29 @@ export class SpecoratorSettingTab extends PluginSettingTab {
         text
           .setValue(this.plugin.settings.archiveFolder)
           .onChange(async (value) => {
-            await this.plugin.updateSettings({ archiveFolder: value.trim() || 'archive' })
+            await this.plugin.updateSettings({ archiveFolder: value.trim() || DEFAULT_SETTINGS.archiveFolder })
+          }),
+      )
+
+    new Setting(containerEl)
+      .setName('Decisions folder')
+      .setDesc('Vault folder for architecture decision records.')
+      .addText((text) =>
+        text
+          .setValue(this.plugin.settings.decisionsFolder)
+          .onChange(async (value) => {
+            await this.plugin.updateSettings({ decisionsFolder: value.trim() || DEFAULT_SETTINGS.decisionsFolder })
+          }),
+      )
+
+    new Setting(containerEl)
+      .setName('Constitution file')
+      .setDesc('Vault path to the project constitution markdown file.')
+      .addText((text) =>
+        text
+          .setValue(this.plugin.settings.constitutionFile)
+          .onChange(async (value) => {
+            await this.plugin.updateSettings({ constitutionFile: value.trim() || DEFAULT_SETTINGS.constitutionFile })
           }),
       )
 

--- a/src/ui/i18n/locales/de.ts
+++ b/src/ui/i18n/locales/de.ts
@@ -55,6 +55,7 @@ export default {
     specsFolder: 'Specs-Ordner',
     archiveFolder: 'Archiv-Ordner',
     decisionsFolder: 'Entscheidungs-Ordner',
+    constitutionFile: 'Verfassungsdatei',
     gateStrictness: 'Gate-Strenge',
     strict: 'Streng',
     lenient: 'Nachsichtig',

--- a/src/ui/i18n/locales/en.ts
+++ b/src/ui/i18n/locales/en.ts
@@ -55,6 +55,7 @@ export default {
     specsFolder: 'Specs folder',
     archiveFolder: 'Archive folder',
     decisionsFolder: 'Decisions folder',
+    constitutionFile: 'Constitution file',
     gateStrictness: 'Gate strictness',
     strict: 'Strict',
     lenient: 'Lenient',

--- a/src/ui/views/SettingsView.vue
+++ b/src/ui/views/SettingsView.vue
@@ -71,6 +71,28 @@ function update<K extends keyof PluginSettings>(key: K, value: PluginSettings[K]
       </div>
 
       <div class="sp-settings__field">
+        <label class="sp-settings__label" for="decisionsFolder">{{ t('settings.decisionsFolder') }}</label>
+        <input
+          id="decisionsFolder"
+          class="sp-settings__input"
+          type="text"
+          :value="settings.decisionsFolder"
+          @input="(e) => update('decisionsFolder', (e.target as HTMLInputElement).value)"
+        />
+      </div>
+
+      <div class="sp-settings__field">
+        <label class="sp-settings__label" for="constitutionFile">{{ t('settings.constitutionFile') }}</label>
+        <input
+          id="constitutionFile"
+          class="sp-settings__input"
+          type="text"
+          :value="settings.constitutionFile"
+          @input="(e) => update('constitutionFile', (e.target as HTMLInputElement).value)"
+        />
+      </div>
+
+      <div class="sp-settings__field">
         <label class="sp-settings__label" for="gateStrictness">{{ t('settings.gateStrictness') }}</label>
         <select
           id="gateStrictness"

--- a/styles.css
+++ b/styles.css
@@ -228,42 +228,42 @@ to { transform: rotate(360deg);
   margin: 0;
 }
 
-.specorator-root :where(.sp-settings[data-v-b10aa702]) {
+.specorator-root :where(.sp-settings[data-v-4e8dcde4]) {
   padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
 }
-.specorator-root :where(.sp-settings__title[data-v-b10aa702]) {
+.specorator-root :where(.sp-settings__title[data-v-4e8dcde4]) {
   margin: 0;
   font-size: 1.1rem;
   font-weight: 700;
   color: var(--text-normal);
 }
-.specorator-root :where(.sp-settings__fields[data-v-b10aa702]) {
+.specorator-root :where(.sp-settings__fields[data-v-4e8dcde4]) {
   display: flex;
   flex-direction: column;
   gap: 0.875rem;
 }
-.specorator-root :where(.sp-settings__field[data-v-b10aa702]) {
+.specorator-root :where(.sp-settings__field[data-v-4e8dcde4]) {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
 }
-.specorator-root :where(.sp-settings__field--inline[data-v-b10aa702]) {
+.specorator-root :where(.sp-settings__field--inline[data-v-4e8dcde4]) {
   flex-direction: row;
   align-items: center;
   gap: 0.5rem;
 }
-.specorator-root :where(.sp-settings__label[data-v-b10aa702]) {
+.specorator-root :where(.sp-settings__label[data-v-4e8dcde4]) {
   font-size: 0.8125rem;
   font-weight: 600;
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
-.specorator-root :where(.sp-settings__input[data-v-b10aa702]),
-.specorator-root :where(.sp-settings__select[data-v-b10aa702]) {
+.specorator-root :where(.sp-settings__input[data-v-4e8dcde4]),
+.specorator-root :where(.sp-settings__select[data-v-4e8dcde4]) {
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
   border-radius: 6px;
@@ -272,16 +272,16 @@ to { transform: rotate(360deg);
   padding: 0.375rem 0.625rem;
   outline: none;
 }
-.specorator-root :where(.sp-settings__input[data-v-b10aa702]:focus),
-.specorator-root :where(.sp-settings__select[data-v-b10aa702]:focus) {
+.specorator-root :where(.sp-settings__input[data-v-4e8dcde4]:focus),
+.specorator-root :where(.sp-settings__select[data-v-4e8dcde4]:focus) {
   border-color: var(--interactive-accent);
 }
-.specorator-root :where(.sp-settings__footer[data-v-b10aa702]) {
+.specorator-root :where(.sp-settings__footer[data-v-4e8dcde4]) {
   display: flex;
   align-items: center;
   gap: 0.75rem;
 }
-.specorator-root :where(.sp-settings__saved[data-v-b10aa702]) {
+.specorator-root :where(.sp-settings__saved[data-v-4e8dcde4]) {
   font-size: 0.875rem;
   color: #4ade80;
 }


### PR DESCRIPTION
## Summary

Closes #117. Audits the `PluginSettings` model (`src/infrastructure/bridge/IBridge.ts`) against both settings surfaces and adds the missing controls so every field has a UI on both sides.

| Field              | Obsidian tab     | Vue panel        |
|--------------------|------------------|------------------|
| `locale`           | added (NEW)      | already          |
| `specsFolder`      | already          | already          |
| `archiveFolder`    | already          | already          |
| `decisionsFolder`  | added (NEW)      | added (NEW)      |
| `constitutionFile` | added (NEW)      | added (NEW)      |
| `gateStrictness`   | already          | already          |
| `teamMode`         | already          | already          |

Round-trip: both surfaces converge on `plugin.updateSettings → plugin.saveData`. The Obsidian tab calls `plugin.updateSettings({field: value})` directly; the Vue panel calls `bridge.saveSettings(full)` → `ObsidianBridge.onSaveSettings` → `plugin.updateSettings(full)`. No store split.

Also replaced the hardcoded fallback literals (`'specs'`, `'archive'`, etc.) in the Obsidian tab with `DEFAULT_SETTINGS.<field>` so the fallbacks cannot drift if defaults change.

i18n: added `settings.constitutionFile` to `en.ts` and `de.ts`.

## Verification

Pre-PR gate ran in this worktree:

- `npm audit --audit-level=high --omit=dev` — 0 vulnerabilities
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run test` — 63 passed
- `npm run build` — succeeds
- `npm run build:web` — succeeds
- `npm run docs:api` — succeeds

The `styles.css` change is the Vue scoped-style hash rotating after `SettingsView.vue` was edited (`data-v-b10aa702 → data-v-4e8dcde4`). Per CLAUDE.md `styles.css` is a committed artifact, so the regeneration is included in the diff.

## Coordination

Issue notes that W7 (#105) declarative-schema work will subsume this surface eventually. This PR keeps the change small (5 files, +73/-14) so the redo cost is bounded; it deliberately does not introduce new abstractions ahead of #105.

## Test plan

- [ ] CI passes
- [ ] Reviewer checks each new control reads + writes the canonical key
- [ ] Reviewer confirms no UI control is bound to a non-`PluginSettings` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)