### PR TITLE
chore: harden local verification gate

### DIFF
--- a/.codex/pre-pr-gate.md
+++ b/.codex/pre-pr-gate.md
@@ -14,21 +14,23 @@ Run this before pushing a branch you intend to open or update a PR with. CI re-r
 
 ```sh
 npm audit --audit-level=high --omit=dev \
+  && npm run validate:manifest \
   && npm run typecheck \
   && npm run lint \
   && npm run test \
   && npm run build \
   && npm run build:web \
-  && npm run docs:api
+  && npm run docs:api \
+  && git diff --check
 ```
 
-All seven steps must succeed in order. `npm audit` runs first because the `verify` job in `.github/workflows/ci.yml` runs it unconditionally on every CI run; matching that locally avoids a slow round-trip if a `high`/`critical` advisory was published since the last install. If any step fails, fix the underlying issue and re-run from the start — do not skip steps that previously passed; later changes may regress them.
+All steps must succeed in order. `npm audit` runs first because the `verify` job in `.github/workflows/ci.yml` runs it unconditionally on every CI run; matching that locally avoids a slow round-trip if a `high`/`critical` advisory was published since the last install. If any step fails, fix the underlying issue and re-run from the start — do not skip steps that previously passed; later changes may regress them.
 
 ### 2. Run the conditional gates
 
 | Condition | Additional gate |
 |---|---|
-| You changed any file under `.github/workflows/` | Run `actionlint` against the changed file(s) and confirm every `uses:` reference is pinned to a 40-character commit SHA. |
+| You changed any file under `.github/workflows/` | Run `npm run verify:workflows` and `actionlint` against the changed file(s). |
 | You changed Vue or browser-side code under `src/ui/` | `npm run dev` and exercise the affected feature in a browser. Type-checks alone do not validate runtime behaviour. |
 | You changed plugin-side code under `src/plugin/` or `src/infrastructure/obsidian/` | Build with `npm run build` and load the resulting `main.js` in an Obsidian test vault if the change is non-trivial. |
 
@@ -36,10 +38,9 @@ All seven steps must succeed in order. `npm audit` runs first because the `verif
 
 ```sh
 git status --short
-git diff --check
 ```
 
-`git diff --check` rejects whitespace errors that ESLint and Prettier may not catch (e.g. trailing whitespace inside code fences in markdown).
+The standard verification chain already runs `git diff --check`; re-check `git status --short` here to confirm only intended files are pending.
 
 ### 4. Confirm the branch is rooted in `develop`
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+echo "Running Specorator pre-push verification..."
+npm run verify
+
+base_ref="origin/develop"
+if git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+  if git diff --name-only "$base_ref"...HEAD | grep -Eq '^\.github/workflows/.*\.ya?ml$'; then
+    echo "Workflow changes detected; running workflow policy checks..."
+    npm run verify:workflows
+
+    if command -v actionlint >/dev/null 2>&1; then
+      actionlint -color
+    else
+      echo "actionlint is not installed; install it before relying on this local workflow check."
+      echo "CI will still run actionlint."
+    fi
+  fi
+else
+  echo "Skipping conditional workflow diff check because origin/develop is not available locally."
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,39 +21,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: lts/*
       - name: Install actionlint
         run: |
           bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
       - name: Run actionlint
         run: ./actionlint -color
       - name: Verify third-party actions are SHA-pinned
-        shell: bash
-        run: |
-          set -euo pipefail
-          mapfile -t files < <(find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) | sort)
-          if [ ${#files[@]} -eq 0 ]; then
-            echo "No workflow files found under .github/workflows."
-            exit 0
-          fi
-          violations=$(awk '
-            /^[[:space:]]*-?[[:space:]]*uses:/ {
-              ref = $0
-              sub(/\r$/, "", ref)
-              sub(/^[^:]*:[[:space:]]*/, "", ref)
-              sub(/[[:space:]]*#.*$/, "", ref)
-              sub(/[[:space:]]+$/, "", ref)
-              gsub(/^["\x27]+|["\x27]+$/, "", ref)
-              if (ref ~ /^\.\//) next
-              if (ref ~ /^docker:\/\//) next
-              if (ref !~ /@[0-9a-f]{40}$/) print FILENAME ":" FNR ": " $0
-            }
-          ' "${files[@]}")
-          if [ -n "$violations" ]; then
-            echo "::error::Unpinned actions found — every 'uses:' must reference a 40-character commit SHA (see docs/security/supply-chain.md)."
-            echo "$violations"
-            exit 1
-          fi
-          echo "All third-party actions are SHA-pinned."
+        run: node scripts/verify-workflows.js
 
   manifest-validation:
     name: Validate manifest and versions.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ main.js.map
 
 # Standalone UI build
 dist-standalone/
+_site/
 
 # TypeScript incremental build info
 *.tsbuildinfo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,19 +38,21 @@ Run all of the following before opening or updating a PR. CI re-runs them, but f
 
 ```sh
 npm audit --audit-level=high --omit=dev \
