### PR TITLE
feature: add typed event bus

### DIFF
--- a/src/domain/shared/__tests__/eventBus.spec.ts
+++ b/src/domain/shared/__tests__/eventBus.spec.ts
@@ -115,6 +115,52 @@ describe('createEventBus', () => {
 		expect(seen).toEqual(['alpha', 'beta']);
 	});
 
+	it('uses priority ordering across channel and onAny listeners', () => {
+		const bus = createEventBus<TestEvents>();
+		const calls: string[] = [];
+
+		bus.on(
+			'alpha',
+			() => {
+				calls.push('channel-low');
+			},
+			{ priority: 1 },
+		);
+		bus.onAny(
+			(event) => {
+				calls.push(`any-high-${event.channel}`);
+			},
+			{ priority: 10 },
+		);
+
+		bus.emit('alpha', { value: 1 });
+
+		expect(calls).toEqual(['any-high-alpha', 'channel-low']);
+	});
+
+	it('uses priority ordering across channel and onAny async listeners', async () => {
+		const bus = createEventBus<TestEvents>();
+		const calls: string[] = [];
+
+		bus.on(
+			'alpha',
+			() => {
+				calls.push('channel-low');
+			},
+			{ priority: 1 },
+		);
+		bus.onAny(
+			async (event) => {
+				calls.push(`any-high-${event.channel}`);
+			},
+			{ priority: 10 },
+		);
+
+		await bus.emitAsync('alpha', { value: 1 });
+
+		expect(calls).toEqual(['any-high-alpha', 'channel-low']);
+	});
+
 	it('propagates trace ids through parent event ids', () => {
 		const bus = createEventBus<TestEvents>({
 			idFactory: createIds(['root-event', 'child-event', 'manual-event']),
@@ -178,6 +224,54 @@ describe('createEventBus', () => {
 
 		const envelope = await emitted;
 		expect(envelope.channel).toBe('alpha');
+	});
+
+	it('routes sync emit listener failures to the listener error hook', async () => {
+		const errors: unknown[] = [];
+		const bus = createEventBus<TestEvents>({
+			onListenerError(error) {
+				errors.push(error);
+			},
+		});
+		const calls: string[] = [];
+
+		bus.on('alpha', async () => {
+			throw new Error('async listener failed');
+		});
+		bus.on('alpha', () => {
+			throw new Error('sync listener failed');
+		});
+		bus.on('alpha', () => {
+			calls.push('after-errors');
+		});
+
+		bus.emit('alpha', { value: 1 });
+		await Promise.resolve();
+
+		expect(errors).toHaveLength(2);
+		expect(errors.every((error) => error instanceof Error)).toBe(true);
+		expect(calls).toEqual(['after-errors']);
+	});
+
+	it('keeps dispatch isolated when the listener error hook fails', () => {
+		const bus = createEventBus<TestEvents>({
+			onListenerError() {
+				throw new Error('reporting failed');
+			},
+		});
+		const calls: string[] = [];
+
+		bus.on('alpha', () => {
+			throw new Error('listener failed');
+		});
+		bus.on('alpha', () => {
+			calls.push('after-error-hook');
+		});
+
+		expect(() => {
+			bus.emit('alpha', { value: 1 });
+		}).not.toThrow();
+		expect(calls).toEqual(['after-error-hook']);
 	});
 
 	it('supports typed envelope handlers', () => {

--- a/src/domain/shared/__tests__/eventBus.spec.ts
+++ b/src/domain/shared/__tests__/eventBus.spec.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest';
+import { createEventBus, type EventEnvelope, type EventMap } from '../event-bus';
+
+interface TestEvents extends EventMap {
+	alpha: { readonly value: number };
+	beta: { readonly label: string };
+}
+
+declare module '../event-bus' {
+	interface EventMap {
+		merged: { readonly ok: boolean };
+	}
+}
+
+function createIds(ids: readonly string[]): () => string {
+	let index = 0;
+	return () => {
+		if (index >= ids.length) {
+			index += 1;
+			return `fallback-${index.toString()}`;
+		}
+		const id = ids[index];
+		index += 1;
+		return id;
+	};
+}
+
+describe('createEventBus', () => {
+	it('dispatches listeners in priority order', () => {
+		const bus = createEventBus<TestEvents>({ idFactory: createIds(['l1', 'l2', 'e1']) });
+		const calls: string[] = [];
+
+		bus.on(
+			'alpha',
+			() => {
+				calls.push('low');
+			},
+			{ priority: 1 },
+		);
+		bus.on(
+			'alpha',
+			() => {
+				calls.push('high');
+			},
+			{ priority: 10 },
+		);
+
+		const envelope = bus.emit('alpha', { value: 42 });
+
+		expect(calls).toEqual(['high', 'low']);
+		expect(envelope).toMatchObject({
+			channel: 'alpha',
+			payload: { value: 42 },
+			eventId: 'e1',
+			traceId: 'e1',
+		});
+	});
+
+	it('snapshots listeners during dispatch', () => {
+		const bus = createEventBus<TestEvents>({
+			idFactory: createIds([
+				'first-listener',
+				'second-listener',
+				'third-listener',
+				'first-event',
+				'second-event',
+			]),
+		});
+		const calls: string[] = [];
+
+		const unsubscribeFirst = bus.on('alpha', () => {
+			calls.push('first');
+			unsubscribeFirst();
+			bus.on('alpha', () => {
+				calls.push('third');
+			});
+		});
+		bus.on('alpha', () => {
+			calls.push('second');
+		});
+
+		bus.emit('alpha', { value: 1 });
+		bus.emit('alpha', { value: 2 });
+
+		expect(calls).toEqual(['first', 'second', 'second', 'third']);
+	});
+
+	it('counts channel-specific listeners and global listeners', () => {
+		const bus = createEventBus<TestEvents>();
+		const unsubscribeAlpha = bus.on('alpha', () => undefined);
+		bus.on('beta', () => undefined);
+		bus.onAny(() => undefined);
+
+		expect(bus.listenerCount('alpha')).toBe(1);
+		expect(bus.listenerCount('beta')).toBe(1);
+		expect(bus.listenerCount()).toBe(3);
+
+		unsubscribeAlpha();
+
+		expect(bus.listenerCount('alpha')).toBe(0);
+		expect(bus.listenerCount()).toBe(2);
+	});
+
+	it('notifies onAny listeners for every channel', () => {
+		const bus = createEventBus<TestEvents>();
+		const seen: string[] = [];
+
+		bus.onAny((event) => {
+			seen.push(event.channel);
+		});
+
+		bus.emit('alpha', { value: 1 });
+		bus.emit('beta', { label: 'ready' });
+
+		expect(seen).toEqual(['alpha', 'beta']);
+	});
+
+	it('propagates trace ids through parent event ids', () => {
+		const bus = createEventBus<TestEvents>({
+			idFactory: createIds(['root-event', 'child-event', 'manual-event']),
+		});
+
+		const root = bus.emit('alpha', { value: 1 });
+		const child = bus.emit('beta', { label: 'child' }, { parentId: root.eventId });
+		const manual = bus.emit('beta', { label: 'manual' }, { traceId: 'external-trace' });
+
+		expect(child.parentId).toBe(root.eventId);
+		expect(child.traceId).toBe(root.traceId);
+		expect(manual.traceId).toBe('external-trace');
+	});
+
+	it('bounds the trace map', () => {
+		const bus = createEventBus<TestEvents>({
+			idFactory: createIds(['first', 'second', 'third']),
+			traceLimit: 1,
+		});
+
+		const first = bus.emit('alpha', { value: 1 });
+		const second = bus.emit('alpha', { value: 2 });
+		const third = bus.emit('beta', { label: 'third' }, { parentId: first.eventId });
+
+		expect(second.traceId).toBe('second');
+		expect(third.parentId).toBe(first.eventId);
+		expect(third.traceId).toBe('third');
+	});
+
+	it('runs async listeners with bounded concurrency', async () => {
+		const bus = createEventBus<TestEvents>({ asyncConcurrency: 2 });
+		const starts: number[] = [];
+		const resolvers: Array<() => void> = [];
+		let resolveThirdStarted: (() => void) | undefined;
+		const thirdStarted = new Promise<void>((resolve) => {
+			resolveThirdStarted = resolve;
+		});
+
+		for (const index of [1, 2, 3]) {
+			bus.on('alpha', async () => {
+				starts.push(index);
+				if (index === 3) resolveThirdStarted?.();
+				await new Promise<void>((resolve) => {
+					resolvers.push(resolve);
+				});
+			});
+		}
+
+		const emitted = bus.emitAsync('alpha', { value: 1 });
+		await Promise.resolve();
+
+		expect(starts).toEqual([1, 2]);
+
+		resolvers[0]?.();
+		await thirdStarted;
+
+		expect(starts).toEqual([1, 2, 3]);
+
+		resolvers[1]?.();
+		resolvers[2]?.();
+
+		const envelope = await emitted;
+		expect(envelope.channel).toBe('alpha');
+	});
+
+	it('supports typed envelope handlers', () => {
+		const bus = createEventBus<TestEvents>();
+		let received: EventEnvelope<TestEvents['alpha']> | undefined;
+
+		bus.on('alpha', (event) => {
+			received = event;
+		});
+
+		bus.emit('alpha', { value: 7 });
+
+		expect(received?.payload.value).toBe(7);
+	});
+
+	it('supports EventMap declaration merging', () => {
+		const bus = createEventBus();
+		let received: EventEnvelope<EventMap['merged']> | undefined;
+
+		bus.on('merged', (event) => {
+			received = event;
+		});
+
+		bus.emit('merged', { ok: true });
+
+		expect(received?.payload.ok).toBe(true);
+	});
+});

--- a/src/domain/shared/event-bus.ts
+++ b/src/domain/shared/event-bus.ts
@@ -1,0 +1,276 @@
+// Intentionally empty so feature modules can add channels by declaration merging.
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface EventMap {}
+
+export type EventKey<Events> = Extract<keyof Events, string>;
+
+export interface EventEnvelope<Payload = unknown> {
+	readonly channel: string;
+	readonly payload: Payload;
+	readonly eventId: string;
+	readonly traceId: string;
+	readonly parentId?: string;
+	readonly emittedAt: Date;
+}
+
+export interface EventBusOptions {
+	readonly asyncConcurrency?: number;
+	readonly traceLimit?: number;
+	readonly idFactory?: () => string;
+	readonly now?: () => Date;
+}
+
+export interface EmitOptions {
+	readonly parentId?: string;
+	readonly traceId?: string;
+}
+
+export interface ListenerOptions {
+	readonly priority?: number;
+}
+
+export type EventUnsubscribe = () => void;
+export type EventListener<Payload> = (envelope: EventEnvelope<Payload>) => void | Promise<void>;
+export type AnyEventListener<Events> = EventListener<Events[EventKey<Events>]>;
+
+export interface EventBus<Events extends EventMap = EventMap> {
+	on<K extends EventKey<Events>>(
+		channel: K,
+		listener: EventListener<Events[K]>,
+		options?: ListenerOptions,
+	): EventUnsubscribe;
+	onAny(listener: AnyEventListener<Events>, options?: ListenerOptions): EventUnsubscribe;
+	emit<K extends EventKey<Events>>(
+		channel: K,
+		payload: Events[K],
+		options?: EmitOptions,
+	): EventEnvelope<Events[K]>;
+	emitAsync<K extends EventKey<Events>>(
+		channel: K,
+		payload: Events[K],
+		options?: EmitOptions,
+	): Promise<EventEnvelope<Events[K]>>;
+	listenerCount(channel?: EventKey<Events>): number;
+}
+
+interface ListenerEntry<Payload> {
+	readonly id: string;
+	readonly priority: number;
+	readonly listener: EventListener<Payload>;
+}
+
+interface EventBusState {
+	readonly asyncConcurrency: number;
+	readonly traceLimit: number;
+	readonly idFactory: () => string;
+	readonly now: () => Date;
+	readonly traceEntries: readonly TraceEntry[];
+}
+
+interface TraceEntry {
+	readonly eventId: string;
+	readonly traceId: string;
+}
+
+const DEFAULT_ASYNC_CONCURRENCY = 4;
+const DEFAULT_TRACE_LIMIT = 200;
+
+let nextDefaultId = 0;
+
+function createDefaultId(): string {
+	nextDefaultId += 1;
+	return `evt_${nextDefaultId.toString(36)}`;
+}
+
+function normalizePositiveInteger(value: number | undefined, fallback: number): number {
+	if (value === undefined) return fallback;
+	if (!Number.isSafeInteger(value) || value < 1) return fallback;
+	return value;
+}
+
+function insertByPriority<Payload>(
+	entries: readonly ListenerEntry<Payload>[],
+	entry: ListenerEntry<Payload>,
+): readonly ListenerEntry<Payload>[] {
+	const next = [...entries, entry];
+	return next.sort((left, right) => right.priority - left.priority);
+}
+
+function removeById<Payload>(
+	entries: readonly ListenerEntry<Payload>[],
+	id: string,
+): readonly ListenerEntry<Payload>[] {
+	return entries.filter((entry) => entry.id !== id);
+}
+
+function appendTrace(
+	entries: readonly TraceEntry[],
+	next: TraceEntry,
+	limit: number,
+): readonly TraceEntry[] {
+	const combined = [...entries, next];
+	return combined.slice(Math.max(0, combined.length - limit));
+}
+
+function findTraceId(
+	entries: readonly TraceEntry[],
+	eventId: string | undefined,
+): string | undefined {
+	if (eventId === undefined) return undefined;
+	return entries.find((entry) => entry.eventId === eventId)?.traceId;
+}
+
+function createEnvelope<Payload>(
+	channel: string,
+	payload: Payload,
+	options: EmitOptions | undefined,
+	state: EventBusState,
+): EventEnvelope<Payload> {
+	const eventId = state.idFactory();
+	const traceId = options?.traceId ?? findTraceId(state.traceEntries, options?.parentId) ?? eventId;
+	const base = {
+		channel,
+		payload,
+		eventId,
+		traceId,
+		emittedAt: state.now(),
+	};
+	if (options?.parentId === undefined) return base;
+	return { ...base, parentId: options.parentId };
+}
+
+async function runBounded(
+	tasks: readonly (() => Promise<void>)[],
+	concurrency: number,
+): Promise<void> {
+	let nextIndex = 0;
+
+	async function worker(): Promise<void> {
+		const task = tasks.at(nextIndex);
+		nextIndex += 1;
+		if (task === undefined) return;
+		await task();
+		await worker();
+	}
+
+	const workerCount = Math.min(concurrency, tasks.length);
+	const workers = Array.from({ length: workerCount }, () => worker());
+	await Promise.all(workers);
+}
+
+export function createEventBus<Events extends EventMap = EventMap>(
+	options: EventBusOptions = {},
+): EventBus<Events> {
+	let state: EventBusState = {
+		asyncConcurrency: normalizePositiveInteger(options.asyncConcurrency, DEFAULT_ASYNC_CONCURRENCY),
+		traceLimit: normalizePositiveInteger(options.traceLimit, DEFAULT_TRACE_LIMIT),
+		idFactory: options.idFactory ?? createDefaultId,
+		now: options.now ?? (() => new Date()),
+		traceEntries: [],
+	};
+	const listeners = new Map<string, readonly ListenerEntry<unknown>[]>();
+	let anyListeners: readonly ListenerEntry<Events[EventKey<Events>]>[] = [];
+
+	function rememberTrace(envelope: EventEnvelope<unknown>): void {
+		state = {
+			...state,
+			traceEntries: appendTrace(
+				state.traceEntries,
+				{ eventId: envelope.eventId, traceId: envelope.traceId },
+				state.traceLimit,
+			),
+		};
+	}
+
+	function getChannelListeners<Payload>(channel: string): readonly ListenerEntry<Payload>[] {
+		return listeners.get(channel) ?? [];
+	}
+
+	function setChannelListeners<Payload>(
+		channel: string,
+		entries: readonly ListenerEntry<Payload>[],
+	): void {
+		listeners.set(channel, entries as readonly ListenerEntry<unknown>[]);
+	}
+
+	function listenerCount(channel?: EventKey<Events>): number {
+		if (channel !== undefined) return getChannelListeners(channel).length;
+		let count = anyListeners.length;
+		listeners.forEach((entries) => {
+			count += entries.length;
+		});
+		return count;
+	}
+
+	function on<K extends EventKey<Events>>(
+		channel: K,
+		listener: EventListener<Events[K]>,
+		listenerOptions: ListenerOptions = {},
+	): EventUnsubscribe {
+		const id = state.idFactory();
+		const entry: ListenerEntry<Events[K]> = {
+			id,
+			priority: listenerOptions.priority ?? 0,
+			listener,
+		};
+		setChannelListeners(channel, insertByPriority(getChannelListeners(channel), entry));
+		return () => {
+			setChannelListeners(channel, removeById(getChannelListeners(channel), id));
+		};
+	}
+
+	function onAny(
+		listener: AnyEventListener<Events>,
+		listenerOptions: ListenerOptions = {},
+	): EventUnsubscribe {
+		const id = state.idFactory();
+		const entry: ListenerEntry<Events[EventKey<Events>]> = {
+			id,
+			priority: listenerOptions.priority ?? 0,
+			listener,
+		};
+		anyListeners = insertByPriority(anyListeners, entry);
+		return () => {
+			anyListeners = removeById(anyListeners, id);
+		};
+	}
+
+	function emit<K extends EventKey<Events>>(
+		channel: K,
+		payload: Events[K],
+		emitOptions?: EmitOptions,
+	): EventEnvelope<Events[K]> {
+		const envelope = createEnvelope(channel, payload, emitOptions, state);
+		rememberTrace(envelope);
+		const snapshot = [...getChannelListeners<Events[K]>(channel), ...anyListeners];
+		snapshot.forEach((entry) => {
+			void entry.listener(envelope);
+		});
+		return envelope;
+	}
+
+	async function emitAsync<K extends EventKey<Events>>(
+		channel: K,
+		payload: Events[K],
+		emitOptions?: EmitOptions,
+	): Promise<EventEnvelope<Events[K]>> {
+		const envelope = createEnvelope(channel, payload, emitOptions, state);
+		rememberTrace(envelope);
+		const snapshot = [...getChannelListeners<Events[K]>(channel), ...anyListeners];
+		await runBounded(
+			snapshot.map((entry) => async () => {
+				await entry.listener(envelope);
+			}),
+			state.asyncConcurrency,
+		);
+		return envelope;
+	}
+
+	return {
+		on,
+		onAny,
+		emit,
+		emitAsync,
+		listenerCount,
+	};
+}

--- a/src/domain/shared/event-bus.ts
+++ b/src/domain/shared/event-bus.ts
@@ -1,3 +1,5 @@
+import { trySync } from './tryAsync';
+
 // Intentionally empty so feature modules can add channels by declaration merging.
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface EventMap {}
@@ -18,6 +20,8 @@ export interface EventBusOptions {
 	readonly traceLimit?: number;
 	readonly idFactory?: () => string;
 	readonly now?: () => Date;
+	/** Receives errors from fire-and-forget listeners invoked through emit(). */
+	readonly onListenerError?: (error: unknown, envelope: EventEnvelope) => void;
 }
 
 export interface EmitOptions {
@@ -64,6 +68,7 @@ interface EventBusState {
 	readonly traceLimit: number;
 	readonly idFactory: () => string;
 	readonly now: () => Date;
+	readonly onListenerError: (error: unknown, envelope: EventEnvelope) => void;
 	readonly traceEntries: readonly TraceEntry[];
 }
 
@@ -94,6 +99,12 @@ function insertByPriority<Payload>(
 ): readonly ListenerEntry<Payload>[] {
 	const next = [...entries, entry];
 	return next.sort((left, right) => right.priority - left.priority);
+}
+
+function sortByPriority<Payload>(
+	entries: readonly ListenerEntry<Payload>[],
+): readonly ListenerEntry<Payload>[] {
+	return [...entries].sort((left, right) => right.priority - left.priority);
 }
 
 function removeById<Payload>(
@@ -166,6 +177,7 @@ export function createEventBus<Events extends EventMap = EventMap>(
 		traceLimit: normalizePositiveInteger(options.traceLimit, DEFAULT_TRACE_LIMIT),
 		idFactory: options.idFactory ?? createDefaultId,
 		now: options.now ?? (() => new Date()),
+		onListenerError: options.onListenerError ?? (() => undefined),
 		traceEntries: [],
 	};
 	const listeners = new Map<string, readonly ListenerEntry<unknown>[]>();
@@ -235,6 +247,21 @@ export function createEventBus<Events extends EventMap = EventMap>(
 		};
 	}
 
+	function createSnapshot<K extends EventKey<Events>>(
+		channel: K,
+	): readonly ListenerEntry<Events[EventKey<Events>]>[] {
+		return sortByPriority([
+			...getChannelListeners<Events[EventKey<Events>]>(channel),
+			...anyListeners,
+		]);
+	}
+
+	function reportListenerError(error: unknown, envelope: EventEnvelope): void {
+		void trySync(() => {
+			state.onListenerError(error, envelope);
+		}, 'event listener error hook failed');
+	}
+
 	function emit<K extends EventKey<Events>>(
 		channel: K,
 		payload: Events[K],
@@ -242,9 +269,16 @@ export function createEventBus<Events extends EventMap = EventMap>(
 	): EventEnvelope<Events[K]> {
 		const envelope = createEnvelope(channel, payload, emitOptions, state);
 		rememberTrace(envelope);
-		const snapshot = [...getChannelListeners<Events[K]>(channel), ...anyListeners];
+		const snapshot = createSnapshot(channel);
 		snapshot.forEach((entry) => {
-			void entry.listener(envelope);
+			const result = trySync(() => entry.listener(envelope), 'event listener failed');
+			if (!result.ok) {
+				reportListenerError(result.error, envelope);
+				return;
+			}
+			void Promise.resolve(result.value).catch((error: unknown) => {
+				reportListenerError(error, envelope);
+			});
 		});
 		return envelope;
 	}
@@ -256,7 +290,7 @@ export function createEventBus<Events extends EventMap = EventMap>(
 	): Promise<EventEnvelope<Events[K]>> {
 		const envelope = createEnvelope(channel, payload, emitOptions, state);
 		rememberTrace(envelope);
-		const snapshot = [...getChannelListeners<Events[K]>(channel), ...anyListeners];
+		const snapshot = createSnapshot(channel);
 		await runBounded(
 			snapshot.map((entry) => async () => {
 				await entry.listener(envelope);


### PR DESCRIPTION
## Summary

Add a pure domain `EventBus` implementation for #101 with typed channel payloads, augmentable `EventMap`, priority-ordered listeners, `onAny` inspection, trace/event envelopes, bounded trace retention, listener counting, unsubscribe handles, snapshot dispatch, and bounded-concurrency async dispatch.

Closes #101

## Verification

- `npx vitest run src/domain/shared/__tests__/eventBus.spec.ts --configLoader runner`
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run verify`

Note: `npm run format:check` was also tried and currently fails on the existing repository baseline across many pre-existing files; the two new EventBus files were formatted with Prettier before the required gate was run.

## Test plan

- [ ] CI passes
- [ ] Review EventBus API shape before W2 module-system work consumes it