### PR TITLE
chore(architecture): add vault schema guardrails

### DIFF
--- a/docs/adr/ADR-005-agentic-workflow-vault-structure.md
+++ b/docs/adr/ADR-005-agentic-workflow-vault-structure.md
@@ -91,7 +91,9 @@ Aligning with upstream conventions removes the translation layer and makes Speco
 ## Consequences
 
 - `FeatureRepository.serializeFeature` writes `feature:` (not `title:`), the `artifacts` YAML block map, and `last_updated` as a date string.
-- `FeatureRepository.deserializeFeature` reads `feature` as the title (with `title` as a fallback for backward compatibility during the transition).
+- `WorkflowStateDocument.serializeWorkflowState` writes `feature:` (not `title:`), the `artifacts` YAML block map, and `last_updated` as a date string.
+- `WorkflowStateDocument.deserializeWorkflowState` reads `feature` as the title (with `title` as a fallback for backward compatibility during the transition).
+- `FeatureRepository` delegates workflow-state parsing and writing to the owned workflow-state document module instead of owning the schema inline.
 - `PluginSettings.specsFolder` defaults to `specs`; `featuresFolder` is treated as an alias of `specsFolder` if present in saved settings (NFR-AVS-004).
 - The `FeatureStep` domain type already maps step numbers to the correct agentic-workflow slugs (`FEATURE_STEPS` in `src/domain/feature/FeatureStep.ts`).
 - All vault files remain plain Markdown with YAML frontmatter — readable and editable without the plugin.

--- a/docs/adr/ADR-006-obsidian-api-and-vault-write-safety.md
+++ b/docs/adr/ADR-006-obsidian-api-and-vault-write-safety.md
@@ -1,0 +1,42 @@
+---
+id: ADR-006
+title: Centralize Obsidian API and vault write safety
+status: accepted
+date: 2026-05-03
+references:
+  - docs/pre-feature-architecture-readiness.md
+  - docs/security/supply-chain.md
+  - src/infrastructure/bridge/IBridge.ts
+  - src/infrastructure/vault/VaultPath.ts
+---
+
+# ADR-006 - Centralize Obsidian API and vault write safety
+
+## Decision
+
+Production Obsidian APIs are allowed only in the plugin adapter boundary:
+
+- `src/plugin/**` owns Obsidian plugin lifecycle, settings registration, and view registration.
+- `src/infrastructure/obsidian/**` owns calls into Obsidian vault, workspace, file, folder, and notice APIs.
+- Domain, application, and UI code use `IBridge` or narrower application abstractions instead of importing `obsidian` directly.
+
+All plugin-owned vault paths must pass through a reviewed path utility before repository or workflow code writes, deletes, opens, lists, or creates files. The current utility rejects empty paths, absolute paths, parent traversal, and reserved roots such as `.obsidian`, while normalizing duplicate separators and Windows path separators.
+
+Repository write paths must preserve user-authored files by default:
+
+- Stage artifact creation is create-if-absent and skips existing files with a user notice.
+- `workflow-state.md` updates are allowed only when the existing file parses as an owned workflow-state document.
+- Malformed `workflow-state.md` blocks overwrite so the user can inspect or repair the file.
+
+## Rationale
+
+Specorator writes into a user's durable vault, not into disposable plugin cache. Path construction and overwrite behavior therefore need one obvious review point before template installation, artifact creation, diagnostics, and future repair flows add more write paths.
+
+Keeping Obsidian APIs behind `IBridge` preserves the current testable architecture and prevents UI or use-case code from quietly growing direct vault permissions.
+
+## Consequences
+
+- New repository or workflow services must use `VaultPath` before touching vault paths.
+- Direct Obsidian imports outside the plugin and Obsidian adapter layers remain an ESLint violation.
+- Low-level bridge methods stay intentionally thin; higher-level repository and workflow services own path and overwrite policy.
+- Any future exception must be documented in the ADR or in a follow-up ADR before implementation expands the write surface.

