### PR TITLE
fix(build): route plugin bundle through dist-plugin/ to silence outDir warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ node_modules/
 main.js
 main.js.map
 
+# Plugin build staging dir (artifacts are copied to project root after build)
+dist-plugin/
+
 # Standalone UI build
 dist-standalone/
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -120,6 +120,7 @@ export default defineConfig(
 		ignores: [
 			'node_modules/',
 			'main.js',
+			'dist-plugin/',
 			'dist-standalone/',
 			'coverage/',
 			'.worktrees/',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import { copyFileSync } from 'fs';
 import { builtinModules } from 'module';
 import { resolve } from 'path';
 import { defineConfig, type Plugin as VitePlugin } from 'vite';
@@ -26,6 +27,19 @@ const ALL_EXTERNALS = [
 	...builtinModules,
 	...builtinModules.map((m) => `node:${m}`),
 ];
+
+function copyPluginArtifacts(): VitePlugin {
+	return {
+		name: 'specorator-copy-plugin-artifacts',
+		closeBundle() {
+			copyFileSync(resolve(__dirname, 'dist-plugin/main.js'), resolve(__dirname, 'main.js'));
+			copyFileSync(
+				resolve(__dirname, 'dist-plugin/styles.css'),
+				resolve(__dirname, 'styles.css'),
+			);
+		},
+	};
+}
 
 function scopeSelector(selector: string): string {
 	const trimmedSelector = selector.trim();
@@ -74,7 +88,7 @@ export default defineConfig(({ mode }) => {
 
 	if (mode === 'plugin') {
 		return {
-			plugins: [vue(), scopeBuiltCss()],
+			plugins: [vue(), scopeBuiltCss(), copyPluginArtifacts()],
 			resolve: { alias },
 			build: {
 				lib: {
@@ -91,7 +105,7 @@ export default defineConfig(({ mode }) => {
 							info.names.some((n) => n.endsWith('.css')) ? 'styles.css' : '[name][extname]',
 					},
 				},
-				outDir: '.',
+				outDir: 'dist-plugin',
 				emptyOutDir: false,
 				sourcemap: 'inline',
 				minify: false,


### PR DESCRIPTION
## Summary

- Moves plugin build staging from `.` (project root) to `dist-plugin/` to eliminate the Vite warning: _build.outDir must not be the same directory of root or a parent directory of root_
- Adds a `closeBundle` Vite plugin hook (`copyPluginArtifacts`) that copies `main.js` and `styles.css` from `dist-plugin/` to the project root after each build — works for both one-shot and `--watch` mode
- Excludes `dist-plugin/` from `.gitignore` and ESLint ignores so the generated bundle is never linted or tracked

## Test plan

- [x] `npm run build` — exits 0, zero warnings, artifacts present at project root
- [x] `npm run verify` — all checks pass, zero warnings in output
- [x] `npm run lint` — clean, `dist-plugin/` correctly excluded

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)