### PR TITLE
chore(test): document coverage gaps

### DIFF
--- a/docs/testing-coverage-gap-matrix.md
+++ b/docs/testing-coverage-gap-matrix.md
@@ -1,0 +1,22 @@
+# Test Coverage Gap Matrix
+
+Issue: #120
+Date: 2026-05-03
+
+This matrix records the current test architecture gaps before the broader W10 test-conventions work in #108. It intentionally avoids moving existing tests to a mirror layout or adding coverage thresholds; those remain in W10 scope.
+
+| Layer | Current coverage | Gap | Priority | Owner issue |
+| --- | --- | --- | --- | --- |
+| Domain | `Feature` and `Slug` unit tests cover aggregate state transitions, slug validation, and edge cases. | Continue adding narrow tests when domain behavior changes. | Medium | Ongoing feature PRs |
+| Application | `CreateFeatureUseCase`, activation, advancement, and repository-backed persistence paths are covered with `MockBridge`. | Split use case tests by source path during mirror-layout migration. | Medium | #108 |
+| Bridge adapters | `MockBridge` and `LocalStorageBridge` had adapter-specific tests, but no shared contract asserting that adapters agree on `IBridge` behavior. | Added shared `IBridge` contract tests for mock and localStorage adapters in this branch. Obsidian adapter still needs a fake Obsidian vault harness before it can join the contract suite. | High | #120, then #108 for harness conventions |
+| Repository persistence | `FeatureRepository` is exercised through use cases, including overwrite protection and deletion. | Add direct repository tests for malformed frontmatter variants, custom settings folders, and path edge cases. | High | Follow-up from #108 |
+| Pinia stores | No direct Pinia store tests. Store behavior is indirectly covered through components/composables only where present. | Add `createTestingPinia`-backed store tests for feature, notification, and settings stores. | High | #108 |
+| Vue components | `CreateFeatureForm` and `FeatureCard` have Vue Test Utils coverage. | Extend interactive component coverage with PageObject examples and `data-testid`-only queries. | Medium | #108 |
+| Router/composables | `fileRoute` has focused route utility tests. Composables are not directly covered. | Add composable tests around bridge failures, loading states, and settings persistence. | Medium | #108 |
+| Standalone smoke | No end-to-end smoke test exercises a full browser-mode happy path through the standalone bridge. | Add a smoke path that creates a feature, opens its workflow state, and verifies persisted bridge state survives reload. | High | #108 or separate smoke-test issue |
+| CI coverage gate | Vitest coverage can be run locally, but CI does not enforce thresholds. | Ratchet and enforce statements 80 / branches 70 / functions 80 / lines 80 when the test layout and fake-port conventions land. | Medium | #108 |
+
+## Scope Decision
+
+#120 should close after this matrix and the first high-value bridge contract layer land. The remaining store, component PageObject, smoke, fake-port, mirror-layout, and coverage-threshold work should be absorbed by W10 (#108), because that issue already defines the conventions needed to keep those tests consistent.

