### PR TITLE
docs(vision): H-ACD, MCP architecture, v1 chat sidebar, and spec gate entries

### DIFF
--- a/docs/product-page-brief.md
+++ b/docs/product-page-brief.md
@@ -123,15 +123,17 @@ Show the lifecycle with plain-language stage labels, not technical slug names.
 
 ### Section 5 — AI assistant
 
-Explain the AI assistant as a first-class v1 feature, not a future roadmap item.
+The AI assistant is a v1 feature — not v2.0 — but **it is not yet shipped**. Describe it as in active development for v1, using future tense for the sidebar capabilities until the feature lands.
 
-**Key points:**
-- Permanent side panel, always visible
-- Knows your persona, active file, current stage, and opted-in knowledge base context — before you type a word
-- Suggests relevant actions per stage (not generic chat prompts)
-- Every proposed change is a review card — nothing applied without acceptance
+**Key points (describe in future tense until shipped):**
+- Permanent side panel, always visible — *will sit alongside your work*
+- Context-aware — *will know your persona, active file, current stage, and opted-in knowledge base before you type a word*
+- Suggests relevant actions per stage — *will surface stage-appropriate prompts, not generic chat*
+- Every proposed change is a review card — *nothing will be applied without acceptance*
 
-**Copy constraint:** Do not describe the AI assistant as "coming in v2.0" — it is a v1 feature. Do not use AI terminology ("prompt", "model", "context window", "LLM"). Do not describe the MCP server or technical integration details.
+**Status indicator:** Include the "⚡ In development for v1" badge on this section until the feature ships.
+
+**Copy constraint:** The AI assistant is a v1 feature — do not describe it as "coming in v2.0". But it is not yet implemented — do not use present tense for sidebar capabilities that do not yet exist in `src/`. Use "will", "is being built to", or "in active development". Update this section to present tense once #161 ships. Do not use AI terminology ("prompt", "model", "context window", "LLM"). Do not describe the MCP server or technical integration details.
 
 ---
 

--- a/docs/product-page-brief.md
+++ b/docs/product-page-brief.md
@@ -196,7 +196,7 @@ The practical entry point for installation.
 2. Create `{vault}/.obsidian/plugins/specorator/` in your Obsidian vault
 3. Copy the three files into that folder
 4. Open Obsidian → Settings → Community plugins → enable Specorator