+  && npm run validate:manifest \
   && npm run typecheck \
   && npm run lint \
   && npm run test \
   && npm run build \
   && npm run build:web \
-  && npm run docs:api
+  && npm run docs:api \
+  && git diff --check
 ```
 
 `npm audit` is part of the standard chain because the CI `verify` job runs it unconditionally on every PR. Matching that locally catches advisories that were published since your last install.
 
 Additional gates depending on what changed:
 
-- **Workflow file changed** (`.github/workflows/*.{yml,yaml}`): run `actionlint` locally and confirm every `uses:` reference is pinned to a 40-character commit SHA. CI enforces both, but the local pass shortens the loop. See [`docs/security/supply-chain.md`](./docs/security/supply-chain.md).
+- **Workflow file changed** (`.github/workflows/*.{yml,yaml}`): run `npm run verify:workflows` and `actionlint` locally. CI enforces both, but the local pass shortens the loop. See [`docs/security/supply-chain.md`](./docs/security/supply-chain.md).
 - **Vue/UI changed**: build the standalone UI (`npm run build:web`) and load it in a browser. Type-checks alone do not validate runtime behaviour.
 
 If any gate fails, fix the underlying issue. Do not bypass with `--no-verify`, `--ignore-scripts`, `if: false`, or by deleting the failing step. If the gate itself is wrong, file an issue and propose the fix in a separate PR before merging the work that needs the bypass.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -243,16 +243,10 @@ Keep commits focused. A commit that does two unrelated things should be two comm
 Run the full pre-PR verification locally:
 
 ```bash
-npm audit --audit-level=high --omit=dev
-npm run typecheck
-npm run lint
-npm run test
-npm run build
-npm run build:web
-npm run docs:api
+npm run verify
 ```
 
-`npm audit` is included because CI's `verify` job runs it unconditionally on every PR (see §9). All checks must pass. See [docs/local-development.md](./local-development.md) for the full verification workflow and [.codex/pre-pr-gate.md](../.codex/pre-pr-gate.md) for the agent-oriented version of the same chain.
+`npm run verify` includes production dependency audit, manifest validation, typecheck, lint, tests, plugin build, standalone UI build, API docs, and whitespace checks. All checks must pass. `npm run format:check` remains available, but it is not yet part of the required gate because the current baseline is not Prettier-clean. See [docs/local-development.md](./local-development.md) for the full verification workflow and [.codex/pre-pr-gate.md](../.codex/pre-pr-gate.md) for the agent-oriented version of the same chain.
 
 ### PR description
 
@@ -330,7 +324,7 @@ The CI workflow (`.github/workflows/ci.yml`) runs on pushes to `develop`, `demo`
 ### `workflow-lint` job
 
 1. `actionlint` — validates workflow YAML syntax and expression types
-2. SHA-pin check — fails the build if any `uses:` reference in `.github/workflows/*.{yml,yaml}` is not pinned to a 40-character commit SHA
+2. `npm run verify:workflows` — fails the build if any `uses:` reference in `.github/workflows/*.{yml,yaml}` is not pinned to a 40-character commit SHA
 
 ### Pull-request-only jobs
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -51,14 +51,32 @@ npm ci
 | `npm run build` | Type-checks and builds the Obsidian plugin bundle |
 | `npm run dev:plugin` | Builds the plugin in watch mode (rebuilds on save) |
 | `npm run build:web` | Builds the standalone browser UI to `dist-standalone/` |
+| `npm run build:pages` | Builds the GitHub Pages preview into `_site/` with the production base path |
 | `npm run dev` | Runs the standalone UI dev server in the browser |
 | `npm run docs:api` | Generates TypeDoc API docs to `docs/api/` |
+| `npm run verify` | Runs the standard local pre-PR gate |
+| `npm run verify:workflows` | Confirms GitHub Actions `uses:` entries are pinned to commit SHAs |
+| `npm run hooks:install` | Points Git at the repo's shared `.githooks/` directory |
 
 Run the full verification gate before opening a pull request:
 
 ```sh
-npm run typecheck && npm run lint && npm run test && npm run build && npm run build:web && npm run docs:api
+npm run verify
 ```
+
+Run `npm ci` before `npm run verify` when `package.json` or `package-lock.json` changed, or when you are validating from a fresh checkout.
+
+### Optional pre-push hook
+
+The repository includes a native Git pre-push hook in `.githooks/pre-push`. Enable it per checkout:
+
+```sh
+npm run hooks:install
+```
+
+The hook runs `npm run verify` before every push. If the branch changes workflow files, it also runs `npm run verify:workflows` and runs `actionlint` when `actionlint` is installed locally. CI remains authoritative, but the hook catches most avoidable failures before a remote push.
+
+Husky would also work for this job and can auto-install hooks through npm lifecycle scripts. The current repo uses native Git hooks instead to avoid adding a dev dependency and to keep hook installation explicit. Reconsider Husky if the team wants automatic hook setup for every `npm install` and accepts that extra lifecycle behavior.
 
 ## Build output
 
@@ -130,7 +148,7 @@ Keep the test vault empty of personal content. The plugin may write files during
 
 ## Verifying plugin behavior before opening a PR
 
-1. Run the full verification gate: `npm run typecheck && npm run lint && npm run test && npm run build && npm run build:web && npm run docs:api`
+1. Run the full verification gate: `npm run verify`
 2. Confirm the plugin loads in Obsidian without errors (check **Settings → Community plugins** and the developer console with `Ctrl+Shift+I` / `Cmd+Option+I`).
 3. Open the Specorator panel and confirm the UI renders correctly.
 4. Exercise the specific code path changed by your PR and confirm it works as expected.
@@ -159,7 +177,7 @@ The repository publishes a product page at `https://luis85.github.io/specorator/
 
 ### How the deployment works
 
-The `.github/workflows/pages.yml` workflow runs on every push to `main`:
+The `.github/workflows/pages.yml` workflow runs on every push to `demo`:
 
 1. Runs `npm run build:web` with `VITE_BASE_URL=/specorator/app/` so all SPA asset paths are prefixed correctly.
 2. Assembles a `_site/` staging directory:
@@ -169,15 +187,12 @@ The `.github/workflows/pages.yml` workflow runs on every push to `main`:
 
 ### Updating the product page
 
-Edit `site/index.html` and push to `main`. The workflow redeploys automatically.
+Edit `site/index.html` and merge the change to `demo`. The workflow redeploys automatically.
 
 ### Building the Pages site locally
 
 ```sh
-VITE_BASE_URL=/specorator/app/ npm run build:web
-mkdir -p _site/app
-cp site/index.html _site/index.html
-cp -r dist-standalone/. _site/app/
+npm run build:pages
 # Open _site/index.html in a browser to preview
 ```
 

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -54,7 +54,7 @@ uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 Two CI checks back this rule:
 
 - `actionlint` validates workflow YAML syntax and expression types.
-- A dedicated `Verify third-party actions are SHA-pinned` step in the `workflow-lint` job greps every `uses:` line across both `.yml` and `.yaml` files under `.github/workflows/` and fails the build if any reference is not pinned to a 40-character commit SHA. Local composite actions (`./...`) and `docker://` references are exempt.
+- `npm run verify:workflows` checks every `uses:` line across both `.yml` and `.yaml` files under `.github/workflows/` and fails the build if any reference is not pinned to a 40-character commit SHA. Local composite actions (`./...`) and `docker://` references are exempt.
 
 A PR that introduces an unpinned `uses:` line cannot merge until the SHA is supplied.
 
@@ -80,7 +80,7 @@ When a PR adds a new runtime dependency (`dependencies` in `package.json`, not `
 
 ### Workflow / action changes
 
-- Any new `uses:` line must be pinned to a SHA in the same PR that introduces it. CI does not enforce this directly today; reviewers do.
+- Any new `uses:` line must be pinned to a SHA in the same PR that introduces it. CI enforces this through `npm run verify:workflows`; reviewers still confirm the SHA matches the intended upstream tag.
 - Granting a workflow `write` permission requires an explicit comment in the PR explaining what is written and why a `read` token is insufficient.
 
 ## Threat model assumptions

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,7 +38,7 @@ export default tseslint.config(
 
 	// Global ignores
 	{
-		ignores: ['node_modules/', 'main.js', 'dist-standalone/', '.worktrees/', 'docs/api/'],
+		ignores: ['node_modules/', 'main.js', 'dist-standalone/', '_site/', '.worktrees/', 'docs/api/'],
 	},
 
 	// Project-wide rules

--- a/package.json
+++ b/package.json
@@ -18,8 +18,11 @@
 		"test": "vitest run --configLoader runner",
 		"test:watch": "vitest --configLoader runner",
 		"build:web": "vue-tsc --noEmit && vite build",
+		"build:pages": "node scripts/build-pages-local.js",
 		"test:coverage": "vitest run --configLoader runner --coverage",
-		"verify": "npm audit --audit-level=high --omit=dev && npm run typecheck && npm run lint && npm run test && npm run build && npm run build:web && npm run docs:api",
+		"verify": "npm audit --audit-level=high --omit=dev && npm run validate:manifest && npm run typecheck && npm run lint && npm run test && npm run build && npm run build:web && npm run docs:api && git diff --check",
+		"verify:workflows": "node scripts/verify-workflows.js",
+		"hooks:install": "git config core.hooksPath .githooks",
 		"docs:api": "typedoc",
 		"validate:manifest": "node scripts/validate-manifest.js",
 		"version": "node version-bump.js && node scripts/validate-manifest.js && git add manifest.json versions.json"

--- a/scripts/build-pages-local.js
+++ b/scripts/build-pages-local.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+import { cpSync, mkdirSync, rmSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const buildEnv = {
+	...process.env,
+	VITE_BASE_URL: '/specorator/app/',
+};
+const result =
+	process.platform === 'win32'
+		? spawnSync('npm run build:web', {
+				stdio: 'inherit',
+				shell: true,
+				env: buildEnv,
+			})
+		: spawnSync('npm', ['run', 'build:web'], {
+				stdio: 'inherit',
+				env: buildEnv,
+			});
+
+if (result.error) {
+	console.error(result.error.message);
+	process.exit(1);
+}
+
+if (result.status !== 0) {
+	process.exit(result.status ?? 1);
+}
+
+rmSync('_site', { recursive: true, force: true });
+mkdirSync(join('_site', 'app'), { recursive: true });
+cpSync(join('site', 'index.html'), join('_site', 'index.html'));
+cpSync('dist-standalone', join('_site', 'app'), { recursive: true });
+
+console.log('Built local GitHub Pages preview in _site/.');

--- a/scripts/verify-workflows.js
+++ b/scripts/verify-workflows.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const WORKFLOW_DIR = '.github/workflows';
+const USES_LINE = /^[\s-]*uses:\s*(.+?)\s*$/;
+const PINNED_REF = /@[0-9a-f]{40}$/i;
+
+function normalizeUses(value) {
+	return value
+		.replace(/\r$/, '')
+		.replace(/\s+#.*$/, '')
+		.trim()
+		.replace(/^["']+|["']+$/g, '');
+}
+
+const files = readdirSync(WORKFLOW_DIR)
+	.filter((file) => /\.ya?ml$/i.test(file))
+	.sort();
+
+const violations = [];
+
+for (const file of files) {
+	const path = join(WORKFLOW_DIR, file);
+	const lines = readFileSync(path, 'utf8').split('\n');
+
+	lines.forEach((line, index) => {
+		const match = USES_LINE.exec(line);
+		if (!match) return;
+
+		const ref = normalizeUses(match[1]);
+		if (ref.startsWith('./') || ref.startsWith('docker://')) return;
+		if (PINNED_REF.test(ref)) return;
+
+		violations.push(`${path}:${index + 1}: ${line.trim()}`);
+	});
+}
+
+if (violations.length > 0) {
+	console.error(
+		"Unpinned GitHub Actions references found. Every third-party 'uses:' entry must reference a 40-character commit SHA.",
+	);
+	for (const violation of violations) {
+		console.error(`  - ${violation}`);
+	}
+	process.exit(1);
+}
+
+console.log(
+	`Verified ${files.length} workflow file${files.length === 1 ? '' : 's'}: all third-party actions are SHA-pinned.`,
+);


### PR DESCRIPTION
## Summary

Harden the local pre-push and pre-PR verification workflow so contributors can catch more CI and release-surface failures before pushing.

Key changes:

- Extends `npm run verify` with manifest validation and `git diff --check`.
- Adds `npm run verify:workflows` as a portable Node implementation of the GitHub Actions SHA-pin check and reuses it from CI.
- Adds `npm run build:pages` for a Windows-safe local GitHub Pages preview build with `VITE_BASE_URL=/specorator/app/`.
- Adds an explicit native `.githooks/pre-push` hook and `npm run hooks:install`.
- Documents why Husky could help, but leaves it as a follow-up decision instead of adding a new dev dependency now.
- Fixes local-development docs drift around the verification command and Pages deploying from `demo`.

## Verification

- `npm run verify`
- `npm run verify:workflows`
- `npm run build:pages`
- `git diff --cached --check`

Known local-only gaps:

- `actionlint` is not installed in this checkout, so the workflow syntax check is left to CI.
- `npm run format:check` currently fails on the existing `develop` baseline; this PR documents it as a follow-up candidate rather than enforcing a guaranteed-failing gate.

## Test plan

- [ ] CI passes, including `Lint workflow files (actionlint)`.
- [ ] Maintainers decide whether native Git hooks are sufficient or Husky should be adopted in a follow-up.