### PR TITLE
chore: harden local verification gate (#139)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+npm run typecheck && npm run lint && npm run validate:manifest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,34 +26,12 @@ jobs:
           bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
       - name: Run actionlint
         run: ./actionlint -color
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: lts/*
       - name: Verify third-party actions are SHA-pinned
-        shell: bash
-        run: |
-          set -euo pipefail
-          mapfile -t files < <(find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) | sort)
-          if [ ${#files[@]} -eq 0 ]; then
-            echo "No workflow files found under .github/workflows."
-            exit 0
-          fi
-          violations=$(awk '
-            /^[[:space:]]*-?[[:space:]]*uses:/ {
-              ref = $0
-              sub(/\r$/, "", ref)
-              sub(/^[^:]*:[[:space:]]*/, "", ref)
-              sub(/[[:space:]]*#.*$/, "", ref)
-              sub(/[[:space:]]+$/, "", ref)
-              gsub(/^["\x27]+|["\x27]+$/, "", ref)
-              if (ref ~ /^\.\//) next
-              if (ref ~ /^docker:\/\//) next
-              if (ref !~ /@[0-9a-f]{40}$/) print FILENAME ":" FNR ": " $0
-            }
-          ' "${files[@]}")
-          if [ -n "$violations" ]; then
-            echo "::error::Unpinned actions found — every 'uses:' must reference a 40-character commit SHA (see docs/security/supply-chain.md)."
-            echo "$violations"
-            exit 1
-          fi
-          echo "All third-party actions are SHA-pinned."
+        run: node scripts/verify-workflows.js
 
   manifest-validation:
     name: Validate manifest and versions.json

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,16 +29,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build standalone SPA
-        run: npm run build:web
-        env:
-          VITE_BASE_URL: /specorator/app/
-
-      - name: Assemble Pages site
-        run: |
-          mkdir -p _site/app
-          cp site/index.html _site/index.html
-          cp -r dist-standalone/. _site/app/
+      - name: Build and assemble Pages site
+        run: npm run build:pages
 
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ main.js.map
 # Standalone UI build
 dist-standalone/
 
+# Local Pages preview build
+_site/
+
 # TypeScript incremental build info
 *.tsbuildinfo
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ npx vitest run src/domain/feature/__tests__/Feature.spec.ts
 
 **Pre-PR verification gate:**
 ```sh
-npm run typecheck && npm run lint && npm run test && npm run build && npm run build:web && npm run docs:api
+npm run verify
 ```
 
 ## Architecture

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -181,7 +181,7 @@ The `.github/workflows/pages.yml` workflow runs on every push to `demo`:
 
 ### Updating the product page
 
-Edit `site/index.html` and push to `main`. The workflow redeploys automatically.
+Edit `site/index.html` and push to `demo`. The workflow redeploys automatically.
 
 ### Building the Pages site locally
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -173,7 +173,7 @@ The repository publishes a product page at `https://luis85.github.io/specorator/
 
 The `.github/workflows/pages.yml` workflow runs on every push to `demo`:
 
-1. Runs `npm run build:web` with `VITE_BASE_URL=/specorator/app/` so all SPA asset paths are prefixed correctly.
+1. Runs `npm run build:pages`, which sets `VITE_BASE_URL=/specorator/app/` and invokes `npm run build:web`, so all SPA asset paths are prefixed correctly.
 2. Assembles a `_site/` staging directory:
    - `site/index.html` → `_site/index.html`
    - `dist-standalone/**` → `_site/app/**`

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -57,8 +57,20 @@ npm ci
 Run the full verification gate before opening a pull request:
 
 ```sh
-npm run typecheck && npm run lint && npm run test && npm run build && npm run build:web && npm run docs:api
+npm run verify
 ```
+
+## Git hooks
+
+Install the pre-push hook with:
+
+```sh
+npm run hooks:install
+```
+
+The hook runs `typecheck`, `lint`, and `validate:manifest` before each push. It is intentionally fast — use `npm run verify` for the full gate.
+
+**Husky:** Native Git hooks (`core.hooksPath`) are sufficient for this project. Husky would add cross-platform convenience (auto-install on `npm ci`) but introduces a dev dependency. It remains a follow-up candidate if onboarding friction becomes a problem.
 
 ## Build output
 
@@ -130,7 +142,7 @@ Keep the test vault empty of personal content. The plugin may write files during
 
 ## Verifying plugin behavior before opening a PR
 
-1. Run the full verification gate: `npm run typecheck && npm run lint && npm run test && npm run build && npm run build:web && npm run docs:api`
+1. Run the full verification gate: `npm run verify`
 2. Confirm the plugin loads in Obsidian without errors (check **Settings → Community plugins** and the developer console with `Ctrl+Shift+I` / `Cmd+Option+I`).
 3. Open the Specorator panel and confirm the UI renders correctly.
 4. Exercise the specific code path changed by your PR and confirm it works as expected.
@@ -159,7 +171,7 @@ The repository publishes a product page at `https://luis85.github.io/specorator/
 
 ### How the deployment works
 
-The `.github/workflows/pages.yml` workflow runs on every push to `main`:
+The `.github/workflows/pages.yml` workflow runs on every push to `demo`:
 
 1. Runs `npm run build:web` with `VITE_BASE_URL=/specorator/app/` so all SPA asset paths are prefixed correctly.
 2. Assembles a `_site/` staging directory:
@@ -174,10 +186,7 @@ Edit `site/index.html` and push to `main`. The workflow redeploys automatically.
 ### Building the Pages site locally
 
 ```sh
-VITE_BASE_URL=/specorator/app/ npm run build:web
-mkdir -p _site/app
-cp site/index.html _site/index.html
-cp -r dist-standalone/. _site/app/
+npm run build:pages
 # Open _site/index.html in a browser to preview
 ```
 

--- a/docs/superpowers/plans/2026-05-03-verification-gate-hardening.md
+++ b/docs/superpowers/plans/2026-05-03-verification-gate-hardening.md
@@ -1,0 +1,477 @@
+# Verification Gate Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden local pre-push/pre-PR verification so contributors catch CI and release-surface failures before pushing, with no Windows-hostile shell constructs.
+
+**Architecture:** Six files change: two new Node.js scripts (`scripts/verify-workflows.js`, `scripts/build-pages.js`), one new git hook (`.githooks/pre-push`), plus updates to `package.json`, `ci.yml`, and `docs/local-development.md`. No new runtime dependencies.
+
+**Tech Stack:** Node 22 LTS (ESM, built-in `node:fs`/`node:path`/`node:child_process`), npm scripts, GitHub Actions, Git hooks (POSIX sh).
+
+---
+
+## Chunk 1: Node scripts and package.json
+
+### Task 1: Create `scripts/verify-workflows.js`
+
+**Files:**
+- Create: `scripts/verify-workflows.js`
+
+This script reimplements the inline bash/awk SHA-pin check from `ci.yml` as portable Node.js. It reads all `.github/workflows/*.yml|.yaml` files, finds every `uses:` line, strips comments and quotes, skips local (`./`), Docker (`docker://`), and internal reusable workflow (`.github/workflows/`) refs, then fails with exit 1 if any remaining ref does not end with `@<40-char-SHA>`.
+
+- [ ] **Step 1: Create the script**
+
+```js
+#!/usr/bin/env node
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const dir = '.github/workflows'
+const files = readdirSync(dir)
+  .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
+  .sort()
+
+if (files.length === 0) {
+  console.log('No workflow files found under .github/workflows.')
+  process.exit(0)
+}
+
+const SHA_RE = /^.+@[0-9a-f]{40}$/
+const violations = []
+
+for (const file of files) {
+  const path = join(dir, file)
+  const lines = readFileSync(path, 'utf8').split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const match = line.match(/^\s*-?\s*uses:\s*(.+)$/)
+    if (!match) continue
+    let ref = match[1].trim()
+    ref = ref.replace(/#.*$/, '').trim()
+    ref = ref.replace(/^["']|["']$/g, '').trim()
+    if (
+      ref.startsWith('./') ||
+      ref.startsWith('docker://') ||
+      ref.startsWith('.github/workflows/')
+    )
+      continue
+    if (!SHA_RE.test(ref)) {
+      violations.push(`${path}:${i + 1}: ${line.trimEnd()}`)
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error(
+    "Unpinned actions found — every 'uses:' must reference a 40-character commit SHA (see docs/security/supply-chain.md).",
+  )
+  for (const v of violations) console.error(`  ${v}`)
+  process.exit(1)
+}
+
+console.log(
+  `All third-party actions are SHA-pinned. (${files.length} workflow file${files.length === 1 ? '' : 's'} checked)`,
+)
+```
+
+- [ ] **Step 2: Run the script to verify it passes on the existing workflows**
+
+```sh
+node scripts/verify-workflows.js
+```
+
+Expected output (exactly):
+```
+All third-party actions are SHA-pinned. (6 workflow files checked)
+```
+
+If it reports violations, the existing workflow files have unpinned actions — fix those before continuing.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add scripts/verify-workflows.js
+git commit -m "feat(tooling): add verify-workflows Node script (SHA-pin check)"
+```
+
+---
+
+### Task 2: Create `scripts/build-pages.js`
+
+**Files:**
+- Create: `scripts/build-pages.js`
+
+Cross-platform equivalent of the Unix shell commands in `docs/local-development.md` and the CI `pages.yml` assembly block. Sets `VITE_BASE_URL`, runs `npm run build:web` as a child process, then assembles `_site/` using Node's `cpSync`.
+
+`cpSync` requires Node 16.7+. This project requires Node 22 LTS — safe to use.
+
+- [ ] **Step 1: Create the script**
+
+```js
+#!/usr/bin/env node
+import { execSync } from 'node:child_process'
+import { mkdirSync, cpSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const siteIndex = join('site', 'index.html')
+if (!existsSync(siteIndex)) {
+  console.error(`Missing ${siteIndex}. Run from the project root.`)
+  process.exit(1)
+}
+
+execSync('npm run build:web', {
+  stdio: 'inherit',
+  env: { ...process.env, VITE_BASE_URL: '/specorator/app/' },
+})
+
+mkdirSync(join('_site', 'app'), { recursive: true })
+cpSync(siteIndex, join('_site', 'index.html'))
+cpSync('dist-standalone', join('_site', 'app'), { recursive: true })
+
+console.log('Pages site assembled at _site/. Open _site/index.html in a browser to preview.')
+```
+
+- [ ] **Step 2: Run the script to verify it works**
+
+```sh
+node scripts/build-pages.js
+```
+
+Expected: Vite build output ending in `dist-standalone/`, then "Pages site assembled at _site/." Check that `_site/index.html` and `_site/app/index.html` both exist.
+
+- [ ] **Step 3: Add `_site/` to `.gitignore`**
+
+`build-pages.js` writes to `_site/` at the project root. Add it to `.gitignore` to prevent accidental staging. After the "Standalone UI build" block add:
+
+```
+# Local Pages preview build
+_site/
+```
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add scripts/build-pages.js .gitignore
+git commit -m "feat(tooling): add build-pages Node script (cross-platform Pages build)"
+```
+
+---
+
+### Task 3: Update `package.json` scripts
+
+**Files:**
+- Modify: `package.json`
+
+Add three new scripts and extend `verify` with manifest validation, workflow check, and whitespace check.
+
+- [ ] **Step 1: Add `verify:workflows`, `build:pages`, `hooks:install` to `package.json`**
+
+In the `"scripts"` block, add after `"validate:manifest"`:
+
+```json
+"verify:workflows": "node scripts/verify-workflows.js",
+"build:pages": "node scripts/build-pages.js",
+"hooks:install": "git config core.hooksPath .githooks",
+```
+
+- [ ] **Step 2: Extend the `verify` script**
+
+Replace the existing `"verify"` value:
+
+Old:
+```json
+"verify": "npm audit --audit-level=high --omit=dev && npm run typecheck && npm run lint && npm run test && npm run build && npm run build:web && npm run docs:api",
+```
+
+New:
+```json
+"verify": "npm audit --audit-level=high --omit=dev && npm run typecheck && npm run lint && npm run test && npm run build && npm run build:web && npm run docs:api && npm run validate:manifest && npm run verify:workflows && git diff --check --ignore-cr-at-eol",
+```
+
+- [ ] **Step 3: Smoke-test the three new scripts**
+
+```sh
+npm run verify:workflows
+npm run hooks:install
+```
+
+Expected: both exit 0. (`build:pages` was already validated in Task 2.)
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add package.json
+git commit -m "feat(tooling): add verify:workflows, build:pages, hooks:install npm scripts; extend verify gate"
+```
+
+---
+
+## Chunk 2: Git hook, CI updates, docs
+
+### Task 4: Create `.githooks/pre-push`
+
+**Files:**
+- Create: `.githooks/pre-push`
+
+The hook runs typecheck + lint + manifest validation — fast enough not to block pushes. Must be committed with the executable bit set so contributors on Linux/macOS can use it without extra setup.
+
+- [ ] **Step 1: Create `.githooks/` directory and the hook file**
+
+Create `.githooks/pre-push` with this content:
+
+```sh
+#!/bin/sh
+set -e
+npm run typecheck && npm run lint && npm run validate:manifest
+```
+
+- [ ] **Step 2: Set the executable bit (required for Linux/macOS contributors)**
+
+```sh
+git add .githooks/pre-push
+git update-index --chmod=+x .githooks/pre-push
+```
+
+- [ ] **Step 3: Verify the hook runs correctly**
+
+```sh
+sh .githooks/pre-push
+```
+
+Expected: typecheck, lint, and manifest validation all pass with exit 0.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git commit -m "feat(tooling): add .githooks/pre-push (typecheck + lint + validate:manifest)"
+```
+
+---
+
+### Task 5: Update `.github/workflows/ci.yml`
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+Two changes:
+1. `workflow-lint` job — add `setup-node` step, replace inline bash SHA-pin block with `node scripts/verify-workflows.js`.
+2. `pages` — wait, `pages.yml` is a separate file. Update `pages.yml` to call `npm run build:pages` instead of duplicating the assembly logic.
+
+**File:** `.github/workflows/ci.yml` — `workflow-lint` job only.
+**File:** `.github/workflows/pages.yml` — `build` job.
+
+- [ ] **Step 1: Update `workflow-lint` job in `ci.yml`**
+
+After the "Install actionlint" step and "Run actionlint" step, replace the entire "Verify third-party actions are SHA-pinned" step with two new steps:
+
+```yaml
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: lts/*
+      - name: Verify third-party actions are SHA-pinned
+        run: node scripts/verify-workflows.js
+```
+
+The old "Verify third-party actions are SHA-pinned" step with the `shell: bash` block and the inline `awk` script is deleted entirely.
+
+Full updated `workflow-lint` job:
+
+```yaml
+  workflow-lint:
+    name: Lint workflow files (actionlint)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install actionlint
+        run: |
+          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
+      - name: Run actionlint
+        run: ./actionlint -color
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: lts/*
+      - name: Verify third-party actions are SHA-pinned
+        run: node scripts/verify-workflows.js
+```
+
+- [ ] **Step 2: Update `pages.yml` build job**
+
+Replace the two separate steps:
+
+```yaml
+      - name: Build standalone SPA
+        run: npm run build:web
+        env:
+          VITE_BASE_URL: /specorator/app/
+
+      - name: Assemble Pages site
+        run: |
+          mkdir -p _site/app
+          cp site/index.html _site/index.html
+          cp -r dist-standalone/. _site/app/
+```
+
+With a single step:
+
+```yaml
+      - name: Build and assemble Pages site
+        run: npm run build:pages
+```
+
+- [ ] **Step 3: Validate both workflow files with the script**
+
+```sh
+node scripts/verify-workflows.js
+```
+
+Expected: still passes (we didn't add any new unpinned actions).
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add .github/workflows/ci.yml .github/workflows/pages.yml
+git commit -m "feat(tooling): use verify-workflows.js and build-pages.js from CI"
+```
+
+---
+
+### Task 6: Fix `docs/local-development.md`
+
+**Files:**
+- Modify: `docs/local-development.md`
+
+Six targeted fixes:
+1. Verification command in "Development commands" section — replace long piped command with `npm run verify`.
+2. Verification command in "Verifying plugin behavior" section — same replacement.
+3. Pages trigger branch — `main` → `demo`.
+4. Local Pages build — replace Unix shell commands with `npm run build:pages`.
+5. Add a note about `hooks:install` and Husky.
+6. Fix `CLAUDE.md` "Pre-PR verification gate" — same long command drift as in `local-development.md`.
+
+- [ ] **Step 1: Fix verification command in "Development commands" section (around line 57)**
+
+Replace:
+```
+Run the full verification gate before opening a pull request:
+
+```sh
+npm run typecheck && npm run lint && npm run test && npm run build && npm run build:web && npm run docs:api
+```
+```
+
+With:
+```
+Run the full verification gate before opening a pull request:
+
+```sh
+npm run verify
+```
+```
+
+- [ ] **Step 2: Fix verification command in "Verifying plugin behavior" section (around line 133)**
+
+Replace:
+```
+1. Run the full verification gate: `npm run typecheck && npm run lint && npm run test && npm run build && npm run build:web && npm run docs:api`
+```
+
+With:
+```
+1. Run the full verification gate: `npm run verify`
+```
+
+- [ ] **Step 3: Fix Pages trigger branch (around line 162)**
+
+Replace:
+```
+The `.github/workflows/pages.yml` workflow runs on every push to `main`:
+```
+
+With:
+```
+The `.github/workflows/pages.yml` workflow runs on every push to `demo`:
+```
+
+- [ ] **Step 4: Replace Unix-only local Pages build with `npm run build:pages` (around line 176)**
+
+Replace the entire "Building the Pages site locally" code block:
+
+```sh
+VITE_BASE_URL=/specorator/app/ npm run build:web
+mkdir -p _site/app
+cp site/index.html _site/index.html
+cp -r dist-standalone/. _site/app/
+# Open _site/index.html in a browser to preview
+```
+
+With:
+
+```sh
+npm run build:pages
+# Open _site/index.html in a browser to preview
+```
+
+- [ ] **Step 5: Add pre-push hook setup section and Husky note**
+
+After the "Development commands" table (before "Build output"), add:
+
+```markdown
+## Git hooks
+
+Install the pre-push hook with:
+
+```sh
+npm run hooks:install
+```
+
+The hook runs `typecheck`, `lint`, and `validate:manifest` before each push. It is intentionally fast — use `npm run verify` for the full gate.
+
+**Husky:** Native Git hooks (`core.hooksPath`) are sufficient for this project. Husky would add cross-platform convenience (auto-install on `npm ci`) but introduces a dev dependency. It remains a follow-up candidate if onboarding friction becomes a problem.
+```
+
+- [ ] **Step 6: Fix `CLAUDE.md` "Pre-PR verification gate" section**
+
+In `CLAUDE.md`, find:
+
+```sh
+npm run typecheck && npm run lint && npm run test && npm run build && npm run build:web && npm run docs:api
+```
+
+Replace with:
+
+```sh
+npm run verify
+```
+
+- [ ] **Step 7: Commit**
+
+```sh
+git add docs/local-development.md CLAUDE.md
+git commit -m "docs: fix local-development drift (verify command, Pages branch, build:pages)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full verify gate**
+
+```sh
+npm run verify
+```
+
+Expected: all steps pass, final output includes "All third-party actions are SHA-pinned."
+
+- [ ] **Check for any remaining drift**
+
+Search the repo for the old long verify command in case it appears in other docs:
+
+```sh
+grep -r "npm run typecheck && npm run lint && npm run test" docs/
+```
+
+Expected: no matches.

--- a/docs/superpowers/specs/2026-05-03-verification-gate-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-03-verification-gate-hardening-design.md
@@ -16,10 +16,10 @@ Harden local pre-push and pre-PR verification so contributors catch CI/release f
 Node.js reimplementation of the CI bash/awk SHA-pin check. Uses only `node:fs` and `node:path` — no install required. Reads all `.github/workflows/*.yml|.yaml`, finds `uses:` lines, skips local (`./`) and Docker (`docker://`) refs, fails if any ref lacks a 40-char hex SHA. Replaces inline bash in CI.
 
 ### scripts/build-pages.js
-Cross-platform Pages build. Sets `VITE_BASE_URL=/specorator/app/`, runs `npm run build:web`, assembles `_site/` (copies `site/index.html` → `_site/index.html`, `dist-standalone/` → `_site/app/`).
+Cross-platform Pages build. Sets `VITE_BASE_URL=/specorator/app/`, runs `npm run build:web`, assembles `_site/` (copies `site/index.html` → `_site/index.html`, `dist-standalone/` → `_site/app/`). `pages.yml` will call `npm run build:pages` instead of duplicating the assembly shell block — single source of truth.
 
 ### .githooks/pre-push
-Runs `npm run typecheck && npm run lint && npm run validate:manifest` — fast enough not to block pushes.
+Runs `npm run typecheck && npm run lint && npm run validate:manifest` — fast enough not to block pushes. Committed with executable bit set (`git update-index --chmod=+x .githooks/pre-push`).
 
 ### package.json scripts
 | Script | Command |
@@ -27,10 +27,14 @@ Runs `npm run typecheck && npm run lint && npm run validate:manifest` — fast e
 | `verify:workflows` | `node scripts/verify-workflows.js` |
 | `build:pages` | `node scripts/build-pages.js` |
 | `hooks:install` | `git config core.hooksPath .githooks` |
-| `verify` (extended) | append `&& npm run validate:manifest && npm run verify:workflows && git diff --check` |
+| `verify` (extended) | append `&& npm run validate:manifest && npm run verify:workflows && git diff --check --ignore-cr-at-eol` |
 
-### ci.yml — workflow-lint job
-Add `setup-node` (lts/*) step. Replace inline bash SHA-pin check with `node scripts/verify-workflows.js`. No `npm ci` needed (script uses only built-ins).
+### ci.yml changes
+- `workflow-lint` job: add `setup-node` (lts/*) step, replace inline bash SHA-pin check with `node scripts/verify-workflows.js`. No `npm ci` needed (script uses only built-ins).
+- `pages` job: replace "Build standalone SPA" + "Assemble Pages site" shell steps with single `npm run build:pages` step (picks up env var internally).
+
+### verify-workflows.js edge cases
+Script skips refs starting with `./` or `docker://`. Also skips `uses: .github/workflows/` paths (reusable workflows called without `./` prefix) to avoid false positives if internal reusable workflows are added later.
 
 ### docs/local-development.md
 - Fix Pages trigger: `main` → `demo`

--- a/docs/superpowers/specs/2026-05-03-verification-gate-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-03-verification-gate-hardening-design.md
@@ -1,0 +1,44 @@
+---
+title: Verification gate hardening (#139)
+date: 2026-05-03
+status: approved
+---
+
+# Verification gate hardening
+
+## Goal
+
+Harden local pre-push and pre-PR verification so contributors catch CI/release failures before pushing. Eliminates Windows-hostile shell constructs and docs drift.
+
+## Deliverables
+
+### scripts/verify-workflows.js
+Node.js reimplementation of the CI bash/awk SHA-pin check. Uses only `node:fs` and `node:path` — no install required. Reads all `.github/workflows/*.yml|.yaml`, finds `uses:` lines, skips local (`./`) and Docker (`docker://`) refs, fails if any ref lacks a 40-char hex SHA. Replaces inline bash in CI.
+
+### scripts/build-pages.js
+Cross-platform Pages build. Sets `VITE_BASE_URL=/specorator/app/`, runs `npm run build:web`, assembles `_site/` (copies `site/index.html` → `_site/index.html`, `dist-standalone/` → `_site/app/`).
+
+### .githooks/pre-push
+Runs `npm run typecheck && npm run lint && npm run validate:manifest` — fast enough not to block pushes.
+
+### package.json scripts
+| Script | Command |
+|---|---|
+| `verify:workflows` | `node scripts/verify-workflows.js` |
+| `build:pages` | `node scripts/build-pages.js` |
+| `hooks:install` | `git config core.hooksPath .githooks` |
+| `verify` (extended) | append `&& npm run validate:manifest && npm run verify:workflows && git diff --check` |
+
+### ci.yml — workflow-lint job
+Add `setup-node` (lts/*) step. Replace inline bash SHA-pin check with `node scripts/verify-workflows.js`. No `npm ci` needed (script uses only built-ins).
+
+### docs/local-development.md
+- Fix Pages trigger: `main` → `demo`
+- Replace long verify command with `npm run verify`
+- Replace Unix-only Pages local build with `npm run build:pages`
+- Add Husky note as follow-up candidate
+
+## Out of scope
+- Husky adoption (documented as follow-up, not implemented)
+- `format:check` enforcement (currently fails on develop baseline — separate follow-up)
+- actionlint local install

--- a/package.json
+++ b/package.json
@@ -19,9 +19,12 @@
 		"test:watch": "vitest --configLoader runner",
 		"build:web": "vue-tsc --noEmit && vite build",
 		"test:coverage": "vitest run --configLoader runner --coverage",
-		"verify": "npm audit --audit-level=high --omit=dev && npm run typecheck && npm run lint && npm run test && npm run build && npm run build:web && npm run docs:api",
+		"verify": "npm audit --audit-level=high --omit=dev && npm run typecheck && npm run lint && npm run test && npm run build && npm run build:web && npm run docs:api && npm run validate:manifest && npm run verify:workflows && git diff --check --ignore-cr-at-eol",
 		"docs:api": "typedoc",
 		"validate:manifest": "node scripts/validate-manifest.js",
+		"verify:workflows": "node scripts/verify-workflows.js",
+		"build:pages": "node scripts/build-pages.js",
+		"hooks:install": "git config core.hooksPath .githooks",
 		"version": "node version-bump.js && node scripts/validate-manifest.js && git add manifest.json versions.json"
 	},
 	"dependencies": {

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process'
+import { mkdirSync, cpSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const siteIndex = join('site', 'index.html')
+if (!existsSync(siteIndex)) {
+  console.error(`Missing ${siteIndex}. Run from the project root.`)
+  process.exit(1)
+}
+
+execSync('npm run build:web', {
+  stdio: 'inherit',
+  env: { ...process.env, VITE_BASE_URL: '/specorator/app/' },
+})
+
+mkdirSync(join('_site', 'app'), { recursive: true })
+cpSync(siteIndex, join('_site', 'index.html'))
+cpSync('dist-standalone', join('_site', 'app'), { recursive: true })
+
+console.log('Pages site assembled at _site/. Open _site/index.html in a browser to preview.')

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { execSync } from 'node:child_process'
-import { mkdirSync, cpSync, existsSync } from 'node:fs'
+import { mkdirSync, cpSync, existsSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 
 const siteIndex = join('site', 'index.html')
@@ -14,6 +14,7 @@ execSync('npm run build:web', {
   env: { ...process.env, VITE_BASE_URL: '/specorator/app/' },
 })
 
+rmSync('_site', { recursive: true, force: true })
 mkdirSync(join('_site', 'app'), { recursive: true })
 cpSync(siteIndex, join('_site', 'index.html'))
 cpSync('dist-standalone', join('_site', 'app'), { recursive: true })

--- a/scripts/verify-workflows.js
+++ b/scripts/verify-workflows.js
@@ -17,7 +17,7 @@ const violations = []
 
 for (const file of files) {
   const path = join(dir, file)
-  const lines = readFileSync(path, 'utf8').split('\n')
+  const lines = readFileSync(path, 'utf8').split(/\r?\n/)
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]
     const match = line.match(/^\s*-?\s*uses:\s*(.+)$/)

--- a/scripts/verify-workflows.js
+++ b/scripts/verify-workflows.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const dir = '.github/workflows'
+const files = readdirSync(dir)
+  .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
+  .sort()
+
+if (files.length === 0) {
+  console.log('No workflow files found under .github/workflows.')
+  process.exit(0)
+}
+
+const SHA_RE = /^.+@[0-9a-f]{40}$/
+const violations = []
+
+for (const file of files) {
+  const path = join(dir, file)
+  const lines = readFileSync(path, 'utf8').split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const match = line.match(/^\s*-?\s*uses:\s*(.+)$/)
+    if (!match) continue
+    let ref = match[1].trim()
+    ref = ref.replace(/#.*$/, '').trim()
+    ref = ref.replace(/^["']|["']$/g, '').trim()
+    if (
+      ref.startsWith('./') ||
+      ref.startsWith('docker://') ||
+      ref.startsWith('.github/workflows/')
+    )
+      continue
+    if (!SHA_RE.test(ref)) {
+      violations.push(`${path}:${i + 1}: ${line.trimEnd()}`)
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error(
+    "Unpinned actions found — every 'uses:' must reference a 40-character commit SHA (see docs/security/supply-chain.md).",
+  )
+  for (const v of violations) console.error(`  ${v}`)
+  process.exit(1)
+}
+
+console.log(
+  `All third-party actions are SHA-pinned. (${files.length} workflow file${files.length === 1 ? '' : 's'} checked)`,
+)


### PR DESCRIPTION
## Summary

- Adds `npm run verify:workflows` — portable Node.js reimplementation of the CI bash/awk SHA-pin check, reused from the `workflow-lint` CI job (replaces inline awk)
- Adds `npm run build:pages` — Windows-safe cross-platform local GitHub Pages preview build (`VITE_BASE_URL=/specorator/app/` set internally); `pages.yml` now calls this instead of duplicating the shell assembly logic
- Adds `.githooks/pre-push` (mode `100755`) running `typecheck + lint + validate:manifest`; install with `npm run hooks:install`
- Extends `npm run verify` with `validate:manifest + verify:workflows + git diff --check --ignore-cr-at-eol`
- Fixes docs drift in `docs/local-development.md`: verify command → `npm run verify`, Pages trigger `main` → `demo`, local Pages build → `npm run build:pages`, adds Git hooks section with Husky follow-up note
- Fixes `CLAUDE.md` Pre-PR verification gate command

## Test Plan

- [ ] CI passes (all jobs: `workflow-lint`, `manifest-validation`, `guard`, `verify`)
- [ ] `npm run verify:workflows` exits 0 locally
- [ ] `npm run build:pages` produces `_site/index.html` and `_site/app/index.html`
- [ ] `npm run hooks:install` + push triggers pre-push hook
- [ ] `npm run verify` completes end-to-end (includes new manifest + workflow + diff checks)

Closes #139