### PR TITLE
feat(domain): tryAsync/trySync helpers + try/catch ban outside infra (#104)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -62,6 +62,18 @@ export default tseslint.config(
 			'@typescript-eslint/no-explicit-any': 'error',
 			'vue/multi-word-component-names': 'off',
 			'vue/component-api-style': ['error', ['script-setup']],
+			// Result discipline (ADR-004): raw try/catch is reserved for the
+			// infrastructure layer and the tryAsync/trySync helper itself.
+			// Domain, application, and UI code must use those helpers to
+			// convert thrown values into Result<T, E>.
+			'no-restricted-syntax': [
+				'error',
+				{
+					selector: 'TryStatement',
+					message:
+						'Use tryAsync/trySync from @/domain/shared/tryAsync instead of try/catch. Raw try/catch is allowed only in src/infrastructure/** and the helper itself.',
+				},
+			],
 		},
 	},
 
@@ -70,6 +82,20 @@ export default tseslint.config(
 		files: ['src/plugin/**/*.ts', 'src/infrastructure/obsidian/**/*.ts'],
 		rules: {
 			'no-restricted-imports': 'off',
+		},
+	},
+
+	// Result-discipline allowlist: the helper itself, the infrastructure
+	// adapter layer, and Node-side scripts are the only places where raw
+	// try/catch is sanctioned.
+	{
+		files: [
+			'src/infrastructure/**/*.ts',
+			'src/domain/shared/tryAsync.ts',
+			'scripts/**/*.js',
+		],
+		rules: {
+			'no-restricted-syntax': 'off',
 		},
 	},
 );

--- a/src/application/feature/CreateFeatureUseCase.ts
+++ b/src/application/feature/CreateFeatureUseCase.ts
@@ -1,4 +1,5 @@
 import { ok, err, type Result } from '@/domain/shared/Result'
+import { tryAsync } from '@/domain/shared/tryAsync'
 import { Slug } from '@/domain/shared/Slug'
 import { Feature } from '@/domain/feature/Feature'
 import type { IFeatureRepository } from '@/domain/feature/IFeatureRepository'
@@ -19,13 +20,9 @@ export class CreateFeatureUseCase implements UseCase<CreateFeatureInput, Feature
 
     // findBySlug throws when the file exists but is malformed, so both the
     // "already exists" and "unreadable file" cases block creation safely.