--- a/src/infrastructure/bridge/__tests__/IBridgeContract.spec.ts
+++ b/src/infrastructure/bridge/__tests__/IBridgeContract.spec.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { DEFAULT_SETTINGS, type IBridge } from '../IBridge';
+import { LocalStorageBridge } from '@/infrastructure/localstorage/LocalStorageBridge';
+import { MockBridge } from '@/infrastructure/mock/MockBridge';
+
+interface BridgeScenario {
+	readonly bridge: IBridge;
+	readonly readOpenedFile: () => string | null;
+	readonly readNotices: () => Array<{ message: string; durationMs: number }>;
+}
+
+interface BridgeHarness {
+	readonly name: string;
+	readonly makeScenario: () => BridgeScenario;
+}
+
+function registerBridgeContract(harness: BridgeHarness): void {
+	describe(`${harness.name} IBridge contract`, () => {
+		let scenario: BridgeScenario;
+		let bridge: IBridge;
+
+		beforeEach(() => {
+			scenario = harness.makeScenario();
+			bridge = scenario.bridge;
+		});
+
+		it('reads content after writeFile and reports existence', async () => {
+			await bridge.writeFile('specs/search/workflow-state.md', 'state');
+
+			expect(await bridge.fileExists('specs/search/workflow-state.md')).toBe(true);
+			expect(await bridge.readFile('specs/search/workflow-state.md')).toBe('state');
+		});
+
+		it('rejects readFile for a missing file', async () => {
+			await expect(bridge.readFile('specs/missing/workflow-state.md')).rejects.toThrow(
+				'File not found',
+			);
+		});
+
+		it('removes files idempotently', async () => {
+			await bridge.writeFile('specs/search/workflow-state.md', 'state');
+
+			await bridge.deleteFile('specs/search/workflow-state.md');
+			await bridge.deleteFile('specs/search/workflow-state.md');
+
+			expect(await bridge.fileExists('specs/search/workflow-state.md')).toBe(false);
+		});
+
+		it('lists direct child files under a folder', async () => {
+			await bridge.writeFile('specs/search/workflow-state.md', 'state');
+			await bridge.writeFile('specs/search/idea.md', 'idea');
+			await bridge.writeFile('specs/search/nested/deep.md', 'deep');
+			await bridge.writeFile('specs/other/workflow-state.md', 'other');
+
+			const files = await bridge.listFiles('specs/search');
+
+			expect(files.sort()).toEqual(['specs/search/idea.md', 'specs/search/workflow-state.md']);
+		});
+
+		it('lists immediate child folders under a parent', async () => {
+			await bridge.writeFile('specs/search/workflow-state.md', 'state');
+			await bridge.writeFile('specs/dark-mode/workflow-state.md', 'state');
+			await bridge.writeFile('notes/today.md', 'note');
+
+			const folders = await bridge.listFolders('specs');
+
+			expect(folders.sort()).toEqual(['dark-mode', 'search']);
+		});
+
+		it('allows createFolder to be called before writing files', async () => {
+			await expect(bridge.createFolder('specs/new-feature')).resolves.toBeUndefined();
+			await bridge.writeFile('specs/new-feature/workflow-state.md', 'state');
+
+			expect(await bridge.readFile('specs/new-feature/workflow-state.md')).toBe('state');
+		});
+
+		it('returns defensive settings copies and persists saved settings', async () => {
+			const initial = await bridge.getSettings();
+			const mutableInitial = initial as { locale: string };
+			mutableInitial.locale = 'de';
+
+			expect((await bridge.getSettings()).locale).toBe(DEFAULT_SETTINGS.locale);
+
+			await bridge.saveSettings({ ...DEFAULT_SETTINGS, locale: 'de', specsFolder: 'plans' });
+			const saved = await bridge.getSettings();
+
+			expect(saved.locale).toBe('de');
+			expect(saved.specsFolder).toBe('plans');
+
+			const mutableSaved = saved as { specsFolder: string };
+			mutableSaved.specsFolder = 'mutated';
+			expect((await bridge.getSettings()).specsFolder).toBe('plans');
+		});
+
+		it('emits openFile and notice signals with default notice duration', async () => {
+			await bridge.openFile('specs/search/workflow-state.md');
+			bridge.showNotice('hello');
+
+			expect(scenario.readOpenedFile()).toBe('specs/search/workflow-state.md');
+			expect(scenario.readNotices()).toEqual([{ message: 'hello', durationMs: 4000 }]);
+		});
+	});
+}
+
+registerBridgeContract({
+	name: 'MockBridge',
+	makeScenario: () => {
+		const bridge = new MockBridge();
+		return {
+			bridge,
+			readOpenedFile: () => bridge.getOpenedFile(),
+			readNotices: () => bridge.getNotices(),
+		};
+	},
+});
+
+registerBridgeContract({
+	name: 'LocalStorageBridge',
+	makeScenario: () => {
+		localStorage.clear();
+		let openedFile: string | null = null;
+		const notices: Array<{ message: string; durationMs: number }> = [];
+		const abort = new AbortController();
+
+		window.addEventListener(
+			'sp:open-file',
+			(event) => {
+				openedFile = (event as CustomEvent<{ path: string }>).detail.path;
+			},
+			{ signal: abort.signal },
+		);
+		window.addEventListener(
+			'sp:notice',
+			(event) => {
+				notices.push((event as CustomEvent<{ message: string; durationMs: number }>).detail);
+			},
+			{ signal: abort.signal },
+		);
+
+		return {
+			bridge: new LocalStorageBridge(),
+			readOpenedFile: () => {
+				abort.abort();
+				return openedFile;
+			},
+			readNotices: () => {
+				abort.abort();
+				return notices;
+			},
+		};
+	},
+});

--- a/src/infrastructure/mock/MockBridge.ts
+++ b/src/infrastructure/mock/MockBridge.ts
@@ -39,7 +39,10 @@ export class MockBridge implements IBridge {
 
   async listFiles(folder: string): Promise<string[]> {
     const prefix = folder.endsWith('/') ? folder : `${folder}/`
-    return [...this.files.keys()].filter((p) => p.startsWith(prefix))
+    return [...this.files.keys()].filter((p) => {
+      if (!p.startsWith(prefix)) return false
+      return !p.slice(prefix.length).includes('/')
+    })
   }
 
   async listFolders(parent: string): Promise<string[]> {


### PR DESCRIPTION
## Summary

Documented the #120 test coverage gap matrix and added a shared `IBridge` adapter contract suite for the mock and localStorage bridges. The contract exposed one adapter mismatch, so `MockBridge.listFiles` now matches the direct-child semantics already used by the localStorage and Obsidian adapters.

Closes #120

## Verification

- `npx vitest run src/infrastructure/bridge/__tests__/IBridgeContract.spec.ts --configLoader runner`
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm audit --audit-level=high --omit=dev && npm run typecheck && npm run lint && npm run test && npm run build && npm run build:web && npm run docs:api`

## Test plan

- [ ] CI passes
- [ ] Confirm #108 absorbs the remaining store, PageObject, smoke, fake-port, mirror-layout, and coverage-threshold work