### PR TITLE
feat(ui): expose stage advancement on feature card (#113)

### DIFF
--- a/src/ui/components/feature/FeatureCard.vue
+++ b/src/ui/components/feature/FeatureCard.vue
@@ -11,6 +11,7 @@ const emit = defineEmits<{
   activate: [id: string]
   archive: [id: string]
   open: [id: string]
+  'advance-step': [id: string]
 }>()
 
 const stepCount = FEATURE_STEP_COUNT
@@ -57,6 +58,14 @@ const progressWidth = computed(() => `${(completedSteps.value / stepCount) * 100
         @click="emit('activate', feature.id)"
       >
         {{ $t('feature.actions.activate') }}
+      </AppButton>
+      <AppButton
+        v-if="feature.status === 'active' && !isComplete"
+        variant="primary"
+        size="sm"
+        @click="emit('advance-step', feature.id)"
+      >
+        {{ $t('feature.actions.advanceStep') }}
       </AppButton>
       <AppButton
         v-if="feature.status === 'active'"

--- a/src/ui/components/feature/__tests__/FeatureCard.spec.ts
+++ b/src/ui/components/feature/__tests__/FeatureCard.spec.ts
@@ -71,4 +71,39 @@ describe('FeatureCard', () => {
     expect(wrapper.text()).toContain('Abandoned')
     expect(wrapper.text()).not.toContain('Step 13 of 12')
   })
+
+  describe('advance step button', () => {
+    function findAdvanceButton(wrapper: ReturnType<typeof mountCard>) {
+      return wrapper.findAll('button').find((b) => b.text() === 'Advance Step')
+    }
+
+    it('renders for active features that have not completed all stages', () => {
+      const wrapper = mountCard(makeFeature({ status: 'active', currentStep: 3 }))
+      expect(findAdvanceButton(wrapper)).toBeTruthy()
+    })
+
+    it('does not render for draft features', () => {
+      const wrapper = mountCard(makeFeature({ status: 'draft', currentStep: 1 }))
+      expect(findAdvanceButton(wrapper)).toBeFalsy()
+    })
+
+    it('does not render once the feature is complete', () => {
+      const wrapper = mountCard(makeFeature({ status: 'active', currentStep: 13 }))
+      expect(findAdvanceButton(wrapper)).toBeFalsy()
+    })
+
+    it('does not render for archived or abandoned features', () => {
+      const archived = mountCard(makeFeature({ status: 'archived', currentStep: 4 }))
+      const abandoned = mountCard(makeFeature({ status: 'abandoned', currentStep: 4 }))
+      expect(findAdvanceButton(archived)).toBeFalsy()
+      expect(findAdvanceButton(abandoned)).toBeFalsy()
+    })
+
+    it('emits advance-step with the feature id when clicked', async () => {
+      const wrapper = mountCard(makeFeature({ id: 'feat-42', status: 'active', currentStep: 2 }))
+      await findAdvanceButton(wrapper)!.trigger('click')
+
+      expect(wrapper.emitted('advance-step')).toEqual([['feat-42']])
+    })
+  })
 })

--- a/src/ui/composables/__tests__/useFeatures.spec.ts
+++ b/src/ui/composables/__tests__/useFeatures.spec.ts
@@ -1,0 +1,74 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import { createPinia } from 'pinia'
+import { describe, expect, it, beforeEach } from 'vitest'
+import { useFeatures } from '../useFeatures'
+import { BRIDGE_KEY } from '@/infrastructure/bridge/BridgeKey'
+import { MockBridge } from '@/infrastructure/mock/MockBridge'
+import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
+import { CreateFeatureUseCase } from '@/application/feature/CreateFeatureUseCase'
+import { ActivateFeatureUseCase } from '@/application/feature/ActivateFeatureUseCase'
+import { DEFAULT_SETTINGS } from '@/infrastructure/bridge/IBridge'
+
+function harness(bridge: MockBridge) {
+  let api!: ReturnType<typeof useFeatures>
+  const Host = defineComponent({
+    setup() {
+      api = useFeatures()
+      return () => h('div')
+    },
+  })
+  mount(Host, {
+    global: {
+      plugins: [createPinia()],
+      provide: { [BRIDGE_KEY as unknown as symbol]: bridge },
+    },
+  })
+  return api
+}
+
+async function seedActiveFeature(bridge: MockBridge, title = 'Search') {
+  const repo = new FeatureRepository(bridge, DEFAULT_SETTINGS)
+  const created = await new CreateFeatureUseCase(repo).execute({ title })
+  if (!created.ok) throw created.error
+  const activated = await new ActivateFeatureUseCase(repo).execute({ featureId: created.value.id })
+  if (!activated.ok) throw activated.error
+  return activated.value
+}
+
+describe('useFeatures.advanceFeatureStage', () => {
+  let bridge: MockBridge
+
+  beforeEach(() => {
+    bridge = new MockBridge()
+  })
+
+  it('advances current step and upserts the updated feature into the store', async () => {
+    const seeded = await seedActiveFeature(bridge)
+    const api = harness(bridge)
+
+    await api.loadFeatures()
+    await flushPromises()
+
+    expect(api.items.value.find((f) => f.id === seeded.id)?.currentStep).toBe(1)
+
+    await api.advanceFeatureStage(seeded.id)
+    await flushPromises()
+
+    const updated = api.items.value.find((f) => f.id === seeded.id)
+    expect(updated?.currentStep).toBe(2)
+    expect(api.error.value).toBeNull()
+    // Stage file must be written for the new stage
+    expect('specs/search/research.md' in bridge.getAllFiles()).toBe(true)
+  })
+
+  it('sets store.error and does not throw when the feature is missing', async () => {
+    const api = harness(bridge)
+
+    await api.advanceFeatureStage('nonexistent-id')
+    await flushPromises()
+
+    expect(api.error.value).toMatch(/not found/)
+    expect(api.loading.value).toBe(false)
+  })
+})

--- a/src/ui/composables/useFeatures.ts
+++ b/src/ui/composables/useFeatures.ts
@@ -5,6 +5,7 @@ import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
 import { GetFeaturesUseCase } from '@/application/feature/GetFeaturesUseCase'
 import { CreateFeatureUseCase } from '@/application/feature/CreateFeatureUseCase'
 import { ActivateFeatureUseCase } from '@/application/feature/ActivateFeatureUseCase'
+import { AdvanceFeatureStageUseCase } from '@/application/feature/AdvanceFeatureStageUseCase'
 import { ArchiveFeatureUseCase } from '@/application/feature/ArchiveFeatureUseCase'
 import { featureDtoFromDomain } from '../types/FeatureDto'
 import type { FeatureDto } from '../types/FeatureDto'
@@ -83,6 +84,19 @@ export function useFeatures() {
     })
   }
 
+  async function advanceFeatureStage(featureId: string): Promise<void> {
+    await withLoading(async () => {
+      const settings = await bridge.getSettings()
+      const repo = new FeatureRepository(bridge, settings)
+      const result = await new AdvanceFeatureStageUseCase(repo).execute({ featureId })
+      if (result.ok) {
+        store.upsert(featureDtoFromDomain(result.value))
+      } else {
+        store.setError(result.error.message)
+      }
+    })
+  }
+
   return {
     items: computed(() => store.items),
     activeItems: computed(() => store.activeItems),
@@ -93,5 +107,6 @@ export function useFeatures() {
     createFeature,
     activateFeature,
     archiveFeature,
+    advanceFeatureStage,
   }
 }

--- a/src/ui/views/FeaturesView.vue
+++ b/src/ui/views/FeaturesView.vue
@@ -9,8 +9,16 @@ import { useBridge } from '../composables/useBridge'
 
 const { t } = useI18n()
 const bridge = useBridge()
-const { items, loading, error, loadFeatures, createFeature, activateFeature, archiveFeature } =
-  useFeatures()
+const {
+  items,
+  loading,
+  error,
+  loadFeatures,
+  createFeature,
+  activateFeature,
+  archiveFeature,
+  advanceFeatureStage,
+} = useFeatures()
 const showCreateForm = ref(false)
 
 onMounted(loadFeatures)
@@ -64,6 +72,7 @@ async function handleOpen(featureId: string) {
           :feature="feature"
           @activate="activateFeature"
           @archive="archiveFeature"
+          @advance-step="advanceFeatureStage"
           @open="handleOpen"
         />
       </div>

--- a/src/ui/views/HomeView.vue
+++ b/src/ui/views/HomeView.vue
@@ -11,7 +11,16 @@ import { useBridge } from '../composables/useBridge'
 const { t } = useI18n()
 const router = useRouter()
 const bridge = useBridge()
-const { activeItems, loading, error, loadFeatures, createFeature, activateFeature, archiveFeature } = useFeatures()
+const {
+  activeItems,
+  loading,
+  error,
+  loadFeatures,
+  createFeature,
+  activateFeature,
+  archiveFeature,
+  advanceFeatureStage,
+} = useFeatures()
 const showCreateForm = ref(false)
 
 onMounted(loadFeatures)
@@ -69,6 +78,7 @@ async function handleOpen(featureId: string) {
           :feature="feature"
           @activate="activateFeature"
           @archive="archiveFeature"
+          @advance-step="advanceFeatureStage"
           @open="handleOpen"
         />
       </div>

--- a/styles.css
+++ b/styles.css
@@ -74,7 +74,7 @@ to { transform: rotate(360deg);
 }
 }
 
-.specorator-root :where(.sp-feature-card[data-v-abdcd6a9]) {
+.specorator-root :where(.sp-feature-card[data-v-bb8a519d]) {
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
   border-radius: 8px;
@@ -83,13 +83,13 @@ to { transform: rotate(360deg);
   flex-direction: column;
   gap: 0.625rem;
 }
-.specorator-root :where(.sp-feature-card__header[data-v-abdcd6a9]) {
+.specorator-root :where(.sp-feature-card__header[data-v-bb8a519d]) {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
 }
-.specorator-root :where(.sp-feature-card__title[data-v-abdcd6a9]) {
+.specorator-root :where(.sp-feature-card__title[data-v-bb8a519d]) {
   margin: 0;
   font-size: 0.9375rem;
   font-weight: 600;
@@ -100,28 +100,28 @@ to { transform: rotate(360deg);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.specorator-root :where(.sp-feature-card__progress[data-v-abdcd6a9]) {
+.specorator-root :where(.sp-feature-card__progress[data-v-bb8a519d]) {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
 }
-.specorator-root :where(.sp-progress-bar[data-v-abdcd6a9]) {
+.specorator-root :where(.sp-progress-bar[data-v-bb8a519d]) {
   height: 4px;
   background: var(--background-modifier-border);
   border-radius: 9999px;
   overflow: hidden;
 }
-.specorator-root :where(.sp-progress-bar__fill[data-v-abdcd6a9]) {
+.specorator-root :where(.sp-progress-bar__fill[data-v-bb8a519d]) {
   height: 100%;
   background: var(--interactive-accent);
   border-radius: 9999px;
   transition: width 0.3s ease;
 }
-.specorator-root :where(.sp-feature-card__step-label[data-v-abdcd6a9]) {
+.specorator-root :where(.sp-feature-card__step-label[data-v-bb8a519d]) {
   font-size: 0.75rem;
   color: var(--text-muted);
 }
-.specorator-root :where(.sp-feature-card__actions[data-v-abdcd6a9]) {
+.specorator-root :where(.sp-feature-card__actions[data-v-bb8a519d]) {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
@@ -162,67 +162,67 @@ to { transform: rotate(360deg);
   margin-top: 0.25rem;
 }
 
-.specorator-root :where(.sp-home[data-v-39731351]) {
+.specorator-root :where(.sp-home[data-v-a5461005]) {
   padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
 }
-.specorator-root :where(.sp-home__header[data-v-39731351]) { display: flex; align-items: flex-start; justify-content: space-between;
+.specorator-root :where(.sp-home__header[data-v-a5461005]) { display: flex; align-items: flex-start; justify-content: space-between;
 }
-.specorator-root :where(.sp-home__title[data-v-39731351]) { margin: 0; font-size: 1.25rem; font-weight: 700; color: var(--text-normal);
+.specorator-root :where(.sp-home__title[data-v-a5461005]) { margin: 0; font-size: 1.25rem; font-weight: 700; color: var(--text-normal);
 }
-.specorator-root :where(.sp-home__subtitle[data-v-39731351]) { margin: 0.25rem 0 0; font-size: 0.875rem; color: var(--text-muted);
+.specorator-root :where(.sp-home__subtitle[data-v-a5461005]) { margin: 0.25rem 0 0; font-size: 0.875rem; color: var(--text-muted);
 }
-.specorator-root :where(.sp-home__section[data-v-39731351]) { display: flex; flex-direction: column; gap: 0.75rem;
+.specorator-root :where(.sp-home__section[data-v-a5461005]) { display: flex; flex-direction: column; gap: 0.75rem;
 }
-.specorator-root :where(.sp-home__section-header[data-v-39731351]) { display: flex; align-items: center; justify-content: space-between;
+.specorator-root :where(.sp-home__section-header[data-v-a5461005]) { display: flex; align-items: center; justify-content: space-between;
 }
-.specorator-root :where(.sp-home__section-title[data-v-39731351]) { margin: 0; font-size: 0.875rem; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em;
+.specorator-root :where(.sp-home__section-title[data-v-a5461005]) { margin: 0; font-size: 0.875rem; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em;
 }
-.specorator-root :where(.sp-home__cards[data-v-39731351]) { display: flex; flex-direction: column; gap: 0.625rem;
+.specorator-root :where(.sp-home__cards[data-v-a5461005]) { display: flex; flex-direction: column; gap: 0.625rem;
 }
-.specorator-root :where(.sp-home__meta[data-v-39731351]) { color: var(--text-muted); font-size: 0.875rem; margin: 0;
+.specorator-root :where(.sp-home__meta[data-v-a5461005]) { color: var(--text-muted); font-size: 0.875rem; margin: 0;
 }
-.specorator-root :where(.sp-home__error[data-v-39731351]) { color: var(--text-error); font-size: 0.875rem; margin: 0;
+.specorator-root :where(.sp-home__error[data-v-a5461005]) { color: var(--text-error); font-size: 0.875rem; margin: 0;
 }
-.specorator-root :where(.sp-home__nav[data-v-39731351]) { display: flex; gap: 0.5rem;
+.specorator-root :where(.sp-home__nav[data-v-a5461005]) { display: flex; gap: 0.5rem;
 }
 
-.specorator-root :where(.sp-features[data-v-caff02d4]) {
+.specorator-root :where(.sp-features[data-v-35e09c13]) {
   padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
-.specorator-root :where(.sp-features__header[data-v-caff02d4]) {
+.specorator-root :where(.sp-features__header[data-v-35e09c13]) {
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
-.specorator-root :where(.sp-features__title[data-v-caff02d4]) {
+.specorator-root :where(.sp-features__title[data-v-35e09c13]) {
   margin: 0;
   font-size: 1.1rem;
   font-weight: 700;
   color: var(--text-normal);
 }
-.specorator-root :where(.sp-features__list[data-v-caff02d4]) {
+.specorator-root :where(.sp-features__list[data-v-35e09c13]) {
   display: flex;
   flex-direction: column;
   gap: 0.625rem;
 }
-.specorator-root :where(.sp-features__meta[data-v-caff02d4]),
-.specorator-root :where(.sp-features__empty[data-v-caff02d4]) {
+.specorator-root :where(.sp-features__meta[data-v-35e09c13]),
+.specorator-root :where(.sp-features__empty[data-v-35e09c13]) {
   color: var(--text-muted);
   font-size: 0.875rem;
   margin: 0;
   line-height: 1.6;
 }
-.specorator-root :where(.sp-features__empty-hint[data-v-caff02d4]) {
+.specorator-root :where(.sp-features__empty-hint[data-v-35e09c13]) {
   font-size: 0.8125rem;
   opacity: 0.7;
 }
-.specorator-root :where(.sp-features__error[data-v-caff02d4]) {
+.specorator-root :where(.sp-features__error[data-v-35e09c13]) {
   color: var(--text-error);
   font-size: 0.875rem;
   margin: 0;


### PR DESCRIPTION
## Summary
- Add an `Advance Step` action on `FeatureCard` for active, non-complete features (hidden for draft / complete / archived / abandoned).
- New `advanceFeatureStage` composable in `useFeatures` runs `AdvanceFeatureStageUseCase`, upserts the resulting DTO on success, surfaces `store.error` on failure (no throw).
- `HomeView` + `FeaturesView` forward the new `advance-step` event into the composable.

Closes #113.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` — 105 / 105 (new `useFeatures.spec.ts` covers happy + error path through `MockBridge`; new `FeatureCard.spec.ts` cases cover button visibility per status and the `advance-step` emit)
- [x] `npm run build`
- [x] `npm run build:web`
- [x] `npm run docs:api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)