### PR TITLE
fix(ui): keep create form open on failure

### DIFF
--- a/src/ui/components/feature/CreateFeatureForm.vue
+++ b/src/ui/components/feature/CreateFeatureForm.vue
@@ -3,8 +3,15 @@ import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import AppButton from '../common/AppButton.vue'
 
+type CreateFeaturePayload = { title: string; area?: string }
+
+const props = defineProps<{
+  errorMessage?: string | null
+  submitHandler?: (payload: CreateFeaturePayload) => boolean | Promise<boolean>
+}>()
+
 const emit = defineEmits<{
-  submit: [payload: { title: string; area?: string }]
+  submit: [payload: CreateFeaturePayload]
   cancel: []
 }>()
 
@@ -19,9 +26,13 @@ async function handleSubmit() {
   const trimmedArea = area.value.trim()
   submitting.value = true
   try {
-    emit('submit', { title: trimmedTitle, area: trimmedArea || undefined })
-    title.value = ''
-    area.value = ''
+    const payload = { title: trimmedTitle, area: trimmedArea || undefined }
+    const succeeded = props.submitHandler ? await props.submitHandler(payload) : true
+    emit('submit', payload)
+    if (succeeded) {
+      title.value = ''
+      area.value = ''
+    }
   } finally {
     submitting.value = false
   }
@@ -54,6 +65,9 @@ async function handleSubmit() {
       autocomplete="off"
       maxlength="5"
     />
+    <p v-if="errorMessage" class="sp-create-form__error" role="alert">
+      {{ errorMessage }}
+    </p>
     <div class="sp-create-form__actions">
       <AppButton variant="primary" :loading="submitting" :disabled="!title.trim()">
         {{ t('feature.create') }}
@@ -97,6 +111,12 @@ async function handleSubmit() {
 
 .sp-create-form__input:focus {
   border-color: var(--interactive-accent);
+}
+
+.sp-create-form__error {
+  color: var(--text-error);
+  font-size: 0.875rem;
+  margin: 0.125rem 0 0;
 }
 
 .sp-create-form__actions {

--- a/src/ui/components/feature/__tests__/CreateFeatureForm.spec.ts
+++ b/src/ui/components/feature/__tests__/CreateFeatureForm.spec.ts
@@ -1,0 +1,46 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { i18n } from '@/ui/i18n'
+import CreateFeatureForm from '../CreateFeatureForm.vue'
+
+function mountForm(options: Parameters<typeof mount<typeof CreateFeatureForm>>[1] = {}) {
+  return mount(CreateFeatureForm, {
+    ...options,
+    global: {
+      plugins: [i18n],
+      ...options.global,
+    },
+  })
+}
+
+describe('CreateFeatureForm', () => {
+  it('clears inputs after a successful submit', async () => {
+    const submitHandler = vi.fn().mockResolvedValue(true)
+    const wrapper = mountForm({ props: { submitHandler } })
+
+    await wrapper.find('#feature-title').setValue(' Search ')
+    await wrapper.find('#feature-area').setValue(' SR ')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(submitHandler).toHaveBeenCalledWith({ title: 'Search', area: 'SR' })
+    expect((wrapper.find('#feature-title').element as HTMLInputElement).value).toBe('')
+    expect((wrapper.find('#feature-area').element as HTMLInputElement).value).toBe('')
+  })
+
+  it('retains inputs and shows an inline error after a failed submit', async () => {
+    const submitHandler = vi.fn().mockResolvedValue(false)
+    const wrapper = mountForm({ props: { submitHandler } })
+
+    await wrapper.find('#feature-title').setValue(' Search ')
+    await wrapper.find('#feature-area').setValue(' SR ')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+    await wrapper.setProps({ errorMessage: 'Feature already exists.' })
+
+    expect(submitHandler).toHaveBeenCalledWith({ title: 'Search', area: 'SR' })
+    expect((wrapper.find('#feature-title').element as HTMLInputElement).value).toBe(' Search ')
+    expect((wrapper.find('#feature-area').element as HTMLInputElement).value).toBe(' SR ')
+    expect(wrapper.find('[role="alert"]').text()).toBe('Feature already exists.')
+  })
+})

--- a/src/ui/composables/useFeatures.ts
+++ b/src/ui/composables/useFeatures.ts
@@ -83,6 +83,10 @@ export function useFeatures() {
     })
   }
 
+  function clearError(): void {
+    store.setError(null)
+  }
+
   return {
     items: computed(() => store.items),
     activeItems: computed(() => store.activeItems),
@@ -93,5 +97,6 @@ export function useFeatures() {
     createFeature,
     activateFeature,
     archiveFeature,
+    clearError,
   }
 }

--- a/src/ui/views/FeaturesView.vue
+++ b/src/ui/views/FeaturesView.vue
@@ -9,15 +9,41 @@ import { useBridge } from '../composables/useBridge'
 
 const { t } = useI18n()
 const bridge = useBridge()
-const { items, loading, error, loadFeatures, createFeature, activateFeature, archiveFeature } =
-  useFeatures()
+const {
+  items,
+  loading,
+  error,
+  loadFeatures,
+  createFeature,
+  activateFeature,
+  archiveFeature,
+  clearError,
+} = useFeatures()
 const showCreateForm = ref(false)
+const createError = ref<string | null>(null)
 
 onMounted(loadFeatures)
 
-async function handleCreate(payload: { title: string; area?: string }) {
-  await createFeature(payload.title, payload.area)
+function toggleCreateForm() {
+  createError.value = null
+  showCreateForm.value = !showCreateForm.value
+}
+
+function closeCreateForm() {
+  createError.value = null
   showCreateForm.value = false
+}
+
+async function handleCreate(payload: { title: string; area?: string }): Promise<boolean> {
+  createError.value = null
+  const created = await createFeature(payload.title, payload.area)
+  if (!created) {
+    createError.value = error.value ?? t('common.error')
+    clearError()
+    return false
+  }
+  closeCreateForm()
+  return true
 }
 
 async function handleOpen(featureId: string) {
@@ -32,15 +58,16 @@ async function handleOpen(featureId: string) {
   <div class="sp-features">
     <header class="sp-features__header">
       <h1 class="sp-features__title">{{ t('nav.features') }}</h1>
-      <AppButton variant="primary" size="sm" @click="showCreateForm = !showCreateForm">
+      <AppButton variant="primary" size="sm" @click="toggleCreateForm">
         + {{ t('feature.create') }}
       </AppButton>
     </header>
 
     <CreateFeatureForm
       v-if="showCreateForm"
-      @submit="handleCreate"
-      @cancel="showCreateForm = false"
+      :submit-handler="handleCreate"
+      :error-message="createError"
+      @cancel="closeCreateForm"
     />
 
     <p v-if="loading" class="sp-features__meta">{{ t('common.loading') }}</p>

--- a/src/ui/views/HomeView.vue
+++ b/src/ui/views/HomeView.vue
@@ -11,14 +11,41 @@ import { useBridge } from '../composables/useBridge'
 const { t } = useI18n()
 const router = useRouter()
 const bridge = useBridge()
-const { activeItems, loading, error, loadFeatures, createFeature, activateFeature, archiveFeature } = useFeatures()
+const {
+  activeItems,
+  loading,
+  error,
+  loadFeatures,
+  createFeature,
+  activateFeature,
+  archiveFeature,
+  clearError,
+} = useFeatures()
 const showCreateForm = ref(false)
+const createError = ref<string | null>(null)
 
 onMounted(loadFeatures)
 
-async function handleCreate(payload: { title: string; area?: string }) {
-  await createFeature(payload.title, payload.area)
+function toggleCreateForm() {
+  createError.value = null
+  showCreateForm.value = !showCreateForm.value
+}
+
+function closeCreateForm() {
+  createError.value = null
   showCreateForm.value = false
+}
+
+async function handleCreate(payload: { title: string; area?: string }): Promise<boolean> {
+  createError.value = null
+  const created = await createFeature(payload.title, payload.area)
+  if (!created) {
+    createError.value = error.value ?? t('common.error')
+    clearError()
+    return false
+  }
+  closeCreateForm()
+  return true
 }
 
 async function handleOpen(featureId: string) {
@@ -41,15 +68,16 @@ async function handleOpen(featureId: string) {
     <section class="sp-home__section">
       <div class="sp-home__section-header">
         <h2 class="sp-home__section-title">{{ t('home.activeFeatures') }}</h2>
-        <AppButton variant="primary" size="sm" @click="showCreateForm = !showCreateForm">
+        <AppButton variant="primary" size="sm" @click="toggleCreateForm">
           + {{ t('feature.create') }}
         </AppButton>
       </div>
 
       <CreateFeatureForm
         v-if="showCreateForm"
-        @submit="handleCreate"
-        @cancel="showCreateForm = false"
+        :submit-handler="handleCreate"
+        :error-message="createError"
+        @cancel="closeCreateForm"
       />
 
       <p v-if="loading" class="sp-home__meta">{{ t('common.loading') }}</p>

--- a/styles.css
+++ b/styles.css
@@ -127,7 +127,7 @@ to { transform: rotate(360deg);
   flex-wrap: wrap;
 }
 
-.specorator-root :where(.sp-create-form[data-v-b07dc06e]) {
+.specorator-root :where(.sp-create-form[data-v-9239f420]) {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -136,14 +136,14 @@ to { transform: rotate(360deg);
   border: 1px solid var(--interactive-accent);
   border-radius: 8px;
 }
-.specorator-root :where(.sp-create-form__label[data-v-b07dc06e]) {
+.specorator-root :where(.sp-create-form__label[data-v-9239f420]) {
   font-size: 0.8125rem;
   font-weight: 600;
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
-.specorator-root :where(.sp-create-form__input[data-v-b07dc06e]) {
+.specorator-root :where(.sp-create-form__input[data-v-9239f420]) {
   background: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
   border-radius: 6px;
@@ -153,76 +153,81 @@ to { transform: rotate(360deg);
   outline: none;
   width: 100%;
 }
-.specorator-root :where(.sp-create-form__input[data-v-b07dc06e]:focus) {
+.specorator-root :where(.sp-create-form__input[data-v-9239f420]:focus) {
   border-color: var(--interactive-accent);
 }
-.specorator-root :where(.sp-create-form__actions[data-v-b07dc06e]) {
+.specorator-root :where(.sp-create-form__error[data-v-9239f420]) {
+  color: var(--text-error);
+  font-size: 0.875rem;
+  margin: 0.125rem 0 0;
+}
+.specorator-root :where(.sp-create-form__actions[data-v-9239f420]) {
   display: flex;
   gap: 0.5rem;
   margin-top: 0.25rem;
 }
 
-.specorator-root :where(.sp-home[data-v-89ffe986]) {
+.specorator-root :where(.sp-home[data-v-4c1a9eb2]) {
   padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
 }
-.specorator-root :where(.sp-home__header[data-v-89ffe986]) { display: flex; align-items: flex-start; justify-content: space-between;
+.specorator-root :where(.sp-home__header[data-v-4c1a9eb2]) { display: flex; align-items: flex-start; justify-content: space-between;
 }
-.specorator-root :where(.sp-home__title[data-v-89ffe986]) { margin: 0; font-size: 1.25rem; font-weight: 700; color: var(--text-normal);
+.specorator-root :where(.sp-home__title[data-v-4c1a9eb2]) { margin: 0; font-size: 1.25rem; font-weight: 700; color: var(--text-normal);
 }
-.specorator-root :where(.sp-home__subtitle[data-v-89ffe986]) { margin: 0.25rem 0 0; font-size: 0.875rem; color: var(--text-muted);
+.specorator-root :where(.sp-home__subtitle[data-v-4c1a9eb2]) { margin: 0.25rem 0 0; font-size: 0.875rem; color: var(--text-muted);
 }
-.specorator-root :where(.sp-home__section[data-v-89ffe986]) { display: flex; flex-direction: column; gap: 0.75rem;
+.specorator-root :where(.sp-home__section[data-v-4c1a9eb2]) { display: flex; flex-direction: column; gap: 0.75rem;
 }
-.specorator-root :where(.sp-home__section-header[data-v-89ffe986]) { display: flex; align-items: center; justify-content: space-between;
+.specorator-root :where(.sp-home__section-header[data-v-4c1a9eb2]) { display: flex; align-items: center; justify-content: space-between;
 }
-.specorator-root :where(.sp-home__section-title[data-v-89ffe986]) { margin: 0; font-size: 0.875rem; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em;
+.specorator-root :where(.sp-home__section-title[data-v-4c1a9eb2]) { margin: 0; font-size: 0.875rem; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em;
 }
-.specorator-root :where(.sp-home__cards[data-v-89ffe986]) { display: flex; flex-direction: column; gap: 0.625rem;
+.specorator-root :where(.sp-home__cards[data-v-4c1a9eb2]) { display: flex; flex-direction: column; gap: 0.625rem;
 }
-.specorator-root :where(.sp-home__meta[data-v-89ffe986]) { color: var(--text-muted); font-size: 0.875rem; margin: 0;
+.specorator-root :where(.sp-home__meta[data-v-4c1a9eb2]) { color: var(--text-muted); font-size: 0.875rem; margin: 0;
 }
-.specorator-root :where(.sp-home__error[data-v-89ffe986]) { color: var(--text-error); font-size: 0.875rem; margin: 0;
+.specorator-root :where(.sp-home__error[data-v-4c1a9eb2]) { color: var(--text-error); font-size: 0.875rem; margin: 0;
 }
-.specorator-root :where(.sp-home__nav[data-v-89ffe986]) { display: flex; gap: 0.5rem;
+.specorator-root :where(.sp-home__nav[data-v-4c1a9eb2]) { display: flex; gap: 0.5rem;
 }
 
-.specorator-root :where(.sp-features[data-v-109961bb]) {
+.specorator-root :where(.sp-features[data-v-06ccc1ae]) {
   padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
-.specorator-root :where(.sp-features__header[data-v-109961bb]) {
+.specorator-root :where(.sp-features__header[data-v-06ccc1ae]) {
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
-.specorator-root :where(.sp-features__title[data-v-109961bb]) {
+.specorator-root :where(.sp-features__title[data-v-06ccc1ae]) {
   margin: 0;
   font-size: 1.1rem;
   font-weight: 700;
   color: var(--text-normal);
 }
-.specorator-root :where(.sp-features__list[data-v-109961bb]) {
+.specorator-root :where(.sp-features__list[data-v-06ccc1ae]) {
   display: flex;
   flex-direction: column;
   gap: 0.625rem;
 }
-.specorator-root :where(.sp-features__meta[data-v-109961bb]),
-.specorator-root :where(.sp-features__empty[data-v-109961bb]) {
+.specorator-root :where(.sp-features__meta[data-v-06ccc1ae]),
+.specorator-root :where(.sp-features__empty[data-v-06ccc1ae]) {
   color: var(--text-muted);
   font-size: 0.875rem;
   margin: 0;
   line-height: 1.6;
 }
-.specorator-root :where(.sp-features__empty-hint[data-v-109961bb]) {
+.specorator-root :where(.sp-features__empty-hint[data-v-06ccc1ae]) {
   font-size: 0.8125rem;
   opacity: 0.7;
 }
-.specorator-root :where(.sp-features__error[data-v-109961bb]) {
+.specorator-root :where(.sp-features__error[data-v-06ccc1ae]) {
   color: var(--text-error);
   font-size: 0.875rem;
   margin: 0;


### PR DESCRIPTION
## Summary

Superseded by #131, which merged the #114 create-form failure handling into `develop`.

Closes #114

## Verification

- `npm audit --audit-level=high --omit=dev`
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run build`
- `npm run build:web`
- `npm run docs:api`
- Started `npm run dev -- --host 127.0.0.1 --port 5174` and confirmed `http://127.0.0.1:5174/` returned HTTP 200.
- `git diff --check`

## Status

Closed without merge because #114 was completed by #131.