-5. Open the Specorator panel from the left sidebar ribbon icon, or via **Command palette → Specorator: Open**. This is your main cockpit for the workflow. *(Alpha note: auto-open onboarding on first install is a tracked requirement — #162 — but not yet shipped. Update this step to describe the guided setup once that feature lands.)*
+5. Open the Specorator panel from the left sidebar ribbon icon, or via **Command palette → Specorator: Open panel**. This is your main cockpit for the workflow. *(Alpha note: auto-open onboarding on first install is a tracked requirement — #162 — but not yet shipped. Update this step to describe the guided setup once that feature lands.)*
 
 **Copy constraint:** Do not describe marketplace installation until the plugin is submitted. Step 5 must reflect what the current plugin actually does on first enable — not the intended onboarding experience that is still in development. Update step 5 when #162 auto-open ships.
 

--- a/docs/product-page-brief.md
+++ b/docs/product-page-brief.md
@@ -3,7 +3,7 @@ title: "Specorator product page content brief"
 doc_type: content-brief
 status: draft
 owner: product
-last_updated: 2026-05-01
+last_updated: 2026-05-05
 references:
   - docs/product-vision.md
   - docs/prd.md
@@ -17,7 +17,7 @@ references:
 **Implements:** GitHub Pages product page for `Luis85/specorator`  
 **Source documents:** [Product Vision](./product-vision.md) · [PRD](./prd.md) · [Use Cases](./design/USE_CASES.md) · [Glossary](./glossary.md)
 
-This brief provides all the structure, copy boundaries, and content decisions needed to implement issue #22 (the GitHub Pages product page). Work from this brief rather than from individual issue descriptions.
+This brief provides all the structure, copy boundaries, and content decisions needed to implement and maintain the GitHub Pages product page. Work from this brief rather than from individual issue descriptions.
 
 ---
 
@@ -27,18 +27,27 @@ This brief provides all the structure, copy boundaries, and content decisions ne
 
 | Audience | Goal on the page |
 |---|---|
-| **Curious user** | Understand what Specorator is, whether it helps their workflow, how to get started |
-| **Obsidian user already using `agentic-workflow`** | See how the plugin automates their current manual steps and makes the methodology accessible inside Obsidian |
+| **Curious builder** | Understand what Specorator is, whether it fits their way of working, and how to get started — regardless of technical background |
+| **Non-technical founder or PM** | See that this tool is for them, not just for engineers; understand that plain language is sufficient to work with the AI assistant |
+| **Engineer or architect** | Understand the workflow discipline, the AI assistance model, and the quality guarantees at each stage |
 | **Potential contributor** | Find out how to get involved, run the project locally, and understand where development is heading |
 | **Evaluator / researcher** | Quickly grasp the product's purpose, scope, and relationship to upstream repos |
 
 ### Primary Message
 
-> Specorator is an Obsidian plugin that turns the `agentic-workflow` methodology into an approachable, guided experience inside your vault. It installs the workflow, navigates your active work, and helps you build better software with discipline — without requiring a heavy process tool.
+> Specorator is a guided development companion that takes you — and your whole team — from first idea to tested code. It brings structured workflow and an AI assistant that knows your work into a single, connected environment. All your files stay plain text, owned by you.
 
 ### Secondary Message
 
-> In v2.0, Specorator becomes a companion app powered by `agentonomous`, giving you a team of agentic coworkers that assist with drafting, reviewing, and improving your workflow outputs while you stay focused on the vault.
+> In v2.0, Specorator becomes a fully orchestrated agentic environment — purpose-built specialist agents covering every role from PM to QA, working in and out of your knowledge base with your explicit oversight at every step.
+
+### Framing principle — Obsidian is the engine, not the product
+
+Specorator is the product. Obsidian is the foundation it runs on — chosen for its powerful local knowledge graph, plugin ecosystem, and deep file-system integration. The page should reflect this hierarchy:
+
+- **Never lead** a section by calling Specorator "an Obsidian plugin."
+- **Do mention** Obsidian where relevant — in a dedicated "Powered by Obsidian" section and in install instructions — but as a substrate, not an identity.
+- **Never use** "vault" as primary user-facing language; prefer "your knowledge base" or "your files" for external copy. ("Vault" is fine in install instructions where users are already inside Obsidian.)
 
 ---
 
@@ -46,173 +55,207 @@ This brief provides all the structure, copy boundaries, and content decisions ne
 
 ### Section 1 — Hero
 
-**Heading (suggested):** *Specorator — structured software work, inside Obsidian*
+**Heading:** *From idea to tested code. Every step, guided.*
 
-**Subheading:** *Install the workflow. Navigate your active work. Build with discipline.*
+**Subheading:** Specorator is your guided development companion — structured workflow, AI assistance, and your knowledge in one place.
 
-**Body:** 2–3 sentences maximum. Establish what Specorator is and who it is for. Do not mention `agentonomous` here — keep the hero focused on the v1 value.
+**Body:** 2–3 sentences. Establish what Specorator is and who it is for. Do not describe Specorator as an Obsidian plugin. Do not mention technical stack. Obsidian may appear as a subordinate clause at most.
 
 **CTA:** Two buttons:
-- Primary: "Get started" → links to quick-start / local-dev section
-- Secondary: "View on GitHub" → links to `Luis85/specorator`
+- Primary: "Try it in your browser" → opens live demo
+- Secondary: "Get started" → links to get-started section
 
-**Copy constraint:** Do not claim agent capabilities in the hero. v1 is a workflow tool, not an AI product.
-
----
-
-### Section 2 — What problem does it solve?
-
-Speak to the target persona (the Focused Builder from the Design Brief): someone who suspects discipline would help them but finds orthodox process daunting.
-
-**Key points to cover:**
-- AI coding tools make it easy to generate code, but not easy to generate *good* software.
-- Without structure, decisions get lost, specs diverge from code, and features don't finish cleanly.
-- The discipline (requirements, decision records, quality gates) exists but is buried in enterprise tooling.
-- Specorator is a plugin-sized, jargon-softened version: it makes the next right action obvious.
-
-**Copy constraint:** One short paragraph or a tight 3-point list. Do not expand into methodology detail here.
+**Badge:** "v1 alpha · in development" — no mention of "Obsidian plugin" in the badge.
 
 ---
 
-### Section 3 — How does it work? (v1 capabilities)
+### Section 2 — What is Specorator?
 
-Explain the three core v1 workflows with short, concrete descriptions. Use past-present tense: what the user *does*, not what the product *will do*.
+Lead with the product value, not the implementation substrate.
 
-**Template installation**
-> Install a supported version of the `agentic-workflow` template into your vault with one command. Specorator checks for existing files and asks before overwriting anything.
+**Opening:** Describe what Specorator does for the user, in one or two plain-language paragraphs.
 
-**Workflow navigation**
-> Open the cockpit to see your active feature, current stage, and the next artifact you need to create. Commands open workflow files directly in Obsidian — no file-system browsing required.
+**Three pillars:**
+1. Guided workflow — 12 stages, always know where you are and what comes next
+2. AI that knows your work — context-aware, stage-aware assistant; no manual prompt construction required
+3. You stay in control — every AI output is a proposal; nothing is written without explicit acceptance
 
-**Artifact creation**
-> Create a new feature scaffold from the plugin UI. All outputs are plain Markdown in your vault — readable and editable with or without the plugin installed.
-
-**Copy constraint:** Do not list v2.0 coworker capabilities in this section. Flag them clearly as "coming in v2.0" if mentioned at all.
+**Copy constraint:** Do not use "Obsidian plugin" as the first or primary descriptor. The product leads; the implementation follows.
 
 ---
 
-### Section 4 — How does it relate to `agentic-workflow`?
+### Section 3 — Who it's for
 
-Short explanation of the three-layer relationship:
+Explicitly address non-technical users. Show that this is not a developer-only tool.
 
-| Layer | Role |
+**Audiences to cover:**
+- Founders and PMs — plain language to spec
+- Engineers and architects — traceability, quality gates, implementation to retrospective
+- Designers and analysts — decisions and requirements alongside artifacts
+- Anyone who wants to try it — browser demo, no setup required
+
+**Copy constraint:** Do not frame the problem as "developers who forget to write specs." Frame it as: everyone in the room benefits from a shared, structured, connected way of working.
+
+---
+
+### Section 4 — The 12 stages
+
+Show the lifecycle with plain-language stage labels, not technical slug names.
+
+| # | Plain-language label |
 |---|---|
-| `agentic-workflow` | The methodology — workflow stages, artifacts, templates, quality gates. Specorator consumes released versions. |
-| Specorator | The Obsidian plugin — installs, navigates, and surfaces the methodology from inside the vault. |
-| `agentonomous` | The agent orchestration engine — powers v2.0 agentic coworkers. Not used in v1. |
+| 1 | Exploring the idea |
+| 2 | Looking into it |
+| 3 | What it needs to do |
+| 4 | How it should look and feel |
+| 5 | The full plan |
+| 6 | Breaking it into steps |
+| 7 | Building it |
+| 8 | How we'll check it works |
+| 9 | What we found |
+| 10 | Checking our work |
+| 11 | Telling people about it |
+| 12 | What we learned |
 
-Link to `Luis85/agentic-workflow` repository.
-
-**Copy constraint:** Do not imply that `agentonomous` is part of v1. Reference it only as the v2.0 direction.
-
----
-
-### Section 5 — What's available now? (v1 status)
-
-Be honest about v1 alpha status. Do not overstate stability.
-
-**What works:**
-- Plugin scaffold and build toolchain
-- Isolated browser runtime for the Vue 3 UI
-- Typed Obsidian-to-UI bridge API
-- CI and dependency automation
-- Local development documentation
-
-**In active development:**
-- Template installation service
-- Workflow navigator UI
-- Artifact creation commands
-
-**Copy constraint:** Only list items that are actually built or in flight. Do not list items as "available" that are still in planning.
+**Copy constraint:** Do not display raw stage slugs (`idea`, `research`, etc.) as the primary labels in user-facing copy.
 
 ---
 
-### Section 6 — v2.0 direction (companion app)
+### Section 5 — AI assistant
 
-One short section on the v2.0 vision. Frame it as a roadmap direction, not a current feature.
+Explain the AI assistant as a first-class v1 feature, not a future roadmap item.
 
-**Heading:** *Where we're going: agentic coworkers in your vault*
+**Key points:**
+- Permanent side panel, always visible
+- Knows your persona, active file, current stage, and opted-in knowledge base context — before you type a word
+- Suggests relevant actions per stage (not generic chat prompts)
+- Every proposed change is a review card — nothing applied without acceptance
 
-**Body:** 2–3 sentences. In v2.0, Specorator becomes a companion app powered by `agentonomous`. Users get a team of purpose-built agentic coworkers — Spec Writer, Design Reviewer, Decision Recorder, Task Planner — that assist with producing workflow outputs while the user retains full control over what gets accepted and written to the vault.
-
-**CTA:** "Follow v2.0 planning →" → links to [issue #23](https://github.com/Luis85/specorator/issues/23)
-
-**Copy constraint:** Use "v2.0" or "coming in v2.0" consistently. Do not use "coming soon" without version context.
-
----
-
-### Section 7 — Quick start / get started
-
-The practical entry point for users who want to try the plugin.
-
-**Steps (draft — update when installation is available):**
-
-1. Clone the repository: `git clone https://github.com/Luis85/specorator`
-2. Install dependencies: `npm install`
-3. Run in browser mode: `npm run dev` → opens at `http://localhost:5173`
-4. Build for Obsidian sideloading: `npm run build`
-5. Copy `main.js` and `manifest.json` to `.obsidian/plugins/specorator/` in your vault
-
-**Note:** Link to [local development docs](./local-development.md) for the full setup guide.
-
-**Copy constraint:** Do not describe marketplace installation until the plugin is submitted. Use "sideloading" and link to the local-dev docs.
+**Copy constraint:** Do not describe the AI assistant as "coming in v2.0" — it is a v1 feature. Do not use AI terminology ("prompt", "model", "context window", "LLM"). Do not describe the MCP server or technical integration details.
 
 ---
 
-### Section 8 — Contributor path
+### Section 6 — Try it live
 
-For developers who want to work on the plugin.
+The browser demo entry point.
 
-**What to link:**
-- [Local development documentation](./local-development.md)
-- [Obsidian marketplace readiness checklist](./marketplace-readiness.md)
-- [Roadmap](./roadmap-v1.md)
-- [Open issues](https://github.com/Luis85/specorator/issues)
-- [CONTRIBUTING guide] (create when issue #4 is fully resolved)
+**Key points:**
+- No account, no sign-up, nothing sent anywhere
+- Data stays in local browser storage
+- Full workflow experience — create a feature, walk through stages
 
-**Short paragraph:** Specorator is an open development project. Contributions to the plugin shell, bridge API, UI, and documentation are welcome. Read the local development guide to set up the test vault and run the CI checks locally.
+**CTA:** "Open the live demo"
 
 ---
 
-### Section 9 — Footer / links
+### Section 7 — Roadmap
 
-| Link | Target |
+Two columns: first increment (in development) and v2.0 (planned).
+
+**First increment — in development:**
+- Onboarding with persona setup
+- Guided workflow template installation
+- AI chat assistant in permanent side panel
+- Workflow navigator
+- Artifact creation
+- Standalone browser demo
+
+**v2.0 — planned:**
+- Purpose-built specialist agent roles (PM, architect, engineer, QA, writer)
+- Fully orchestrated sessions
+- Live execution state in the panel
+- All outputs remain reviewable proposals
+- Powered by `agentonomous`
+
+**Copy constraint:** Always use "first increment" or "v1" for the current scope. Always use "v2.0" for planned items — never "coming soon" without version context.
+
+---
+
+### Section 8 — Powered by Obsidian
+
+Dedicated section positioning Obsidian as the engine.
+
+**Key points:**
+- Specorator runs as a plugin inside Obsidian — chosen as the foundation for its knowledge graph, plugin ecosystem, and deep file integration
+- Obsidian is the engine; Specorator is the product that runs on it
+- Because of this foundation, the AI assistant can reason over the full connected graph of your knowledge, not just the active file
+- All files are plain Markdown — readable anywhere, version-controllable, permanently yours
+
+**Copy constraint:** This is where Obsidian is explained — not in the hero or the "what is Specorator?" section.
+
+---
+
+### Section 9 — Get started
+
+The practical entry point for installation.
+
+**Steps:**
+1. Download the latest release (`manifest.json`, `main.js`, `styles.css`) from GitHub Releases
+2. Create `{vault}/.obsidian/plugins/specorator/` in your Obsidian vault
+3. Copy the three files into that folder
+4. Open Obsidian → Settings → Community plugins → enable Specorator
+5. Specorator opens and guides you through a short setup
+
+**Copy constraint:** Do not describe marketplace installation until the plugin is submitted. Last step should mention the onboarding experience, not raw configuration.
+
+---
+
+### Section 10 — Ecosystem
+
+Brief section on the related repositories.
+
+| Repo | Role |
 |---|---|
-| GitHub repository | `https://github.com/Luis85/specorator` |
-| `agentic-workflow` | `https://github.com/Luis85/agentic-workflow` |
-| `agentonomous` | `https://github.com/Luis85/agentonomous` |
-| v1 alpha planning | Issue #1 |
-| v2.0 planning | Issue #23 |
-| Roadmap | `docs/roadmap-v1.md` |
+| `Luis85/specorator` | This repository. The guided workflow and AI assistant. |
+| `Luis85/agentic-workflow` | Upstream workflow methodology, templates, and quality gates. |
+| `Luis85/agentonomous` | Agent implementation library. Powers the v2.0 specialist roles. |
+| `Luis85/specorator-runtime` | Execution engine for v2.0 orchestrated sessions. |
+
+---
+
+### Section 11 — Contribute
+
+Short section for contributors.
+
+**Links:**
+- GitHub repository
+- #1 — v1 alpha planning
+- #23 — v2.0 planning
+- #47 — Roadmap progress tracker
+- Local development guide
+- Contributing guide
 
 ---
 
 ## 3. Copy Boundaries
 
-These rules prevent the page from overpromising capabilities that are not yet built.
-
 | Rule | Rationale |
 |---|---|
-| Never describe coworkers, agent runs, or proposed outputs as current features. | These are v2.0 capabilities. Claiming them in v1 creates false expectations. |
-| Never use "AI" to describe v1 without qualification. | v1 has no live AI integration. The coach text is static guidance, not generated content. |
-| Always distinguish "v1" from "v2.0" when describing roadmap items. | Users should know what they can try now vs. what is planned. |
+| Never call Specorator "an Obsidian plugin" in the hero, meta description, or section leads. | Obsidian is the engine, not the product identity. |
+| Never use AI terminology with users: "prompt", "model", "context window", "LLM", "system prompt". | The product promise is plain-language interaction; technical terms undermine trust. |
+| Never describe the AI assistant as a v2.0 feature. | It ships in v1. Misrepresenting this creates false low expectations. |
+| Always use plain-language stage labels in user-facing copy, not technical slugs. | Non-technical users should not encounter `implementation-log` or `test-report` as primary labels. |
+| Always distinguish "first increment / v1" from "v2.0" when describing roadmap items. | Users should know what they can try now vs. what is planned. |
 | Always link to an issue or doc for any claim about upcoming capabilities. | Keeps the page accountable and avoids vague promises. |
-| Do not describe sideloading as "installing from the Obsidian marketplace" until submission. | The plugin has not been submitted. Sideloading is a manual process. |
+| Never describe agent outputs as automatically applied. | All outputs are proposals; misrepresenting this breaks user trust. |
 
 ---
 
 ## 4. Page Structure Summary
 
 ```
-1. Hero — what it is, primary CTA
-2. Problem — why structured workflow matters
-3. How it works — three v1 capabilities
-4. Ecosystem — relationship to agentic-workflow and agentonomous
-5. Current status — what's built vs. in progress
-6. v2.0 direction — companion app roadmap
-7. Get started — quick-start steps
-8. Contribute — contributor path
-9. Footer links
+1. Hero — product-centric headline, try-live and get-started CTAs
+2. What is Specorator — three pillars: workflow, AI, control
+3. Who it's for — non-technical users front and centre
+4. The 12 stages — plain-language labels, numbered grid
+5. AI assistant — permanent side panel, context-aware, proposal model
+6. Try it live — browser demo CTA
+7. Roadmap — first increment vs. v2.0
+8. Powered by Obsidian — engine framing, knowledge graph, plain files
+9. Get started — install steps with onboarding mention
+10. Ecosystem — four related repositories
+11. Contribute — contributor path links
+12. Footer — "Powered by Obsidian · Vue 3 · TypeScript"
 ```
 
 ---
@@ -220,9 +263,9 @@ These rules prevent the page from overpromising capabilities that are not yet bu
 ## 5. Hosting Notes
 
 - Host via GitHub Pages on `Luis85/specorator` (configure in repository Settings → Pages).
-- Source: `docs/` directory on `main` branch, or a dedicated `gh-pages` branch — decide before implementation.
-- Link the page URL from the README `<p>` tag / shields row once live.
-- Update this brief alongside meaningful product or status changes; do not let it drift from the actual plugin state.
+- Source: `site/` directory on `demo` branch (aligns with the branching model; CI deploys on push to `demo`).
+- Link the page URL from the README once live.
+- Update this brief whenever the product scope or roadmap changes meaningfully.
 
 ---
 
@@ -230,8 +273,9 @@ These rules prevent the page from overpromising capabilities that are not yet bu
 
 | Trigger | Section(s) to review |
 |---|---|
-| Template installation shipped | Section 5 (current status), Section 7 (quick start steps) |
-| Marketplace submission | Section 7 (update from sideloading to marketplace install) |
-| v2.0 integration begins | Section 6, Section 4 (ecosystem table) |
-| New contributor docs added | Section 8 (contributor path links) |
-| New `agentic-workflow` release consumed | Section 3, Section 7 |
+| Claude CLI chat sidebar ships | Section 5 (AI assistant — mark as available) |
+| Template installation ships | Section 7 (roadmap status), Section 9 (get started steps) |
+| Marketplace submission | Section 9 (update from sideloading to marketplace install) |
+| v2.0 planning matures | Section 7 (roadmap), Section 10 (ecosystem) |
+| New contributor docs added | Section 11 (contributor path links) |
+| New `agentic-workflow` release consumed | Section 9 (get started), Section 10 (ecosystem) |

--- a/docs/product-page-brief.md
+++ b/docs/product-page-brief.md
@@ -194,9 +194,9 @@ The practical entry point for installation.
 2. Create `{vault}/.obsidian/plugins/specorator/` in your Obsidian vault
 3. Copy the three files into that folder
 4. Open Obsidian → Settings → Community plugins → enable Specorator
-5. Specorator opens and guides you through a short setup
+5. Open the Specorator panel from the left sidebar ribbon icon, or via **Command palette → Specorator: Open**. This is your main cockpit for the workflow. *(Alpha note: auto-open onboarding on first install is a tracked requirement — #162 — but not yet shipped. Update this step to describe the guided setup once that feature lands.)*
 
-**Copy constraint:** Do not describe marketplace installation until the plugin is submitted. Last step should mention the onboarding experience, not raw configuration.
+**Copy constraint:** Do not describe marketplace installation until the plugin is submitted. Step 5 must reflect what the current plugin actually does on first enable — not the intended onboarding experience that is still in development. Update step 5 when #162 auto-open ships.
 
 ---
 

--- a/docs/product-page-brief.md
+++ b/docs/product-page-brief.md
@@ -35,7 +35,7 @@ This brief provides all the structure, copy boundaries, and content decisions ne
 
 ### Primary Message
 
-> Specorator is a guided development companion that takes you — and your whole team — from first idea to tested code. It brings structured workflow and an AI assistant that knows your work into a single, connected environment. All your files stay plain text, owned by you.
+> Specorator is a guided development companion that takes you — and your whole team — from first idea to tested code. It brings structured workflow into a single, connected environment — with an AI assistant that will know your work coming in v1. All your files stay plain text, owned by you.
 
 ### Secondary Message
 

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -3,7 +3,7 @@ title: "Specorator product vision"
 doc_type: vision
 status: draft
 owner: product
-last_updated: 2026-05-04
+last_updated: 2026-05-05
 references:
   - docs/prd.md
   - docs/roadmap-v1.md
@@ -16,105 +16,187 @@ references:
 Specorator is one component in a four-part ecosystem. The plugin is the **user-facing layer** — the cockpit through which a user interacts with everything else.
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│                   specorator-plugin                      │
-│         (UI cockpit — Obsidian, standalone browser)      │
-│   triggers sessions · subscribes to events · review UI   │
-└────────────────────┬────────────────────────────────────┘
-          commands / session triggers ↓ ↑ event stream
-┌────────────────────▼────────────────────────────────────┐
-│                  specorator-runtime                      │
-│     execution engine · session model · event bus         │
-│     workflow interpreter · agent executor · scheduler    │
-└──────────┬──────────────────────────┬───────────────────┘
-           │ workflow definitions      │ agent invocations
-┌──────────▼──────────┐    ┌──────────▼───────────────────┐
-│   agentic-workflow  │    │        agentonomous           │
-│  stage model        │    │  agent implementations        │
-│  templates          │    │  cognition · capabilities     │
-│  quality gates      │    │  structured I/O contracts     │
-└─────────────────────┘    └──────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────┐
+│                      specorator-plugin                           │
+│        (UI cockpit — Obsidian sidebar + standalone browser)      │
+│  onboarding · chat sidebar · workflow navigator · review cards   │
+└──────────────────────┬──────────────────────────────────────────┘
+         commands / session triggers ↓ ↑ event stream
+┌──────────────────────▼──────────────────────────────────────────┐
+│              Obsidian MCP Server (v1: built in)                  │
+│    obsidian:// tools · vault tools · canvas tools · bases tools  │
+│    write proposals → accept / reject queue                       │
+└─────────────┬─────────────────────────────┬─────────────────────┘
+              │ MCP tool calls               │ MCP tool responses
+┌─────────────▼─────────────┐   ┌────────────▼─────────────────────┐
+│     Claude CLI subprocess  │   │         specorator-runtime        │
+│  @anthropic-ai/claude-code │   │  execution engine · session model │
+│  SDK · ClaudeCliPort (v1)  │   │  RuntimePort (v2.0 replacement)   │
+└────────────────────────────┘   └──────────────────────────────────┘
+                                                    │
+                                     ┌──────────────▼──────────────┐
+                                     │         agentonomous         │
+                                     │  PM · architect · engineer   │
+                                     │  QA · writer agent roles     │
+                                     └─────────────────────────────┘
 ```
 
 | Component | Role |
 |---|---|
-| [`specorator-plugin`](https://github.com/Luis85/specorator) | UI layer. Obsidian plugin and standalone browser app. In v1: surfaces workflow state, scaffolds artifacts, and runs quality checks without a runtime dependency. In v2.0: triggers runtime sessions, subscribes to runtime events, presents execution state, and gives users the review and accept surface for agent outputs. |
-| [`specorator-runtime`](https://github.com/Luis85/specorator-runtime) | Execution engine. Interprets workflow definitions, manages session lifecycle, invokes agents, emits typed events, and exposes queryable state. Published as an npm library consumed by the plugin. |
+| [`specorator-plugin`](https://github.com/Luis85/specorator) | UI layer. Obsidian plugin and standalone browser app. In v1: onboarding, Claude CLI chat sidebar, workflow state navigator, vault scaffolding, and quality checks. In v2.0: triggers runtime sessions, subscribes to runtime events, and presents execution state. |
+| **Obsidian MCP Server** | Native in-process MCP server embedded in the plugin. Exposes Obsidian's full data model — Markdown, frontmatter, wikilinks, Canvas, Bases, MetadataCache — as tool surfaces. All write operations go through a proposal queue; nothing is applied without user acceptance. Claude CLI connects as MCP client in v1; agentonomous agents connect in v2.0. |
+| [`specorator-runtime`](https://github.com/Luis85/specorator-runtime) | Execution engine (v2.0). Interprets workflow definitions, manages session lifecycle, invokes agents, emits typed events, and exposes queryable state. Replaces `ClaudeCliPort` with `RuntimePort`. |
 | [`agentic-workflow`](https://github.com/Luis85/agentic-workflow) | Methodology and definitions. Stage model, templates, quality gates, and traceability conventions. Released versions are the source of truth for workflow structure. |
-| [`agentonomous`](https://github.com/Luis85/agentonomous) | Agent capabilities. TypeScript autonomous-agent library. Provides the agent implementations the runtime invokes — structured input/output contracts, cognition models. |
+| [`agentonomous`](https://github.com/Luis85/agentonomous) | Agent capabilities. TypeScript autonomous-agent library. Provides PM, architect, engineering, QA, and writer agent roles. In v2.0, these connect to the same MCP server the plugin hosts. |
 
 ---
 
 ## Vision
 
-Specorator is the user interface for the Specorator ecosystem. It gives users a single, approachable cockpit inside Obsidian — or a standalone browser — to understand workflow state, take the next valid action, trigger agentic execution, and review outputs, without needing to touch the runtime, agents, or methodology files directly.
+Specorator gives individuals and teams a single, approachable cockpit inside Obsidian — or a standalone browser — to move from rough idea to tested code through a fully guided, AI-assisted workflow.
 
-The plugin surfaces deterministic workflow tooling (validation, templates, quality gates, scaffolding) in v1. In v2.0, it connects to `specorator-runtime` to run agentic workflows end-to-end — executing tasks, invoking agents from `agentonomous`, and streaming live session state back to the user.
+The plugin surfaces deterministic workflow tooling (validation, templates, quality gates, scaffolding) and a Claude CLI-powered chat sidebar in v1. The sidebar is context-aware: it knows the user's persona, the active file, the current workflow stage, and opted-in vault content. Agents interact with the vault through the embedded MCP server — not through system-prompt text dumps — so every operation (reading Canvas, writing a spec, updating frontmatter) uses Obsidian's native data model.
 
-LLM-assisted execution is a v2.0 capability, not a prerequisite for v1 utility.
+In v2.0, the plugin connects to `specorator-runtime` to run fully orchestrated agentic sessions end-to-end. The MCP server serves both: Claude CLI in v1 and agentonomous agents in v2.0.
+
+The plugin is designed for non-technical users. No AI terminology, methodology jargon, or technical language is exposed in the interface.
+
+---
 
 ## Product Promise
 
-Specorator helps individuals and teams move from idea to release through visible, auditable workflow stages. In v1, the vault stays the durable source of truth and all tooling works offline. In v2.0, the runtime executes the workflow while the user retains full control over what runs, what context agents receive, and what outputs get accepted.
+Specorator helps individuals and teams move from idea to release through visible, auditable workflow stages. The vault is the durable output — all artifacts are plain Markdown files that remain useful without the plugin. Agents propose; users decide. Nothing is applied to the vault without explicit acceptance.
+
+---
+
+## Human-Agent Centered Design (H-ACD)
+
+H-ACD is the named design philosophy that governs every product and engineering decision in Specorator. It has four principles.
+
+### 1. Workflow Encapsulation
+
+The plugin presents the full Agentic Development Lifecycle — all 12 stages from idea to retrospective — as a unified, navigable surface. Users never need to know the underlying methodology structure. Stage transitions are guided; blockers are named in plain language.
+
+### 2. Human Authority Over Outcomes
+
+Every agent output arrives as a proposal. The user reviews, edits, accepts, or rejects it before any change is committed to the vault. This applies to all write operations — whether triggered from the chat sidebar or from an automated agent task.
+
+### 3. Intent-First Interaction
+
+Users express intent ("write this up", "what should I do next?"). The plugin assembles context silently (persona, active file, workflow state, vault graph) and translates intent into agent instructions. Users never write prompts, configure tools, or manage context manually.
+
+### 4. The Vault as the Agentic Operating Environment
+
+The vault is not just an output store — it is the agents' operating environment. Agents read Canvas files to understand visual plans, query Bases to work with structured data, traverse the wikilink graph for context, and write back through tool calls. All of this happens through the embedded MCP server. The vault retains full Obsidian compatibility at all times.
+
+---
+
+## Agentic Development Lifecycle (ADLC)
+
+Specorator covers all 12 workflow stages with context-appropriate agent roles and a clear governance model.
+
+| # | Stage | Plain-language label | Agent role | Who leads |
+|---|---|---|---|---|
+| 1 | `idea` | Exploring the idea | PM agent | User |
+| 2 | `research` | Looking into it | PM agent | User |
+| 3 | `requirements` | What it needs to do | PM agent | User |
+| 4 | `design` | How it should look and feel | Architect agent | User |
+| 5 | `spec` | The full plan | Architect agent | User |
+| 6 | `tasks` | Breaking it into steps | Architect agent | User |
+| 7 | `implementation-log` | Building it | Engineering agent | Agent proposes, user governs |
+| 8 | `test-plan` | How we'll check it works | QA agent | Agent proposes, user governs |
+| 9 | `test-report` | What we found | QA agent | Agent executes, user decides |
+| 10 | `review` | Checking our work | Writer agent | User |
+| 11 | `release-notes` | Telling people about it | Writer agent | User |
+| 12 | `retrospective` | What we learned | PM agent | User |
+
+**Governance model:**
+
+- **Stages 1–6 (Planning):** User leads the conversation. Agents assist, draft, and suggest. All outputs are proposals the user accepts or refines.
+- **Stages 7–8 (Execution):** Agents generate code and test plans. User reviews diffs and output proposals before anything is applied. User retains authority to accept, reject, or redirect.
+- **Stage 9 (Verification):** Agent executes tests and reports results in plain language. User decides whether the results are acceptable to proceed.
+- **Stages 10–12 (Closure):** User leads. Agents draft documents and summaries. User reviews and accepts.
+
+---
 
 ## v1 Alpha — Foundation
 
-The v1 alpha establishes the plugin foundation and proves the end-to-end loop without a live runtime:
+The v1 alpha establishes the plugin foundation and delivers the first meaningful AI-assisted workflow experience:
 
-1. Select or use a supported released [`agentic-workflow`](https://github.com/Luis85/agentic-workflow) template version.
-2. Install the required workflow files into an Obsidian vault with overwrite protection.
-3. Show the current workflow state, active project or feature, and available process steps.
-4. Let the user create or open workflow artifacts in Obsidian.
-5. Preserve all outputs as plain Markdown files that remain useful without the plugin.
-6. Leave a clean, documented extension point for the v2.0 runtime integration.
+1. **Onboarding:** Welcome the user, capture a personal introduction ("Tell us about yourself"), verify Claude CLI availability, configure the vault, and install the agentic-workflow template — all in a single guided flow.
+2. **Workflow installer:** Install `agentic-workflow` template content into the active vault with overwrite protection.
+3. **Claude CLI chat sidebar:** A Cursor-like always-visible side panel. Context-aware (persona, active file, workflow state, opt-in vault files). Agents interact with the vault through the embedded MCP server. Plain language throughout.
+4. **Workflow navigator:** Show the current project, active stage, required artifacts, and next valid actions.
+5. **Artifact creation:** Scaffold new workflow artifacts from plugin commands.
+6. **Obsidian MCP server:** Embedded in-process MCP server exposing Markdown, frontmatter, wikilinks, Canvas, Bases, and MetadataCache as tool surfaces. All write operations queue a proposal for user acceptance.
+7. **Vault-compatible outputs:** All artifacts are plain Markdown files that remain useful without the plugin.
+8. **v2.0 extension point:** `ClaudeCliPort` and `ObsidianMcpServerPort` designed as stable seams that v2.0 satisfies with `RuntimePort` and agentonomous agents — no rewrite required.
 
-v1 has no runtime dependency. It is the stable UI scaffold on which v2.0 is built.
+v1 includes live AI assistance via Claude CLI. The experience is designed to work without an LLM configured — scaffolding, validation, and navigation are always available.
+
+---
 
 ## v2.0 — Runtime-Connected Agentic Cockpit
 
-v2.0 connects the plugin to [`specorator-runtime`](https://github.com/Luis85/specorator-runtime), turning it into a live agentic cockpit.
+v2.0 connects the plugin to [`specorator-runtime`](https://github.com/Luis85/specorator-runtime), turning it into a fully orchestrated agentic cockpit.
 
-The user triggers a workflow session from the plugin. The runtime interprets the active workflow definition, resolves the task graph (the ordered set of tasks derived from the workflow definition), and invokes agents from [`agentonomous`](https://github.com/Luis85/agentonomous) at each task. The plugin subscribes to the runtime's event stream and renders execution state in real time — which tasks are running, which agents are active, what outputs have been produced.
+The user triggers a workflow session from the plugin. The runtime interprets the active workflow definition, resolves the task graph, and invokes agents from [`agentonomous`](https://github.com/Luis85/agentonomous) at each task. The agentonomous agents connect to the same MCP server the plugin already hosts — they use the same tool surface that the Claude CLI subprocess used in v1.
 
-All agent outputs arrive as proposals. The user reviews, edits, accepts, or rejects each one before it becomes a vault artifact. Nothing is silently applied.
+The plugin subscribes to the runtime's event stream and renders execution state in real time. All agent outputs arrive as proposals; the user reviews, edits, accepts, or rejects each one before it becomes a vault artifact.
 
-The user stays in Obsidian. The runtime and agents operate behind the plugin's UI surface. The vault remains the durable output store.
+---
 
 ## Target Users
 
-- Solo builders who want a guided path from rough idea to implemented feature.
-- Product-minded engineers who want requirements, design, tasks, tests, and release notes connected.
-- Teams adopting agentic development who need workflow discipline without making an LLM the only operator.
-- Maintainers who need vault quality checks, repair paths, and traceability signals available inside Obsidian.
+| Role | Primary need |
+|---|---|
+| Solo builder | A guided path from rough idea to implemented feature |
+| Product manager | Requirements, design decisions, and tasks connected and traceable |
+| Non-technical founder | Express ideas and get structured output without touching code or prompts |
+| Business analyst | Turn stakeholder conversations into structured requirements and specs |
+| Engineering lead | Workflow discipline, code review, and release documentation without leaving the vault |
+| Designer | UX brief, design decisions, and review artifacts in one place |
+| Teams adopting agentic development | Workflow discipline without making an LLM the sole operator |
+| Maintainers | Vault quality checks, repair paths, and traceability signals inside Obsidian |
+
+---
 
 ## Principles
 
-- **Workflow first.** The plugin models the full workflow, not just note editing shortcuts.
-- **Local first.** v1 tooling works offline. The runtime itself runs locally and requires no hosted Specorator service. LLM provider access for agents is user-configured and optional per the "LLM optional" principle.
-- **LLM optional.** v1 is fully productive without any LLM provider configured. v2.0 degrades gracefully when no provider is available.
+- **Workflow first.** The plugin models the full 12-stage lifecycle, not just note editing shortcuts.
+- **Vault first.** The vault is the agents' operating environment. Agents read and write through MCP tools that honour the Obsidian data model — Markdown, frontmatter, wikilinks, Canvas, Bases.
+- **Local first.** v1 tooling works offline. The runtime runs locally. No hosted Specorator service is required.
+- **LLM optional.** v1 scaffolding, validation, and navigation are fully productive without any LLM provider configured. v2.0 degrades gracefully when no provider is available.
+- **Plain language.** No AI terminology, methodology jargon, or technical language is exposed to the user. Stage names, actions, and messages are written for people, not developers.
+- **Intent first.** Users express what they want. The plugin assembles context and translates intent into agent instructions silently.
+- **Human-owned decisions.** The interface surfaces choices and risks, but the user remains responsible for intent, priority, and acceptance.
 - **Inspectable state.** Users see the active stage, required artifacts, quality gates, blockers, and next actions — and in v2.0, live session state from the runtime.
 - **Deterministic upkeep.** Validation, linting, traceability checks, scaffolders, and repair helpers are exposed as normal plugin capabilities.
-- **Human-owned decisions.** The interface surfaces choices and risks, but the user remains responsible for intent, priority, and acceptance.
-- **Runtime transparency.** In v2.0, the plugin shows what the runtime is doing — which tasks are executing, which agents are active, what events have fired — so users are never left guessing about the state of a running session.
+- **Runtime transparency.** In v2.0, the plugin shows what the runtime is doing — which tasks are executing, which agents are active, what events have fired.
 - **User-controlled agents.** Agents propose; the user decides. Context shared with agents is explicit and revocable per run.
+
+---
 
 ## Core Experience
 
 The first-class experience is a workflow cockpit inside Obsidian:
 
-- Shows the current project, feature, workflow stage, and completion state.
-- Presents the next valid actions for the active stage.
-- Creates or updates workflow artifacts from templates.
-- Runs local scripts and checks from plugin controls.
-- Displays validation results with direct links to affected notes.
-- Tracks requirements, tasks, tests, decisions, and release artifacts.
+- **Chat sidebar (always visible):** A Cursor-like side panel showing a warm, context-aware greeter and conversation interface. Suggested actions per stage ("Write this up", "What should I do next?"). Agents operate on the vault through MCP tool calls; write operations surface as review cards the user accepts or rejects.
+- **Workflow navigator:** Shows the current project, feature, workflow stage, completion state, and next valid actions.
+- **Artifact creation:** Creates or updates workflow artifacts from templates via plugin commands.
+- **Validation and repair:** Runs local checks and shows results with direct links to affected notes.
+- **Traceability:** Tracks requirements, tasks, tests, decisions, and release artifacts.
 - **v2.0:** Triggers runtime sessions and streams live execution state — task graph, agent activity, event log — directly in the panel.
 - **v2.0:** Presents agent-proposed outputs in a review interface; user accepts, edits, or rejects before any vault write.
 
+---
+
 ## Required Tooling Surface
 
-The plugin should make these capabilities available without requiring chat-based operation:
+The plugin makes these capabilities available without requiring chat-based operation:
 
+- Onboarding and persona setup.
+- Template installation and vault initialisation.
 - Project and feature scaffolding.
 - Stage transition checks.
 - Template-driven artifact creation.
@@ -127,6 +209,26 @@ The plugin should make these capabilities available without requiring chat-based
 - **v2.0:** Runtime session management — start, monitor, cancel, inspect.
 - **v2.0:** Agent output review — accept, edit, reject, or request refinement.
 
+---
+
+## Obsidian MCP Server — Tool Surface
+
+The embedded MCP server exposes Obsidian's data model as callable tools across seven groups:
+
+| Group | Representative tools |
+|---|---|
+| Vault navigation | `vault_list_files`, `vault_search`, `vault_get_metadata` |
+| Markdown read | `note_read`, `note_get_frontmatter`, `note_get_links` |
+| Markdown write (queued) | `note_create`, `note_update`, `note_append`, `note_delete` |
+| Frontmatter (queued) | `frontmatter_set_property`, `frontmatter_bulk_update` |
+| Canvas read | `canvas_read`, `canvas_list_nodes`, `canvas_find_connected` |
+| Canvas write (queued) | `canvas_add_node`, `canvas_add_edge`, `canvas_update_node` |
+| Bases / structured data | `bases_query`, `bases_get_property_schema`, `bases_set_property` (queued) |
+
+All write-group tools return `{ proposalId, status: "pending" }`. The plugin renders each proposal as a review card in the chat sidebar. The vault is not modified until the user accepts.
+
+---
+
 ## Non-Goals
 
 - Replacing Obsidian as the editing environment.
@@ -136,17 +238,22 @@ The plugin should make these capabilities available without requiring chat-based
 - Turning the workflow into a generic project management board detached from specs.
 - Giving agents unrestricted vault access by default.
 - Automatically accepting or applying agent outputs without user review.
-- Implementing execution, scheduling, or session management inside the plugin — `specorator-runtime` owns that.
+- Implementing execution, scheduling, or session management inside the plugin beyond v1 ClaudeCliPort — `specorator-runtime` owns that in v2.0.
 - Implementing agent cognition or capabilities inside the plugin — `agentonomous` owns that.
+
+---
 
 ## Success Signals
 
-- A new user can create a project, start a feature, and find the next required action without reading the full methodology first.
+- A new user completes onboarding, describes themselves in plain language, and starts a conversation about their idea — without reading any documentation.
+- A non-technical founder can move from idea to requirements without writing a single prompt or configuring a tool.
+- An agent reads a Canvas file, proposes an update, and the user accepts or rejects it from a review card — without touching JSON.
 - A maintainer can run vault quality checks from the plugin and understand every reported issue.
 - The same workflow artifacts remain readable and usable as Markdown files.
 - LLM-disabled usage remains productive for scaffolding, validation, upkeep, and review preparation.
-- Advanced users can still use scripts and command-line tools directly when they prefer.
 - **v2.0:** A user can trigger a runtime session, watch execution progress in the panel, review a proposed agent output, and accept or reject it — without leaving Obsidian or losing control of their vault.
+
+---
 
 ## Open Questions
 
@@ -155,8 +262,10 @@ The plugin should make these capabilities available without requiring chat-based
 | OQ-01 | Which workflow stages must be supported in the first usable v1 slice? |
 | OQ-02 | Which `agentic-workflow` scripts should become plugin commands first? |
 | OQ-03 | What vault health checks are mandatory before any agentic session is triggered? |
-| OQ-04 | Given the runtime is consumed as an npm library, does the Obsidian plugin require an IPC or worker-thread boundary to avoid blocking the UI thread during execution? |
-| OQ-05 | What is the minimum runtime event set the plugin must handle to render useful session state in v2.0? |
-| OQ-06 | Which `agentonomous` agents should be available in the first v2.0 session? |
-| OQ-07 | How should interrupted or failed runtime sessions be surfaced and recovered from in the UI? |
-| OQ-08 | How should run provenance (agent, session ID, date) be stored in accepted vault artifacts? |
+| OQ-04 | Given the MCP server runs in-process in Obsidian, what are the performance boundaries for long-running tool calls? Should heavy operations run in a worker thread? |
+| OQ-05 | What is the minimum MCP tool set required for a useful v1 chat session (read-only first, or write tools from day one)? |
+| OQ-06 | How should the five-layer context system degrade when some layers are unavailable (no active file, no workflow state, no persona set)? |
+| OQ-07 | How should interrupted or failed MCP tool calls be surfaced and recovered from in the chat sidebar? |
+| OQ-08 | How should run provenance (agent, session ID, date, MCP tool calls made) be stored in accepted vault artifacts? |
+| OQ-09 | What is the minimum persona description that makes agent responses meaningfully more relevant — how do we guide users to write a useful one without making it feel like a form? |
+| OQ-10 | Which `agentonomous` agents should be available in the first v2.0 session, and does the MCP server tool surface need to change to support them? |

--- a/site/index.html
+++ b/site/index.html
@@ -427,8 +427,8 @@
             </div>
             <div class="pillar">
               <div class="pillar-num">02</div>
-              <h3>AI that knows your work</h3>
-              <p>An always-visible AI assistant understands your persona, your current stage, and the active work in your knowledge base. Ask questions, get drafts, request reviews — in plain language.</p>
+              <h3>AI that knows your work <em style="font-style:normal; font-size:0.75rem; color:var(--color-muted);">— in development</em></h3>
+              <p>An always-visible AI assistant will understand your persona, your current stage, and the active work in your knowledge base — before you type a word. Ask questions, get drafts, request reviews — in plain language. <em>(Coming in v1 — see roadmap.)</em></p>
             </div>
             <div class="pillar">
               <div class="pillar-num">03</div>
@@ -647,7 +647,7 @@
               <span>
                 Open the Specorator panel from the left sidebar ribbon icon, or via
                 <strong>Command palette → Specorator: Open panel</strong>. This is your main cockpit —
-                create features, advance stages, and chat with your assistant from here.
+                create features, advance stages, and navigate your workflow from here.
                 <em style="color: var(--color-muted);">Onboarding (auto-opens on first install) is in active development — see the roadmap above.</em>
               </span>
             </li>

--- a/site/index.html
+++ b/site/index.html
@@ -643,9 +643,10 @@
             </li>
             <li>
               <span>
-                Specorator opens automatically and walks you through a short setup. Tell it a
-                little about yourself — it'll use that to give you better, more relevant answers
-                right from the first message.
+                Open the Specorator panel from the left sidebar ribbon icon, or via
+                <strong>Command palette → Specorator: Open</strong>. This is your main cockpit —
+                create features, advance stages, and chat with your assistant from here.
+                <em style="color: var(--color-muted);">Onboarding (auto-opens on first install) is in active development — see the roadmap above.</em>
               </span>
             </li>
           </ol>

--- a/site/index.html
+++ b/site/index.html
@@ -6,7 +6,7 @@
     <title>Specorator — guided software development from idea to tested code</title>
     <meta
       name="description"
-      content="Specorator guides you through the full development lifecycle — from first idea to retrospective — with an AI assistant that knows your context and a structured workflow that keeps everyone aligned."
+      content="Specorator guides you through the full development lifecycle — from first idea to retrospective — with structured workflow today and an AI assistant coming in v1 that will know your context and keep everyone aligned."
     />
     <style>
       /* ── Reset & base ───────────────────────────────────── */

--- a/site/index.html
+++ b/site/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Specorator — spec-driven, agentic software development for Obsidian</title>
+    <title>Specorator — guided software development from idea to tested code</title>
     <meta
       name="description"
-      content="Specorator is an Obsidian plugin that guides you through a structured spec-driven workflow — from idea to release — keeping all artifacts as editable Markdown in your vault."
+      content="Specorator guides you through the full development lifecycle — from first idea to retrospective — with an AI assistant that knows your context and a structured workflow that keeps everyone aligned."
     />
     <style>
       /* ── Reset & base ───────────────────────────────────── */
@@ -132,8 +132,8 @@
       }
       section p { color: var(--color-muted); margin-bottom: 1rem; max-width: 700px; }
 
-      /* ── What / problem ─────────────────────────────────── */
-      .what-grid {
+      /* ── Cards ──────────────────────────────────────────── */
+      .card-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
         gap: 1rem;
@@ -154,22 +154,60 @@
       }
       .card p { font-size: 0.9rem; margin-bottom: 0; color: var(--color-muted); }
 
-      /* ── Workflow steps ─────────────────────────────────── */
-      .stage-list {
-        display: flex;
-        flex-wrap: wrap;
+      /* ── Pillars ─────────────────────────────────────────── */
+      .pillar-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        gap: 1.25rem;
+        margin-top: 1.5rem;
+      }
+      .pillar {
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius);
+        padding: 1.5rem;
+      }
+      .pillar-num {
+        font-size: 0.75rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--color-accent-lt);
+        margin-bottom: 0.5rem;
+      }
+      .pillar h3 { font-size: 1.05rem; font-weight: 700; margin-bottom: 0.5rem; }
+      .pillar p { font-size: 0.9rem; color: var(--color-muted); margin: 0; }
+
+      /* ── Stage list ─────────────────────────────────────── */
+      .stage-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
         gap: 0.5rem;
         margin-top: 1.25rem;
       }
-      .stage-pill {
-        background: var(--color-code-bg);
-        color: var(--color-accent-lt);
-        border: 1px solid rgba(124, 58, 237, 0.25);
-        border-radius: 999px;
-        font-size: 0.78rem;
-        padding: 0.2rem 0.7rem;
-        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      .stage-item {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius);
+        padding: 0.55rem 0.9rem;
       }
+      .stage-num {
+        flex-shrink: 0;
+        width: 1.4rem;
+        height: 1.4rem;
+        border-radius: 50%;
+        background: rgba(124, 58, 237, 0.2);
+        color: var(--color-accent-lt);
+        font-size: 0.72rem;
+        font-weight: 700;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .stage-label { font-size: 0.88rem; color: var(--color-text); }
 
       /* ── Try it live ────────────────────────────────────── */
       .try-live {
@@ -184,6 +222,17 @@
         margin-top: 1.5rem;
       }
       .try-live p { margin: 0; }
+
+      /* ── Callout ─────────────────────────────────────────── */
+      .callout {
+        background: rgba(124, 58, 237, 0.07);
+        border: 1px solid rgba(124, 58, 237, 0.25);
+        border-radius: var(--radius);
+        padding: 1.25rem 1.5rem;
+        margin-top: 1.5rem;
+      }
+      .callout p { margin: 0; font-size: 0.95rem; color: var(--color-text); max-width: none; }
+      .callout strong { color: var(--color-accent-lt); }
 
       /* ── Install ────────────────────────────────────────── */
       .install-steps { margin-top: 1.25rem; counter-reset: step; }
@@ -219,7 +268,7 @@
         font-size: 0.88em;
       }
 
-      /* ── Vision / roadmap ───────────────────────────────── */
+      /* ── Roadmap ────────────────────────────────────────── */
       .roadmap-row {
         display: grid;
         grid-template-columns: 1fr 1fr;
@@ -293,7 +342,7 @@
       }
       .repo-card p { font-size: 0.85rem; color: var(--color-muted); margin: 0; }
 
-      /* ── Contribute ─────────────────────────────────────── */
+      /* ── Link list ──────────────────────────────────────── */
       .link-list { margin-top: 1rem; }
       .link-list li {
         list-style: none;
@@ -325,7 +374,7 @@
         <span class="logo">Spec<span>orator</span></span>
         <nav>
           <a href="#try-live">Try live</a>
-          <a href="#install">Install</a>
+          <a href="#get-started">Get started</a>
           <a href="#contribute">Contribute</a>
           <a href="https://github.com/Luis85/specorator">GitHub</a>
         </nav>
@@ -336,19 +385,19 @@
     <main>
       <section class="hero" style="border-top: none;">
         <div class="container">
-          <div class="badge">Obsidian plugin · v1 alpha</div>
-          <h1>Spec-driven workflow,<br /><em>inside your vault</em></h1>
+          <div class="badge">v1 alpha · in development</div>
+          <h1>From idea to tested code.<br /><em>Every step, guided.</em></h1>
           <p>
-            Specorator guides you from idea to release through a structured 12-stage workflow.
-            Every artifact lives as editable Markdown in your Obsidian vault — owned by you,
-            readable without the plugin, and ready for agentic assistance when you want it.
+            Specorator is your guided development companion — structured workflow,
+            AI assistance, and your knowledge in one place. Express what you want to build
+            and let Specorator keep you moving, every stage of the way.
           </p>
           <div class="hero-cta">
             <a href="app/" class="btn btn-primary">
               ▶&nbsp; Try it in your browser
             </a>
-            <a href="#install" class="btn btn-secondary">
-              Install in Obsidian
+            <a href="#get-started" class="btn btn-secondary">
+              Get started
             </a>
           </div>
         </div>
@@ -359,73 +408,119 @@
         <div class="container">
           <h2>What is Specorator?</h2>
           <p>
-            Specorator is an <strong>Obsidian plugin</strong> that embeds the
-            <a href="https://github.com/Luis85/agentic-workflow">agentic-workflow</a> methodology
-            directly into your vault. It gives you a cockpit view of your active feature, tracks
-            which stage you are on, surfaces the next required artifacts, and enforces quality
-            gates before you advance.
+            Specorator is a guided development companion that takes you through the entire lifecycle
+            of a software feature — from the first conversation about an idea, all the way to a
+            retrospective. It gives you a cockpit view of your active work, an AI assistant that
+            knows your context, and a structured workflow that keeps everyone aligned — whether
+            you're a solo developer, a product manager, or a founder who doesn't write code.
           </p>
           <p>
-            All content stays in plain Markdown. You never need to log into a separate tool,
-            upload files to an external service, or hand over control of your context.
-            Specorator is a helping hand, not a gatekeeper.
+            All your work stays as plain files — owned by you, readable without the tool, and never
+            locked into a cloud service. Specorator is the guide, not the gatekeeper.
           </p>
 
-          <div class="what-grid">
-            <div class="card">
-              <div class="card-icon">🗂️</div>
-              <h3>Vault-first</h3>
-              <p>Every artifact is a Markdown file in <code>specs/{slug}/</code>. Open, edit, and version-control it with any tool you already use.</p>
+          <div class="pillar-grid">
+            <div class="pillar">
+              <div class="pillar-num">01</div>
+              <h3>Guided workflow</h3>
+              <p>12 stages from first idea to retrospective. Always know where you are, what comes next, and what you need to produce before you move on.</p>
             </div>
-            <div class="card">
-              <div class="card-icon">🔁</div>
-              <h3>Stage-gated workflow</h3>
-              <p>12 stages from <code>idea</code> to <code>retrospective</code>. Advance only when quality gates pass — no skipping, no guessing what comes next.</p>
+            <div class="pillar">
+              <div class="pillar-num">02</div>
+              <h3>AI that knows your work</h3>
+              <p>An always-visible AI assistant understands your persona, your current stage, and the active work in your knowledge base. Ask questions, get drafts, request reviews — in plain language.</p>
             </div>
-            <div class="card">
-              <div class="card-icon">🤝</div>
+            <div class="pillar">
+              <div class="pillar-num">03</div>
               <h3>You stay in control</h3>
-              <p>You decide what context agents can see, what they propose, and what becomes a durable artifact. Specorator surfaces options — you make decisions.</p>
-            </div>
-            <div class="card">
-              <div class="card-icon">🧩</div>
-              <h3>Try without installing</h3>
-              <p>The standalone UI runs fully in your browser with <code>localStorage</code> — no Obsidian, no sign-up, no backend required.</p>
+              <p>Every AI suggestion is a proposal. You review, edit, accept, or reject it before anything is written. Your files are never modified without your explicit say-so.</p>
             </div>
           </div>
         </div>
       </section>
 
-      <!-- ── The problem ────────────────────────────────── -->
-      <section id="problem">
+      <!-- ── Who it's for ──────────────────────────────── -->
+      <section id="for-who">
         <div class="container">
-          <h2>The problem it solves</h2>
+          <h2>Built for everyone in the room</h2>
           <p>
-            Most developers start coding before the problem is well understood. They jump from
-            a vague idea to a PR without a spec, without a test plan, and without a retrospective.
-            The result is rework, scope creep, and knowledge scattered across chat threads,
-            Notion pages, and half-finished documents.
-          </p>
-          <p>
-            Specorator brings the <em>whole workflow</em> — ideation, research, requirements,
-            design, spec, tasks, implementation, testing, review, release, and retrospective —
-            into a single, consistent place: your Obsidian vault. It keeps you focused on the
-            work, not on process admin.
+            Good software comes from good collaboration between people who think differently.
+            Specorator is designed for all of them — not just the ones who write code.
           </p>
 
-          <div class="stage-list">
-            <span class="stage-pill">idea</span>
-            <span class="stage-pill">research</span>
-            <span class="stage-pill">requirements</span>
-            <span class="stage-pill">design</span>
-            <span class="stage-pill">spec</span>
-            <span class="stage-pill">tasks</span>
-            <span class="stage-pill">implementation-log</span>
-            <span class="stage-pill">test-plan</span>
-            <span class="stage-pill">test-report</span>
-            <span class="stage-pill">review</span>
-            <span class="stage-pill">release-notes</span>
-            <span class="stage-pill">retrospective</span>
+          <div class="card-grid">
+            <div class="card">
+              <div class="card-icon">💡</div>
+              <h3>Founders and PMs</h3>
+              <p>Turn a vague idea into a clear, structured brief. Describe what you want in plain language — Specorator helps you get to requirements, decisions, and a solid spec.</p>
+            </div>
+            <div class="card">
+              <div class="card-icon">🏗️</div>
+              <h3>Engineers and architects</h3>
+              <p>Go from spec to tasks to implementation with clear traceability. Quality gates catch gaps before they become bugs. Retrospectives make the next feature better.</p>
+            </div>
+            <div class="card">
+              <div class="card-icon">🎨</div>
+              <h3>Designers and analysts</h3>
+              <p>Design decisions and requirements live alongside the code artifacts. Everything is connected — no context lost in a separate tool.</p>
+            </div>
+            <div class="card">
+              <div class="card-icon">🧩</div>
+              <h3>Try without installing</h3>
+              <p>The standalone UI runs fully in your browser — no account, no setup, no data sent anywhere. Create a feature and walk through the workflow right now.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ── The 12 stages ────────────────────────────────── -->
+      <section id="stages">
+        <div class="container">
+          <h2>The full lifecycle, from first thought to lessons learned</h2>
+          <p>
+            Most tools support a fraction of the journey. Specorator covers all 12 stages —
+            with AI assistance at every one. The further you go, the more context your AI
+            assistant has to give you useful, grounded answers.
+          </p>
+
+          <div class="stage-grid">
+            <div class="stage-item"><span class="stage-num">1</span><span class="stage-label">Exploring the idea</span></div>
+            <div class="stage-item"><span class="stage-num">2</span><span class="stage-label">Looking into it</span></div>
+            <div class="stage-item"><span class="stage-num">3</span><span class="stage-label">What it needs to do</span></div>
+            <div class="stage-item"><span class="stage-num">4</span><span class="stage-label">How it should look and feel</span></div>
+            <div class="stage-item"><span class="stage-num">5</span><span class="stage-label">The full plan</span></div>
+            <div class="stage-item"><span class="stage-num">6</span><span class="stage-label">Breaking it into steps</span></div>
+            <div class="stage-item"><span class="stage-num">7</span><span class="stage-label">Building it</span></div>
+            <div class="stage-item"><span class="stage-num">8</span><span class="stage-label">How we'll check it works</span></div>
+            <div class="stage-item"><span class="stage-num">9</span><span class="stage-label">What we found</span></div>
+            <div class="stage-item"><span class="stage-num">10</span><span class="stage-label">Checking our work</span></div>
+            <div class="stage-item"><span class="stage-num">11</span><span class="stage-label">Telling people about it</span></div>
+            <div class="stage-item"><span class="stage-num">12</span><span class="stage-label">What we learned</span></div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ── How AI works ────────────────────────────────── -->
+      <section id="ai-assistant">
+        <div class="container">
+          <h2>An AI assistant that works <em style="font-style:normal; color: var(--color-accent-lt)">with</em> your work</h2>
+          <p>
+            The AI assistant sits in a permanent side panel. It knows who you are, what you're
+            working on, and where you are in the workflow — before you type a single word. It reads
+            your notes, understands your decisions, and can propose new content using your existing
+            knowledge as context.
+          </p>
+          <p>
+            Rather than asking you to describe your entire project every time, Specorator builds
+            that context silently. You just say what you need.
+          </p>
+
+          <div class="callout">
+            <p>
+              <strong>Proposals, not surprises.</strong> Every file the AI wants to create or
+              change appears as a review card first. You read it, adjust if needed, and accept —
+              or reject it entirely. Nothing is written until you decide.
+            </p>
           </div>
         </div>
       </section>
@@ -435,9 +530,9 @@
         <div class="container">
           <h2>Try it live in your browser</h2>
           <p>
-            The standalone UI uses your browser's <code>localStorage</code> as a vault — no
-            Obsidian runtime, no sign-up, no data sent anywhere. Create a feature, walk through
-            the stages, and see the workflow in action.
+            The standalone UI stores everything in your browser's local storage — no account,
+            no sign-up, nothing sent anywhere. Create a feature, walk through the stages, and
+            see the workflow in action.
           </p>
 
           <div class="try-live">
@@ -448,59 +543,41 @@
               </p>
             </div>
             <a href="app/" class="btn btn-primary" style="font-size: 1rem; padding: 0.75rem 2rem;">
-              ▶&nbsp; Open the live plugin UI
+              ▶&nbsp; Open the live demo
             </a>
           </div>
         </div>
       </section>
 
-      <!-- ── Relationship to agentic-workflow ─────────────── -->
-      <section id="workflow">
-        <div class="container">
-          <h2>Relationship to <code>agentic-workflow</code></h2>
-          <p>
-            <a href="https://github.com/Luis85/agentic-workflow">agentic-workflow</a> is the
-            upstream methodology: a detailed 12-stage process with templates, quality gates,
-            and heuristics for what "good" looks like at each stage.
-            Specorator is the Obsidian <em>runtime</em> for that methodology.
-          </p>
-          <p>
-            The plugin installs the <code>agentic-workflow</code> template set into your vault,
-            creates the correct folder structure, and exposes the cockpit UI for tracking and
-            advancing features. Changes to the upstream methodology flow into Specorator as
-            template and validation updates.
-          </p>
-        </div>
-      </section>
-
-      <!-- ── Roadmap ────────────────────────────────────────── -->
+      <!-- ── What's available / roadmap ─────────────────── -->
       <section id="roadmap">
         <div class="container">
-          <h2>What is available now, and what is coming</h2>
+          <h2>What's available now, and what's coming</h2>
 
           <div class="roadmap-row">
             <div class="roadmap-card">
-              <div class="version">v1 alpha — in progress</div>
-              <h3>Plugin foundation</h3>
+              <div class="version">First increment — in development</div>
+              <h3>Guided workflow + AI assistant</h3>
               <ul>
-                <li>Create and manage features from the Obsidian sidebar</li>
-                <li>Advance through all 12 stages with quality-gate checks</li>
-                <li>Auto-creates stage stub files in <code>specs/{slug}/</code></li>
-                <li>Standalone browser UI (try without installing)</li>
-                <li>LocalStorage persistence for browser demo</li>
+                <li>Onboarding — set up your workspace and introduce yourself to your AI assistant</li>
+                <li>Guided installation of the workflow template into your knowledge base</li>
+                <li>AI chat assistant in a permanent side panel — context-aware from the start</li>
+                <li>Workflow navigator — active feature, current stage, next actions</li>
+                <li>Artifact creation from the UI</li>
+                <li>Standalone browser demo (try without installing anything)</li>
               </ul>
               <span class="status-badge status-alpha">⚡ Active development</span>
             </div>
 
             <div class="roadmap-card">
               <div class="version">v2.0 — planned</div>
-              <h3>Agentonomous integration</h3>
+              <h3>Fully orchestrated agentic teams</h3>
               <ul>
-                <li>Team of agentic coworkers powered by <a href="https://github.com/Luis85/agentonomous">agentonomous</a></li>
-                <li>Agents assist with drafting, review, and quality checking</li>
-                <li>You control what context agents see and what they propose</li>
-                <li>All agent outputs remain editable Markdown in your vault</li>
-                <li>Companion-app experience alongside the Obsidian plugin</li>
+                <li>Purpose-built agent roles: PM, architect, engineer, QA, writer</li>
+                <li>Agents run full workflow sessions end-to-end</li>
+                <li>Live execution state streamed to the panel</li>
+                <li>All agent outputs remain reviewable proposals</li>
+                <li>Powered by <a href="https://github.com/Luis85/agentonomous">agentonomous</a></li>
               </ul>
               <span class="status-badge status-planned">🔭 Planned</span>
             </div>
@@ -508,13 +585,35 @@
         </div>
       </section>
 
-      <!-- ── Install ────────────────────────────────────────── -->
-      <section id="install">
+      <!-- ── Powered by Obsidian ──────────────────────────── -->
+      <section id="obsidian">
         <div class="container">
-          <h2>Install or sideload into Obsidian</h2>
+          <h2>Powered by Obsidian</h2>
+          <p>
+            Specorator runs as a plugin inside <a href="https://obsidian.md">Obsidian</a> — chosen
+            as its foundation for its powerful local knowledge graph, rich plugin ecosystem, and deep
+            file-system integration. Obsidian is the engine; Specorator is the product that runs on it.
+          </p>
+          <p>
+            Because of this foundation, your entire knowledge base — notes, diagrams, structured
+            data, linked documents — becomes part of the context your AI assistant reasons over.
+            The AI doesn't just read your active file; it can navigate your whole graph of connected
+            knowledge to give you grounded, relevant answers.
+          </p>
+          <p>
+            All files are plain Markdown in a folder you own. They're readable in any text editor,
+            version-controllable with git, and useful long after this tool is gone.
+          </p>
+        </div>
+      </section>
+
+      <!-- ── Get started ────────────────────────────────────── -->
+      <section id="get-started">
+        <div class="container">
+          <h2>Get started</h2>
           <p>
             Specorator is not yet listed in the Obsidian Community Plugin directory.
-            Use the manual sideload method until it is submitted.
+            Use the manual sideload method to install it today.
           </p>
 
           <ol class="install-steps">
@@ -544,15 +643,16 @@
             </li>
             <li>
               <span>
-                Open the Specorator panel from the left sidebar ribbon or via
-                <strong>Command palette → Specorator: Open</strong>.
+                Specorator opens automatically and walks you through a short setup. Tell it a
+                little about yourself — it'll use that to give you better, more relevant answers
+                right from the first message.
               </span>
             </li>
           </ol>
 
           <p style="margin-top: 1rem;">
             For the full local development setup — including running the standalone UI in a browser
-            and sideloading a dev build — see
+            and building a dev build — see
             <a href="https://github.com/Luis85/specorator/blob/main/docs/local-development.md">docs/local-development.md</a>.
           </p>
         </div>
@@ -562,12 +662,12 @@
       <section id="ecosystem">
         <div class="container">
           <h2>Related repositories</h2>
-          <p>Specorator is part of a small, focused ecosystem.</p>
+          <p>Specorator is part of a focused ecosystem of connected tools.</p>
 
           <div class="related-grid">
             <a href="https://github.com/Luis85/specorator" class="repo-card" style="text-decoration: none;">
               <span class="repo-name">Luis85/specorator</span>
-              <p>This repository. Obsidian plugin + standalone browser UI.</p>
+              <p>This repository. The guided workflow and AI assistant plugin.</p>
             </a>
             <a href="https://github.com/Luis85/agentic-workflow" class="repo-card" style="text-decoration: none;">
               <span class="repo-name">Luis85/agentic-workflow</span>
@@ -575,7 +675,11 @@
             </a>
             <a href="https://github.com/Luis85/agentonomous" class="repo-card" style="text-decoration: none;">
               <span class="repo-name">Luis85/agentonomous</span>
-              <p>Agent orchestration engine. Powers v2.0 agentic coworkers.</p>
+              <p>Agent implementation library. Powers the v2.0 specialist agent roles.</p>
+            </a>
+            <a href="https://github.com/Luis85/specorator-runtime" class="repo-card" style="text-decoration: none;">
+              <span class="repo-name">Luis85/specorator-runtime</span>
+              <p>Execution engine for v2.0 orchestrated sessions.</p>
             </a>
           </div>
         </div>
@@ -592,12 +696,11 @@
 
           <ul class="link-list">
             <li><a href="https://github.com/Luis85/specorator">GitHub repository</a> — source code, issues, and pull requests</li>
-            <li><a href="https://github.com/Luis85/specorator/issues/1">#1 — v1 alpha planning</a> — v1 feature scope and acceptance criteria</li>
-            <li><a href="https://github.com/Luis85/specorator/issues/23">#23 — v2.0 planning</a> — companion-app and agentonomous direction</li>
+            <li><a href="https://github.com/Luis85/specorator/issues/1">#1 — v1 alpha planning</a> — first increment scope and acceptance criteria</li>
+            <li><a href="https://github.com/Luis85/specorator/issues/23">#23 — v2.0 planning</a> — orchestrated agentic teams direction</li>
             <li><a href="https://github.com/Luis85/specorator/issues/47">#47 — Roadmap progress tracker</a> — phase-by-phase checklist</li>
             <li><a href="https://github.com/Luis85/specorator/blob/main/docs/local-development.md">Local development guide</a> — prerequisites, commands, and sideloading</li>
             <li><a href="https://github.com/Luis85/specorator/blob/main/docs/contributing.md">Contributing guide</a> — labels, milestones, branch naming, and merge policy</li>
-            <li><a href="https://github.com/Luis85/agentic-workflow/issues/96">Upstream planning issue</a> — agentic-workflow #96</li>
           </ul>
         </div>
       </section>
@@ -609,7 +712,7 @@
         <p>
           <a href="https://github.com/Luis85/specorator">Specorator</a> ·
           MIT licence ·
-          Built with Obsidian · Vue 3 · TypeScript
+          Powered by Obsidian · Vue 3 · TypeScript
         </p>
       </div>
     </footer>

--- a/site/index.html
+++ b/site/index.html
@@ -646,7 +646,7 @@
             <li>
               <span>
                 Open the Specorator panel from the left sidebar ribbon icon, or via
-                <strong>Command palette → Specorator: Open</strong>. This is your main cockpit —
+                <strong>Command palette → Specorator: Open panel</strong>. This is your main cockpit —
                 create features, advance stages, and chat with your assistant from here.
                 <em style="color: var(--color-muted);">Onboarding (auto-opens on first install) is in active development — see the roadmap above.</em>
               </span>

--- a/site/index.html
+++ b/site/index.html
@@ -503,23 +503,25 @@
       <!-- ── How AI works ────────────────────────────────── -->
       <section id="ai-assistant">
         <div class="container">
-          <h2>An AI assistant that works <em style="font-style:normal; color: var(--color-accent-lt)">with</em> your work</h2>
+          <h2>AI assistance — <em style="font-style:normal; color: var(--color-accent-lt)">in active development</em></h2>
+          <span class="status-badge status-alpha" style="margin-bottom: 1.25rem; display: inline-flex;">⚡ In development for v1</span>
           <p>
-            The AI assistant sits in a permanent side panel. It knows who you are, what you're
-            working on, and where you are in the workflow — before you type a single word. It reads
-            your notes, understands your decisions, and can propose new content using your existing
-            knowledge as context.
+            The AI assistant will sit in a permanent side panel alongside your work. It will know
+            who you are, what you're working on, and where you are in the workflow — before you
+            type a single word. Rather than asking you to describe your project every time,
+            Specorator will build that context silently. You just say what you need.
           </p>
           <p>
-            Rather than asking you to describe your entire project every time, Specorator builds
-            that context silently. You just say what you need.
+            The assistant will be able to read your notes, understand your decisions, and propose
+            new content using your existing knowledge as context — all through the same files you
+            already work with.
           </p>
 
           <div class="callout">
             <p>
               <strong>Proposals, not surprises.</strong> Every file the AI wants to create or
-              change appears as a review card first. You read it, adjust if needed, and accept —
-              or reject it entirely. Nothing is written until you decide.
+              change will appear as a review card first. You read it, adjust if needed, and accept —
+              or reject it entirely. Nothing will be written until you decide.
             </p>
           </div>
         </div>

--- a/specs/claude-cli-chat-sidebar/idea.md
+++ b/specs/claude-cli-chat-sidebar/idea.md
@@ -1,0 +1,58 @@
+---
+id: IDEA-CCS-001
+title: "Claude CLI chat sidebar"
+stage: idea
+feature: claude-cli-chat-sidebar
+status: accepted
+owner: pm
+created: 2026-05-05
+updated: 2026-05-05
+references:
+  - github: "luis85/specorator#161"
+  - github: "luis85/specorator#163"
+  - github: "luis85/specorator#164"
+  - github: "luis85/specorator#165"
+---
+
+## Problem statement
+
+Specorator users — including non-technical founders, product managers, and business analysts — need a natural, always-accessible way to interact with an AI assistant while working in their Obsidian vault. Without a chat interface, users must either operate manually through static plugin commands or leave Obsidian to use a separate AI tool. Neither option is acceptable: static commands lack the flexibility to handle the open-ended questions that arise at every workflow stage, and leaving Obsidian breaks the flow and loses vault context. The plugin must provide a first-class AI conversation surface that understands where the user is in their workflow and what is in their vault.
+
+## Primary users
+
+- **Non-technical founders and PMs** who want to express ideas in natural language and receive structured, actionable output.
+- **Solo developers and engineering leads** who want AI assistance scoped to the active workflow stage without writing prompts manually.
+- **Any user at any stage** who wants to ask a question, get a suggestion, or request a draft without knowing the underlying methodology.
+
+## Success criteria
+
+- A Cursor-like side panel is always visible in Obsidian and shows a warm, context-aware greeter using the user's name.
+- The panel provides stage-appropriate suggested actions ("Write this up", "What should I do next?", "Help me think through this") that users can tap without typing.
+- Sending a message streams the response in real time with visible progress.
+- Agent responses are aware of: (1) the user's persona, (2) the active file and its metadata, (3) the current workflow stage, (4) opted-in vault context files.
+- Agents interact with the vault through the embedded MCP server (tool calls), not through system-prompt text injection.
+- Write operations surface as review cards in the sidebar; the user accepts or rejects before anything is applied to the vault.
+- The interface uses plain language throughout — no AI terminology, prompt references, or methodology jargon.
+- The sidebar is accessible via `obsidian://specorator?action=open-chat` and `obsidian://specorator?action=send-message&text=...`.
+
+## Constraints
+
+- Must use the `@anthropic-ai/claude-code` SDK for Claude CLI subprocess management.
+- `ClaudeCliPort` must be a narrow domain port (ADR-008 pattern) — designed as a stable seam that v2.0 satisfies with `RuntimePort` without modifying call sites.
+- Must degrade gracefully when Claude CLI is not installed: chat is hidden or shows a plain-language install prompt; all other plugin capabilities remain available.
+- The sidebar must work in both Obsidian and standalone browser UI contexts (MockBridge and LocalStorageBridge).
+- No AI terminology, system-prompt references, or configuration surface is exposed to the user.
+- All context assembly (persona, active file, workflow state, opt-in files) happens silently before each message.
+
+## Research questions
+
+- What is the minimum context payload (Layer 0–4) that makes responses meaningfully more relevant without exceeding Claude CLI's context limits for typical vault sizes?
+- How should conversation history be managed across sessions — persisted in the vault, in plugin settings, or kept in memory only?
+- What is the right interaction model for the proposal review card — inline in the chat stream, or a separate review panel?
+- How should suggested conversation starters be determined per stage — hardcoded per stage slug, or driven by active artifact state?
+
+## Preliminary scope
+
+**In scope:** `ClaudeCliPort` narrow port; `ClaudeCliAdapter` using `@anthropic-ai/claude-code` SDK; five-layer context assembly (`buildSystemPrompt()`); streaming response rendering; stage-aware suggested starters; write-operation proposal cards; `obsidian://specorator` URI handlers for chat actions; plain-language error messages; MockBridge stub for browser/test.
+
+**Out of scope:** Conversation history persistence to vault (deferred), provider selection UI, API key management, fine-tuning or model configuration, multi-agent orchestration (v2.0), direct `agentonomous` integration.

--- a/specs/claude-cli-chat-sidebar/workflow-state.md
+++ b/specs/claude-cli-chat-sidebar/workflow-state.md
@@ -1,0 +1,55 @@
+---
+id: b1c2d3e4-f567-4a89-b012-c3d4e5f6a7b8
+feature: "Claude CLI chat sidebar"
+area: CCS
+slug: claude-cli-chat-sidebar
+current_stage: idea
+status: active
+last_updated: 2026-05-05
+last_agent: pm
+createdAt: 2026-05-05T00:00:00+02:00
+updatedAt: 2026-05-05T00:00:00+02:00
+artifacts:
+  idea: complete
+  research: pending
+  requirements: pending
+  design: pending
+  spec: pending
+  tasks: pending
+  implementation-log: pending
+  test-plan: pending
+  test-report: pending
+  review: pending
+  release-notes: pending
+  retrospective: pending
+---
+
+## Stage progress
+
+| Stage | Status | Artifact | Notes |
+|---|---|---|---|
+| 1 — Idea | complete | `idea.md` | |
+| 2 — Research | pending | — | |
+| 3 — Requirements | pending | — | |
+| 4 — Design | pending | — | |
+| 5 — Specification | pending | — | |
+| 6 — Tasks | pending | — | |
+| 7 — Implementation | pending | — | |
+| 8 — Testing | pending | — | |
+| 9 — Review | pending | — | |
+| 10 — Release | pending | — | |
+| 11 — Retrospective | pending | — | |
+
+## Blocks
+
+Blocked on Phase 3 gate: #11 (plugin shell) must be closed. W13 (#163) narrow ports and MCP server must be at sufficient completion before implementation begins.
+
+## Hand-off notes
+
+| Date | From | To | Note |
+|---|---|---|---|
+| 2026-05-05 | pm | — | Spec entry created to satisfy Phase 4 spec-first gate; idea authored based on #161 |
+
+## Open clarifications
+
+None.

--- a/specs/plugin-onboarding/idea.md
+++ b/specs/plugin-onboarding/idea.md
@@ -1,0 +1,57 @@
+---
+id: IDEA-POB-001
+title: "Plugin onboarding flow"
+stage: idea
+feature: plugin-onboarding
+status: accepted
+owner: pm
+created: 2026-05-05
+updated: 2026-05-05
+references:
+  - github: "luis85/specorator#162"
+  - github: "luis85/specorator#161"
+  - github: "luis85/specorator#164"
+---
+
+## Problem statement
+
+A new user installing Specorator faces several immediate barriers before they can do anything useful: they need to know what the plugin does, configure their vault folder, install the agentic-workflow template, and (optionally) set up Claude CLI for AI assistance. Without a guided flow, users must discover these steps from documentation, which creates friction and drops the conversion rate from install to first meaningful action. Additionally, without knowing anything about the user, the AI assistant cannot give relevant, personalised responses — a PM gets the same answer as an engineering lead, which degrades trust in the tool. The onboarding flow solves both: it guides the user to a working state and collects the personal context that makes every subsequent AI interaction more useful.
+
+## Primary users
+
+- **First-time installers** who have never used Specorator and need to reach a working state quickly.
+- **Non-technical users** (founders, PMs, business analysts) who may be unfamiliar with Obsidian vault configuration and need clear, plain-language guidance.
+- **Any user whose AI responses feel generic** — the onboarding persona step is also accessible from settings to let users update or add their introduction at any time.
+
+## Success criteria
+
+- A new user completes onboarding in under three minutes and arrives at the workflow navigator or chat sidebar in a ready state.
+- The persona step ("Tell us about yourself") uses warm, non-technical copy; provides three example persona cards as inspiration; and has a de-emphasised "I'll do this later" option — not a cancel button.
+- Claude CLI availability is checked and communicated in plain language: "Your AI assistant is ready" or "To get AI help, you'll need Claude installed" — never "ClaudeCliPort unavailable" or similar.
+- The vault configuration step defaults sensibly and only shows advanced options on demand.
+- The template installation step reuses the existing install use case with overwrite protection.
+- Completing onboarding sets `onboardingComplete: true` and `userPersona: string` in `PluginSettings`.
+- The user's persona is injected as the highest-priority layer in every system prompt: "About the person you're helping:\n{userPersona}".
+- A user who skips the persona step receives a gentle nudge at completion and can return to it from settings at any time.
+- The flow works in both Obsidian and standalone browser UI contexts.
+
+## Constraints
+
+- Must not introduce any breaking changes to `PluginSettings` — additions only (`userPersona: string`, `onboardingComplete: boolean`).
+- The persona textarea must feel like a friendly invitation, not a form field. No labels like "User persona", "Configure persona", or "Role and responsibilities".
+- Claude CLI check must use `ClaudeCliPort.isAvailable()` — never call the CLI directly from the UI layer.
+- Onboarding must remain accessible from settings after initial completion so users can update their persona or re-run installation.
+- Skipping onboarding entirely must not break any plugin functionality — all features must work with an empty persona.
+
+## Research questions
+
+- What is the shortest persona description that meaningfully improves AI response relevance — should we guide users with a character count hint or example prompts?
+- Should the onboarding wizard block the main UI (modal) or run in the main panel? Modal reduces distractions but may feel heavy on first install.
+- How should the persona field handle multi-paragraph input — single textarea or structured fields (role, team, context)?
+- Is a six-step wizard the right length, or should steps 4 and 5 (vault config and template install) be merged?
+
+## Preliminary scope
+
+**In scope:** Six-step wizard (welcome → persona → Claude check → vault config → template install → completion); `PluginSettings` additions (`userPersona`, `onboardingComplete`); `ClaudeCliPort.isAvailable()` integration; persona injection into `buildSystemPrompt()`; skip-and-return path; re-accessible from settings.
+
+**Out of scope:** Persona versioning or history, team/multi-user persona management, guided tour of plugin features post-onboarding (separate concern), advanced Claude CLI configuration (provider, model selection — deferred).

--- a/specs/plugin-onboarding/idea.md
+++ b/specs/plugin-onboarding/idea.md
@@ -25,6 +25,7 @@ A new user installing Specorator faces several immediate barriers before they ca
 
 ## Success criteria
 
+- **Auto-open on first install:** When `onboardingComplete` is absent or `false`, the plugin opens the onboarding wizard automatically when Obsidian loads — without requiring any ribbon click, command palette action, or prior knowledge. A first-time installer must never be left staring at an empty Obsidian window wondering what to do next.
 - A new user completes onboarding in under three minutes and arrives at the workflow navigator or chat sidebar in a ready state.
 - The persona step ("Tell us about yourself") uses warm, non-technical copy; provides three example persona cards as inspiration; and has a de-emphasised "I'll do this later" option — not a cancel button.
 - Claude CLI availability is checked and communicated in plain language: "Your AI assistant is ready" or "To get AI help, you'll need Claude installed" — never "ClaudeCliPort unavailable" or similar.
@@ -37,6 +38,7 @@ A new user installing Specorator faces several immediate barriers before they ca
 
 ## Constraints
 
+- **Auto-open must ship with the wizard:** The `onLayoutReady()` hook in `main.ts` must call `activateView()` when `onboardingComplete` is absent or `false`. This is not a follow-up — it ships as part of the same feature. A wizard that requires manual discovery is not onboarding.
 - Must not introduce any breaking changes to `PluginSettings` — additions only (`userPersona: string`, `onboardingComplete: boolean`).
 - The persona textarea must feel like a friendly invitation, not a form field. No labels like "User persona", "Configure persona", or "Role and responsibilities".
 - Claude CLI check must use `ClaudeCliPort.isAvailable()` — never call the CLI directly from the UI layer.

--- a/specs/plugin-onboarding/workflow-state.md
+++ b/specs/plugin-onboarding/workflow-state.md
@@ -1,0 +1,55 @@
+---
+id: c2d3e4f5-a678-4b90-c123-d4e5f6a7b8c9
+feature: "Plugin onboarding flow"
+area: POB
+slug: plugin-onboarding
+current_stage: idea
+status: active
+last_updated: 2026-05-05
+last_agent: pm
+createdAt: 2026-05-05T00:00:00+02:00
+updatedAt: 2026-05-05T00:00:00+02:00
+artifacts:
+  idea: complete
+  research: pending
+  requirements: pending
+  design: pending
+  spec: pending
+  tasks: pending
+  implementation-log: pending
+  test-plan: pending
+  test-report: pending
+  review: pending
+  release-notes: pending
+  retrospective: pending
+---
+
+## Stage progress
+
+| Stage | Status | Artifact | Notes |
+|---|---|---|---|
+| 1 — Idea | complete | `idea.md` | |
+| 2 — Research | pending | — | |
+| 3 — Requirements | pending | — | |
+| 4 — Design | pending | — | |
+| 5 — Specification | pending | — | |
+| 6 — Tasks | pending | — | |
+| 7 — Implementation | pending | — | |
+| 8 — Testing | pending | — | |
+| 9 — Review | pending | — | |
+| 10 — Release | pending | — | |
+| 11 — Retrospective | pending | — | |
+
+## Blocks
+
+Blocked on Phase 3 gate: #11 (plugin shell) must be closed. ClaudeCliPort (`claude-cli-chat-sidebar` spec) should be sufficiently defined before implementation begins, as onboarding integrates `ClaudeCliPort.isAvailable()`.
+
+## Hand-off notes
+
+| Date | From | To | Note |
+|---|---|---|---|
+| 2026-05-05 | pm | — | Spec entry created to satisfy Phase 4 spec-first gate; idea authored based on #162 |
+
+## Open clarifications
+
+None.


### PR DESCRIPTION
## Summary

- Rewrites `docs/product-vision.md` to reflect the evolved v1 scope: H-ACD as named design philosophy (4 principles including vault-as-operating-environment), updated ecosystem architecture diagram with embedded MCP server and Claude CLI as MCP client, full 12-stage ADLC lifecycle table with agent roles and governance model, expanded non-technical target users, intent-first and plain-language as explicit principles, MCP tool surface (7 groups, write-tool proposal queue) documented.
- Updates v1 Alpha section to include onboarding, Claude CLI chat sidebar, and MCP server alongside workflow navigator and artifact creation.
- Creates `specs/claude-cli-chat-sidebar/{idea,workflow-state}.md` (IDEA-CCS-001) to satisfy the Phase 4 spec-first gate for issue #161.
- Creates `specs/plugin-onboarding/{idea,workflow-state}.md` (IDEA-POB-001) to satisfy the Phase 4 spec-first gate for issue #162.

## Test plan

- [ ] Read `docs/product-vision.md` and verify H-ACD section, ADLC table, and MCP architecture diagram are present and accurate.
- [ ] Confirm `specs/claude-cli-chat-sidebar/idea.md` status is `accepted` and references #161, #163, #164, #165.
- [ ] Confirm `specs/plugin-onboarding/idea.md` status is `accepted` and references #162, #161, #164.
- [ ] Both `workflow-state.md` files have `current_stage: idea` and all artifact statuses set correctly.
- [ ] `npm run typecheck && npm run lint && npm run test` all pass (no source code changes in this PR).

https://claude.ai/code/session_01XQ3oK5HyY1mR9i3AJtfcjR

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQ3oK5HyY1mR9i3AJtfcjR)_