-    let existing: Feature | null
-    try {
-      existing = await this.repository.findBySlug(slugResult.value)
-    } catch (e) {
-      return err(e instanceof Error ? e : new Error(String(e)))
-    }
-    if (existing) {
+    const existingResult = await tryAsync(() => this.repository.findBySlug(slugResult.value))
+    if (!existingResult.ok) return existingResult
+    if (existingResult.value) {
       return err(new Error(`A feature with slug "${slugResult.value}" already exists`))
     }
 

--- a/src/domain/shared/__tests__/tryAsync.spec.ts
+++ b/src/domain/shared/__tests__/tryAsync.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { tryAsync, trySync } from '../tryAsync'
+
+describe('trySync', () => {
+  it('wraps a value in ok', () => {
+    const result = trySync(() => 42)
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value).toBe(42)
+  })
+
+  it('wraps a thrown Error in err', () => {
+    const boom = new Error('boom')
+    const result = trySync(() => {
+      throw boom
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe(boom)
+  })
+
+  it('coerces a non-Error throw into an Error', () => {
+    const result = trySync(() => {
+      throw 'plain string'
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(Error)
+      expect(result.error.message).toBe('plain string')
+    }
+  })
+
+  it('prefixes the error message with context and preserves cause', () => {
+    const original = new Error('original')
+    const result = trySync(() => {
+      throw original
+    }, 'while parsing')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toBe('while parsing: original')
+      expect(result.error.cause).toBe(original)
+    }
+  })
+})
+
+describe('tryAsync', () => {
+  it('wraps a resolved value in ok', async () => {
+    const result = await tryAsync(async () => 'hi')
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value).toBe('hi')
+  })
+
+  it('wraps a rejection in err', async () => {
+    const boom = new Error('async boom')
+    const result = await tryAsync(async () => {
+      throw boom
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe(boom)
+  })
+
+  it('coerces a non-Error rejection', async () => {
+    const result = await tryAsync(async () => {
+      throw { code: 42 }
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBeInstanceOf(Error)
+  })
+
+  it('prefixes the rejection message with context', async () => {
+    const result = await tryAsync(async () => {
+      throw new Error('inner')
+    }, 'while loading')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.message).toBe('while loading: inner')
+  })
+})

--- a/src/domain/shared/__tests__/tryAsync.spec.ts
+++ b/src/domain/shared/__tests__/tryAsync.spec.ts
@@ -72,4 +72,37 @@ describe('tryAsync', () => {
     expect(result.ok).toBe(false)
     if (!result.ok) expect(result.error.message).toBe('while loading: inner')
   })
+
+  it('returns err — never rejects — when the thrown value cannot be stringified', async () => {
+    const unstringifiable = Object.create(null) as object
+    const result = await tryAsync(async () => {
+      throw unstringifiable
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBeInstanceOf(Error)
+  })
+
+  it('returns err — never rejects — when toString itself throws', async () => {
+    const hostile = {
+      toString() {
+        throw new Error('toString-boom')
+      },
+    }
+    const result = await tryAsync(async () => {
+      throw hostile
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBeInstanceOf(Error)
+  })
+})
+
+describe('trySync — coercion hardening', () => {
+  it('returns err — never throws — when the thrown value cannot be stringified', () => {
+    const unstringifiable = Object.create(null) as object
+    const result = trySync(() => {
+      throw unstringifiable
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBeInstanceOf(Error)
+  })
 })

--- a/src/domain/shared/tryAsync.ts
+++ b/src/domain/shared/tryAsync.ts
@@ -1,0 +1,35 @@
+import { ok, err, type Result } from './Result'
+
+function toError(thrown: unknown, context?: string): Error {
+  const base = thrown instanceof Error ? thrown : new Error(String(thrown))
+  if (!context) return base
+  const wrapped = new Error(`${context}: ${base.message}`)
+  if (thrown instanceof Error) wrapped.cause = thrown
+  return wrapped
+}
+
+/**
+ * Run an async function and return its outcome as a Result.
+ * Domain and application code use this instead of raw try/catch.
+ */
+export async function tryAsync<T>(
+  fn: () => Promise<T>,
+  context?: string,
+): Promise<Result<T>> {
+  try {
+    return ok(await fn())
+  } catch (thrown) {
+    return err(toError(thrown, context))
+  }
+}
+
+/**
+ * Run a synchronous function and return its outcome as a Result.
+ */
+export function trySync<T>(fn: () => T, context?: string): Result<T> {
+  try {
+    return ok(fn())
+  } catch (thrown) {
+    return err(toError(thrown, context))
+  }
+}

--- a/src/domain/shared/tryAsync.ts
+++ b/src/domain/shared/tryAsync.ts
@@ -1,11 +1,26 @@
 import { ok, err, type Result } from './Result'
 
+// `String(thrown)` invokes the value's `Symbol.toPrimitive` / `toString` /
+// `valueOf` — any of which can throw (e.g. on `Object.create(null)`, or
+// objects with throwing coercion hooks). The helper guarantees callers
+// receive a Result, so coercion must never escape.
+function safeStringify(value: unknown): string {
+  try {
+    return String(value)
+  } catch {
+    return '[unstringifiable thrown value]'
+  }
+}
+
 function toError(thrown: unknown, context?: string): Error {
-  const base = thrown instanceof Error ? thrown : new Error(String(thrown))
-  if (!context) return base
-  const wrapped = new Error(`${context}: ${base.message}`)
-  if (thrown instanceof Error) wrapped.cause = thrown
-  return wrapped
+  if (thrown instanceof Error) {
+    if (!context) return thrown
+    const wrapped = new Error(`${context}: ${thrown.message}`)
+    wrapped.cause = thrown
+    return wrapped
+  }
+  const message = safeStringify(thrown)
+  return new Error(context ? `${context}: ${message}` : message)
 }
 
 /**

--- a/src/ui/components/feature/CreateFeatureForm.vue
+++ b/src/ui/components/feature/CreateFeatureForm.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import AppButton from '../common/AppButton.vue'
+import { tryAsync } from '@/domain/shared/tryAsync'
 
 const props = defineProps<{
   submitHandler: (payload: { title: string; area?: string }) => Promise<boolean>
@@ -22,14 +23,15 @@ async function handleSubmit() {
   if (!trimmedTitle) return
   const trimmedArea = area.value.trim()
   submitting.value = true
-  try {
-    const succeeded = await props.submitHandler({ title: trimmedTitle, area: trimmedArea || undefined })
-    if (succeeded) {
-      title.value = ''
-      area.value = ''
-    }
-  } finally {
-    submitting.value = false
+  const result = await tryAsync(() =>
+    props.submitHandler({ title: trimmedTitle, area: trimmedArea || undefined }),
+  )
+  submitting.value = false
+  if (result.ok && result.value) {
+    title.value = ''
+    area.value = ''
+  } else if (!result.ok) {
+    throw result.error
   }
 }
 </script>

--- a/src/ui/composables/useFeatures.ts
+++ b/src/ui/composables/useFeatures.ts
@@ -7,6 +7,7 @@ import { CreateFeatureUseCase } from '@/application/feature/CreateFeatureUseCase
 import { ActivateFeatureUseCase } from '@/application/feature/ActivateFeatureUseCase'
 import { AdvanceFeatureStageUseCase } from '@/application/feature/AdvanceFeatureStageUseCase'
 import { ArchiveFeatureUseCase } from '@/application/feature/ArchiveFeatureUseCase'
+import { tryAsync } from '@/domain/shared/tryAsync'
 import { featureDtoFromDomain } from '../types/FeatureDto'
 import type { FeatureDto } from '../types/FeatureDto'
 
@@ -17,14 +18,11 @@ export function useFeatures() {
   async function withLoading<T>(fn: () => Promise<T>): Promise<T | undefined> {
     store.setLoading(true)
     store.setError(null)
-    try {
-      return await fn()
-    } catch (e) {
-      store.setError(e instanceof Error ? e.message : 'Unknown error')
-      return undefined
-    } finally {
-      store.setLoading(false)
-    }
+    const result = await tryAsync(fn)
+    store.setLoading(false)
+    if (result.ok) return result.value
+    store.setError(result.error.message)
+    return undefined
   }
 
   async function loadFeatures(): Promise<void> {

--- a/src/ui/composables/useSettings.ts
+++ b/src/ui/composables/useSettings.ts
@@ -3,6 +3,7 @@ import { useBridge } from './useBridge'
 import { useSettingsStore } from '../stores/settingsStore'
 import { setLocale } from '../i18n'
 import type { SupportedLocale } from '../i18n'
+import { tryAsync } from '@/domain/shared/tryAsync'
 import type { PluginSettings } from '@/infrastructure/bridge/IBridge'
 
 export function useSettings() {
@@ -12,13 +13,13 @@ export function useSettings() {
 
   async function loadSettings(): Promise<void> {
     store.setLoading(true)
-    try {
+    const result = await tryAsync(async () => {
       const s = await bridge.getSettings()
       store.setSettings(s)
       if (s.locale) setLocale(s.locale as SupportedLocale)
-    } finally {
-      store.setLoading(false)
-    }
+    })
+    store.setLoading(false)
+    if (!result.ok) throw result.error
   }
 
   async function saveSettings(updated: PluginSettings): Promise<void> {

--- a/src/ui/router/fileRoute.ts
+++ b/src/ui/router/fileRoute.ts
@@ -1,11 +1,10 @@
+import { trySync } from '@/domain/shared/tryAsync'
+
 const ENCODED_OCTET = /%[0-9a-f]{2}/i
 
 export function normalizeFileRoutePath(filePath: string): string {
   if (filePath.includes('/') || !ENCODED_OCTET.test(filePath)) return filePath
 
-  try {
-    return decodeURIComponent(filePath)
-  } catch {
-    return filePath
-  }
+  const decoded = trySync(() => decodeURIComponent(filePath))
+  return decoded.ok ? decoded.value : filePath
 }

--- a/src/ui/views/FileView.vue
+++ b/src/ui/views/FileView.vue
@@ -5,6 +5,7 @@ import { useI18n } from 'vue-i18n'
 import AppButton from '../components/common/AppButton.vue'
 import { useBridge } from '../composables/useBridge'
 import { normalizeFileRoutePath } from '../router/fileRoute'
+import { tryAsync } from '@/domain/shared/tryAsync'
 
 const { t } = useI18n()
 const route = useRoute()
@@ -17,11 +18,9 @@ const notFound = ref(false)
 const copied = ref(false)
 
 onMounted(async () => {
-  try {
-    content.value = await bridge.readFile(filePath)
-  } catch {
-    notFound.value = true
-  }
+  const result = await tryAsync(() => bridge.readFile(filePath))
+  if (result.ok) content.value = result.value
+  else notFound.value = true
 })
 
 async function copyContent() {

--- a/src/ui/views/SettingsView.vue
+++ b/src/ui/views/SettingsView.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import AppButton from '../components/common/AppButton.vue'
 import { useSettings } from '../composables/useSettings'
 import { SUPPORTED_LOCALES } from '../i18n'
+import { tryAsync } from '@/domain/shared/tryAsync'
 import type { PluginSettings } from '@/infrastructure/bridge/IBridge'
 
 const { t } = useI18n()
@@ -15,13 +16,11 @@ onMounted(loadSettings)
 
 async function handleSave() {
   saving.value = true
-  try {
-    await saveSettings({ ...settings.value })
-    saved.value = true
-    setTimeout(() => { saved.value = false }, 2500)
-  } finally {
-    saving.value = false
-  }
+  const result = await tryAsync(() => saveSettings({ ...settings.value }))
+  saving.value = false
+  if (!result.ok) throw result.error
+  saved.value = true
+  setTimeout(() => { saved.value = false }, 2500)
 }
 
 function update<K extends keyof PluginSettings>(key: K, value: PluginSettings[K]) {

--- a/styles.css
+++ b/styles.css
@@ -127,7 +127,7 @@ to { transform: rotate(360deg);
   flex-wrap: wrap;
 }
 
-.specorator-root :where(.sp-create-form[data-v-fe0e72d3]) {
+.specorator-root :where(.sp-create-form[data-v-463f7cec]) {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -136,14 +136,14 @@ to { transform: rotate(360deg);
   border: 1px solid var(--interactive-accent);
   border-radius: 8px;
 }
-.specorator-root :where(.sp-create-form__label[data-v-fe0e72d3]) {
+.specorator-root :where(.sp-create-form__label[data-v-463f7cec]) {
   font-size: 0.8125rem;
   font-weight: 600;
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
-.specorator-root :where(.sp-create-form__input[data-v-fe0e72d3]) {
+.specorator-root :where(.sp-create-form__input[data-v-463f7cec]) {
   background: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
   border-radius: 6px;
@@ -153,10 +153,10 @@ to { transform: rotate(360deg);
   outline: none;
   width: 100%;
 }
-.specorator-root :where(.sp-create-form__input[data-v-fe0e72d3]:focus) {
+.specorator-root :where(.sp-create-form__input[data-v-463f7cec]:focus) {
   border-color: var(--interactive-accent);
 }
-.specorator-root :where(.sp-create-form__actions[data-v-fe0e72d3]) {
+.specorator-root :where(.sp-create-form__actions[data-v-463f7cec]) {
   display: flex;
   gap: 0.5rem;
   margin-top: 0.25rem;
@@ -228,42 +228,42 @@ to { transform: rotate(360deg);
   margin: 0;
 }
 
-.specorator-root :where(.sp-settings[data-v-4e8dcde4]) {
+.specorator-root :where(.sp-settings[data-v-2762917a]) {
   padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
 }
-.specorator-root :where(.sp-settings__title[data-v-4e8dcde4]) {
+.specorator-root :where(.sp-settings__title[data-v-2762917a]) {
   margin: 0;
   font-size: 1.1rem;
   font-weight: 700;
   color: var(--text-normal);
 }
-.specorator-root :where(.sp-settings__fields[data-v-4e8dcde4]) {
+.specorator-root :where(.sp-settings__fields[data-v-2762917a]) {
   display: flex;
   flex-direction: column;
   gap: 0.875rem;
 }
-.specorator-root :where(.sp-settings__field[data-v-4e8dcde4]) {
+.specorator-root :where(.sp-settings__field[data-v-2762917a]) {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
 }
-.specorator-root :where(.sp-settings__field--inline[data-v-4e8dcde4]) {
+.specorator-root :where(.sp-settings__field--inline[data-v-2762917a]) {
   flex-direction: row;
   align-items: center;
   gap: 0.5rem;
 }
-.specorator-root :where(.sp-settings__label[data-v-4e8dcde4]) {
+.specorator-root :where(.sp-settings__label[data-v-2762917a]) {
   font-size: 0.8125rem;
   font-weight: 600;
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
-.specorator-root :where(.sp-settings__input[data-v-4e8dcde4]),
-.specorator-root :where(.sp-settings__select[data-v-4e8dcde4]) {
+.specorator-root :where(.sp-settings__input[data-v-2762917a]),
+.specorator-root :where(.sp-settings__select[data-v-2762917a]) {
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
   border-radius: 6px;
@@ -272,33 +272,33 @@ to { transform: rotate(360deg);
   padding: 0.375rem 0.625rem;
   outline: none;
 }
-.specorator-root :where(.sp-settings__input[data-v-4e8dcde4]:focus),
-.specorator-root :where(.sp-settings__select[data-v-4e8dcde4]:focus) {
+.specorator-root :where(.sp-settings__input[data-v-2762917a]:focus),
+.specorator-root :where(.sp-settings__select[data-v-2762917a]:focus) {
   border-color: var(--interactive-accent);
 }
-.specorator-root :where(.sp-settings__footer[data-v-4e8dcde4]) {
+.specorator-root :where(.sp-settings__footer[data-v-2762917a]) {
   display: flex;
   align-items: center;
   gap: 0.75rem;
 }
-.specorator-root :where(.sp-settings__saved[data-v-4e8dcde4]) {
+.specorator-root :where(.sp-settings__saved[data-v-2762917a]) {
   font-size: 0.875rem;
   color: #4ade80;
 }
 
-.specorator-root :where(.sp-file-view[data-v-95874630]) {
+.specorator-root :where(.sp-file-view[data-v-b88d9952]) {
   padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 1rem;
   height: 100%;
 }
-.specorator-root :where(.sp-file-view__header[data-v-95874630]) {
+.specorator-root :where(.sp-file-view__header[data-v-b88d9952]) {
   display: flex;
   align-items: center;
   gap: 0.75rem;
 }
-.specorator-root :where(.sp-file-view__path[data-v-95874630]) {
+.specorator-root :where(.sp-file-view__path[data-v-b88d9952]) {
   flex: 1;
   margin: 0;
   font-size: 0.875rem;
@@ -308,11 +308,11 @@ to { transform: rotate(360deg);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.specorator-root :where(.sp-file-view__not-found[data-v-95874630]) {
+.specorator-root :where(.sp-file-view__not-found[data-v-b88d9952]) {
   color: var(--text-muted);
   font-size: 0.875rem;
 }
-.specorator-root :where(.sp-file-view__content[data-v-95874630]) {
+.specorator-root :where(.sp-file-view__content[data-v-b88d9952]) {
   flex: 1;
   margin: 0;
   padding: 1rem;
@@ -327,7 +327,7 @@ to { transform: rotate(360deg);
   word-break: break-all;
   color: var(--text-normal);
 }
-.specorator-root :where(.sp-file-view__loading[data-v-95874630]) {
+.specorator-root :where(.sp-file-view__loading[data-v-b88d9952]) {
   color: var(--text-muted);
   font-size: 0.875rem;
   margin: 0;


### PR DESCRIPTION
## Summary
- New `src/domain/shared/tryAsync.ts` exporting `tryAsync` (async) and `trySync` (sync). Both coerce non-`Error` throws into `Error`, preserve `.cause`, and accept an optional `context` prefix that gets glued to the original message.
- Refactor every non-infra `try/catch` (8 sites: `fileRoute`, `useFeatures.withLoading`, `useSettings`, `FileView`, `SettingsView`, `CreateFeatureForm`, `CreateFeatureUseCase`) to route through the helpers. Behavior is preserved.
- Add `no-restricted-syntax: TryStatement` to ESLint, with an allowlist for `src/infrastructure/**`, `src/domain/shared/tryAsync.ts`, and Node-side `scripts/`. Domain, application, and UI cannot reintroduce raw `try/catch` without changing the override list — enforces ADR-004 mechanically.

Note: this is the W6 work from Epic #85. The W5 ESLint hardening epic (#103) will expand the rule pack further; this PR ships only the rule needed to enforce the helper allowlist so #104's acceptance #3 lands with teeth.

Closes #104.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` — 113 / 113 (new `tryAsync.spec.ts` covers ok / Error throw / non-Error throw / context prefix for both helpers)
- [x] `npm run build`
- [x] `npm run build:web`
- [x] `npm run docs:api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)