### PR TITLE
docs(vision): reframe plugin as UI layer for four-component ecosystem

### DIFF
--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -74,7 +74,7 @@ v1 has no runtime dependency. It is the stable UI scaffold on which v2.0 is buil
 
 v2.0 connects the plugin to [`specorator-runtime`](https://github.com/Luis85/specorator-runtime), turning it into a live agentic cockpit.
 
-The user triggers a workflow session from the plugin. The runtime interprets the active workflow definition, resolves the task graph, and invokes agents from [`agentonomous`](https://github.com/Luis85/agentonomous) at each task. The plugin subscribes to the runtime's event stream and renders execution state in real time — which tasks are running, which agents are active, what outputs have been produced.
+The user triggers a workflow session from the plugin. The runtime interprets the active workflow definition, resolves the task graph (the ordered set of tasks derived from the workflow definition), and invokes agents from [`agentonomous`](https://github.com/Luis85/agentonomous) at each task. The plugin subscribes to the runtime's event stream and renders execution state in real time — which tasks are running, which agents are active, what outputs have been produced.
 
 All agent outputs arrive as proposals. The user reviews, edits, accepts, or rejects each one before it becomes a vault artifact. Nothing is silently applied.
 

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -21,7 +21,7 @@ Specorator is one component in a four-part ecosystem. The plugin is the **user-f
 │         (UI cockpit — Obsidian, standalone browser)      │
 │   triggers sessions · subscribes to events · review UI   │
 └────────────────────┬────────────────────────────────────┘
-                     │ events / commands
+          commands / session triggers ↓ ↑ event stream
 ┌────────────────────▼────────────────────────────────────┐
 │                  specorator-runtime                      │
 │     execution engine · session model · event bus         │
@@ -38,7 +38,7 @@ Specorator is one component in a four-part ecosystem. The plugin is the **user-f
 
 | Component | Role |
 |---|---|
-| [`specorator-plugin`](https://github.com/Luis85/specorator) | UI layer. Obsidian plugin and standalone browser app. Triggers runtime sessions, subscribes to runtime events, presents execution state, and gives users the review and accept surface for agent outputs. |
+| [`specorator-plugin`](https://github.com/Luis85/specorator) | UI layer. Obsidian plugin and standalone browser app. In v1: surfaces workflow state, scaffolds artifacts, and runs quality checks without a runtime dependency. In v2.0: triggers runtime sessions, subscribes to runtime events, presents execution state, and gives users the review and accept surface for agent outputs. |
 | [`specorator-runtime`](https://github.com/Luis85/specorator-runtime) | Execution engine. Interprets workflow definitions, manages session lifecycle, invokes agents, emits typed events, and exposes queryable state. Published as an npm library consumed by the plugin. |
 | [`agentic-workflow`](https://github.com/Luis85/agentic-workflow) | Methodology and definitions. Stage model, templates, quality gates, and traceability conventions. Released versions are the source of truth for workflow structure. |
 | [`agentonomous`](https://github.com/Luis85/agentonomous) | Agent capabilities. TypeScript autonomous-agent library. Provides the agent implementations the runtime invokes — structured input/output contracts, cognition models. |
@@ -90,7 +90,7 @@ The user stays in Obsidian. The runtime and agents operate behind the plugin's U
 ## Principles
 
 - **Workflow first.** The plugin models the full workflow, not just note editing shortcuts.
-- **Local first.** v1 tooling works offline. v2.0 runtime runs locally; no hosted service required.
+- **Local first.** v1 tooling works offline. The runtime itself runs locally and requires no hosted Specorator service. LLM provider access for agents is user-configured and optional per the "LLM optional" principle.
 - **LLM optional.** v1 is fully productive without any LLM provider configured. v2.0 degrades gracefully when no provider is available.
 - **Inspectable state.** Users see the active stage, required artifacts, quality gates, blockers, and next actions — and in v2.0, live session state from the runtime.
 - **Deterministic upkeep.** Validation, linting, traceability checks, scaffolders, and repair helpers are exposed as normal plugin capabilities.
@@ -130,7 +130,7 @@ The plugin should make these capabilities available without requiring chat-based
 ## Non-Goals
 
 - Replacing Obsidian as the editing environment.
-- Requiring a single LLM provider or hosted service.
+- Requiring any specific LLM provider or any hosted Specorator service.
 - Hiding workflow artifacts behind opaque plugin state.
 - Automating human approval gates.
 - Turning the workflow into a generic project management board detached from specs.
@@ -155,7 +155,7 @@ The plugin should make these capabilities available without requiring chat-based
 | OQ-01 | Which workflow stages must be supported in the first usable v1 slice? |
 | OQ-02 | Which `agentic-workflow` scripts should become plugin commands first? |
 | OQ-03 | What vault health checks are mandatory before any agentic session is triggered? |
-| OQ-04 | How should the plugin communicate with `specorator-runtime` — direct npm import, local IPC, or CLI bridge? |
+| OQ-04 | Given the runtime is consumed as an npm library, does the Obsidian plugin require an IPC or worker-thread boundary to avoid blocking the UI thread during execution? |
 | OQ-05 | What is the minimum runtime event set the plugin must handle to render useful session state in v2.0? |
 | OQ-06 | Which `agentonomous` agents should be available in the first v2.0 session? |
 | OQ-07 | How should interrupted or failed runtime sessions be surfaced and recovered from in the UI? |

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -3,7 +3,7 @@ title: "Specorator product vision"
 doc_type: vision
 status: draft
 owner: product
-last_updated: 2026-05-01
+last_updated: 2026-05-04
 references:
   - docs/prd.md
   - docs/roadmap-v1.md
@@ -11,44 +11,74 @@ references:
 
 # Product Vision
 
+## Ecosystem Architecture
+
+Specorator is one component in a four-part ecosystem. The plugin is the **user-facing layer** — the cockpit through which a user interacts with everything else.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   specorator-plugin                      │
+│         (UI cockpit — Obsidian, standalone browser)      │
+│   triggers sessions · subscribes to events · review UI   │
+└────────────────────┬────────────────────────────────────┘
+                     │ events / commands
+┌────────────────────▼────────────────────────────────────┐
+│                  specorator-runtime                      │
+│     execution engine · session model · event bus         │
+│     workflow interpreter · agent executor · scheduler    │
+└──────────┬──────────────────────────┬───────────────────┘
+           │ workflow definitions      │ agent invocations
+┌──────────▼──────────┐    ┌──────────▼───────────────────┐
+│   agentic-workflow  │    │        agentonomous           │
+│  stage model        │    │  agent implementations        │
+│  templates          │    │  cognition · capabilities     │
+│  quality gates      │    │  structured I/O contracts     │
+└─────────────────────┘    └──────────────────────────────┘
+```
+
+| Component | Role |
+|---|---|
+| [`specorator-plugin`](https://github.com/Luis85/specorator) | UI layer. Obsidian plugin and standalone browser app. Triggers runtime sessions, subscribes to runtime events, presents execution state, and gives users the review and accept surface for agent outputs. |
+| [`specorator-runtime`](https://github.com/Luis85/specorator-runtime) | Execution engine. Interprets workflow definitions, manages session lifecycle, invokes agents, emits typed events, and exposes queryable state. Published as an npm library consumed by the plugin. |
+| [`agentic-workflow`](https://github.com/Luis85/agentic-workflow) | Methodology and definitions. Stage model, templates, quality gates, and traceability conventions. Released versions are the source of truth for workflow structure. |
+| [`agentonomous`](https://github.com/Luis85/agentonomous) | Agent capabilities. TypeScript autonomous-agent library. Provides the agent implementations the runtime invokes — structured input/output contracts, cognition models. |
+
+---
+
 ## Vision
 
-Specorator turns a spec-driven delivery workflow into an approachable Obsidian product. A user should be able to understand where work stands, choose the next valid workflow action, run the supporting tools, and keep the vault healthy from one interface.
+Specorator is the user interface for the Specorator ecosystem. It gives users a single, approachable cockpit inside Obsidian — or a standalone browser — to understand workflow state, take the next valid action, trigger agentic execution, and review outputs, without needing to touch the runtime, agents, or methodology files directly.
 
-LLM integrations can accelerate drafting and review, but they are not the product's foundation. The plugin should expose deterministic workflow tooling, validation scripts, templates, and quality checks directly so users are not dependent on an assistant to upkeep the vault.
+The plugin surfaces deterministic workflow tooling (validation, templates, quality gates, scaffolding) in v1. In v2.0, it connects to `specorator-runtime` to run agentic workflows end-to-end — executing tasks, invoking agents from `agentonomous`, and streaming live session state back to the user.
+
+LLM-assisted execution is a v2.0 capability, not a prerequisite for v1 utility.
 
 ## Product Promise
 
-Specorator helps teams move from idea to release through visible, auditable workflow stages while preserving the vault as the durable source of truth.
+Specorator helps individuals and teams move from idea to release through visible, auditable workflow stages. In v1, the vault stays the durable source of truth and all tooling works offline. In v2.0, the runtime executes the workflow while the user retains full control over what runs, what context agents receive, and what outputs get accepted.
 
 ## v1 Alpha — Foundation
 
-The v1 alpha establishes the plugin foundation and proves the end-to-end loop:
+The v1 alpha establishes the plugin foundation and proves the end-to-end loop without a live runtime:
 
 1. Select or use a supported released [`agentic-workflow`](https://github.com/Luis85/agentic-workflow) template version.
 2. Install the required workflow files into an Obsidian vault with overwrite protection.
 3. Show the current workflow state, active project or feature, and available process steps.
 4. Let the user create or open workflow artifacts in Obsidian.
 5. Preserve all outputs as plain Markdown files that remain useful without the plugin.
-6. Leave a documented, clean extension point for the v2.0 agent coworker experience.
+6. Leave a clean, documented extension point for the v2.0 runtime integration.
 
-v1 does not implement agent orchestration. It is the stable scaffold on which v2.0 is built.
+v1 has no runtime dependency. It is the stable UI scaffold on which v2.0 is built.
 
-## v2.0 — Companion App with Agentic Coworkers
+## v2.0 — Runtime-Connected Agentic Cockpit
 
-v2.0 turns Specorator into an Obsidian companion app that gives the user a team of agentic coworkers through an easy-to-use interface, powered by [`agentonomous`](https://github.com/Luis85/agentonomous).
+v2.0 connects the plugin to [`specorator-runtime`](https://github.com/Luis85/specorator-runtime), turning it into a live agentic cockpit.
 
-The user stays focused on their vault and the work within it. Specorator guides them through the workflow, understands their input, helps formulate and improve outputs, and coordinates agentic coworkers that can assist with analysis, planning, drafting, review, and workflow-state progression.
+The user triggers a workflow session from the plugin. The runtime interprets the active workflow definition, resolves the task graph, and invokes agents from [`agentonomous`](https://github.com/Luis85/agentonomous) at each task. The plugin subscribes to the runtime's event stream and renders execution state in real time — which tasks are running, which agents are active, what outputs have been produced.
 
-The plugin goes out of its way to reduce process friction, but it must not take control away from the user. The user decides:
+All agent outputs arrive as proposals. The user reviews, edits, accepts, or rejects each one before it becomes a vault artifact. Nothing is silently applied.
 
-- where assistance is wanted;
-- what vault context is shared with agents;
-- which agent suggestions are accepted;
-- what gets edited;
-- when outputs become durable workflow artifacts.
-
-Agent outputs are always proposed, never silently applied.
+The user stays in Obsidian. The runtime and agents operate behind the plugin's UI surface. The vault remains the durable output store.
 
 ## Target Users
 
@@ -60,12 +90,13 @@ Agent outputs are always proposed, never silently applied.
 ## Principles
 
 - **Workflow first.** The plugin models the full workflow, not just note editing shortcuts.
-- **Local first.** Vault content, scripts, templates, and checks should work locally and remain useful outside hosted services.
-- **LLM optional.** AI assistance is an accelerator, not a prerequisite for running or maintaining the workflow.
-- **Inspectable state.** Users can see the active stage, required artifacts, quality gates, blockers, and next actions.
+- **Local first.** v1 tooling works offline. v2.0 runtime runs locally; no hosted service required.
+- **LLM optional.** v1 is fully productive without any LLM provider configured. v2.0 degrades gracefully when no provider is available.
+- **Inspectable state.** Users see the active stage, required artifacts, quality gates, blockers, and next actions — and in v2.0, live session state from the runtime.
 - **Deterministic upkeep.** Validation, linting, traceability checks, scaffolders, and repair helpers are exposed as normal plugin capabilities.
 - **Human-owned decisions.** The interface surfaces choices and risks, but the user remains responsible for intent, priority, and acceptance.
-- **User-controlled agents.** In v2.0, agents propose; the user decides. Context shared with agents is explicit and revocable.
+- **Runtime transparency.** In v2.0, the plugin shows what the runtime is doing — which tasks are executing, which agents are active, what events have fired — so users are never left guessing about the state of a running session.
+- **User-controlled agents.** Agents propose; the user decides. Context shared with agents is explicit and revocable per run.
 
 ## Core Experience
 
@@ -77,7 +108,8 @@ The first-class experience is a workflow cockpit inside Obsidian:
 - Runs local scripts and checks from plugin controls.
 - Displays validation results with direct links to affected notes.
 - Tracks requirements, tasks, tests, decisions, and release artifacts.
-- In v2.0: offers agentic coworkers that assist with drafting, review, and stage progression under explicit user control.
+- **v2.0:** Triggers runtime sessions and streams live execution state — task graph, agent activity, event log — directly in the panel.
+- **v2.0:** Presents agent-proposed outputs in a review interface; user accepts, edits, or rejects before any vault write.
 
 ## Required Tooling Surface
 
@@ -92,14 +124,8 @@ The plugin should make these capabilities available without requiring chat-based
 - Issue, decision, and clarification tracking.
 - Repair guidance for missing or inconsistent artifacts.
 - Export or handoff summaries for pull requests, releases, and reviews.
-
-## Relationship to Upstream Projects
-
-| Project | Role |
-|---------|------|
-| [`agentic-workflow`](https://github.com/Luis85/agentic-workflow) | Workflow methodology, stage model, templates, traceability conventions, and quality gates. Released versions are the source of truth for what high-quality workflow outputs look like. |
-| [`agentonomous`](https://github.com/Luis85/agentonomous) | Agent orchestration engine for v2.0. Provides agent definitions, coworker concepts, routing, handoffs, run state, and tool abstractions. |
-| Specorator | Obsidian plugin lifecycle, user interface, vault access, permission boundaries, and the bridge between the user's vault and upstream capabilities. |
+- **v2.0:** Runtime session management — start, monitor, cancel, inspect.
+- **v2.0:** Agent output review — accept, edit, reject, or request refinement.
 
 ## Non-Goals
 
@@ -109,8 +135,9 @@ The plugin should make these capabilities available without requiring chat-based
 - Automating human approval gates.
 - Turning the workflow into a generic project management board detached from specs.
 - Giving agents unrestricted vault access by default.
-- Automatically accepting or applying agent outputs without user approval.
-- Implementing a separate orchestration engine inside Specorator (agentonomous owns that).
+- Automatically accepting or applying agent outputs without user review.
+- Implementing execution, scheduling, or session management inside the plugin — `specorator-runtime` owns that.
+- Implementing agent cognition or capabilities inside the plugin — `agentonomous` owns that.
 
 ## Success Signals
 
@@ -119,15 +146,17 @@ The plugin should make these capabilities available without requiring chat-based
 - The same workflow artifacts remain readable and usable as Markdown files.
 - LLM-disabled usage remains productive for scaffolding, validation, upkeep, and review preparation.
 - Advanced users can still use scripts and command-line tools directly when they prefer.
-- In v2.0: a user can ask a coworker for help at a workflow stage, review the proposed output, and accept or reject it — without leaving Obsidian or losing control of their vault.
+- **v2.0:** A user can trigger a runtime session, watch execution progress in the panel, review a proposed agent output, and accept or reject it — without leaving Obsidian or losing control of their vault.
 
 ## Open Questions
 
-- Which workflow stages must be supported in the first usable plugin slice?
-- Which existing scripts should become plugin commands first?
-- What vault health checks are mandatory before any LLM-assisted workflow is added?
-- How should plugin state be stored so Markdown remains the source of truth?
-- What does a minimal but useful traceability dashboard need to show?
-- What is the right runtime boundary for agentonomous inside an Obsidian plugin — direct import, local service process, or CLI bridge?
-- Which agentic coworkers should be available first in v2.0?
-- How should long-running or interrupted agent runs be resumed?
+| # | Question |
+|---|---|
+| OQ-01 | Which workflow stages must be supported in the first usable v1 slice? |
+| OQ-02 | Which `agentic-workflow` scripts should become plugin commands first? |
+| OQ-03 | What vault health checks are mandatory before any agentic session is triggered? |
+| OQ-04 | How should the plugin communicate with `specorator-runtime` — direct npm import, local IPC, or CLI bridge? |
+| OQ-05 | What is the minimum runtime event set the plugin must handle to render useful session state in v2.0? |
+| OQ-06 | Which `agentonomous` agents should be available in the first v2.0 session? |
+| OQ-07 | How should interrupted or failed runtime sessions be surfaced and recovered from in the UI? |
+| OQ-08 | How should run provenance (agent, session ID, date) be stored in accepted vault artifacts? |

--- a/docs/superpowers/plans/2026-05-04-ecosystem-product-vision-refinement.md
+++ b/docs/superpowers/plans/2026-05-04-ecosystem-product-vision-refinement.md
@@ -359,6 +359,8 @@ Open the PR created in Task 1 and confirm all commits from Chunks 2–5 appear i
 - Create: `docs/index.html` — static GitHub Pages product page
 - Create: PR `develop → demo` to publish
 
+**Branch:** Run all steps on the existing `feature/product-vision-refinement` branch (same branch as Chunks 1–5). Steps 1–6 commit to that branch; Step 7 opens a `develop → demo` PR *after* the feature branch has been merged to `develop` via the PR from Task 1.
+
 **Note:** The actual HTML product page does not yet exist (issue #22, Phase 4). This task implements it. Use the `frontend-design` skill when building `docs/index.html`.
 
 - [ ] **Step 1: Fix product-page-brief.md Section 4 ecosystem table**
@@ -426,15 +428,19 @@ Create `docs/index.html` — a static HTML product page with no build step, read
 - Must render correctly via `file://` (no relative path issues)
 - Obsidian-appropriate aesthetic: clean, dark-mode compatible, minimal
 
-**Use the `frontend-design` skill for this step.** Invoke it before writing any HTML.
+**Step 4a — Invoke `frontend-design` skill before writing any HTML.** This is not optional.
+
+**Step 4b — Write `docs/index.html`** following the skill's output and the content rules above.
 
 - [ ] **Step 5: Verify page renders correctly**
 
 Open `docs/index.html` directly in a browser (`file://`) and confirm:
 - All 9 sections render
-- No broken links within the page
+- All internal `#anchor` links resolve (every `href="#id"` must have a matching `id=` on a target element)
 - 4-component ecosystem table appears correctly
 - v1/v2.0 distinction is clear throughout
+
+For a more realistic check, also run: `npx serve docs/` and open `http://localhost:3000`
 
 - [ ] **Step 6: Commit the product page**
 
@@ -443,16 +449,38 @@ git add docs/index.html
 git commit -m "feat(product-page): add GitHub Pages product page (issue #22)"
 ```
 
-- [ ] **Step 7: Merge feature branch to develop, then open PR develop → demo**
+- [ ] **Step 7: Open PR develop → demo to publish**
 
-First ensure all chunks are merged into `develop` via the PR from Task 1. Then:
+Before opening this PR:
+1. Confirm the feature branch PR (Task 1) has been merged into `develop`.
+2. Verify GitHub Pages is configured to serve from the `docs/` folder on the `demo` branch (GitHub repo Settings → Pages → Source). If not configured, set it before merging.
+
+**On Linux/macOS or Git Bash (recommended):**
 
 ```bash
 gh pr create \
   --base demo \
   --head develop \
   --title "chore(demo): publish ecosystem vision update + product page" \
-  --body "$(cat <<'EOF'
+  --body "## What this publishes
+
+- Updated product vision (ecosystem-first restructure)
+- Updated product-page-brief, glossary, PRD, roadmap
+- New GitHub Pages product page (docs/index.html — issue #22)
+
+## Verify after merge
+
+- [ ] \`https://luis85.github.io/specorator/\` resolves and renders the product page
+- [ ] Ecosystem table shows all 4 components correctly
+- [ ] v1/v2.0 distinction is clear throughout"
+```
+
+**On Windows PowerShell:**
+
+```powershell
+gh pr create --base demo --head develop `
+  --title "chore(demo): publish ecosystem vision update + product page" `
+  --body @'
 ## What this publishes
 
 - Updated product vision (ecosystem-first restructure)
@@ -464,6 +492,5 @@ gh pr create \
 - [ ] `https://luis85.github.io/specorator/` resolves and renders the product page
 - [ ] Ecosystem table shows all 4 components correctly
 - [ ] v1/v2.0 distinction is clear throughout
-EOF
-)"
+'@
 ```

--- a/docs/superpowers/plans/2026-05-04-ecosystem-product-vision-refinement.md
+++ b/docs/superpowers/plans/2026-05-04-ecosystem-product-vision-refinement.md
@@ -1,0 +1,469 @@
+# Ecosystem Product Vision Refinement — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Propagate the ecosystem-first product vision update through all dependent docs so every document in the repo consistently reflects the 4-component architecture (`specorator-plugin`, `specorator-runtime`, `agentic-workflow`, `agentonomous`).
+
+**Architecture:** `docs/product-vision.md` was restructured on branch `feature/product-vision-refinement` (commits `ace3de3`, `17105bb`, `d9528b5`). That doc is the source of truth. All other docs must be brought into alignment with it — no document should describe `agentonomous` as the orchestration engine, and every doc covering v2.0 or ecosystem architecture must include `specorator-runtime`.
+
+**Tech Stack:** Markdown only. No code changes. Branch: `feature/product-vision-refinement`. All edits happen in `.worktrees/feature/product-vision-refinement/`.
+
+---
+
+## Chunk 1: PR for product-vision.md
+
+### Task 1: Open PR for the product vision update
+
+**Files:**
+- Already committed: `docs/product-vision.md` (3 commits on branch `feature/product-vision-refinement`)
+
+- [ ] **Step 1: Verify the worktree is clean**
+
+```bash
+cd .worktrees/feature/product-vision-refinement
+git status
+```
+
+Expected: `nothing to commit, working tree clean`
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push origin feature/product-vision-refinement
+```
+
+Expected: branch pushed, no errors.
+
+- [ ] **Step 3: Open PR targeting develop**
+
+```bash
+gh pr create \
+  --title "docs(vision): ecosystem-first restructure — add specorator-runtime, fix agentonomous role" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds `specorator-runtime` as a first-class ecosystem component (was entirely absent)
+- Fixes `agentonomous` role description (was "orchestration engine"; it is the agent capabilities provider)
+- Leads the doc with a 4-component ecosystem architecture diagram
+- Reframes the plugin explicitly as the UI layer for the whole ecosystem
+- Updates v2.0 section to reference `specorator-runtime` as the execution layer
+- Adds "Runtime transparency" principle
+
+## Related
+
+- Part of #148 (dependent docs follow-up tracked in Chunks 2–5 of this branch)
+- Spec reviewed and approved (2 reviewer passes, 0 blockers)
+
+## Test plan
+
+- [ ] Read `docs/product-vision.md` in the PR diff — every section should consistently describe plugin as UI layer
+- [ ] Verify no section describes `agentonomous` as the orchestration engine
+- [ ] Verify `specorator-runtime` appears in ecosystem table with correct role
+- [ ] Verify v1/v2.0 split is consistent throughout
+EOF
+)"
+```
+
+Expected: PR URL printed to stdout (e.g. `https://github.com/Luis85/specorator/pull/NNN`)
+
+---
+
+## Chunk 2: prd.md alignment
+
+### Task 2: Add specorator-runtime to PRD relationship table and fix agentonomous description
+
+**Files:**
+- Modify: `docs/prd.md` — section "Relationship to Upstream Projects" (near line 98–102 in original)
+
+Context: The PRD has a relationship table at the bottom of the v1 section. It needs a `specorator-runtime` row and an updated `agentonomous` description.
+
+- [ ] **Step 1: Locate the relationship table in prd.md**
+
+Open `docs/prd.md`. Find the section titled `## Relationship to Upstream Projects` (it exists in the original product-vision.md, but the PRD does not have a direct equivalent — the PRD has dependencies tables in §10.1 and §12). Check both.
+
+In `docs/prd.md`:
+- Search for "agentonomous" to find every occurrence of the incorrect description.
+- The v1 PRD §10.1 Dependencies table references `agentic-workflow` releases. It does not currently mention `agentonomous` or `specorator-runtime`.
+- The v2.0 PRD §12 Dependencies table currently lists `agentonomous` as "Coworker definitions, invocation contracts, run lifecycle, and output structures are defined in `agentonomous`."
+- The v2.0 PRD §5.5 Integration Bridge requirements reference `agentonomous` directly.
+- Open questions V2-OQ-001 and V2-OQ-002 ask about the `agentonomous` runtime boundary — now answered by `specorator-runtime`.
+
+- [ ] **Step 2: Update v2.0 §12 Dependencies — add specorator-runtime row**
+
+In the v2.0 PRD `## 12. Dependencies on agentonomous and agentic-workflow` table, add a new first row before the existing agentonomous row:
+
+```markdown
+| `specorator-runtime` execution engine | Hard | The npm library that orchestrates workflow execution, manages session lifecycle, invokes agents, and emits the event stream the plugin subscribes to. Must be available and stable before v2.0 integration implementation begins. |
+```
+
+Also rename the section heading from `## 12. Dependencies on agentonomous and agentic-workflow` to `## 12. Dependencies` to reflect the now-broader scope (keep the number).
+
+- [ ] **Step 3: Update v2.0 §12 — fix agentonomous row**
+
+Change the existing `agentonomous coworker/agent model` row description from:
+> "Coworker definitions, invocation contracts, run lifecycle, and output structures are defined in `agentonomous`."
+
+To:
+> "Agent implementations and capabilities are defined in `agentonomous`. The runtime invokes these agents; the plugin does not call `agentonomous` directly."
+
+- [ ] **Step 4: Update v2.0 §5.5 Integration Bridge — clarify specorator-runtime as the boundary**
+
+In requirement `V2-FR-040`, update the text to reflect that the plugin integrates with `specorator-runtime` (not `agentonomous` directly):
+
+Change:
+> "The plugin SHALL integrate with `agentonomous` through a typed service interface; the Vue UI SHALL NOT import `agentonomous` directly."
+
+To:
+> "The plugin SHALL integrate with `specorator-runtime` through a typed service interface; the Vue UI SHALL NOT import `specorator-runtime` or `agentonomous` directly."
+
+Update `V2-FR-042`:
+Change:
+> "The bridge interface SHALL represent: coworker capabilities, context bundles, run invocation, run state, proposed outputs, review decisions, and diagnostics."
+
+To:
+> "The bridge interface SHALL represent: runtime session lifecycle, task graph state, agent invocation events, proposed outputs, review decisions, and diagnostics."
+
+- [ ] **Step 5: Retire V2-OQ-001 and V2-OQ-002**
+
+In `## 13. Open Questions and Architectural Decisions Needed`, mark V2-OQ-001 and V2-OQ-002 as resolved:
+
+Change V2-OQ-001:
+> "What is the correct runtime boundary for `agentonomous` inside an Obsidian plugin..."
+
+To:
+> "~~What is the correct runtime boundary for `agentonomous` inside an Obsidian plugin...~~ **Resolved:** `specorator-runtime` is the execution boundary. The plugin depends on `specorator-runtime` as an npm library; `agentonomous` agents are invoked by the runtime, not the plugin directly."
+
+Change V2-OQ-002:
+> "Can `agentonomous` run safely within the Obsidian plugin renderer process..."
+
+To:
+> "~~Can `agentonomous` run safely within the Obsidian plugin renderer process...~~ **Resolved:** `agentonomous` runs within `specorator-runtime`, which is responsible for its isolation boundary. See `specorator-runtime` PRD issue #1 OQ for the module format decision."
+
+- [ ] **Step 6: Verify no remaining incorrect agentonomous descriptions**
+
+```bash
+grep -n "agentonomous.*orchestration\|orchestration.*agentonomous" docs/prd.md
+```
+
+Expected: zero matches. (`routing` and `handoff` appear legitimately elsewhere in the PRD — e.g. `V2-AO-006` references agent-to-agent handoffs — so do not treat those as errors.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/prd.md
+git commit -m "docs(prd): add specorator-runtime dependency, fix agentonomous role, retire V2-OQ-001/OQ-002"
+```
+
+---
+
+## Chunk 3: roadmap-v1.md alignment
+
+### Task 3: Update roadmap Phase 4 agent placeholder description
+
+**Files:**
+- Modify: `docs/roadmap-v1.md` — Phase 4 table row "Agent interaction placeholder"
+
+- [ ] **Step 1: Update Phase 4 agent placeholder row**
+
+In `docs/roadmap-v1.md`, find the Phase 4 table. Change the "Agent interaction placeholder" row:
+
+Change:
+```markdown
+| Agent interaction placeholder | Extension point and documented handoff for v2.0 coworkers | #16, #23, #27 |
+```
+
+To:
+```markdown
+| Agent interaction placeholder | Extension point and documented handoff for v2.0 `specorator-runtime` integration; defines the plugin-side event subscription surface | #16, #23, #27 |
+```
+
+- [ ] **Step 2: Replace the existing v2.0 direction note in Phase 4**
+
+Find and replace this exact text:
+
+```markdown
+**v2.0 direction:** Issue #23 defines the companion-app and `agentonomous` integration vision. No v2.0 orchestration features are in scope for v1 alpha, but the shell (#11) and bridge API (#16) must leave clean, documented extension points for them.
+```
+
+With:
+
+```markdown
+**v2.0 direction:** v2.0 runtime integration work is tracked in the [`specorator-runtime`](https://github.com/Luis85/specorator-runtime) repository. The plugin's v2.0 scope is confined to the UI surface — session trigger, event subscription, and output review. Execution, scheduling, and agent invocation are owned by the runtime.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/roadmap-v1.md
+git commit -m "docs(roadmap): update Phase 4 agent placeholder to reference specorator-runtime"
+```
+
+---
+
+## Chunk 4: glossary.md alignment
+
+### Task 4: Add specorator-runtime entry and fix agentonomous entry
+
+**Files:**
+- Modify: `docs/glossary.md` — Ecosystem Terms section
+
+- [ ] **Step 1: Fix the "Specorator" term entry**
+
+The current "Specorator" entry says v2.0 is "powered by `agentonomous`." Update to:
+
+Change:
+> "In v2.0, Specorator becomes a companion app offering a team of agentic coworkers powered by `agentonomous`."
+
+To:
+> "In v2.0, Specorator connects to `specorator-runtime` as a live agentic cockpit — triggering workflow sessions, subscribing to runtime events, and presenting agent-proposed outputs for user review."
+
+- [ ] **Step 2: Fix the "companion app" term entry**
+
+Change:
+> "A Specorator instance with active `agentonomous` integration..."
+
+To:
+> "A Specorator instance connected to `specorator-runtime`, enabling live agentic workflow execution. The companion app presents session state, agent activity, and proposed outputs while the runtime and `agentonomous` agents operate behind the UI surface."
+
+- [ ] **Step 3: Fix the "agentonomous" ecosystem entry**
+
+Change:
+> "The upstream agent orchestration library (`Luis85/agentonomous`) that will power v2.0 agentic coworker interactions."
+
+To:
+> "The upstream autonomous-agent library (`Luis85/agentonomous`) that provides the agent implementations invoked by `specorator-runtime`. Agents are selected per workflow task, provided context, and return structured output. The plugin does not call `agentonomous` directly."
+
+- [ ] **Step 4: Fix the "agent run" term entry**
+
+Change:
+> "A single execution of an agentic coworker flow in `agentonomous`, triggered by a user action in the Specorator UI."
+
+To:
+> "A single workflow session execution managed by `specorator-runtime`, triggered by a user action in the Specorator UI. The runtime interprets the workflow definition, invokes `agentonomous` agents at each task, and emits a typed event stream the plugin subscribes to."
+
+- [ ] **Step 5: Add "specorator-runtime" ecosystem entry**
+
+After the `agentonomous` entry (not after `agentic-workflow` — keeps ecosystem component entries together) in the Ecosystem Terms section, add:
+
+```markdown
+### specorator-runtime
+
+The execution engine library (`Luis85/specorator-runtime`) that sits between the plugin and the rest of the ecosystem. Consumed by the Specorator plugin as an npm package. Responsible for: session lifecycle, workflow interpretation (consuming `agentic-workflow` definitions), agent invocation (calling `agentonomous`), event bus, state store, and runtime API. The plugin is a subscriber and trigger surface; the runtime owns all execution logic.
+```
+
+- [ ] **Step 6: Add "runtime session" term entry**
+
+After the "specorator-runtime" entry, add:
+
+```markdown
+### runtime session
+
+A single execution instance of a workflow managed by `specorator-runtime`. A session contains: a workflow reference, execution state, task graph, agent interactions, produced artifacts, and event log. The plugin surfaces session state in the cockpit and allows the user to start, monitor, cancel, and inspect sessions. **v2.0 concept; not available in v1.**
+```
+
+- [ ] **Step 7: Update the Scope Boundaries table**
+
+In the Scope Boundaries section, update the `agentonomous` integration row and add a `specorator-runtime` row:
+
+Change:
+```markdown
+| `agentonomous` integration | Extension point only | Full integration |
+```
+
+To:
+```markdown
+| `specorator-runtime` integration | Not implemented | Full integration as npm library |
+| `agentonomous` integration | Not applicable (accessed via runtime only) | Invoked by runtime per task |
+```
+
+- [ ] **Step 8: Verify no remaining "orchestration library" description for agentonomous**
+
+```bash
+grep -n "orchestration" docs/glossary.md
+```
+
+Expected: zero matches.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add docs/glossary.md
+git commit -m "docs(glossary): add specorator-runtime entry, fix agentonomous role, add runtime session term"
+```
+
+---
+
+## Chunk 5: DESIGN_BRIEF.md check + final verification
+
+### Task 5: Check DESIGN_BRIEF and USE_CASES, then close issue #148
+
+**Files:**
+- Check: `docs/design/DESIGN_BRIEF.md`
+- Check: `docs/design/USE_CASES.md`
+
+- [ ] **Step 1: Check DESIGN_BRIEF for incorrect agentonomous description**
+
+```bash
+grep -n "agentonomous\|specorator-runtime\|orchestration" docs/design/DESIGN_BRIEF.md
+```
+
+The DESIGN_BRIEF lists "AI agent inside Specorator" as out-of-scope for v1 (line 167). It does not describe `agentonomous` as an orchestration engine. If grep returns no incorrect descriptions, no edit is needed. If any "orchestration" usage is found describing agentonomous, apply the same fix as in the glossary.
+
+- [ ] **Step 2: Check USE_CASES for incorrect agentonomous description**
+
+```bash
+grep -n "agentonomous\|specorator-runtime\|orchestration" docs/design/USE_CASES.md
+```
+
+If any use case describes the plugin calling `agentonomous` directly (bypassing the runtime), note it. For v1 use cases, no fix is needed since agentonomous is not in scope. For v2.0 use cases that say "Specorator calls agentonomous," update to "Specorator triggers a runtime session; the runtime invokes agentonomous agents."
+
+- [ ] **Step 3: Commit any changes from the above checks**
+
+Only commit if edits were made:
+
+```bash
+git add docs/design/DESIGN_BRIEF.md docs/design/USE_CASES.md
+git commit -m "docs(design): align agentonomous role with ecosystem architecture"
+```
+
+Skip this step if no edits were needed.
+
+- [ ] **Step 4: Run final grep across all docs**
+
+Verify no remaining incorrect descriptions across all updated docs:
+
+```bash
+grep -rn "orchestration engine\|orchestration library" docs/
+```
+
+Expected: zero matches.
+
+- [ ] **Step 5: Close issue #148**
+
+```bash
+gh issue close 148 --repo Luis85/specorator --comment "All dependent docs updated on branch feature/product-vision-refinement. Changes: prd.md (specorator-runtime added, V2-OQ-001/002 retired), roadmap-v1.md (Phase 4 agent placeholder updated), glossary.md (specorator-runtime entry added, agentonomous role fixed). DESIGN_BRIEF and USE_CASES verified clean."
+```
+
+- [ ] **Step 6: Verify all chunks committed and PR up to date**
+
+Open the PR created in Task 1 and confirm all commits from Chunks 2–5 appear in the PR diff.
+
+---
+
+## Chunk 6: Product page — update brief, build page, publish
+
+### Task 6: Update product-page-brief.md and build the GitHub Pages product page
+
+**Files:**
+- Modify: `docs/product-page-brief.md` — Section 4 ecosystem table + Section 6 v2.0 description
+- Create: `docs/index.html` — static GitHub Pages product page
+- Create: PR `develop → demo` to publish
+
+**Note:** The actual HTML product page does not yet exist (issue #22, Phase 4). This task implements it. Use the `frontend-design` skill when building `docs/index.html`.
+
+- [ ] **Step 1: Fix product-page-brief.md Section 4 ecosystem table**
+
+In `docs/product-page-brief.md`, find Section 4 ("How does it relate to `agentic-workflow`?"). The current ecosystem table reads:
+
+```markdown
+| `agentic-workflow` | The methodology — workflow stages, artifacts, templates, quality gates. Specorator consumes released versions. |
+| Specorator | The Obsidian plugin — installs, navigates, and surfaces the methodology from inside the vault. |
+| `agentonomous` | The agent orchestration engine — powers v2.0 agentic coworkers. Not used in v1. |
+```
+
+Replace with the 4-component table:
+
+```markdown
+| `agentic-workflow` | The methodology — workflow stages, artifacts, templates, quality gates. Specorator consumes released versions. |
+| `specorator-runtime` | The execution engine — interprets workflow definitions, invokes agents, manages sessions, emits events. npm library consumed by the plugin. v2.0 only. |
+| `agentonomous` | The agent capabilities library — provides the agent implementations the runtime invokes. v2.0 only. |
+| Specorator (this plugin) | The UI layer — installs the methodology, navigates workflow state, and in v2.0 becomes the cockpit for live agentic sessions. |
+```
+
+- [ ] **Step 2: Fix product-page-brief.md Section 6 v2.0 description**
+
+In Section 6, update the body copy:
+
+Change:
+> "In v2.0, Specorator becomes a companion app powered by `agentonomous`. Users get a team of purpose-built agentic coworkers..."
+
+To:
+> "In v2.0, Specorator connects to `specorator-runtime` to become a live agentic cockpit. The runtime executes workflow sessions, invoking agents from `agentonomous` at each task. Users see real-time execution state in the panel and review every agent-proposed output before it is written to the vault."
+
+Also update the Secondary Message in Section 1:
+
+Change:
+> "In v2.0, Specorator becomes a companion app powered by `agentonomous`, giving you a team of agentic coworkers..."
+
+To:
+> "In v2.0, Specorator connects to `specorator-runtime` as a live agentic cockpit — executing workflow sessions, invoking agents from `agentonomous`, and surfacing every proposed output for your review before it touches the vault."
+
+- [ ] **Step 3: Commit product-page-brief.md changes**
+
+```bash
+git add docs/product-page-brief.md
+git commit -m "docs(product-page-brief): update ecosystem table and v2.0 description to reflect 4-component architecture"
+```
+
+- [ ] **Step 4: Build the GitHub Pages product page**
+
+Create `docs/index.html` — a static HTML product page with no build step, readable via `file://` in a browser. Follow the 9-section structure in `docs/product-page-brief.md` exactly.
+
+**Content rules (from the brief):**
+- Hero: plugin name + tagline, no agent capabilities claimed
+- Problem: AI coding generates code fast but not good software — structure makes the difference
+- How it works (v1 only): template installation, workflow navigation, artifact creation
+- Ecosystem: 4-component table from the updated Section 4
+- Status: what's built vs. in active development (be honest — plugin shell built, Phase 4 features in progress)
+- v2.0 direction: cockpit + runtime + agentonomous, link to issue #23
+- Get started: `npm install`, `npm run dev`, `npm run build` + sideloading note
+- Contribute: links to local-dev docs, open issues, roadmap
+- Footer: repo links for all 4 ecosystem components
+
+**Technical constraints:**
+- Single static HTML file, no external JS frameworks or build step
+- CSS inline or in `<style>` block — no external stylesheets other than system fonts
+- Must render correctly via `file://` (no relative path issues)
+- Obsidian-appropriate aesthetic: clean, dark-mode compatible, minimal
+
+**Use the `frontend-design` skill for this step.** Invoke it before writing any HTML.
+
+- [ ] **Step 5: Verify page renders correctly**
+
+Open `docs/index.html` directly in a browser (`file://`) and confirm:
+- All 9 sections render
+- No broken links within the page
+- 4-component ecosystem table appears correctly
+- v1/v2.0 distinction is clear throughout
+
+- [ ] **Step 6: Commit the product page**
+
+```bash
+git add docs/index.html
+git commit -m "feat(product-page): add GitHub Pages product page (issue #22)"
+```
+
+- [ ] **Step 7: Merge feature branch to develop, then open PR develop → demo**
+
+First ensure all chunks are merged into `develop` via the PR from Task 1. Then:
+
+```bash
+gh pr create \
+  --base demo \
+  --head develop \
+  --title "chore(demo): publish ecosystem vision update + product page" \
+  --body "$(cat <<'EOF'
+## What this publishes
+
+- Updated product vision (ecosystem-first restructure)
+- Updated product-page-brief, glossary, PRD, roadmap
+- New GitHub Pages product page (docs/index.html — issue #22)
+
+## Verify after merge
+
+- [ ] `https://luis85.github.io/specorator/` resolves and renders the product page
+- [ ] Ecosystem table shows all 4 components correctly
+- [ ] v1/v2.0 distinction is clear throughout
+EOF
+)"
+```


### PR DESCRIPTION
## Summary

- Restructures `docs/product-vision.md` to lead with a four-component ecosystem architecture diagram (specorator-plugin → specorator-runtime → agentic-workflow + agentonomous)
- Corrects the role of `agentonomous` (agent capabilities library, not orchestration engine)
- Introduces `specorator-runtime` as the execution engine component the plugin connects to in v2.0
- Retitles v2.0 section as "Runtime-Connected Agentic Cockpit"
- Adds "Runtime transparency" and "User-controlled agents" principles
- Updates Non-Goals and Open Questions to reflect ecosystem boundaries

Part of #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)