### PR TITLE
chore: codify release/compatibility model (#119)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,20 @@ jobs:
           fi
           echo "All third-party actions are SHA-pinned."
 
+  manifest-validation:
+    name: Validate manifest and versions.json
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: lts/*
+      - name: Validate manifest
+        run: node scripts/validate-manifest.js
+
   guard:
     name: Verify PR source is develop
     if: github.event_name == 'pull_request' && github.base_ref == 'main'

--- a/docs/marketplace-readiness.md
+++ b/docs/marketplace-readiness.md
@@ -3,17 +3,23 @@ title: Obsidian marketplace readiness
 doc_type: checklist
 status: draft
 owner: engineering
-last_updated: 2026-05-02
+last_updated: 2026-05-03
 references:
   - manifest.json
+  - docs/release-process.md
   - docs/roadmap-v1.md
   - docs/pre-feature-architecture-readiness.md
+  - scripts/validate-manifest.js
   - https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md
 ---
 
 # Obsidian Marketplace Readiness
 
 This document captures the constraints, requirements, and pre-submission checklist for submitting Specorator to the [Obsidian community plugins](https://obsidian.md/plugins) marketplace. It must be reviewed before every release candidate.
+
+For the end-to-end mechanical release flow (versioning policy, develop → main → tag → published release), see [`docs/release-process.md`](./release-process.md). This file covers the *marketplace-specific* prerequisites that sit on top of that flow.
+
+Items marked **auto-enforced** are checked by `scripts/validate-manifest.js` (run in CI as the `manifest-validation` job and via the `version` lifecycle hook). The remaining items still require manual review.
 
 ---
 
@@ -31,7 +37,7 @@ The `.gitignore` correctly excludes `main.js` and `main.js.map` from source cont
 
 ### Version alignment rule
 
-`manifest.json` → `version` **must** match `package.json` → `version` at release time. The GitHub release tag **must** match both. Mismatches are rejected by the marketplace submission bot.
+`manifest.json` → `version` **must** match `package.json` → `version` at release time. The GitHub release tag **must** match both. Mismatches are rejected by the marketplace submission bot. **Auto-enforced** by `scripts/validate-manifest.js` in CI and by `release.yml` on tag push.
 
 ---
 
@@ -39,16 +45,16 @@ The `.gitignore` correctly excludes `main.js` and `main.js.map` from source cont
 
 The current `manifest.json` satisfies the mandatory fields. Review each field before submission:
 
-| Field | Current value | Requirement |
-|---|---|---|
-| `id` | `specorator` | Unique across all community plugins; lowercase, no spaces |
-| `name` | `Specorator` | Human-readable display name |
-| `version` | `0.0.1` | Semver; must match `package.json` and release tag |
-| `minAppVersion` | `1.4.0` | Minimum Obsidian desktop version tested against |
-| `description` | `"Spec-driven workflow cockpit…"` | ≤250 characters; plain text only; no marketing language |
-| `author` | `Luis85` | Real name or consistent handle |
-| `authorUrl` | `https://github.com/Luis85` | Must be a reachable URL |
-| `isDesktopOnly` | `true` | Correct: the plugin writes vault files via Node.js APIs unavailable in Obsidian mobile |
+| Field | Current value | Requirement | Auto-enforced |
+|---|---|---|---|
+| `id` | `specorator` | Unique across all community plugins; lowercase, no spaces | ✅ format check (lowercase alphanumeric, hyphens) |
+| `name` | `Specorator` | Human-readable display name | ✅ non-empty string |
+| `version` | `0.0.1` | Semver; must match `package.json` and release tag | ✅ semver + cross-file alignment |
+| `minAppVersion` | `1.4.0` | Minimum Obsidian desktop version tested against | ✅ semver + matches `versions.json[<current>]` |
+| `description` | `"Spec-driven workflow cockpit…"` | ≤250 characters; plain text only; no marketing language | ✅ length check (plain-text and marketing tone are manual) |
+| `author` | `Luis85` | Real name or consistent handle | ✅ non-empty string |
+| `authorUrl` | `https://github.com/Luis85` | Must be a reachable URL | ✅ http(s) URL format (reachability is manual) |
+| `isDesktopOnly` | `true` | Correct: the plugin writes vault files via Node.js APIs unavailable in Obsidian mobile | ✅ boolean type (semantic correctness is manual) |
 
 **Before submission, also add:**
 
@@ -140,12 +146,12 @@ Versioning is automated via `npm version <patch|minor|major>`, which:
 
 Manual checklist before pushing the tag to `main`:
 
-- [ ] `manifest.json` → `version` matches `package.json` → `version`.
-- [ ] `versions.json` contains an entry for the new version mapping it to the current `minAppVersion`.
-- [ ] Local tag is plain semver, no `v` prefix (e.g. `0.1.0`).
-- [ ] Tag points at the `main` HEAD commit (the release workflow rejects tags not on `main` HEAD).
+- [ ] `manifest.json` → `version` matches `package.json` → `version`. **Auto-enforced** (`manifest-validation` CI job + `release.yml`).
+- [ ] `versions.json` contains an entry for the new version mapping it to the current `minAppVersion`. **Auto-enforced**.
+- [ ] Local tag is plain semver, no `v` prefix (e.g. `0.1.0`). Manual — `.npmrc` removes the prefix automatically when using `npm version`.
+- [ ] Tag points at the `main` HEAD commit. **Auto-enforced** by `release.yml`'s "Verify tag is on main HEAD" step.
 
-The release workflow re-checks all three files at run time and refuses to publish on any mismatch.
+The release workflow re-checks all three files at run time and refuses to publish on any mismatch. The full mechanical flow (including the develop → main merge step) is documented in [`docs/release-process.md`](./release-process.md).
 
 ### Automated checks
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -109,10 +109,10 @@ CI runs the standard verify + workflow-lint + dependency-review + manifest-valid
 After CI is green and the PR is reviewed:
 
 ```sh
-gh pr merge <pr-number> --merge          # NOT --squash. Use a merge commit.
+gh pr merge <pr-number> --squash
 ```
 
-> Use a merge commit (not squash) for `develop → main` PRs. The release tag must point at the merge commit on `main`, and squash-merging would replace it with a fresh commit whose history does not show the released `develop` work.
+Squash-merge per the repository merge policy in [`docs/contributing.md`](./contributing.md) §7. The squash commit on `main` becomes the new release point; step 5 below re-tags the release on it. The full per-PR history of what shipped is recoverable from the auto-generated release notes (which use PR titles since the previous tag) and from `develop`'s linear log.
 
 After merge:
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -73,13 +73,15 @@ Before opening the release PR:
 
 ---
 
-## 3. Bump versions
+## 3. Bump versions on a release branch
 
-From a clean checkout on `develop`:
+`develop` is PR-only — direct pushes are forbidden by the branching model documented in [`docs/contributing.md`](./contributing.md) §5 and [`AGENTS.md`](../AGENTS.md) §4. The version bump therefore lives on a short-lived release branch that gets PR-merged into `develop` before the `develop → main` promotion.
+
+From a clean checkout:
 
 ```sh
-git checkout develop
-git pull --ff-only origin develop
+git fetch origin develop --prune
+git checkout -b chore/release-X.Y.Z origin/develop
 
 npm version <patch|minor|major>
 ```
@@ -89,16 +91,33 @@ npm version <patch|minor|major>
 1. Bumps `package.json` → `version`.
 2. Runs `version-bump.js`, which updates `manifest.json` → `version` and appends an entry to `versions.json` mapping the new version to the current `minAppVersion`.
 3. Runs `scripts/validate-manifest.js` to assert all three files are consistent.
-4. Stages `manifest.json` + `versions.json` and creates a commit named `vX.Y.Z` *(npm default)*. The tag uses plain semver per `.npmrc` `tag-version-prefix=""`, so the tag is `X.Y.Z` (no `v`).
+4. Stages `manifest.json` + `versions.json`, creates a commit, and creates a local annotated tag named `X.Y.Z` (plain semver — `.npmrc` sets `tag-version-prefix=""`).
 
-**Do not push the tag yet.** The tag must point at `main` HEAD, not `develop` HEAD.
+The local `X.Y.Z` tag now points at the bump commit on the release branch. **Do not push the tag yet** — it must end up on `main` HEAD, not on the release branch HEAD.
+
+Push the branch (without the tag) and open a PR:
+
+```sh
+git push -u origin chore/release-X.Y.Z         # branch only, no --tags
+gh pr create --base develop --head chore/release-X.Y.Z \
+  --title "chore(release): bump to X.Y.Z" \
+  --body "Closes <issue-if-any>. Pre-step for release X.Y.Z; the develop->main PR will follow."
+```
+
+CI runs the full verify + workflow-lint + dependency-review + manifest-validation chain. After review:
+
+```sh
+gh pr merge <pr-number> --squash --delete-branch
+```
+
+The squash-merge produces a fresh commit on `develop` containing the version-bump diff. The local `X.Y.Z` tag still points at the original release-branch commit, which is now an orphan; step 5 below re-anchors the tag.
 
 ---
 
 ## 4. Promote `develop` → `main`
 
 ```sh
-git push origin develop
+git fetch origin develop
 gh pr create --base main --head develop \
   --title "release: X.Y.Z" \
   --body "Release notes draft. Closes #<release-tracking-issue> if any."
@@ -126,10 +145,10 @@ git pull --ff-only origin main
 
 ## 5. Push the release tag
 
-The version-bump commit produced a local tag (`X.Y.Z`) that currently points at the *develop* commit. Re-tag the merge commit on `main`:
+The version-bump commit's original tag still points at the now-orphaned release-branch commit. Re-tag the squash commit on `main`:
 
 ```sh
-git tag -d X.Y.Z                  # remove the develop-pointing tag
+git tag -d X.Y.Z                  # remove the orphan release-branch tag
 git tag X.Y.Z                     # re-create on the current main HEAD
 git push origin X.Y.Z
 ```
@@ -163,7 +182,8 @@ After the release workflow finishes:
 | Failure | Recovery |
 |---|---|
 | Pre-PR gate fails locally | Fix the underlying issue and re-run. Do not push a known-broken release PR. |
-| `manifest-validation` fails on the develop→main PR | The bump produced an invalid state. Inspect the validator output, fix `manifest.json` / `versions.json` / `package.json`, force-push the develop branch *only if no one else has pulled it*; otherwise revert the bump commit on develop and start over. |
+| `manifest-validation` fails on the release-branch PR (step 3) | The bump produced an invalid state. Inspect the validator output, fix `manifest.json` / `versions.json` / `package.json` on the release branch, push, let CI re-run. The PR is the only thing failing; develop is untouched. |
+| `manifest-validation` fails on the develop→main PR (step 4) | A commit landed on `develop` between step 3 and step 4 that altered one of the three files. Open a fix PR (chore branch → develop) to reconcile, merge, then re-open / re-trigger the develop→main PR. |
 | Release workflow fails on `Verify tag is on main HEAD` | The tag does not point at `main` HEAD. Delete the remote tag (`git push origin :X.Y.Z`), re-tag locally on `main` HEAD, push. |
 | Release workflow fails on `Verify manifest, package, and versions.json all match tag` | The bump created a mismatch that slipped past the develop→main PR. Most likely cause: a follow-up commit on `develop` between bump and merge altered one of the three files. Open a fix PR to reconcile, merge, then delete and re-create the tag on the new `main` HEAD. |
 | GitHub release was created but a wrong file is attached | Edit the release on GitHub and re-upload the missing asset. Do *not* delete and re-create the release — direct download links break. |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,188 @@
+---
+title: Specorator release process
+doc_type: runbook
+status: active
+owner: engineering
+last_updated: 2026-05-03
+references:
+  - docs/marketplace-readiness.md
+  - docs/contributing.md
+  - .github/workflows/release.yml
+  - .github/workflows/ci.yml
+  - manifest.json
+  - versions.json
+  - scripts/validate-manifest.js
+---
+
+# Release process
+
+This is the canonical end-to-end runbook for cutting a Specorator release. It complements [`docs/marketplace-readiness.md`](./marketplace-readiness.md) (the pre-submission checklist) and [`docs/contributing.md`](./contributing.md) §5 (the branching model). When in doubt, this document wins.
+
+> Marketplace submission to the Obsidian community plugins registry is a **separate** step, gated on the criteria in `marketplace-readiness.md`. This runbook covers the path from `develop` to a published GitHub release.
+
+---
+
+## 1. Versioning policy
+
+### Semver discipline
+
+| Bump | When |
+|---|---|
+| `patch` (`X.Y.Z+1`) | Bug fix, doc-only change, CI-only change, dependency patch with no behavioural impact. |
+| `minor` (`X.Y+1.0`) | New user-visible feature, additive API surface, new setting, new bridge port. No removed/renamed surface. |
+| `major` (`X+1.0.0`) | Removed setting, renamed setting key, breaking workflow-state schema change, raised `minAppVersion`. |
+
+A `pre-1.0` major bump is rare and reserved for the first public alpha. Until 1.0, the minor digit carries breaking changes provided they are clearly noted in the release notes.
+
+### `minAppVersion` policy
+
+`minAppVersion` is bumped **only** when the plugin uses an Obsidian API or behaviour that is not present in older Obsidian versions. Bumping `minAppVersion` is itself a breaking change for end users on older Obsidian builds and triggers a `major` plugin-version bump.
+
+The current `minAppVersion` lives in `manifest.json`. The active mapping of `plugin-version → minAppVersion` lives in `versions.json` and is consulted by Obsidian when deciding which plugin version to install for a user's Obsidian version.
+
+### `versions.json` contract
+
+`versions.json` maps every released plugin version to the minimum Obsidian version it requires:
+
+```json
+{
+  "0.0.1": "1.4.0",
+  "0.1.0": "1.4.0",
+  "1.0.0": "1.5.0"
+}
+```
+
+Rules enforced by `scripts/validate-manifest.js` (run in CI):
+
+- Every key is a valid semver string.
+- Every value is a valid semver string (the `minAppVersion` for that plugin version).
+- The current `manifest.json` → `version` exists as a key.
+- `versions.json[<current version>]` equals `manifest.json` → `minAppVersion`.
+
+Never hand-edit `versions.json` to retroactively change a published plugin version's `minAppVersion`. Old entries are immutable; only new entries are appended.
+
+---
+
+## 2. Pre-release checks
+
+Before opening the release PR:
+
+1. Run the marketplace-readiness checklist in [`docs/marketplace-readiness.md`](./marketplace-readiness.md). Manual items (Obsidian smoke test, README/CHANGELOG content) are still required.
+2. Run the local pre-PR gate (see [`AGENTS.md`](../AGENTS.md) §3 / [`.codex/pre-pr-gate.md`](../.codex/pre-pr-gate.md)).
+3. Confirm `develop` is in a releasable state: every PR you intend to ship is merged, no in-flight branches that must land in this release.
+
+---
+
+## 3. Bump versions
+
+From a clean checkout on `develop`:
+
+```sh
+git checkout develop
+git pull --ff-only origin develop
+
+npm version <patch|minor|major>
+```
+
+`npm version <bump>` runs the project's `version` lifecycle hook, which:
+
+1. Bumps `package.json` → `version`.
+2. Runs `version-bump.js`, which updates `manifest.json` → `version` and appends an entry to `versions.json` mapping the new version to the current `minAppVersion`.
+3. Runs `scripts/validate-manifest.js` to assert all three files are consistent.
+4. Stages `manifest.json` + `versions.json` and creates a commit named `vX.Y.Z` *(npm default)*. The tag uses plain semver per `.npmrc` `tag-version-prefix=""`, so the tag is `X.Y.Z` (no `v`).
+
+**Do not push the tag yet.** The tag must point at `main` HEAD, not `develop` HEAD.
+
+---
+
+## 4. Promote `develop` → `main`
+
+```sh
+git push origin develop
+gh pr create --base main --head develop \
+  --title "release: X.Y.Z" \
+  --body "Release notes draft. Closes #<release-tracking-issue> if any."
+```
+
+CI runs the standard verify + workflow-lint + dependency-review + manifest-validation jobs. The PR is also gated by the `Verify PR source is develop` check (rejects PRs to `main` from any branch other than `develop`).
+
+After CI is green and the PR is reviewed:
+
+```sh
+gh pr merge <pr-number> --merge          # NOT --squash. Use a merge commit.
+```
+
+> Use a merge commit (not squash) for `develop → main` PRs. The release tag must point at the merge commit on `main`, and squash-merging would replace it with a fresh commit whose history does not show the released `develop` work.
+
+After merge:
+
+```sh
+git fetch origin main
+git checkout main
+git pull --ff-only origin main
+```
+
+---
+
+## 5. Push the release tag
+
+The version-bump commit produced a local tag (`X.Y.Z`) that currently points at the *develop* commit. Re-tag the merge commit on `main`:
+
+```sh
+git tag -d X.Y.Z                  # remove the develop-pointing tag
+git tag X.Y.Z                     # re-create on the current main HEAD
+git push origin X.Y.Z
+```
+
+`.github/workflows/release.yml` triggers on the tag push and:
+
+1. Verifies the tag points at `main` HEAD (refuses to publish otherwise).
+2. Re-installs dependencies, typechecks, lints, tests, and builds.
+3. Re-checks `manifest.json`, `package.json`, and `versions.json` against the tag (defence in depth — `manifest-validation` already ran on the develop→main PR).
+4. Creates the GitHub release with `main.js`, `manifest.json`, and `styles.css` attached. Auto-generated release notes are produced from PR titles since the previous tag.
+5. Marks the release as a prerelease iff the tag contains a `-` (e.g. `0.1.0-rc1`).
+
+Watch the workflow run in GitHub Actions until it completes. If it fails, see "Failure recovery" below.
+
+---
+
+## 6. Post-release verification
+
+After the release workflow finishes:
+
+- [ ] The GitHub release page lists `main.js`, `manifest.json`, and `styles.css` as assets.
+- [ ] Each asset is non-empty.
+- [ ] The release page's body contains the auto-generated changelog.
+- [ ] The "latest release" badge on the README points to the new tag (badges update within ~5 min).
+- [ ] If this is a planned marketplace submission, proceed with `docs/marketplace-readiness.md` §"Pre-release checklist" → submission PR to `obsidianmd/obsidian-releases`.
+
+---
+
+## 7. Failure recovery
+
+| Failure | Recovery |
+|---|---|
+| Pre-PR gate fails locally | Fix the underlying issue and re-run. Do not push a known-broken release PR. |
+| `manifest-validation` fails on the develop→main PR | The bump produced an invalid state. Inspect the validator output, fix `manifest.json` / `versions.json` / `package.json`, force-push the develop branch *only if no one else has pulled it*; otherwise revert the bump commit on develop and start over. |
+| Release workflow fails on `Verify tag is on main HEAD` | The tag does not point at `main` HEAD. Delete the remote tag (`git push origin :X.Y.Z`), re-tag locally on `main` HEAD, push. |
+| Release workflow fails on `Verify manifest, package, and versions.json all match tag` | The bump created a mismatch that slipped past the develop→main PR. Most likely cause: a follow-up commit on `develop` between bump and merge altered one of the three files. Open a fix PR to reconcile, merge, then delete and re-create the tag on the new `main` HEAD. |
+| GitHub release was created but a wrong file is attached | Edit the release on GitHub and re-upload the missing asset. Do *not* delete and re-create the release — direct download links break. |
+| The release was published but should not have been | Treat as immutable. Open a `release: X.Y.Z+1` follow-up that reverts or supersedes the bad change rather than retracting the published artifact. |
+
+Never delete a published tag from `origin`. Even if the release is broken, the tag is part of the audit trail and may be cached by Obsidian or BRAT.
+
+---
+
+## 8. Automation summary
+
+| Step | Automated by |
+|---|---|
+| Version bump in three files | `npm version <bump>` → `version-bump.js` |
+| Manifest / versions.json schema check | `scripts/validate-manifest.js`, run in CI (`manifest-validation` job) and via the `version` lifecycle hook |
+| Tag points at `main` HEAD | `release.yml` |
+| Tag matches manifest + package + versions.json | `release.yml` |
+| GitHub release creation with correct assets | `release.yml` (`softprops/action-gh-release`) |
+| Prerelease flagging for tags containing `-` | `release.yml` |
+| Marketplace submission | **Manual** — see `marketplace-readiness.md` |
+
+If you find a release activity that is still manual but should not be, file an issue tagged `release` so it can be added to the automation list.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 		"build:web": "vue-tsc --noEmit && vite build",
 		"test:coverage": "vitest run --configLoader runner --coverage",
 		"docs:api": "typedoc",
-		"version": "node version-bump.js && git add manifest.json versions.json"
+		"validate:manifest": "node scripts/validate-manifest.js",
+		"version": "node version-bump.js && node scripts/validate-manifest.js && git add manifest.json versions.json"
 	},
 	"dependencies": {
 		"pinia": "^3.0.4",

--- a/scripts/validate-manifest.js
+++ b/scripts/validate-manifest.js
@@ -1,7 +1,13 @@
 #!/usr/bin/env node
 import { readFileSync } from 'node:fs'
 
-const SEMVER = /^\d+\.\d+\.\d+(?:-[\w.]+)?$/
+// Official semver.org regex (https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string)
+// Accepts the prerelease and build-metadata grammar; rejects empty identifiers,
+// leading zeros on numeric identifiers, and stray underscores.
+const SEMVER =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
+// Obsidian's minAppVersion is documented as plain X.Y.Z without prerelease/build metadata.
+const MINAPP_VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/
 const ID_FORMAT = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
 const URL_FORMAT = /^https?:\/\/[^\s]+$/
 const errors = []
@@ -74,9 +80,9 @@ if (manifest && versions && pkg) {
     errors.push(`manifest.version must match semver \`X.Y.Z[-prerelease]\`; got: ${manifest.version}`)
   }
 
-  if (typeof manifest.minAppVersion !== 'string' || !SEMVER.test(manifest.minAppVersion)) {
+  if (typeof manifest.minAppVersion !== 'string' || !MINAPP_VERSION.test(manifest.minAppVersion)) {
     errors.push(
-      `manifest.minAppVersion must match semver \`X.Y.Z\`; got: ${manifest.minAppVersion}`,
+      `manifest.minAppVersion must match semver \`X.Y.Z\` (no prerelease or build metadata); got: ${manifest.minAppVersion}`,
     )
   }
 
@@ -93,8 +99,10 @@ if (manifest && versions && pkg) {
       if (!SEMVER.test(k)) {
         errors.push(`versions.json key not semver: ${k}`)
       }
-      if (typeof v !== 'string' || !SEMVER.test(v)) {
-        errors.push(`versions.json[${k}] value must be semver string; got: ${JSON.stringify(v)}`)
+      if (typeof v !== 'string' || !MINAPP_VERSION.test(v)) {
+        errors.push(
+          `versions.json[${k}] value must be plain X.Y.Z (Obsidian minAppVersion form); got: ${JSON.stringify(v)}`,
+        )
       }
     }
 

--- a/scripts/validate-manifest.js
+++ b/scripts/validate-manifest.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs'
+
+const SEMVER = /^\d+\.\d+\.\d+(?:-[\w.]+)?$/
+const ID_FORMAT = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
+const URL_FORMAT = /^https?:\/\/[^\s]+$/
+const errors = []
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'))
+  } catch (err) {
+    errors.push(`failed to read or parse ${path}: ${err.message}`)
+    return null
+  }
+}
+
+const manifest = readJson('manifest.json')
+const versions = readJson('versions.json')
+const pkg = readJson('package.json')
+
+if (manifest && versions && pkg) {
+  const required = [
+    'id',
+    'name',
+    'version',
+    'minAppVersion',
+    'description',
+    'author',
+    'authorUrl',
+    'isDesktopOnly',
+  ]
+  for (const field of required) {
+    if (!(field in manifest)) {
+      errors.push(`manifest.json missing required field: ${field}`)
+    }
+  }
+
+  if (typeof manifest.id !== 'string' || !ID_FORMAT.test(manifest.id)) {
+    errors.push(
+      `manifest.id must be lowercase alphanumeric (hyphens allowed in the middle); got: ${JSON.stringify(manifest.id)}`,
+    )
+  }
+
+  if (typeof manifest.name !== 'string' || manifest.name.length === 0) {
+    errors.push('manifest.name must be a non-empty string')
+  }
+
+  if (typeof manifest.description !== 'string') {
+    errors.push('manifest.description must be a string')
+  } else if (manifest.description.length > 250) {
+    errors.push(
+      `manifest.description must be 250 characters or fewer; got: ${manifest.description.length}`,
+    )
+  } else if (manifest.description.length === 0) {
+    errors.push('manifest.description must not be empty')
+  }
+
+  if (typeof manifest.author !== 'string' || manifest.author.length === 0) {
+    errors.push('manifest.author must be a non-empty string')
+  }
+
+  if (typeof manifest.authorUrl !== 'string' || !URL_FORMAT.test(manifest.authorUrl)) {
+    errors.push(
+      `manifest.authorUrl must be an http(s) URL; got: ${JSON.stringify(manifest.authorUrl)}`,
+    )
+  }
+
+  if (typeof manifest.isDesktopOnly !== 'boolean') {
+    errors.push('manifest.isDesktopOnly must be a boolean')
+  }
+
+  if (typeof manifest.version !== 'string' || !SEMVER.test(manifest.version)) {
+    errors.push(`manifest.version must match semver \`X.Y.Z[-prerelease]\`; got: ${manifest.version}`)
+  }
+
+  if (typeof manifest.minAppVersion !== 'string' || !SEMVER.test(manifest.minAppVersion)) {
+    errors.push(
+      `manifest.minAppVersion must match semver \`X.Y.Z\`; got: ${manifest.minAppVersion}`,
+    )
+  }
+
+  if (typeof pkg.version !== 'string') {
+    errors.push('package.json missing version field')
+  } else if (typeof manifest.version === 'string' && pkg.version !== manifest.version) {
+    errors.push(
+      `package.json version (${pkg.version}) does not match manifest.json version (${manifest.version})`,
+    )
+  }
+
+  if (versions && typeof versions === 'object' && !Array.isArray(versions)) {
+    for (const [k, v] of Object.entries(versions)) {
+      if (!SEMVER.test(k)) {
+        errors.push(`versions.json key not semver: ${k}`)
+      }
+      if (typeof v !== 'string' || !SEMVER.test(v)) {
+        errors.push(`versions.json[${k}] value must be semver string; got: ${JSON.stringify(v)}`)
+      }
+    }
+
+    if (typeof manifest.version === 'string') {
+      if (!(manifest.version in versions)) {
+        errors.push(
+          `versions.json missing entry for current manifest.version (${manifest.version})`,
+        )
+      } else if (
+        typeof manifest.minAppVersion === 'string' &&
+        versions[manifest.version] !== manifest.minAppVersion
+      ) {
+        errors.push(
+          `versions.json[${manifest.version}] (${versions[manifest.version]}) does not match manifest.minAppVersion (${manifest.minAppVersion})`,
+        )
+      }
+    }
+  } else {
+    errors.push('versions.json must be a JSON object')
+  }
+}
+
+if (errors.length > 0) {
+  console.error(`✗ manifest validation failed (${errors.length} error${errors.length === 1 ? '' : 's'}):`)
+  for (const e of errors) console.error(`  - ${e}`)
+  process.exit(1)
+}
+
+console.log(
+  `✓ manifest.json + versions.json + package.json valid (version ${manifest.version}, minAppVersion ${manifest.minAppVersion}).`,
+)

--- a/styles.css
+++ b/styles.css
@@ -127,7 +127,7 @@ to { transform: rotate(360deg);
   flex-wrap: wrap;
 }
 
-.specorator-root :where(.sp-create-form[data-v-dda9ef54]) {
+.specorator-root :where(.sp-create-form[data-v-fe0e72d3]) {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -136,14 +136,14 @@ to { transform: rotate(360deg);
   border: 1px solid var(--interactive-accent);
   border-radius: 8px;
 }
-.specorator-root :where(.sp-create-form__label[data-v-dda9ef54]) {
+.specorator-root :where(.sp-create-form__label[data-v-fe0e72d3]) {
   font-size: 0.8125rem;
   font-weight: 600;
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
-.specorator-root :where(.sp-create-form__input[data-v-dda9ef54]) {
+.specorator-root :where(.sp-create-form__input[data-v-fe0e72d3]) {
   background: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
   border-radius: 6px;
@@ -153,10 +153,10 @@ to { transform: rotate(360deg);
   outline: none;
   width: 100%;
 }
-.specorator-root :where(.sp-create-form__input[data-v-dda9ef54]:focus) {
+.specorator-root :where(.sp-create-form__input[data-v-fe0e72d3]:focus) {
   border-color: var(--interactive-accent);
 }
-.specorator-root :where(.sp-create-form__actions[data-v-dda9ef54]) {
+.specorator-root :where(.sp-create-form__actions[data-v-fe0e72d3]) {
   display: flex;
   gap: 0.5rem;
   margin-top: 0.25rem;


### PR DESCRIPTION
## Summary

Closes #119. Codifies the release flow, manifest field discipline, versions.json policy, and adds a CI gate for the schema rules.

### What's new

- **`scripts/validate-manifest.js`** — pure-node validator (no deps) enforcing:
  - `manifest.json` required fields (`id`, `name`, `version`, `minAppVersion`, `description`, `author`, `authorUrl`, `isDesktopOnly`).
  - Field formats: lowercase-hyphen `id`, ≤250-char `description`, http(s) `authorUrl`, semver `version` and `minAppVersion`, boolean `isDesktopOnly`.
  - Cross-file alignment: `manifest.version == package.json.version`; `manifest.version` exists as a key in `versions.json`; `versions.json[<current>] == manifest.minAppVersion`.
  - `versions.json` schema: keys and values must be semver strings.
- **`manifest-validation` CI job** in `ci.yml` — runs the validator on every push/PR to `develop`, `demo`, `main`. No `npm ci`; pure node, ~10 s.
- **`npm version` lifecycle hook** now runs the validator after `version-bump.js`, so a bad bump fails locally before the commit + tag are created.
- **`npm run validate:manifest`** for ad-hoc local checks.
- **`docs/release-process.md`** (new) — end-to-end runbook: versioning policy (`patch`/`minor`/`major` rules, `minAppVersion` policy, `versions.json` immutability), bump procedure, `develop`→`main` PR, tag re-anchor on `main` HEAD, release workflow behaviour, failure recovery.
- **`docs/marketplace-readiness.md`** — cross-links to `release-process.md`, adds an "Auto-enforced" column to the `manifest.json` requirements table, and marks each version-alignment checklist item as auto-enforced where applicable.

### What was already in place (no change)

- `release.yml` already verifies tag is on `main` HEAD and re-checks manifest+package+versions alignment at run time.
- `version-bump.js` already updates all three files in lockstep.
- `.npmrc` already strips the `v` prefix from tags.

### Acceptance mapping

- [x] Documented release flow from `develop` → `main` tag → marketplace zip → `docs/release-process.md`.
- [x] CI verifies `manifest.json` version equals tag and `versions.json` has an entry → `manifest-validation` job + existing `release.yml` check.
- [x] Marketplace prerequisite checklist committed under `docs/` → `docs/marketplace-readiness.md` already existed; this PR cross-links it and marks auto-enforced items.

## Verification

Local pre-PR gate ran in this worktree:

- `npm audit --audit-level=high --omit=dev` — 0 vulnerabilities
- `node scripts/validate-manifest.js` — passes on current state; mutating the manifest to inject `description.length > 250`, malformed `id`, or non-URL `authorUrl` produces 3 distinct errors and exit-1
- `npm run typecheck`, `npm run lint`, `npm run test` (68 passed), `npm run build`, `npm run build:web`, `npm run docs:api` — all green

The `styles.css` change is a Vue scoped-style hash refresh from PR #131's build state (`data-v-dda9ef54 → data-v-fe0e72d3`); included per CLAUDE.md "styles.css is committed".

## Test plan

- [ ] CI passes (verify, workflow-lint, dependency-review, **manifest-validation**)
- [ ] Reviewer mutates `manifest.json` locally (e.g. shortens `version`) and confirms `node scripts/validate-manifest.js` rejects it
- [ ] Reviewer reads `docs/release-process.md` end-to-end and flags any step that would block a real release attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)