--- a/docs/adr/ADR-007-agent-runtime-boundary.md
+++ b/docs/adr/ADR-007-agent-runtime-boundary.md
@@ -1,0 +1,45 @@
+---
+id: ADR-007
+title: Defer live agent runtime behind a review boundary
+status: accepted
+date: 2026-05-03
+references:
+  - docs/product-vision.md
+  - docs/glossary.md
+  - docs/pre-feature-architecture-readiness.md
+  - specs/agent-interaction-placeholder/idea.md
+---
+
+# ADR-007 - Defer live agent runtime behind a review boundary
+
+## Decision
+
+Specorator v1 does not execute live agents and does not grant automated coworkers direct write access to vault files.
+
+The v1 architecture may expose placeholders, terminology, and typed extension points for future agent interaction, but durable vault mutation remains deterministic and user initiated. Agent-produced content in v2 must enter the system as proposed output that a user can review, edit, accept, or reject before it becomes a vault artifact.
+
+Future agent integration must be introduced through a dedicated application boundary that separates:
+
+- selected vault context from unrestricted vault access;
+- agent execution from deterministic workflow-state parsing and validation;
+- proposed outputs from accepted vault writes;
+- runtime provider choices from domain and UI workflow rules.
+
+The following decisions are explicitly deferred until the v2 agent work starts:
+
+- provider/runtime selection, including whether `agentonomous` is embedded, launched out of process, or reached through a companion service;
+- credential and API key storage;
+- long-running job orchestration, cancellation, and retry semantics;
+- concurrent edits and conflict resolution between human and agent output;
+- telemetry, audit log, and redaction policy.
+
+## Rationale
+
+The product vision depends on agentic coworkers, but v1's safety property is that workflow state is plain Markdown in the user's vault and deterministic code controls writes. Introducing a runtime too early would blur permission, review, and persistence boundaries before the core workflow is stable.
+
+## Consequences
+
+- v1 UI may reserve space for agent interaction, but it must not imply live execution is available.
+- Agent output cannot bypass the same vault path and overwrite guardrails used by ordinary repository writes.
+- Workflow-state parsing remains a deterministic infrastructure concern, not an agent-runtime concern.
+- v2 implementation work needs a fresh ADR or an update to this ADR before adding live execution.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"test:watch": "vitest --configLoader runner",
 		"build:web": "vue-tsc --noEmit && vite build",
 		"test:coverage": "vitest run --configLoader runner --coverage",
+		"verify": "npm audit --audit-level=high --omit=dev && npm run typecheck && npm run lint && npm run test && npm run build && npm run build:web && npm run docs:api",
 		"docs:api": "typedoc",
 		"version": "node version-bump.js && git add manifest.json versions.json"
 	},

--- a/src/application/feature/__tests__/CreateFeatureUseCase.spec.ts
+++ b/src/application/feature/__tests__/CreateFeatureUseCase.spec.ts
@@ -4,10 +4,10 @@ import { AdvanceFeatureStageUseCase } from '../AdvanceFeatureStageUseCase'
 import { ActivateFeatureUseCase } from '../ActivateFeatureUseCase'
 import { MockBridge } from '@/infrastructure/mock/MockBridge'
 import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
-import { DEFAULT_SETTINGS } from '@/infrastructure/bridge/IBridge'
+import { DEFAULT_SETTINGS, type PluginSettings } from '@/infrastructure/bridge/IBridge'
 
-function makeRepo(bridge: MockBridge) {
-  return new FeatureRepository(bridge, DEFAULT_SETTINGS)
+function makeRepo(bridge: MockBridge, settings: PluginSettings = DEFAULT_SETTINGS) {
+  return new FeatureRepository(bridge, settings)
 }
 function makeUseCase(bridge: MockBridge) {
   return new CreateFeatureUseCase(makeRepo(bridge))
@@ -121,6 +121,15 @@ describe('CreateFeatureUseCase', () => {
     expect(bridge.getAllFiles()['specs/dark-mode/workflow-state.md']).toBe('not valid frontmatter')
   })
 
+  it('rejects unsafe configured specs paths before writing vault files', async () => {
+    const repo = makeRepo(bridge, { ...DEFAULT_SETTINGS, specsFolder: '../outside' })
+    const result = await new CreateFeatureUseCase(repo).execute({ title: 'Dark mode' })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.message).toMatch(/parent traversal/)
+    expect(bridge.getAllFiles()).toEqual({})
+  })
+
   it('quotes area and applies sanitization to the slug-derived fallback', async () => {
     // A purely numeric title produces a numeric-only slug → deriveArea gives digits only
     // After sanitization the quoted scalar must never look like a YAML number
@@ -183,6 +192,21 @@ describe('ActivateFeatureUseCase', () => {
 
     const meta = bridge.getAllFiles()['specs/search/workflow-state.md']
     expect(meta).toContain('status: active')
+  })
+
+  it('does not overwrite malformed workflow-state.md during direct repository save', async () => {
+    const bridge = new MockBridge()
+    const repo = makeRepo(bridge)
+    const created = await new CreateFeatureUseCase(repo).execute({ title: 'Search' })
+    expect(created.ok).toBe(true)
+    if (!created.ok) return
+
+    await bridge.writeFile('specs/search/workflow-state.md', 'not valid frontmatter')
+
+    const saveResult = await repo.save(created.value)
+
+    expect(saveResult.ok).toBe(false)
+    expect(bridge.getAllFiles()['specs/search/workflow-state.md']).toBe('not valid frontmatter')
   })
 })
 

--- a/src/infrastructure/bridge/FeatureRepository.ts
+++ b/src/infrastructure/bridge/FeatureRepository.ts
@@ -1,142 +1,24 @@
-import { ok, err, type Result } from '@/domain/shared/Result'
-import { Slug } from '@/domain/shared/Slug'
-import { Feature } from '@/domain/feature/Feature'
-import { isFeatureStatus } from '@/domain/feature/FeatureStatus'
-import { FEATURE_STEPS, getStepMeta } from '@/domain/feature/FeatureStep'
-import type { IFeatureRepository } from '@/domain/feature/IFeatureRepository'
-import type { IBridge, PluginSettings } from './IBridge'
+import { ok, err, type Result } from '@/domain/shared/Result';
+import { Slug } from '@/domain/shared/Slug';
+import { Feature } from '@/domain/feature/Feature';
+import { getStepMeta } from '@/domain/feature/FeatureStep';
+import type { IFeatureRepository } from '@/domain/feature/IFeatureRepository';
+import type { IBridge, PluginSettings } from './IBridge';
+import { joinVaultPath } from '../vault/VaultPath';
+import {
+	deserializeWorkflowState,
+	serializeWorkflowState,
+} from '../workflow-state/WorkflowStateDocument';
 
-const META_FILE = 'workflow-state.md'
-
-// ── Derivation helpers ────────────────────────────────────────────────────────
-
-/** Derive a 2–5 uppercase-letter area code from a slug when none is provided. */
-function deriveArea(slugValue: string): string {
-	return slugValue
-		.split('-')
-		.map((w) => w[0]?.toUpperCase() ?? '')
-		.join('')
-		.slice(0, 5)
-}
-
-/**
- * Build the `artifacts:` YAML block map from the feature's current step.
- * - Steps before currentStep → `complete`
- * - currentStep = 1 (idea, draft) → `complete` (idea was formulated to create the feature)
- * - currentStep > 1 → `in-progress`
- * - Steps after currentStep → `pending`
- */
-function buildArtifactsBlock(currentStep: number): string {
-	// Mirror the same lower-bound clamp applied to stageIndex in serializeFeature
-	// so artifact statuses stay consistent with current_stage (e.g. currentStep ≤ 0
-	// still marks idea as complete rather than pending).
-	const effective = Math.max(1, currentStep)
-	return FEATURE_STEPS.map((slug, idx) => {
-		const stepNum = idx + 1
-		let status: string
-		if (stepNum < effective) {
-			status = 'complete'
-		} else if (stepNum === effective) {
-			status = effective === 1 ? 'complete' : 'in-progress'
-		} else {
-			status = 'pending'
-		}
-		return `  ${slug}: ${status}`
-	}).join('\n')
-}
-
-function serializeFeature(feature: Feature): string {
-	const p = feature.toPlainObject()
-	// Clamp index to [0, last] so currentStep ≤ 0 or > 12 both produce a valid stage.
-	const stageIndex = Math.max(0, Math.min(p.currentStep - 1, FEATURE_STEPS.length - 1))
-	const currentStage = FEATURE_STEPS[stageIndex]
-	// Sanitize area: keep only A-Z, apply to both user value and derived fallback,
-	// then quote the scalar so the YAML value is always a safe string (never a number).
-	const sanitize = (s: string) => s.replace(/[^A-Z]/g, '').slice(0, 5)
-	const area = sanitize(p.area || deriveArea(p.slug)) || sanitize(deriveArea(p.slug)) || 'XX'
-	const lastUpdated = p.updatedAt.toISOString().slice(0, 10)
-	return [
-		'---',
-		`id: ${p.id}`,
-		`slug: ${p.slug}`,
-		`feature: "${p.title.replace(/"/g, '\\"')}"`,
-		`area: "${area}"`,
-		`status: ${p.status}`,
-		`currentStep: ${p.currentStep}`,
-		`current_stage: ${currentStage}`,
-		`last_updated: ${lastUpdated}`,
-		`last_agent: ""`,
-		`artifacts:`,
-		buildArtifactsBlock(p.currentStep),
-		`createdAt: ${p.createdAt.toISOString()}`,
-		`updatedAt: ${p.updatedAt.toISOString()}`,
-		'---',
-		'',
-	].join('\n')
-}
-
-/**
- * Parse YAML frontmatter into a flat string map.
- * Handles block maps (e.g. `artifacts:`) by skipping the parent key and
- * ignoring indented child lines — we do not need artifact statuses for
- * domain reconstitution since we derive them from `currentStep`.
- */
-function parseFrontmatter(content: string): Record<string, string> {
-	const match = /^---\n([\s\S]*?)\n---/.exec(content)
-	if (!match) return {}
-
-	let inArtifactsBlock = false
-	return Object.fromEntries(
-		match[1].split('\n').flatMap((line) => {
-			const isIndented = line.startsWith(' ') || line.startsWith('\t')
-			if (inArtifactsBlock) {
-				// Stay in the block while lines are indented; exit on the first non-indented line.
-				if (isIndented) return []
-				inArtifactsBlock = false
-			}
-			const colonIdx = line.indexOf(':')
-			if (colonIdx === -1) return []
-			const key = line.slice(0, colonIdx).trim()
-			const raw = line.slice(colonIdx + 1).trim()
-			// A key with no inline value is a block-map parent (e.g. `artifacts:`).
-			if (!raw) {
-				if (key === 'artifacts') inArtifactsBlock = true
-				return []
-			}
-			const value = raw.startsWith('"')
-				? raw.slice(1, raw.lastIndexOf('"')).replace(/\\"/g, '"')
-				: raw
-			return [[key, value]]
-		}),
-	)
-}
-
-function deserializeFeature(content: string): Feature | null {
-	const data = parseFrontmatter(content)
-
-	// `feature:` is canonical; `title:` is kept as backward-compat fallback
-	const title = data.feature || data.title
-	if (!data.id || !title || !data.slug || !data.status || !data.currentStep) return null
-	if (!isFeatureStatus(data.status)) return null
-
-	const slug = Slug.reconstitute(data.slug)
-	const currentStep = parseInt(data.currentStep, 10)
-	if (isNaN(currentStep)) return null
-
-	return Feature.reconstitute({
-		id: data.id,
-		slug,
-		title,
-		area: data.area || '',
-		status: data.status,
-		currentStep,
-		createdAt: new Date(data.createdAt ?? Date.now()),
-		updatedAt: new Date(data.updatedAt ?? Date.now()),
-	})
-}
+const META_FILE = 'workflow-state.md';
 
 /** Build a minimal stage artifact stub compatible with agentic-workflow conventions. */
-function buildStageStub(stageName: string, slugValue: string, featureTitle: string, date: string): string {
+function buildStageStub(
+	stageName: string,
+	slugValue: string,
+	featureTitle: string,
+	date: string,
+): string {
 	return [
 		'---',
 		`stage: ${stageName}`,
@@ -147,7 +29,7 @@ function buildStageStub(stageName: string, slugValue: string, featureTitle: stri
 		'',
 		`<!-- ${stageName.charAt(0).toUpperCase() + stageName.slice(1).replace(/-/g, ' ')} artifact for ${featureTitle}. -->`,
 		'',
-	].join('\n')
+	].join('\n');
 }
 
 // ── Repository ────────────────────────────────────────────────────────────────
@@ -158,45 +40,56 @@ export class FeatureRepository implements IFeatureRepository {
 		private readonly settings: PluginSettings,
 	) {}
 
+	private checkedPath(...segments: string[]): string {
+		const path = joinVaultPath(...segments);
+		if (!path.ok) throw path.error;
+		return path.value;
+	}
+
+	private folderPath(slugValue: string): string {
+		return this.checkedPath(this.settings.specsFolder, slugValue);
+	}
+
 	private metaPath(slugValue: string): string {
-		return `${this.settings.specsFolder}/${slugValue}/${META_FILE}`
+		return this.checkedPath(this.settings.specsFolder, slugValue, META_FILE);
 	}
 
 	private stagePath(slugValue: string, stageName: string): string {
-		return `${this.settings.specsFolder}/${slugValue}/${stageName}.md`
+		return this.checkedPath(this.settings.specsFolder, slugValue, `${stageName}.md`);
 	}
 
 	async findAll(): Promise<Feature[]> {
-		const folders = await this.bridge.listFolders(this.settings.specsFolder)
+		const specsFolder = this.checkedPath(this.settings.specsFolder);
+		const folders = await this.bridge.listFolders(specsFolder);
 		const features = await Promise.all(
 			folders.map(async (folder) => {
-				const path = `${this.settings.specsFolder}/${folder}/${META_FILE}`
+				const path = this.checkedPath(specsFolder, folder, META_FILE);
 				try {
-					const content = await this.bridge.readFile(path)
-					return deserializeFeature(content)
+					const content = await this.bridge.readFile(path);
+					return deserializeWorkflowState(content);
 				} catch {
-					return null
+					return null;
 				}
 			}),
-		)
-		return features.filter((f): f is Feature => f !== null)
+		);
+		return features.filter((f): f is Feature => f !== null);
 	}
 
 	async findBySlug(slug: Slug): Promise<Feature | null> {
-		const path = this.metaPath(slug.toString())
-		if (!(await this.bridge.fileExists(path))) return null
-		const content = await this.bridge.readFile(path)
-		const feature = deserializeFeature(content)
+		const path = this.metaPath(slug.toString());
+		if (!(await this.bridge.fileExists(path))) return null;
+		const content = await this.bridge.readFile(path);
+		const feature = deserializeWorkflowState(content);
 		// File exists but is malformed — throw so callers cannot silently overwrite it.
 		if (feature === null) {
-			throw new Error(`Spec at "${path}" exists but could not be parsed — will not overwrite.`)
+			throw new Error(`Spec at "${path}" exists but could not be parsed — will not overwrite.`);
 		}
-		return feature
+		return feature;
 	}
 
 	async findById(id: string): Promise<Feature | null> {
-		const all = await this.findAll()
-		return all.find((f) => f.id === id) ?? null
+		const all = await this.findAll();
+		return all.find((f) => f.id === id) ?? null;
 	}
 
 	/**
@@ -205,10 +98,15 @@ export class FeatureRepository implements IFeatureRepository {
 	 */
 	async save(feature: Feature): Promise<Result<void>> {
 		try {
-			const folder = `${this.settings.specsFolder}/${feature.slug.toString()}`
-			await this.bridge.createFolder(folder)
-			const path = this.metaPath(feature.slug.toString())
-			const isNew = !(await this.bridge.fileExists(path))
+			const folder = this.folderPath(feature.slug.toString());
+			await this.bridge.createFolder(folder);
+			const path = this.metaPath(feature.slug.toString());
+			const isNew = !(await this.bridge.fileExists(path));
+			if (!isNew && deserializeWorkflowState(await this.bridge.readFile(path)) === null) {
+				return err(
+					new Error(`Spec at "${path}" exists but could not be parsed — will not overwrite.`),
+				);
+			}
 			// On first creation, write idea.md before workflow-state.md so the
 			// operation is retry-safe.  idea.md creation is idempotent (preserves
 			// an existing file and returns ok), so if workflow-state.md then fails
@@ -217,20 +115,21 @@ export class FeatureRepository implements IFeatureRepository {
 			// check.  If we wrote workflow-state.md first, an idea.md failure
 			// would leave a valid metadata file and block any retry.
 			if (isNew) {
-				const ideaPath = this.stagePath(feature.slug.toString(), 'idea')
+				const ideaPath = this.stagePath(feature.slug.toString(), 'idea');
 				if (await this.bridge.fileExists(ideaPath)) {
-					this.bridge.showNotice(
-						`Specorator: idea.md already exists — keeping your version.`,
-					)
+					this.bridge.showNotice(`Specorator: idea.md already exists — keeping your version.`);
 				} else {
-					const date = feature.createdAt.toISOString().slice(0, 10)
-					await this.bridge.writeFile(ideaPath, buildStageStub('idea', feature.slug.toString(), feature.title, date))
+					const date = feature.createdAt.toISOString().slice(0, 10);
+					await this.bridge.writeFile(
+						ideaPath,
+						buildStageStub('idea', feature.slug.toString(), feature.title, date),
+					);
 				}
 			}
-			await this.bridge.writeFile(path, serializeFeature(feature))
-			return ok(undefined)
+			await this.bridge.writeFile(path, serializeWorkflowState(feature));
+			return ok(undefined);
 		} catch (e) {
-			return err(e instanceof Error ? e : new Error(String(e)))
+			return err(e instanceof Error ? e : new Error(String(e)));
 		}
 	}
 
@@ -241,34 +140,37 @@ export class FeatureRepository implements IFeatureRepository {
 	 */
 	async createStageFile(feature: Feature, stepNumber: number): Promise<Result<void>> {
 		try {
-			const meta = getStepMeta(stepNumber)
-			if (!meta) return err(new Error(`Unknown step number: ${stepNumber}`))
+			const meta = getStepMeta(stepNumber);
+			if (!meta) return err(new Error(`Unknown step number: ${stepNumber}`));
 
-			const path = this.stagePath(feature.slug.toString(), meta.slug)
+			const path = this.stagePath(feature.slug.toString(), meta.slug);
 			if (await this.bridge.fileExists(path)) {
 				this.bridge.showNotice(
 					`Specorator: ${meta.slug}.md already exists — keeping your version.`,
-				)
-				return ok(undefined)
+				);
+				return ok(undefined);
 			}
-			const date = new Date().toISOString().slice(0, 10)
-			await this.bridge.writeFile(path, buildStageStub(meta.slug, feature.slug.toString(), feature.title, date))
-			return ok(undefined)
+			const date = new Date().toISOString().slice(0, 10);
+			await this.bridge.writeFile(
+				path,
+				buildStageStub(meta.slug, feature.slug.toString(), feature.title, date),
+			);
+			return ok(undefined);
 		} catch (e) {
-			return err(e instanceof Error ? e : new Error(String(e)))
+			return err(e instanceof Error ? e : new Error(String(e)));
 		}
 	}
 
 	async delete(id: string): Promise<Result<void>> {
 		try {
-			const feature = await this.findById(id)
-			if (!feature) return err(new Error(`Feature "${id}" not found`))
-			const folder = `${this.settings.specsFolder}/${feature.slug.toString()}`
-			const files = await this.bridge.listFiles(folder)
-			await Promise.all(files.map((path) => this.bridge.deleteFile(path)))
-			return ok(undefined)
+			const feature = await this.findById(id);
+			if (!feature) return err(new Error(`Feature "${id}" not found`));
+			const folder = this.folderPath(feature.slug.toString());
+			const files = await this.bridge.listFiles(folder);
+			await Promise.all(files.map((path) => this.bridge.deleteFile(path)));
+			return ok(undefined);
 		} catch (e) {
-			return err(e instanceof Error ? e : new Error(String(e)))
+			return err(e instanceof Error ? e : new Error(String(e)));
 		}
 	}
 }

--- a/src/infrastructure/vault/VaultPath.ts
+++ b/src/infrastructure/vault/VaultPath.ts
@@ -1,0 +1,48 @@
+import { err, ok, type Result } from '@/domain/shared/Result';
+
+export class UnsafeVaultPathError extends Error {
+	constructor(path: string, reason: string) {
+		super(`Unsafe vault path "${path}": ${reason}`);
+		this.name = 'UnsafeVaultPathError';
+	}
+}
+
+const WINDOWS_DRIVE_PREFIX = /^[A-Za-z]:[\\/]/;
+const RESERVED_ROOTS = new Set(['.obsidian']);
+
+export function normalizeVaultPath(path: string): Result<string, UnsafeVaultPathError> {
+	const original = path;
+	const trimmed = path.trim();
+
+	if (!trimmed) return err(new UnsafeVaultPathError(original, 'path must not be empty'));
+	if (WINDOWS_DRIVE_PREFIX.test(trimmed)) {
+		return err(new UnsafeVaultPathError(original, 'absolute paths are not allowed'));
+	}
+	if (trimmed.startsWith('/') || trimmed.startsWith('\\')) {
+		return err(new UnsafeVaultPathError(original, 'absolute paths are not allowed'));
+	}
+
+	const parts = trimmed.replace(/\\/g, '/').split('/');
+	const normalizedParts: string[] = [];
+
+	for (const part of parts) {
+		if (!part || part === '.') continue;
+		if (part === '..') {
+			return err(new UnsafeVaultPathError(original, 'parent traversal is not allowed'));
+		}
+		normalizedParts.push(part);
+	}
+
+	if (normalizedParts.length === 0) {
+		return err(new UnsafeVaultPathError(original, 'path must not be empty'));
+	}
+	if (RESERVED_ROOTS.has(normalizedParts[0].toLowerCase())) {
+		return err(new UnsafeVaultPathError(original, 'reserved vault roots are not plugin-owned'));
+	}
+
+	return ok(normalizedParts.join('/'));
+}
+
+export function joinVaultPath(...segments: string[]): Result<string, UnsafeVaultPathError> {
+	return normalizeVaultPath(segments.join('/'));
+}

--- a/src/infrastructure/vault/__tests__/VaultPath.spec.ts
+++ b/src/infrastructure/vault/__tests__/VaultPath.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { joinVaultPath, normalizeVaultPath } from '../VaultPath';
+
+describe('VaultPath', () => {
+	it('normalizes duplicate slashes, dot segments, and Windows separators', () => {
+		const result = normalizeVaultPath(' specs\\\\dark-mode//./workflow-state.md ');
+
+		expect(result.ok).toBe(true);
+		if (result.ok) expect(result.value).toBe('specs/dark-mode/workflow-state.md');
+	});
+
+	it.each([
+		'../outside.md',
+		'specs/../outside.md',
+		'/absolute.md',
+		'C:\\vault\\file.md',
+		'.obsidian/plugins/specorator/data.json',
+		'',
+	])('rejects unsafe path %s', (path) => {
+		const result = normalizeVaultPath(path);
+
+		expect(result.ok).toBe(false);
+	});
+
+	it('joins path segments through the same guardrails', () => {
+		const result = joinVaultPath('specs', 'dark-mode', 'research.md');
+
+		expect(result.ok).toBe(true);
+		if (result.ok) expect(result.value).toBe('specs/dark-mode/research.md');
+	});
+});

--- a/src/infrastructure/workflow-state/WorkflowStateDocument.ts
+++ b/src/infrastructure/workflow-state/WorkflowStateDocument.ts
@@ -1,0 +1,114 @@
+import { Feature } from '@/domain/feature/Feature';
+import { isFeatureStatus } from '@/domain/feature/FeatureStatus';
+import { FEATURE_STEPS } from '@/domain/feature/FeatureStep';
+import { Slug } from '@/domain/shared/Slug';
+
+/** Derive a 2-5 uppercase-letter area code from a slug when none is provided. */
+function deriveArea(slugValue: string): string {
+	return slugValue
+		.split('-')
+		.map((w) => w[0]?.toUpperCase() ?? '')
+		.join('')
+		.slice(0, 5);
+}
+
+function buildArtifactsBlock(currentStep: number): string {
+	const effective = Math.max(1, currentStep);
+	return FEATURE_STEPS.map((slug, idx) => {
+		const stepNum = idx + 1;
+		let status: string;
+		if (stepNum < effective) {
+			status = 'complete';
+		} else if (stepNum === effective) {
+			status = effective === 1 ? 'complete' : 'in-progress';
+		} else {
+			status = 'pending';
+		}
+		return `  ${slug}: ${status}`;
+	}).join('\n');
+}
+
+export function serializeWorkflowState(feature: Feature): string {
+	const p = feature.toPlainObject();
+	const stageIndex = Math.max(0, Math.min(p.currentStep - 1, FEATURE_STEPS.length - 1));
+	const currentStage = FEATURE_STEPS[stageIndex];
+	const sanitize = (s: string) => s.replace(/[^A-Z]/g, '').slice(0, 5);
+	const area = sanitize(p.area || deriveArea(p.slug)) || sanitize(deriveArea(p.slug)) || 'XX';
+	const lastUpdated = p.updatedAt.toISOString().slice(0, 10);
+
+	return [
+		'---',
+		`id: ${p.id}`,
+		`slug: ${p.slug}`,
+		`feature: "${p.title.replace(/"/g, '\\"')}"`,
+		`area: "${area}"`,
+		`status: ${p.status}`,
+		`currentStep: ${p.currentStep}`,
+		`current_stage: ${currentStage}`,
+		`last_updated: ${lastUpdated}`,
+		`last_agent: ""`,
+		`artifacts:`,
+		buildArtifactsBlock(p.currentStep),
+		`createdAt: ${p.createdAt.toISOString()}`,
+		`updatedAt: ${p.updatedAt.toISOString()}`,
+		'---',
+		'',
+	].join('\n');
+}
+
+function parseWorkflowStateFrontmatter(content: string): Record<string, string> {
+	const match = /^---\n([\s\S]*?)\n---/.exec(content);
+	if (!match) return {};
+
+	let inArtifactsBlock = false;
+	return Object.fromEntries(
+		match[1].split('\n').flatMap((line) => {
+			const isIndented = line.startsWith(' ') || line.startsWith('\t');
+			if (inArtifactsBlock) {
+				if (isIndented) return [];
+				inArtifactsBlock = false;
+			}
+
+			const colonIdx = line.indexOf(':');
+			if (colonIdx === -1) return [];
+			const key = line.slice(0, colonIdx).trim();
+			const raw = line.slice(colonIdx + 1).trim();
+			if (!raw) {
+				if (key === 'artifacts') inArtifactsBlock = true;
+				return [];
+			}
+
+			const value = parseScalar(raw);
+			return [[key, value]];
+		}),
+	);
+}
+
+function parseScalar(raw: string): string {
+	if (raw.startsWith('"')) return raw.slice(1, raw.lastIndexOf('"')).replace(/\\"/g, '"');
+	if (raw.startsWith("'")) return raw.slice(1, raw.lastIndexOf("'")).replace(/''/g, "'");
+	return raw;
+}
+
+export function deserializeWorkflowState(content: string): Feature | null {
+	const data = parseWorkflowStateFrontmatter(content);
+
+	const title = data.feature || data.title;
+	if (!data.id || !title || !data.slug || !data.status || !data.currentStep) return null;
+	if (!isFeatureStatus(data.status)) return null;
+
+	const slug = Slug.reconstitute(data.slug);
+	const currentStep = parseInt(data.currentStep, 10);
+	if (isNaN(currentStep)) return null;
+
+	return Feature.reconstitute({
+		id: data.id,
+		slug,
+		title,
+		area: data.area || '',
+		status: data.status,
+		currentStep,
+		createdAt: new Date(data.createdAt ?? Date.now()),
+		updatedAt: new Date(data.updatedAt ?? Date.now()),
+	});
+}

--- a/src/infrastructure/workflow-state/__fixtures__/malformed-workflow-state.md
+++ b/src/infrastructure/workflow-state/__fixtures__/malformed-workflow-state.md
@@ -1,0 +1,1 @@
+not valid frontmatter

--- a/src/infrastructure/workflow-state/__fixtures__/valid-workflow-state.md
+++ b/src/infrastructure/workflow-state/__fixtures__/valid-workflow-state.md
@@ -1,0 +1,26 @@
+---
+id: fixture-id
+slug: dark-mode
+feature: 'Dark mode'
+area: 'DM'
+status: active
+currentStep: 2
+current_stage: research
+last_updated: 2026-05-03
+last_agent: ''
+artifacts:
+  idea: complete
+  research: in-progress
+  requirements: pending
+  design: pending
+  spec: pending
+  tasks: pending
+  implementation-log: pending
+  test-plan: pending
+  test-report: pending
+  review: pending
+  release-notes: pending
+  retrospective: pending
+createdAt: 2026-05-03T10:00:00.000Z
+updatedAt: 2026-05-03T11:00:00.000Z
+---

--- a/src/infrastructure/workflow-state/__tests__/WorkflowStateDocument.spec.ts
+++ b/src/infrastructure/workflow-state/__tests__/WorkflowStateDocument.spec.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { Feature } from '@/domain/feature/Feature';
+import { Slug } from '@/domain/shared/Slug';
+import { deserializeWorkflowState, serializeWorkflowState } from '../WorkflowStateDocument';
+
+function fixture(name: string): string {
+	return readFileSync(
+		resolve(process.cwd(), 'src/infrastructure/workflow-state/__fixtures__', name),
+		'utf8',
+	);
+}
+
+describe('WorkflowStateDocument', () => {
+	it('parses the canonical fixture', () => {
+		const feature = deserializeWorkflowState(fixture('valid-workflow-state.md'));
+
+		expect(feature?.id).toBe('fixture-id');
+		expect(feature?.title).toBe('Dark mode');
+		expect(feature?.slug.toString()).toBe('dark-mode');
+		expect(feature?.currentStep).toBe(2);
+		expect(feature?.status).toBe('active');
+	});
+
+	it('rejects malformed workflow-state content', () => {
+		expect(deserializeWorkflowState(fixture('malformed-workflow-state.md'))).toBeNull();
+	});
+
+	it('rejects workflow-state data with an unknown status', () => {
+		const content = fixture('valid-workflow-state.md').replace('status: active', 'status: paused');
+
+		expect(deserializeWorkflowState(content)).toBeNull();
+	});
+
+	it('serializes a valid workflow-state document', () => {
+		const slug = Slug.reconstitute('quoted-title');
+		const feature = Feature.reconstitute({
+			id: 'serialize-id',
+			slug,
+			title: 'Quoted "Title"',
+			area: 'QT',
+			status: 'draft',
+			currentStep: 1,
+			createdAt: new Date('2026-05-03T10:00:00.000Z'),
+			updatedAt: new Date('2026-05-03T11:00:00.000Z'),
+		});
+
+		const content = serializeWorkflowState(feature);
+
+		expect(content).toContain('feature: "Quoted \\"Title\\""');
+		expect(content).toContain('area: "QT"');
+		expect(content).toContain('current_stage: idea');
+		expect(content).toContain('  idea: complete');
+		expect(deserializeWorkflowState(content)?.id).toBe('serialize-id');
+	});
+});


### PR DESCRIPTION
## Summary

Adds the architecture-readiness guardrails from #95: workflow-state parsing/writing now lives in an owned infrastructure module with fixtures, repository vault paths now pass through a shared path validator, malformed workflow-state files are not overwritten, and the Obsidian API plus future agent runtime boundaries are captured in ADRs.

Closes #95

## Verification

- `npx vitest run src/application/feature/__tests__/CreateFeatureUseCase.spec.ts src/infrastructure/vault/__tests__/VaultPath.spec.ts src/infrastructure/workflow-state/__tests__/WorkflowStateDocument.spec.ts --configLoader runner`
- `npm run lint`
- `npm run verify`
- `git diff --check`

Note: `npm run format:check` was also tried and currently reports pre-existing formatting warnings across many repository files outside this PR's scope.

## Test plan

- [ ] CI passes
- [ ] Reviewer checks ADR scope for the Obsidian API and agent runtime boundaries