### PR TITLE
docs: CI/CD pipeline monitoring vision — new issues, updated epics, and per-term glossary

### DIFF
--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -1,0 +1,86 @@
+---
+title: "Specorator Glossary"
+doc_type: glossary-index
+status: stable
+owner: product
+last_updated: 2026-05-05
+references:
+  - docs/glossary.md
+  - docs/product-vision.md
+  - docs/prd.md
+---
+
+# Specorator Glossary
+
+Canonical definitions for every term used across product, design, engineering, and user-facing communication. Each term lives in its own file so it can be linked, versioned, and cross-referenced independently.
+
+The monolith reference is at [`docs/glossary.md`](../glossary.md). These files supersede it for all new usage.
+
+---
+
+## Core Product
+
+| Term | File | Version |
+|---|---|---|
+| Specorator | [specorator.md](./specorator.md) | v1 and v2.0 |
+| Companion app | [companion-app.md](./companion-app.md) | v2.0 |
+| Agentic coworker | [agentic-coworker.md](./agentic-coworker.md) | v2.0 |
+
+## Governance Model (H-ACD)
+
+| Term | File | Version |
+|---|---|---|
+| Human-Agent Centered Design | [h-acd.md](./h-acd.md) | v1 and v2.0 |
+| Workflow encapsulation | [workflow-encapsulation.md](./workflow-encapsulation.md) | v1 and v2.0 |
+| Human authority over outcomes | [human-authority.md](./human-authority.md) | v1 and v2.0 |
+| Intent-first interaction | [intent-first.md](./intent-first.md) | v1 and v2.0 |
+| Human-in-the-Loop (HITL) | [hitl.md](./hitl.md) | v1 and v2.0 |
+| Human-on-the-Loop (HOTL) | [hotl.md](./hotl.md) | v2.0 |
+| Oversight mode | [oversight-mode.md](./oversight-mode.md) | v2.0 |
+
+## Workflow / ADLC
+
+| Term | File | Version |
+|---|---|---|
+| Agentic Development Lifecycle | [adlc.md](./adlc.md) | v1 and v2.0 |
+| Pipeline | [pipeline.md](./pipeline.md) | v1 and v2.0 |
+| Workflow stage | [workflow-stage.md](./workflow-stage.md) | v1 and v2.0 |
+| Artifact | [artifact.md](./artifact.md) | v1 and v2.0 |
+| Workflow state | [workflow-state.md](./workflow-state.md) | v1 and v2.0 |
+| Feature | [feature.md](./feature.md) | v1 and v2.0 |
+| Gate | [gate.md](./gate.md) | v1 and v2.0 |
+| Gate check | [gate-check.md](./gate-check.md) | v1 and v2.0 |
+| Scaffold | [scaffold.md](./scaffold.md) | v1 and v2.0 |
+| Open question | [open-question.md](./open-question.md) | v1 and v2.0 |
+| Decision note | [decision-note.md](./decision-note.md) | v1 and v2.0 |
+| Session log | [session-log.md](./session-log.md) | v2.0 |
+| Traceability chain | [traceability-chain.md](./traceability-chain.md) | v1 and v2.0 |
+
+## UI
+
+| Term | File | Version |
+|---|---|---|
+| Cockpit | [cockpit.md](./cockpit.md) | v1 and v2.0 |
+| Fleet dashboard | [fleet-dashboard.md](./fleet-dashboard.md) | v2.0 |
+| Workflow navigator | [workflow-navigator.md](./workflow-navigator.md) | v1 |
+| Chat sidebar | [chat-sidebar.md](./chat-sidebar.md) | v1 and v2.0 |
+| Proposed output | [proposed-output.md](./proposed-output.md) | v1 and v2.0 |
+| Accepted output | [accepted-output.md](./accepted-output.md) | v1 and v2.0 |
+
+## Technical
+
+| Term | File | Version |
+|---|---|---|
+| Narrow port | [narrow-port.md](./narrow-port.md) | v1 and v2.0 |
+| MCP server | [mcp-server.md](./mcp-server.md) | v1 and v2.0 |
+| ClaudeCliPort | [claude-cli-port.md](./claude-cli-port.md) | v1 |
+| RuntimePort | [runtime-port.md](./runtime-port.md) | v2.0 |
+| Vault as operating environment | [vault-as-operating-environment.md](./vault-as-operating-environment.md) | v1 and v2.0 |
+
+## Ecosystem
+
+| Term | File | Version |
+|---|---|---|
+| agentic-workflow | [agentic-workflow.md](./agentic-workflow.md) | v1 and v2.0 |
+| agentonomous | [agentonomous.md](./agentonomous.md) | v2.0 |
+| specorator-runtime | [specorator-runtime.md](./specorator-runtime.md) | v2.0 |

--- a/docs/glossary/accepted-output.md
+++ b/docs/glossary/accepted-output.md
@@ -1,0 +1,46 @@
+---
+term: "Accepted output"
+aliases: ["accepted proposal", "accepted artifact"]
+category: ui
+status: stable
+version: "v1 and v2.0"
+related:
+  - proposed-output.md
+  - artifact.md
+  - session-log.md
+  - human-authority.md
+issues:
+  - "#164"
+  - "#165"
+last_updated: 2026-05-05
+---
+
+# Accepted output
+
+A proposed output that the user has explicitly reviewed and approved, after which it is written to the vault as a durable Markdown artifact. Acceptance is the moment at which agent work becomes vault content.
+
+## What acceptance does
+
+When the user accepts a proposed output:
+
+1. The MCP server applies the write operation through the appropriate narrow port
+2. `workflow-state.md` is updated to reflect the new artifact status
+3. The session log records the acceptance with a timestamp and any user note
+4. The artifact enters the vault's knowledge graph as a first-class note with wikilinks
+
+## What rejection does
+
+When the user rejects a proposed output:
+
+1. The write is not applied — the vault remains unchanged
+2. The agent receives a rejection signal with the user's feedback (if provided)
+3. The agent may propose an alternative within the same session
+4. The rejection is recorded in the session log
+
+## Partial acceptance
+
+Users can accept a proposed output with modifications: they review the agent's proposal, edit it directly in the preview, and accept the edited version. The session log records both the original proposal and the accepted version with edits noted.
+
+## Why explicit acceptance matters
+
+The acceptance moment is not a formality — it is the governance event. Before acceptance, agent work is provisional. After acceptance, it is the vault's content and the input to subsequent stages. The traceability chain records this boundary precisely.

--- a/docs/glossary/adlc.md
+++ b/docs/glossary/adlc.md
@@ -1,0 +1,47 @@
+---
+term: "Agentic Development Lifecycle"
+aliases: ["ADLC"]
+category: workflow
+status: stable
+version: "v1 and v2.0"
+related:
+  - pipeline.md
+  - workflow-stage.md
+  - gate.md
+  - h-acd.md
+  - fleet-dashboard.md
+issues:
+  - "#1"
+  - "#23"
+  - "#164"
+last_updated: 2026-05-05
+---
+
+# Agentic Development Lifecycle (ADLC)
+
+The complete twelve-stage lifecycle through which a feature travels from initial idea to retrospective. The ADLC is the backbone of the `agentic-workflow` methodology that Specorator surfaces. Each stage has a defined agent role, expected artifacts, and a human governance gate before the next stage begins.
+
+## The twelve stages
+
+| # | Stage slug | Plain label | Agent role | User's governance decision |
+|---|---|---|---|---|
+| 1 | `idea` | Exploring the idea | Articulates and stress-tests the concept | "Is this worth pursuing?" |
+| 2 | `research` | Understanding the space | Structures research, surfaces patterns | "What does this mean for us?" |
+| 3 | `requirements` | Defining what to build | Transforms discussion into structured requirements | "Does this describe what we want?" |
+| 4 | `design` | Figuring out how it works | Proposes architecture, documents tradeoffs | "Is this the right approach?" |
+| 5 | `spec` | Writing it all down | Synthesises prior work into a complete spec | "Is this ready to build?" |
+| 6 | `tasks` | Planning the work | Breaks spec into tasks, surfaces dependencies | "Is this plan realistic?" |
+| 7 | `implementation-log` | Building it | Writes code from spec and task list | "Does this match what we wanted?" |
+| 8 | `test-plan` | Making sure it works | Writes tests from requirements and implementation | "Does this plan catch the right things?" |
+| 9 | `test-report` | What we found | Runs tests, reports results in plain language | "Are we ready to ship?" |
+| 10 | `review` | Getting a second opinion | Reviews code, design, and requirements | "Is this good enough?" |
+| 11 | `release-notes` | Telling people what changed | Drafts release notes from implementation log | "Does this tell the right story?" |
+| 12 | `retrospective` | What we learned | Structures retrospective, identifies patterns | "What do we do differently next time?" |
+
+## The pipeline view
+
+The ADLC stages form a **pipeline**: every feature enters at `idea` and exits at `retrospective`. The fleet dashboard (#168) visualises this pipeline as a matrix — features as rows, stages as columns — so the user can see the state of all features simultaneously. See [pipeline.md](./pipeline.md).
+
+## v1 vs v2.0
+
+In v1, the ADLC is served conversationally via the Claude CLI chat sidebar. In v2.0, `specorator-runtime` orchestrates dedicated agents through each stage with stateful, resumable sessions.

--- a/docs/glossary/agentic-coworker.md
+++ b/docs/glossary/agentic-coworker.md
@@ -1,0 +1,40 @@
+---
+term: "Agentic coworker"
+aliases: ["coworker", "AI coworker", "agent role"]
+category: core
+status: draft
+version: "v2.0"
+related:
+  - companion-app.md
+  - agentonomous.md
+  - specorator-runtime.md
+  - adlc.md
+issues:
+  - "#23"
+  - "#164"
+last_updated: 2026-05-05
+---
+
+# Agentic coworker
+
+A purpose-built agent defined in `agentonomous` that appears as a named, role-specific helper in the Specorator UI. Coworkers are invoked by `specorator-runtime` for the appropriate ADLC stage; they produce proposed outputs that the user reviews, edits, and accepts or rejects. **Not available in v1.**
+
+## Coworker roles
+
+| Role | Stages | Responsibility |
+|---|---|---|
+| PM agent | 1–3 (idea, research, requirements) | Articulates concepts, structures research, drafts requirements |
+| Architect agent | 4 (design) | Proposes architecture, documents tradeoffs |
+| Writer agent | 5, 11 (spec, release notes) | Synthesises prior work into complete documents |
+| Planner agent | 6 (tasks) | Breaks spec into tasks, surfaces dependencies |
+| Engineering agent | 7 (implementation-log) | Writes code from spec and task list |
+| QA agent | 8–9 (test-plan, test-report) | Writes tests, runs them, reports results |
+| Review agent | 10 (review) | Reviews code, design, and requirements; flags issues |
+
+## What coworkers are not
+
+Coworkers are not generic AI assistants that can do anything. Each coworker has a defined input contract (from the runtime), a defined output contract (a specific artifact type or action), and explicit scope limits. A coworker that tries to do work outside its scope is a configuration bug, not a feature.
+
+## User-facing representation
+
+In the chat sidebar and fleet dashboard, coworkers may have plain-language names visible to the user ("your requirements assistant", "the engineer reviewing this"). The underlying `agentonomous` role name, model, or tool set is never exposed. See [workflow-encapsulation.md](./workflow-encapsulation.md).

--- a/docs/glossary/agentic-workflow.md
+++ b/docs/glossary/agentic-workflow.md
@@ -1,0 +1,42 @@
+---
+term: "agentic-workflow"
+aliases: ["agentic workflow", "workflow methodology", "upstream methodology"]
+category: ecosystem
+status: stable
+version: "v1 and v2.0"
+related:
+  - adlc.md
+  - workflow-stage.md
+  - artifact.md
+  - scaffold.md
+  - specorator.md
+issues:
+  - "#97"
+  - "#76"
+last_updated: 2026-05-05
+---
+
+# agentic-workflow
+
+The upstream methodology repository (`Luis85/agentic-workflow`) that defines the twelve ADLC stages, stage artifacts, templates, traceability conventions, and quality gates that Specorator surfaces. Specorator consumes released versions of the `agentic-workflow` template package as the authoritative source of template content.
+
+## What it defines
+
+- The twelve stage slugs and their sequencing
+- The `specs/{slug}/` vault structure (ADR-005)
+- The `workflow-state.md` schema and required frontmatter fields
+- Stage artifact filenames and template content
+- Quality gate conventions and gate check definitions
+- AGENTS.md instructions for coding agents working within the methodology
+
+## Relationship to Specorator
+
+Specorator is the Obsidian plugin that *surfaces* `agentic-workflow`. The methodology is the content; the plugin is the interface. Specorator's role is to make the methodology invisible to the user while ensuring its benefits (structure, traceability, quality gates) are delivered automatically.
+
+## Version tracking
+
+The plugin tracks the installed `agentic-workflow` template version in plugin settings and will notify the user when an update is available. Issue #97 tracks adoption of the upstream v1 release.
+
+## Ambiguity note
+
+"Workflow" can refer to the `agentic-workflow` methodology, a feature's per-feature workflow path, or a GitHub Actions CI workflow. Use "`agentic-workflow`" for the methodology repository, "the ADLC" or "the workflow methodology" for the methodology itself, and "CI workflow" for GitHub Actions.

--- a/docs/glossary/agentonomous.md
+++ b/docs/glossary/agentonomous.md
@@ -1,0 +1,29 @@
+---
+term: "agentonomous"
+aliases: ["agentonomous library"]
+category: ecosystem
+status: draft
+version: "v2.0"
+related:
+  - specorator-runtime.md
+  - agentic-coworker.md
+  - companion-app.md
+  - runtime-port.md
+issues:
+  - "#23"
+last_updated: 2026-05-05
+---
+
+# agentonomous
+
+The upstream agent orchestration library (`Luis85/agentonomous`) that powers v2.0 agentic coworker interactions. `agentonomous` defines agent roles, their input/output contracts, and the execution model for multi-step agentic sessions. **Not integrated in v1.**
+
+In v1, the plugin is designed to leave clean extension points for `agentonomous` without depending on it. The `ClaudeCliPort` interface is the designed seam; in v2.0 it is replaced by `RuntimePort` which routes through `specorator-runtime` → `agentonomous`.
+
+## Relationship to specorator-runtime
+
+`agentonomous` provides the agent implementations (PM agent, Architect agent, Engineering agent, QA agent, etc.). `specorator-runtime` is the orchestration engine that invokes `agentonomous` agents at the right stage, manages session state, and emits typed events to the plugin. Neither is exposed to the user.
+
+## v1 status
+
+Extension point only. The plugin architecture is designed for `agentonomous` integration without implementing it. No `agentonomous` dependency in v1.

--- a/docs/glossary/artifact.md
+++ b/docs/glossary/artifact.md
@@ -1,0 +1,38 @@
+---
+term: "Artifact"
+aliases: ["workflow artifact", "stage artifact"]
+category: workflow
+status: stable
+version: "v1 and v2.0"
+related:
+  - workflow-stage.md
+  - workflow-state.md
+  - proposed-output.md
+  - accepted-output.md
+  - traceability-chain.md
+issues:
+  - "#1"
+  - "#165"
+last_updated: 2026-05-05
+---
+
+# Artifact
+
+A plain Markdown file produced or managed through the workflow. Artifacts are stored in the vault at `specs/{feature-slug}/{stage-slug}.md` and remain useful and editable without the plugin installed.
+
+## Types of artifacts
+
+- **Stage artifacts** — the canonical output of a workflow stage (e.g., `requirements.md`, `design.md`, `spec.md`). Created lazily when the user advances to that stage.
+- **Session logs** — records of agent session reasoning, stored at `specs/{slug}/sessions/{stage}-session-{timestamp}.md`. See [session-log.md](./session-log.md).
+- **The workflow state file** — `workflow-state.md`, the frontmatter anchor of the traceability chain for a feature.
+
+## Artifact properties
+
+- Plain Markdown — no proprietary format, no plugin-private state
+- Wikilinked — relationships to related artifacts are expressed as `[[wikilinks]]` that enter Obsidian's knowledge graph
+- Frontmatter-tagged — key properties (stage, status, feature slug) are stored as YAML frontmatter for Bases querying
+- Overwrite-protected — if an artifact already exists when a stage begins, Specorator skips creation rather than overwriting (REQ-AVS-005)
+
+## User-facing language
+
+Users never see "artifact" in the Specorator UI. The vocabulary mapping is: artifact → note / document / draft. See [workflow-encapsulation.md](./workflow-encapsulation.md) and [chat-sidebar.md](./chat-sidebar.md) for the full vocabulary table.

--- a/docs/glossary/chat-sidebar.md
+++ b/docs/glossary/chat-sidebar.md
@@ -1,0 +1,52 @@
+---
+term: "Chat sidebar"
+aliases: ["Claude CLI chat sidebar", "chat panel", "conversation sidebar"]
+category: ui
+status: stable
+version: "v1 and v2.0"
+related:
+  - cockpit.md
+  - claude-cli-port.md
+  - runtime-port.md
+  - intent-first.md
+  - h-acd.md
+issues:
+  - "#161"
+  - "#1"
+last_updated: 2026-05-05
+---
+
+# Chat sidebar
+
+The primary AI collaboration surface in Specorator — always visible alongside the main Obsidian workspace, always context-aware, never requiring the user to configure it. The chat sidebar is the user-facing expression of the H-ACD intent-first principle.
+
+## What makes it context-aware
+
+Five context layers are assembled silently before every message the user sends:
+
+| Layer | Source | What it provides |
+|---|---|---|
+| 0 | User persona (from onboarding) | Who the user is and their background |
+| 1 | Active file (`WorkspacePort` + `MetadataCachePort`) | What the user is looking at right now |
+| 2 | Workflow stage (`workflow-state.md`) | Where the feature is in the ADLC |
+| 3 | Optional attached notes (user opt-in) | Additional context the user chooses to share |
+| 4 | Vault metadata (`MetadataCachePort`) | Knowledge graph connections available to reason about |
+
+The user never configures these layers. They open the sidebar and start talking.
+
+## Plain language everywhere
+
+The sidebar enforces the H-ACD vocabulary contract. Nothing the user sees should require technical knowledge:
+
+- Agents are "your assistant", not "the LLM"
+- Stages are plain labels, never slugs
+- Artifacts are "notes" or "documents", never "artifacts"
+- Action prompts use natural language ("Write this up", "Move on") not technical operations
+
+## v1 vs v2.0
+
+In v1, the sidebar backs onto the `ClaudeCliPort` which spawns the Claude CLI subprocess. In v2.0, it backs onto `RuntimePort` which routes through `specorator-runtime`. The sidebar Vue component does not change between versions — only the port binding.
+
+## Full specification
+
+Issue #161.

--- a/docs/glossary/claude-cli-port.md
+++ b/docs/glossary/claude-cli-port.md
@@ -1,0 +1,45 @@
+---
+term: "ClaudeCliPort"
+aliases: ["claude-cli-port", "ClaudeCliPort interface"]
+category: technical
+status: stable
+version: "v1"
+related:
+  - runtime-port.md
+  - narrow-port.md
+  - chat-sidebar.md
+  - mcp-server.md
+issues:
+  - "#161"
+  - "#23"
+last_updated: 2026-05-05
+---
+
+# ClaudeCliPort
+
+The narrow port interface that abstracts the Claude CLI subprocess from the chat sidebar UI. Defined in `src/domain/ports/` as part of the W13 port set (#163), it is the **v2.0 upgrade seam**: in v2.0 it is replaced by `RuntimePort` without any change to the sidebar UI.
+
+## Interface
+
+```ts
+interface ClaudeCliPort {
+  isAvailable(): Promise<boolean>;
+  sendMessage(params: {
+    systemPrompt: string;           // assembled context layers; never shown to user
+    conversationHistory: Message[];
+    userMessage: string;
+  }): AsyncIterable<string>;        // streaming token chunks
+}
+```
+
+## Why this seam exists
+
+The chat sidebar must not know whether it is talking to a local `claude` subprocess (v1) or a `specorator-runtime` orchestration session (v2.0). `ClaudeCliPort` is the boundary that enforces this ignorance. The port has a mock implementation for `npm run dev` (no subprocess needed) and an `ObsidianClaudeCliAdapter` for production.
+
+## v1 implementation
+
+`ObsidianClaudeCliAdapter` spawns the `claude` CLI subprocess configured with `--mcp-server` pointing to Specorator's native MCP server. The subprocess streams token chunks back through the port.
+
+## v2.0 migration
+
+`RuntimePort` satisfies the same interface, routing through `specorator-runtime` instead of a CLI subprocess. The sidebar Vue component never needs to change; only the port binding changes.

--- a/docs/glossary/cockpit.md
+++ b/docs/glossary/cockpit.md
@@ -1,0 +1,33 @@
+---
+term: "Cockpit"
+aliases: ["Specorator cockpit", "navigator view"]
+category: ui
+status: stable
+version: "v1 and v2.0"
+related:
+  - fleet-dashboard.md
+  - workflow-navigator.md
+  - chat-sidebar.md
+issues:
+  - "#1"
+  - "#168"
+last_updated: 2026-05-05
+---
+
+# Cockpit
+
+The primary Specorator panel inside Obsidian. The cockpit is the user's single point of contact with the agentic workflow: it shows the current feature's stage, provides access to artifacts, surfaces agent activity, and presents governance decisions.
+
+## v1
+
+In v1, "cockpit" and "workflow navigator" are used interchangeably. The cockpit shows the active feature, its current stage (in plain language), expected next artifacts, and controls for opening or creating workflow files. The Claude CLI chat sidebar is always visible alongside the workflow state strip.
+
+## v2.0
+
+In v2.0, "cockpit" broadens to encompass the fleet dashboard: the full multi-feature portfolio view with the pipeline matrix, live session feed, intervention controls, artifact links, and health signals. The per-feature navigator view is retained as a drill-down within the cockpit.
+
+The v2.0 cockpit is where the user "overwatches" their agentic workforce — seeing all active features and their pipeline state simultaneously, steering the agents that need redirection, and approving the governance gates that need their decision.
+
+## Etymology
+
+"Cockpit" is used deliberately rather than "dashboard" or "panel": the user is the pilot who sets direction and makes decisions; the agents are the instruments and systems that execute. The cockpit is not an observation window — it is a steering interface.

--- a/docs/glossary/companion-app.md
+++ b/docs/glossary/companion-app.md
@@ -1,0 +1,39 @@
+---
+term: "Companion app"
+aliases: []
+category: core
+status: draft
+version: "v2.0"
+related:
+  - specorator.md
+  - agentic-coworker.md
+  - specorator-runtime.md
+  - agentonomous.md
+  - fleet-dashboard.md
+issues:
+  - "#23"
+  - "#1"
+last_updated: 2026-05-05
+---
+
+# Companion app
+
+The v2.0 framing of Specorator: a fully orchestrated agentic system that gives the user a team of specialised AI coworkers inside Obsidian, coordinated by `specorator-runtime` and backed by `agentonomous`. **Not available in v1.**
+
+The companion app framing emphasises the relational nature of the v2.0 experience: the user is not operating a tool, they are directing a team. The agents are coworkers with defined roles, not generic AI assistants. The user's job is to maintain direction, review proposals, and make the decisions that only they can make.
+
+## What changes in v2.0
+
+| Capability | v1 | v2.0 companion app |
+|---|---|---|
+| AI assistance | Conversational (Claude CLI) | Orchestrated multi-agent sessions |
+| Stage coverage | All 12 stages, conversationally | All 12 stages, with specialised agents |
+| Portfolio view | Per-feature workflow navigator | Fleet dashboard: all features simultaneously |
+| Session state | Per-conversation | Persistent across Obsidian restarts |
+| Agent transparency | Chat responses | Live session feed + session logs |
+| Code execution | Agent can write code | Engineering agent executes and proposes diffs |
+| Test execution | Agent can assist | QA agent runs tests, reports in plain language |
+
+## What does not change
+
+The vault remains the source of truth. All outputs are plain Markdown. The user's authority over every stage transition is unconditional. The sidebar UI does not change. The plain-language vocabulary does not change.

--- a/docs/glossary/decision-note.md
+++ b/docs/glossary/decision-note.md
@@ -1,0 +1,40 @@
+---
+term: "Decision note"
+aliases: ["ADR", "Architecture Decision Record"]
+category: workflow
+status: stable
+version: "v1 and v2.0"
+related:
+  - open-question.md
+  - artifact.md
+  - traceability-chain.md
+issues:
+  - "#1"
+last_updated: 2026-05-05
+---
+
+# Decision note
+
+A structured Markdown record of a decision made during a feature's workflow, documenting the options considered, the rationale, and the outcome. Decision notes are the primary form of Architecture Decision Record (ADR) in the Specorator workflow.
+
+## Structure
+
+A decision note captures:
+
+- **The decision** — what was decided, stated clearly
+- **The context** — what situation or open question triggered this decision
+- **The options considered** — at least two alternatives with their tradeoffs
+- **The rationale** — why this option was chosen over the others
+- **The outcome** — consequences, constraints, or follow-on decisions
+
+## Relationship to ADRs
+
+In the plugin codebase, architectural decisions use the ADR format in `docs/adr/`. In the `agentic-workflow` methodology, decision notes serve the same purpose for product and design decisions within a feature's workflow. The formats are closely related but the storage location differs.
+
+## Relationship to open questions
+
+Open questions that require formal documentation are promoted to decision notes. The open question record links to the decision note that resolved it. This creates a traceable chain: uncertainty identified → question documented → decision made → decision noted.
+
+## Agents and decision notes
+
+In v2.0, the architect and PM agents can propose decision notes based on the options they surfaced during design or requirements stages. The user reviews the proposed note, edits for completeness and accuracy, and accepts it as a vault artifact.

--- a/docs/glossary/feature.md
+++ b/docs/glossary/feature.md
@@ -1,0 +1,50 @@
+---
+term: "Feature"
+aliases: ["project feature", "workflow feature"]
+category: workflow
+status: stable
+version: "v1 and v2.0"
+related:
+  - workflow-state.md
+  - workflow-stage.md
+  - artifact.md
+  - traceability-chain.md
+  - scaffold.md
+issues:
+  - "#1"
+  - "#169"
+last_updated: 2026-05-05
+---
+
+# Feature
+
+A unit of work tracked through the ADLC. A feature has a name, a slug-based folder under `specs/`, a `workflow-state.md` state file, a set of stage artifact files, and a root issue that it traces back to.
+
+## Vault structure
+
+```
+specs/
+└── auth-flow/                    ← feature slug
+    ├── workflow-state.md         ← state file (frontmatter anchor)
+    ├── idea.md                   ← stage artifact (Stage 1)
+    ├── research.md               ← stage artifact (Stage 2)
+    ├── requirements.md           ← stage artifact (Stage 3)
+    └── sessions/                 ← agent session logs
+        ├── idea-session-20260504-0900.md
+        └── requirements-session-20260505-1437.md
+```
+
+## Feature states
+
+A feature can be:
+- **Active** — currently being worked on; has a `current_stage` in `workflow-state.md`
+- **Archived** — completed through all relevant stages; preserved in the vault
+- **Abandoned** — work stopped before completion; documented with a reason
+
+## Feature hierarchy
+
+Features can be nested: a root epic feature can have child features, each with their own ADLC pipeline. `workflow-state.md` records `parent_feature` and `child_features` to make the hierarchy queryable. The fleet dashboard renders this as a tree where the user can see both the portfolio overview and any feature's sub-pipeline.
+
+## Relationship to GitHub issues
+
+A feature corresponds to one or more GitHub issues, with a `root_issue` field in `workflow-state.md` linking back to the primary issue. The vault is the source of truth for feature state; GitHub is the coordination surface.

--- a/docs/glossary/fleet-dashboard.md
+++ b/docs/glossary/fleet-dashboard.md
@@ -1,0 +1,61 @@
+---
+term: "Fleet dashboard"
+aliases: ["Mission Control", "workflow fleet dashboard", "cockpit fleet view"]
+category: ui
+status: draft
+version: "v2.0"
+related:
+  - cockpit.md
+  - pipeline.md
+  - adlc.md
+  - hitl.md
+  - hotl.md
+  - oversight-mode.md
+  - session-log.md
+  - traceability-chain.md
+issues:
+  - "#168"
+  - "#23"
+last_updated: 2026-05-05
+---
+
+# Fleet dashboard
+
+The portfolio-level cockpit view that shows all active features across all projects on a single screen, with each feature's pipeline stage, active agent session status, oversight mode, and pending governance decisions visible at a glance. The fleet dashboard is a v2.0 feature; its v1 foundation is the workflow navigator.
+
+## The pipeline matrix
+
+The primary panel of the fleet dashboard is a matrix: **features as rows, stages as columns**, with each cell showing the state of that stage for that feature:
+
+```
+Feature                    | idea | research | requirements | design | spec | tasks | impl | …
+───────────────────────────────────────────────────────────────────────────────────────────
+auth-flow                  |  ✓   |    ✓     |      ✓       |   ●    |      |       |      |
+user-profile-editor        |  ✓   |    ⟳    |              |        |      |       |      |
+onboarding-redesign        |  ✓   |    ✓     |      ✓       |   ✓    |  ✓   |   ✓   |  ⟳  |
+notification-service       |  ✓   |    ✓     |      ⏸       |        |      |       |      |
+```
+
+Legend: `✓` done · `●` agent working (HOTL) · `⟳` awaiting review (HITL) · `⏸` blocked
+
+The user scans the matrix and immediately knows where their attention is needed.
+
+## The five panels
+
+1. **Fleet status** — the pipeline matrix described above
+2. **Live session feed** — streaming plain-language progress for the selected feature's active agent session
+3. **Intervention controls** — approve, redirect, pause, resume, or abandon from inline actions on any feature row
+4. **Artifact links** — one click from any stage cell to the stage artifact, session log, or root issue
+5. **Health signals** — automatic flags for stuck features, review backlog, scope drift, agent failures, and high escalation rate
+
+## Recursive hierarchy
+
+The fleet dashboard supports recursive feature trees: a root epic shows child features; each child shows its pipeline. The user can view the full portfolio tree or drill into any subtree while maintaining awareness of the whole.
+
+## v1 foundation
+
+The Increment 2 workflow navigator (see [workflow-navigator.md](./workflow-navigator.md)) is the per-feature pipeline view that establishes the pipeline mental model. The fleet dashboard in v2.0 extends this to N features with live agent session data.
+
+## Full specification
+
+Issue #168.

--- a/docs/glossary/gate-check.md
+++ b/docs/glossary/gate-check.md
@@ -1,0 +1,40 @@
+---
+term: "Gate check"
+aliases: ["quality gate check"]
+category: workflow
+status: stable
+version: "v1 and v2.0"
+related:
+  - gate.md
+  - artifact.md
+  - workflow-state.md
+issues:
+  - "#1"
+last_updated: 2026-05-05
+---
+
+# Gate check
+
+A specific condition evaluated at a stage gate. Gate checks verify that the required work for a stage is complete before the user is presented with the option to advance to the next stage.
+
+## Common checks
+
+- **Artifact existence** — the stage artifact file exists at `specs/{slug}/{stage}.md`
+- **Required frontmatter** — the artifact contains specified YAML frontmatter fields with non-empty values
+- **Quality gate status** — `workflow-state.md` records a `passed` status for this stage's gate
+- **Explicit user acceptance** — the user has reviewed and accepted the agent's proposal for this stage
+
+## Results
+
+A gate check can return:
+
+| Result | Meaning |
+|---|---|
+| `passed` | Check satisfied; gate can proceed |
+| `failed` | Check not satisfied; blocks gate (if hard gate) |
+| `warning` | Check not satisfied but advisory only; user can override |
+| `skipped` | Check disabled for this workflow configuration |
+
+## Implementation
+
+Gate checks are exposed through the `workflow_get_quality_gates(feature_slug, stage)` MCP tool, which returns the full check results for a given stage. The workflow navigator and fleet dashboard use this tool to compute stage cell states.

--- a/docs/glossary/gate.md
+++ b/docs/glossary/gate.md
@@ -1,0 +1,45 @@
+---
+term: "Gate"
+aliases: ["quality gate", "stage gate", "workflow gate"]
+category: workflow
+status: stable
+version: "v1 and v2.0"
+related:
+  - gate-check.md
+  - hitl.md
+  - workflow-stage.md
+  - adlc.md
+  - human-authority.md
+issues:
+  - "#1"
+  - "#165"
+last_updated: 2026-05-05
+---
+
+# Gate
+
+A quality checkpoint between two ADLC stages. A gate is the formal expression of the H-ACD principle of human authority over outcomes: no feature advances from stage N to stage N+1 without the user passing the gate.
+
+In mechanical terms, a gate is a HITL checkpoint: the agent (or the system) proposes advancement; the user explicitly approves or rejects. Rejection returns to stage N; approval creates the next stage's artifact and begins stage N+1.
+
+## Gate checks
+
+A gate comprises one or more **gate checks**: specific conditions that must be satisfied for the gate to pass. Examples:
+
+- The stage artifact exists at the expected path
+- The artifact's frontmatter includes required fields
+- The quality gate status in `workflow-state.md` is `passed`
+- The user has explicitly approved the stage output
+
+Gate checks are implemented via `workflow_get_quality_gates` in the MCP tool surface.
+
+## Gate strictness
+
+Gates can be configured with different strictness levels:
+- **Hard** — advancement is blocked until all checks pass
+- **Advisory** — checks surface as warnings; the user can advance despite failures with an explicit override
+- **Disabled** — checks are skipped for this gate (used in low-formality workflows)
+
+## User-facing language
+
+The word "gate" is internal vocabulary. Users see "Ready to move on?", "Are you happy with this?", or stage-appropriate governance prompts — not "gate" or "gate check". See [workflow-encapsulation.md](./workflow-encapsulation.md).

--- a/docs/glossary/h-acd.md
+++ b/docs/glossary/h-acd.md
@@ -1,0 +1,40 @@
+---
+term: "Human-Agent Centered Design"
+aliases: ["H-ACD"]
+category: governance
+status: stable
+version: "v1 and v2.0"
+related:
+  - workflow-encapsulation.md
+  - human-authority.md
+  - intent-first.md
+  - vault-as-operating-environment.md
+  - hitl.md
+  - hotl.md
+issues:
+  - "#164"
+last_updated: 2026-05-05
+---
+
+# Human-Agent Centered Design (H-ACD)
+
+The foundational product philosophy that governs every design decision in Specorator. H-ACD defines a model in which agents handle execution and humans govern outcomes — making rigorous product delivery accessible to everyone, regardless of technical background.
+
+H-ACD is built on four principles:
+
+1. **Workflow encapsulation** — methodology complexity is hidden from the user; they experience results, not machinery
+2. **Human authority over outcomes** — agents propose; humans decide; nothing is committed without user approval
+3. **Intent-first interaction** — the user expresses what they want; the system handles the how
+4. **The vault as the agentic operating environment** — agents operate through Obsidian's own data model; the vault is not a storage location but the primary workspace
+
+## Why it matters
+
+Traditional software delivery gates participation behind technical expertise. H-ACD removes that gate. A product manager with no coding background can govern every stage of a feature's lifecycle — from idea articulation to test result review — because the governance decisions are human decisions, not technical ones. Agents bring the expertise; the user brings the intent and the final authority.
+
+## In practice
+
+Every feature, interaction, and piece of copy in Specorator is evaluated against H-ACD's four principles. If a proposed UI element exposes a stage slug, a methodology term, or an agent configuration option to the user, it violates workflow encapsulation and must be redesigned. If a workflow can advance without user approval, it violates human authority and must be corrected.
+
+## Reference
+
+[Human-Agent Centered Design](https://hacd.lovable.app/) — the foundational framework that Specorator applies.

--- a/docs/glossary/hitl.md
+++ b/docs/glossary/hitl.md
@@ -1,0 +1,43 @@
+---
+term: "Human-in-the-Loop"
+aliases: ["HITL"]
+category: governance
+status: stable
+version: "v1 and v2.0"
+related:
+  - hotl.md
+  - oversight-mode.md
+  - gate.md
+  - h-acd.md
+issues:
+  - "#164"
+  - "#168"
+  - "#23"
+last_updated: 2026-05-05
+---
+
+# Human-in-the-Loop (HITL)
+
+An oversight mode in which an agent **pauses** and waits for explicit user approval before proceeding. The agent session is suspended; no further action is taken until the user acts.
+
+HITL applies unconditionally at two points in Specorator:
+
+1. **Stage gate transitions** — no feature advances from one ADLC stage to the next without an explicit user decision. This is the primary HITL invariant and cannot be configured away.
+2. **Vault write operations** — every proposed write to the vault (a new note, a frontmatter update, a canvas addition) is queued as a pending proposal and displayed for user review before being applied. This applies to all write operations exposed through the MCP tool surface.
+
+## In the UI
+
+A feature in HITL mode shows `↩ Waiting for you` in the fleet dashboard. The inline action (Approve / Request changes / Reject) is prominent. Nothing will progress until the user acts.
+
+## HITL vs HOTL
+
+HITL and HOTL are not opposites — they apply at different scopes:
+
+- **HITL at gates** — the boundary between stages always requires the user's explicit decision
+- **HOTL within stages** — the agent can work autonomously within a stage while the user monitors
+
+A feature can be HOTL-mode while the agent is drafting requirements, and then automatically switch to HITL-mode when the draft is ready and the user must decide whether to advance to design. See [hotl.md](./hotl.md) and [oversight-mode.md](./oversight-mode.md).
+
+## Why this matters for non-technical users
+
+HITL is the mechanism that makes H-ACD's "human authority over outcomes" principle concrete. It is not a safety feature for technical users — it is the product model. Non-technical users can confidently let agents work because they know nothing will change without their approval.

--- a/docs/glossary/hotl.md
+++ b/docs/glossary/hotl.md
@@ -1,0 +1,48 @@
+---
+term: "Human-on-the-Loop"
+aliases: ["HOTL"]
+category: governance
+status: stable
+version: "v2.0"
+related:
+  - hitl.md
+  - oversight-mode.md
+  - fleet-dashboard.md
+  - h-acd.md
+issues:
+  - "#164"
+  - "#168"
+  - "#23"
+last_updated: 2026-05-05
+---
+
+# Human-on-the-Loop (HOTL)
+
+An oversight mode in which an agent works **autonomously** within its stage scope while the user monitors and can intervene at any time. Unlike HITL, the agent does not pause and wait — it continues executing while the user observes.
+
+HOTL applies within a stage when the agent is doing work the user has authorised: drafting a requirements document, running tests, writing implementation code. The agent is trusted to complete the work within its defined scope; the user reviews the result when it is done.
+
+## In the UI
+
+A feature in HOTL mode shows `● Working` in the fleet dashboard, with a live session feed showing what the agent is doing in plain language. Inline Pause and Redirect controls are always available — the user can intervene at any point without waiting for the agent to finish.
+
+## HOTL invariant
+
+Even in HOTL mode, Specorator maintains the H-ACD principle: no vault write is applied without user review, and no stage advances without explicit user approval. HOTL means the agent works without constant interruption; it does not mean the agent has unchecked authority.
+
+## HITL vs HOTL relationship
+
+The two modes work together across the ADLC:
+
+```
+Stage N (agent working on draft)     → HOTL: agent executes, user monitors
+Stage N complete (draft ready)       → HITL: agent pauses, user reviews draft
+Gate: advance to stage N+1?          → HITL: user decides explicitly
+Stage N+1 (agent working on next)    → HOTL: agent executes again
+```
+
+A feature alternates between HOTL (execution) and HITL (governance gates) as it moves through the pipeline.
+
+## v1 note
+
+In v1 with the Claude CLI chat sidebar, HOTL is implicit — the user sends a message and the assistant works. The HOTL/HITL distinction becomes explicit in v2.0 when `specorator-runtime` orchestrates autonomous multi-step sessions that can run for minutes without user interaction.

--- a/docs/glossary/human-authority.md
+++ b/docs/glossary/human-authority.md
@@ -1,0 +1,36 @@
+---
+term: "Human authority over outcomes"
+aliases: ["human authority"]
+category: governance
+status: stable
+version: "v1 and v2.0"
+related:
+  - h-acd.md
+  - workflow-encapsulation.md
+  - hitl.md
+  - proposed-output.md
+  - accepted-output.md
+issues:
+  - "#164"
+last_updated: 2026-05-05
+---
+
+# Human authority over outcomes
+
+One of the four H-ACD principles. The user retains full authority at every stage transition. Agents propose; humans decide. Nothing is written to the vault, advanced to the next stage, or committed without the user's explicit approval.
+
+This is not a safety feature bolted onto an autonomous system — it is the product model. The user is the director; agents are the execution team. The principle holds in v1 (conversational) and v2.0 (orchestrated), and it applies at every level of the governance hierarchy.
+
+## What this means in practice
+
+When an agent generates code, the user sees a plain-language summary of what was built and why — not raw source files — and decides: accept, request changes, or redirect. When tests run, the user sees "7 of 8 passed; here's what needs fixing" — not test output — and decides whether they are ready to ship. The decision is always theirs; the execution was the agent's.
+
+## What this principle forbids
+
+- Autonomous stage advancement (the agent cannot move a feature to the next stage without user approval)
+- Unreviewed vault writes (every proposed write is displayed and awaits acceptance before being applied)
+- Silent state changes (every governance event is visible and reversible before it is committed)
+
+## Relationship to HITL
+
+Human authority over outcomes is the principle; HITL is the mechanism. Every stage gate is a HITL checkpoint — the agent pauses, the user decides, the pipeline only advances on explicit approval. See [hitl.md](./hitl.md).

--- a/docs/glossary/intent-first.md
+++ b/docs/glossary/intent-first.md
@@ -1,0 +1,38 @@
+---
+term: "Intent-first interaction"
+aliases: ["intent-first"]
+category: governance
+status: stable
+version: "v1 and v2.0"
+related:
+  - h-acd.md
+  - workflow-encapsulation.md
+  - chat-sidebar.md
+issues:
+  - "#164"
+  - "#161"
+last_updated: 2026-05-05
+---
+
+# Intent-first interaction
+
+One of the four H-ACD principles. The user expresses what they want; the system handles the how. Users never need to think about how to phrase a prompt, what context to provide, which agent to invoke, or what stage they should be at. Specorator assembles and injects the right context automatically.
+
+## In practice
+
+Opening the chat sidebar and typing "help me think through this" is enough. The sidebar already knows the user's persona (from onboarding), the active note (from the workspace), the current workflow stage (from `workflow-state.md`), and the expected next steps (from the ADLC stage definition). The user brings the direction; the system brings the context.
+
+## What this principle forbids
+
+- Requiring the user to select an agent, model, or capability before getting help
+- Requiring the user to specify stage context or attach files manually in normal use
+- Prompting the user with methodology-specific questions ("What stage are you in?")
+- Asking the user to configure context injection or prompt templates
+
+## v1 implementation
+
+In v1, intent-first is implemented through the five-layer context assembly in the Claude CLI chat sidebar: persona (Layer 0), active file (Layer 1), workflow stage (Layer 2), optional attached notes (Layer 3), and vault metadata (Layer 4). The user sees none of this assembly — they just open the sidebar and start talking.
+
+## v2.0 extension
+
+In v2.0, intent-first extends to multi-step agentic sessions: the user approves a stage goal ("let's figure out what to build"), and `specorator-runtime` handles agent selection, context assembly, tool invocation, and session management. The user expresses intent once; the system executes until it has a proposal ready for review.

--- a/docs/glossary/mcp-server.md
+++ b/docs/glossary/mcp-server.md
@@ -1,0 +1,47 @@
+---
+term: "MCP server"
+aliases: ["Obsidian MCP server", "ObsidianMcpServer", "native MCP server"]
+category: technical
+status: draft
+version: "v1 and v2.0"
+related:
+  - vault-as-operating-environment.md
+  - narrow-port.md
+  - claude-cli-port.md
+  - runtime-port.md
+  - artifact.md
+issues:
+  - "#165"
+  - "#161"
+  - "#163"
+last_updated: 2026-05-05
+---
+
+# MCP server
+
+The native Obsidian MCP (Model Context Protocol) server that Specorator runs inside the plugin process, with full access to Obsidian's internal APIs. It is the mechanism through which all agents — Claude CLI in v1, `agentonomous` agents in v2.0 — interact with the vault.
+
+The MCP server exposes a structured tool surface: vault read/write, frontmatter manipulation, wikilink graph traversal, Canvas operations, Bases queries, and Specorator-specific workflow tools. Claude CLI connects to it as an MCP client; all vault operations go through these tools rather than through ad-hoc file system access.
+
+## Why native
+
+Running the MCP server inside the plugin (not as a separate process or REST intermediary) gives it full access to Obsidian's internal APIs: `MetadataCache`, `Canvas`, `Bases`, `WorkspaceLeaf`, and the complete `App` and `Vault` object graph. This is the difference between an MCP server that knows about Obsidian and one that *is* Obsidian.
+
+## Tool catalogue (summary)
+
+- **Vault tools** — `vault_read_note`, `vault_write_note`, `vault_append_to_note`, `vault_search`, `vault_list_folder`
+- **Frontmatter tools** — `frontmatter_get`, `frontmatter_set_field`, `frontmatter_set_many`
+- **Graph tools** — `links_get_outgoing`, `links_get_backlinks`, `links_resolve`, `graph_traverse`
+- **Canvas tools** — `canvas_read`, `canvas_add_text_node`, `canvas_add_file_node`, `canvas_add_edge`
+- **Bases tools** — `bases_query`, `bases_get_record`, `bases_update_record`
+- **Workflow tools** — `workflow_get_state`, `workflow_list_features`, `workflow_propose_advance`, `workflow_get_quality_gates`
+
+Write tools go through the accept/reject flow — no vault write is applied without user approval.
+
+## Accept/reject flow
+
+When an agent calls a write tool, the MCP server queues the operation as a **pending proposal** and returns a receipt. The chat sidebar displays the proposal for user review. On acceptance, the write is applied through the appropriate narrow port. On rejection, the agent receives a rejection signal and may propose an alternative.
+
+## Full specification
+
+Issue #165.

--- a/docs/glossary/narrow-port.md
+++ b/docs/glossary/narrow-port.md
@@ -1,0 +1,51 @@
+---
+term: "Narrow port"
+aliases: ["port", "narrow ports", "ADR-008"]
+category: technical
+status: stable
+version: "v1 and v2.0"
+related:
+  - mcp-server.md
+  - claude-cli-port.md
+  - runtime-port.md
+issues:
+  - "#99"
+  - "#163"
+last_updated: 2026-05-05
+---
+
+# Narrow port
+
+A focused TypeScript interface in `src/domain/ports/` that exposes exactly the Obsidian API surface needed for one concern. Each port has one job; consumers depend on one port per dependency; there is no aggregate interface that bundles multiple concerns.
+
+Specorator defines five narrow ports for Obsidian API access:
+
+| Port | Concern |
+|---|---|
+| `SettingsPort` | `getSettings`, `saveSettings` |
+| `VaultPort` | File read/write/delete/list/exists/createFolder |
+| `WorkspacePort` | `openFile` |
+| `NotificationPort` | `showError`, `showWarning`, `showSuccess`, `showInfo` |
+| `LoggerPort` | `debug`, `info`, `warn`, `error` |
+
+W13 (#163) adds `MetadataCachePort`, `CanvasPort`, and `ClaudeCliPort` as the Phase 4 feature set requires.
+
+## Why narrow
+
+A broad interface (`IBridge`) that exposes everything fails in two ways: components import more than they need (coupling), and mocking in tests requires implementing the entire surface even when only one method is used. Narrow ports make each dependency explicit and each mock minimal.
+
+## Three implementations
+
+Each port has three concrete implementations:
+
+- `ObsidianBridge` — production, wraps `App` and `Vault`
+- `MockBridge` — unit tests and `npm run dev`
+- `LocalStorageBridge` — GitHub Pages demo
+
+## ESLint enforcement
+
+`no-restricted-imports` forbids re-introducing the deleted `IBridge`, `BridgeKey`, and `useBridge` symbols. Vue components may not import `obsidian` directly.
+
+## Reference
+
+ADR-008 (`docs/adr/ADR-008-narrow-ports-supersede-ibridge.md`).

--- a/docs/glossary/open-question.md
+++ b/docs/glossary/open-question.md
@@ -1,0 +1,33 @@
+---
+term: "Open question"
+aliases: ["OQ", "open questions"]
+category: workflow
+status: stable
+version: "v1 and v2.0"
+related:
+  - decision-note.md
+  - artifact.md
+  - workflow-stage.md
+issues:
+  - "#1"
+last_updated: 2026-05-05
+---
+
+# Open question (OQ)
+
+A documented uncertainty or unresolved decision point logged during a feature's workflow. Open questions are tracked as Markdown artifacts in the vault, can be resolved collaboratively or escalated to a decision note, and remain visible in the workflow state until resolved.
+
+## Why open questions are first-class
+
+Unresolved decisions left implicit are the most common source of rework in product delivery. Making open questions explicit and trackable — as named vault artifacts with their own workflow state — forces resolution before they become problems downstream. An open question about a requirements assumption that surfaces at the requirements stage is dramatically cheaper to resolve than the same ambiguity discovered at the implementation stage.
+
+## Lifecycle
+
+1. **Logged** — identified during work on a stage; written to the vault as a Markdown note with frontmatter
+2. **Assigned** — optionally assigned to a person or role for resolution
+3. **Resolved** — answered with a documented resolution; status updated to `resolved`
+4. **Escalated** — if the question requires a formal decision, promoted to a decision note
+
+## Relationship to decision notes
+
+An open question becomes a decision note when it requires a formal, documented decision with options considered and rationale recorded. Not all open questions reach this threshold — routine clarifications can be resolved inline.

--- a/docs/glossary/oversight-mode.md
+++ b/docs/glossary/oversight-mode.md
@@ -1,0 +1,42 @@
+---
+term: "Oversight mode"
+aliases: []
+category: governance
+status: stable
+version: "v2.0"
+related:
+  - hitl.md
+  - hotl.md
+  - fleet-dashboard.md
+  - h-acd.md
+issues:
+  - "#164"
+  - "#168"
+last_updated: 2026-05-05
+---
+
+# Oversight mode
+
+The current relationship between the user and an active agent session for a given feature. Specorator surfaces exactly two oversight modes: **HITL** (Human-in-the-Loop) and **HOTL** (Human-on-the-Loop).
+
+The oversight mode for each feature is always visible in the fleet dashboard as a status indicator on the feature row. The user is never uncertain about whether an agent is waiting for them or working autonomously.
+
+## Mode states
+
+| Indicator | Mode | Meaning |
+|---|---|---|
+| `↩ Waiting for you` | HITL | Agent suspended; user action required to proceed |
+| `● Working` | HOTL | Agent executing autonomously; user can interrupt |
+| `⏸ Paused` | — | Session manually paused by user; can be resumed |
+| `✓ Done` | — | Stage complete; no active session |
+| `⚠ Needs attention` | — | Session failed or blocked; user decision required |
+
+## Why oversight mode must be explicit
+
+Most agentic tools do not distinguish between HITL and HOTL — the user cannot tell whether the system is waiting for them or working independently. This creates uncertainty: did the agent stop because it finished, or because it hit a problem, or because it is waiting for input?
+
+Specorator makes the distinction explicit because governance depends on it. A user who does not know the system is in HITL mode may wait indefinitely for progress that will never come. A user who does not know the system is in HOTL mode may feel anxious about unsupervised activity. Clarity about oversight mode is a product requirement, not a nice-to-have.
+
+## Stored in the session log
+
+The oversight mode for each session is recorded in the session log's frontmatter as `oversight-mode: HITL` or `oversight-mode: HOTL`, along with the redirect count. This makes the governance history of each stage queryable from the vault.

--- a/docs/glossary/pipeline.md
+++ b/docs/glossary/pipeline.md
@@ -1,0 +1,41 @@
+---
+term: "Pipeline"
+aliases: ["ADLC pipeline", "workflow pipeline"]
+category: workflow
+status: stable
+version: "v1 and v2.0"
+related:
+  - adlc.md
+  - workflow-stage.md
+  - gate.md
+  - fleet-dashboard.md
+  - hitl.md
+issues:
+  - "#164"
+  - "#168"
+last_updated: 2026-05-05
+---
+
+# Pipeline
+
+The mental model for understanding how a feature moves through the twelve ADLC stages. Each feature is conceptually a "build" running through a pipeline: it enters at `idea`, passes through stages with agent execution and human governance gates, and exits at `retrospective`.
+
+This framing maps intentionally to CI/CD pipelines in software delivery. Just as a CI pipeline defines stages (lint → test → build → deploy) with pass/fail gates between them, the ADLC defines stages (idea → research → requirements → … → retrospective) with human approval gates between them. The difference is who approves the gates: in CI/CD, automated checks; in the ADLC, the user — always.
+
+## Why the pipeline model matters
+
+The pipeline model makes the governance structure explicit:
+
+- **Stages** are units of execution (agents work within a stage)
+- **Gates** are units of governance (the user decides at the boundary)
+- **The fleet dashboard** is the pipeline monitor (all features, all stages, one view)
+
+Without this mental model, the ADLC can feel like a vague checklist. With it, every interaction has a clear place: either you are inside a stage (agent working or awaiting review) or you are at a gate (user deciding whether to advance).
+
+## The pipeline as a portfolio view
+
+When N features are active simultaneously, the portfolio IS a set of parallel pipelines. The fleet dashboard renders this as a matrix: features as rows, stages as columns, each cell showing the current state of that stage for that feature. The user can scan the entire portfolio at a glance and see where their attention is needed.
+
+## Ambiguity note
+
+"Pipeline" can refer to a CI/CD pipeline (GitHub Actions workflow), the ADLC feature pipeline, or a data processing pipeline. In Specorator documentation, "pipeline" without qualification means the ADLC feature pipeline unless the context clearly indicates otherwise.

--- a/docs/glossary/proposed-output.md
+++ b/docs/glossary/proposed-output.md
@@ -1,0 +1,43 @@
+---
+term: "Proposed output"
+aliases: ["proposal", "agent proposal", "pending proposal"]
+category: ui
+status: stable
+version: "v1 and v2.0"
+related:
+  - accepted-output.md
+  - human-authority.md
+  - hitl.md
+  - artifact.md
+  - mcp-server.md
+issues:
+  - "#164"
+  - "#165"
+last_updated: 2026-05-05
+---
+
+# Proposed output
+
+An artifact, patch, document, or vault write operation that an agent has generated and queued for user review. Proposed outputs do not become durable vault content until the user explicitly accepts them.
+
+The proposed output mechanism is the technical implementation of H-ACD's human authority principle: agents produce; humans decide. Every agent action that would modify the vault is expressed as a proposed output first.
+
+## How proposals surface
+
+In v1, the chat sidebar displays a **proposal review card** when the agent has generated something for the user to review: a note to create, a frontmatter field to update, a canvas node to add. The card shows what will change, where, and why (the agent's plain-language reasoning). The user accepts, requests changes, or rejects.
+
+In v2.0, proposals can be batched: a multi-step agent session may produce several related proposals (a requirements document + two frontmatter updates + a wikilink) presented as a single batch review.
+
+## Proposal types
+
+| Type | Example | Review format |
+|---|---|---|
+| Note creation | Create `requirements.md` with draft content | Full document preview |
+| Note update | Append a section to `design.md` | Diff view |
+| Frontmatter update | Set `review-status: approved` in `spec.md` | Field-level change summary |
+| Canvas addition | Add a node to `features.canvas` | Canvas diff card |
+| Stage advancement | Advance `auth-flow` from `design` to `spec` | Stage transition confirmation |
+
+## Relationship to MCP write tools
+
+The MCP server intercepts all agent write tool calls, queues them as pending proposals, and returns a receipt to the agent. The agent continues working (in HOTL mode) or pauses (in HITL mode) until the user reviews. See [mcp-server.md](./mcp-server.md).

--- a/docs/glossary/runtime-port.md
+++ b/docs/glossary/runtime-port.md
@@ -1,0 +1,32 @@
+---
+term: "RuntimePort"
+aliases: ["runtime-port", "RuntimePort interface"]
+category: technical
+status: draft
+version: "v2.0"
+related:
+  - claude-cli-port.md
+  - specorator-runtime.md
+  - narrow-port.md
+  - chat-sidebar.md
+issues:
+  - "#23"
+  - "#161"
+last_updated: 2026-05-05
+---
+
+# RuntimePort
+
+The v2.0 replacement for `ClaudeCliPort`. A narrow port interface that routes the chat sidebar's messages through `specorator-runtime` rather than the Claude CLI subprocess, enabling stateful orchestrated multi-agent sessions while keeping the sidebar UI unchanged.
+
+`RuntimePort` satisfies the same interface contract as `ClaudeCliPort` — `isAvailable()` and `sendMessage()` — so the binding swap is a one-line change at the plugin's composition root with no UI impact.
+
+## What changes in v2.0
+
+Behind `RuntimePort`, `specorator-runtime` maintains full session state, routes to the appropriate `agentonomous` agent for the current workflow stage, emits typed events to the fleet dashboard, persists session context across Obsidian restarts, and writes session logs to the vault automatically.
+
+From the sidebar's perspective, nothing changes: it calls `sendMessage()` and receives streaming token chunks. The orchestration complexity is entirely behind the port.
+
+## Not yet implemented
+
+`RuntimePort` is a planned interface. Its specification is derived from the `ClaudeCliPort` contract and the `specorator-runtime` event model. See issue #23 for the v2.0 scope.

--- a/docs/glossary/scaffold.md
+++ b/docs/glossary/scaffold.md
@@ -1,0 +1,40 @@
+---
+term: "Scaffold"
+aliases: ["project scaffold", "feature scaffold"]
+category: workflow
+status: stable
+version: "v1 and v2.0"
+related:
+  - feature.md
+  - artifact.md
+  - workflow-state.md
+issues:
+  - "#1"
+  - "#162"
+last_updated: 2026-05-05
+---
+
+# Scaffold
+
+The initial set of folders and template files created when the user starts a new feature through the plugin. The scaffold establishes the feature's vault structure and creates the `workflow-state.md` state file and the first stage artifact (`idea.md`).
+
+## What scaffolding creates
+
+For a new feature with slug `auth-flow`:
+
+```
+specs/
+└── auth-flow/
+    ├── workflow-state.md       ← created with initial frontmatter
+    └── idea.md                 ← Stage 1 artifact, ready to fill in
+```
+
+Subsequent stage artifacts are created lazily — only when the user advances to that stage — rather than all at once. This prevents an overwhelming folder of empty files and means every present file represents real work.
+
+## Overwrite protection
+
+If any scaffold file already exists when a scaffold operation runs, Specorator shows a notice and skips creation for that file without overwriting. This is a hard requirement (REQ-AVS-005) that applies equally to manual scaffold operations and agent-proposed scaffold writes.
+
+## Template installation vs feature scaffold
+
+Template installation (see the onboarding flow) installs the `agentic-workflow` template into the vault — creating the folder structure, AGENTS instructions, and process docs. Feature scaffolding creates the per-feature folder under `specs/` for a single new feature. These are distinct operations.

--- a/docs/glossary/session-log.md
+++ b/docs/glossary/session-log.md
@@ -1,0 +1,56 @@
+---
+term: "Session log"
+aliases: ["agent session log"]
+category: workflow
+status: draft
+version: "v2.0"
+related:
+  - traceability-chain.md
+  - artifact.md
+  - proposed-output.md
+  - oversight-mode.md
+  - fleet-dashboard.md
+issues:
+  - "#169"
+  - "#23"
+last_updated: 2026-05-05
+---
+
+# Session log
+
+A plain Markdown vault artifact that records what happened during a single agent session on a feature stage: what context the agent worked from, what decisions it made and why, what it proposed, and what the user accepted, rejected, or redirected. Session logs are stored at `specs/{slug}/sessions/{stage}-session-{timestamp}.md`.
+
+Session logs are the audit trail. They are the mechanism that makes agent reasoning inspectable and the traceability chain complete. Without session logs, the vault contains outputs but not the reasoning that produced them.
+
+## Schema
+
+```yaml
+---
+feature: auth-flow
+stage: requirements
+session-id: sess-2026-05-05-1437
+agent-role: PM agent
+started-at: 2026-05-05T14:37:00Z
+completed-at: 2026-05-05T15:02:00Z
+outcome: proposal-accepted      # proposal-accepted | proposal-rejected | redirected | abandoned | interrupted
+oversight-mode: HOTL            # HITL | HOTL
+redirect-count: 0
+---
+```
+
+The body contains plain-language sections: context loaded, key decisions, proposal reference, and user outcome.
+
+## What session logs enable
+
+- **Auditability** — for any vault artifact, the user can find the session that produced it and understand the reasoning behind it
+- **Context continuity** — a new agent session on the same feature reads prior session logs to understand what was tried, accepted, and deferred
+- **Fleet dashboard health signals** — redirect-count, outcome, and elapsed time are queryable via `workflow_list_features` and `bases_query`
+- **Retrospective input** — session logs for all twelve stages feed into the Stage 12 retrospective; the agent can synthesise the full project decision history from them
+
+## v1 approximation
+
+In v1, after a Claude CLI session proposes an artifact, the chat sidebar shows a session summary card. This summary is stored as a lightweight session log. Full structured session logs with queryable frontmatter are a v2.0 capability when `specorator-runtime` manages sessions.
+
+## Full specification
+
+Issue #169.

--- a/docs/glossary/specorator-runtime.md
+++ b/docs/glossary/specorator-runtime.md
@@ -1,0 +1,36 @@
+---
+term: "specorator-runtime"
+aliases: ["runtime", "the runtime"]
+category: ecosystem
+status: draft
+version: "v2.0"
+related:
+  - agentonomous.md
+  - runtime-port.md
+  - companion-app.md
+  - session-log.md
+  - fleet-dashboard.md
+issues:
+  - "#23"
+last_updated: 2026-05-05
+---
+
+# specorator-runtime
+
+The v2.0 orchestration engine that interprets the active workflow definition for a feature, resolves the task graph, invokes the appropriate `agentonomous` agent at each ADLC stage, manages session state, and emits typed events to the Specorator plugin. Published as an npm library consumed by the plugin. **Not implemented in v1.**
+
+## What specorator-runtime does
+
+- **Stage resolution** — determines which agent to invoke based on the current workflow stage
+- **Session management** — starts, resumes, pauses, and cancels agent sessions; persists session state across Obsidian restarts
+- **Event streaming** — emits typed events (stage progress, proposed outputs, session log entries) to the plugin's event bus for real-time fleet dashboard updates
+- **Session log generation** — writes session logs to the vault at `specs/{slug}/sessions/` automatically on session close
+- **`RuntimePort` implementation** — satisfies the `ClaudeCliPort`-compatible interface so the sidebar UI requires no changes
+
+## Relationship to the plugin
+
+The plugin subscribes to `specorator-runtime`'s event stream and renders execution state in the chat sidebar and fleet dashboard in real time. `specorator-runtime` is an internal implementation detail; the user never knows it exists.
+
+## v1 status
+
+Not implemented. The v1 `ClaudeCliPort` is the designed upgrade seam that `RuntimePort` (backed by `specorator-runtime`) replaces in v2.0.

--- a/docs/glossary/specorator.md
+++ b/docs/glossary/specorator.md
@@ -1,0 +1,33 @@
+---
+term: "Specorator"
+aliases: []
+category: core
+status: stable
+version: "v1 and v2.0"
+related:
+  - companion-app.md
+  - agentic-workflow.md
+  - cockpit.md
+issues:
+  - "#1"
+  - "#164"
+last_updated: 2026-05-05
+---
+
+# Specorator
+
+The Obsidian plugin described in this repository. Specorator surfaces the `agentic-workflow` methodology inside Obsidian, providing workflow navigation, artifact creation, and AI-assisted collaboration through every stage of the product development lifecycle — from idea to tested, shipped code.
+
+The name is a portmanteau of *spec* and *decorator*: Specorator layers workflow structure and AI assistance onto a vault without owning the underlying content. Everything it produces is plain Markdown that remains useful without the plugin installed.
+
+## v1
+
+In v1, Specorator installs the `agentic-workflow` template into a vault and provides a workflow navigator and a Claude CLI chat sidebar. The user governs their work through a conversational interface; the plugin handles context assembly, stage tracking, and artifact creation.
+
+## v2.0
+
+In v2.0, Specorator becomes a fully orchestrated companion: `specorator-runtime` coordinates specialised `agentonomous` agents through each workflow stage, the fleet dashboard shows all active features and their pipeline state simultaneously, and the user steers the agentic workforce from a single cockpit inside Obsidian.
+
+## What does not change between versions
+
+The vault remains the source of truth. All outputs are plain Markdown. The user's authority over every stage transition is unconditional. The UI vocabulary never exposes technical internals to the user.

--- a/docs/glossary/traceability-chain.md
+++ b/docs/glossary/traceability-chain.md
@@ -1,0 +1,68 @@
+---
+term: "Traceability chain"
+aliases: ["traceability", "end-to-end traceability"]
+category: workflow
+status: draft
+version: "v1 and v2.0"
+related:
+  - session-log.md
+  - artifact.md
+  - workflow-state.md
+  - fleet-dashboard.md
+  - vault-as-operating-environment.md
+issues:
+  - "#169"
+  - "#164"
+last_updated: 2026-05-05
+---
+
+# Traceability chain
+
+The complete, navigable link from a feature's root issue through every stage artifact to the final retrospective note, where every node references the ones before and after it via vault `[[wikilinks]]`. The traceability chain is the property that makes the vault an audit trail rather than a file collection.
+
+## The chain
+
+For any feature with slug `auth-flow`, the chain runs:
+
+```
+Root issue (#161)
+  └── specs/auth-flow/idea.md                    (Stage 1)
+  └── specs/auth-flow/workflow-state.md           (canonical state; references all artifacts)
+  └── specs/auth-flow/research.md                 (Stage 2)
+  └── specs/auth-flow/requirements.md             (Stage 3)
+  └── specs/auth-flow/design.md                   (Stage 4)
+  └── specs/auth-flow/spec.md                     (Stage 5)
+  └── specs/auth-flow/tasks.md                    (Stage 6)
+  └── specs/auth-flow/implementation-log.md       (Stage 7)
+  └── specs/auth-flow/test-plan.md                (Stage 8)
+  └── specs/auth-flow/test-report.md              (Stage 9)
+  └── specs/auth-flow/review.md                   (Stage 10)
+  └── specs/auth-flow/release-notes.md            (Stage 11)
+  └── specs/auth-flow/retrospective.md            (Stage 12)
+  └── specs/auth-flow/sessions/                   (session logs for each stage)
+```
+
+Every artifact in this chain links to related artifacts via `[[wikilinks]]`, so the relationship enters Obsidian's knowledge graph as first-class backlinks.
+
+## Why traceability is a requirement, not a feature
+
+Without a complete traceability chain:
+
+- The fleet dashboard cannot reconstruct the state of any feature from vault data alone
+- Agents starting a new session cannot discover what was decided in prior sessions
+- The user cannot answer "how did we get here?" for any stage output
+- The retrospective agent cannot synthesise the project's full decision history
+
+Traceability is the property that makes the vault the authoritative source of truth rather than a collection of disconnected files.
+
+## The mechanism: `workflow-state.md`
+
+`workflow-state.md` is the anchor of the traceability chain. Its frontmatter references every stage artifact and session log, stores the root issue number, and links parent and child features. It is the single file from which the complete chain can be reconstructed without graph traversal.
+
+## The mechanism: wikilinks
+
+Every stage artifact links to adjacent artifacts and related decisions via `[[wikilinks]]`. This means Obsidian's backlink graph encodes the traceability chain as a navigable knowledge graph — the user can follow the chain in either direction from any note.
+
+## Full specification
+
+Issue #169.

--- a/docs/glossary/vault-as-operating-environment.md
+++ b/docs/glossary/vault-as-operating-environment.md
@@ -1,0 +1,50 @@
+---
+term: "Vault as the agentic operating environment"
+aliases: ["vault-first", "vault as operating environment"]
+category: governance
+status: stable
+version: "v1 and v2.0"
+related:
+  - h-acd.md
+  - mcp-server.md
+  - artifact.md
+  - traceability-chain.md
+  - workflow-state.md
+issues:
+  - "#164"
+  - "#165"
+last_updated: 2026-05-05
+---
+
+# Vault as the agentic operating environment
+
+One of the four H-ACD principles. The Obsidian vault is not a storage location for agent outputs — it is the primary workspace where all agents operate. Agents read from the vault to understand context, write to it to produce results, and navigate its knowledge graph to discover relationships. Every agent capability is implemented through Obsidian's own data model.
+
+This principle distinguishes Specorator from tools that happen to run inside Obsidian. Specorator is *of* Obsidian: agents use wikilinks as their relationship graph, frontmatter as their structured database, Canvas as their visual workspace, and Bases as their query layer.
+
+## The four Obsidian data surfaces
+
+| Surface | How agents use it |
+|---|---|
+| **Markdown** | Native read/write; headings, callouts, tasks, code fences, embeds |
+| **Frontmatter** | First-class structured data; field updates are non-destructive and schema-aware |
+| **Wikilinks** | Graph relationships; every artifact-to-artifact connection is a proper `[[wikilink]]`, not a file path |
+| **Canvas** | Visual workspace; agents can read canvas structure and propose new cards and connections |
+| **Bases** | Structured query layer; agents query and update frontmatter properties that Bases reflects |
+
+## The mechanism
+
+Specorator implements a native **MCP server** running inside the plugin with full access to Obsidian's internal APIs. All agent-to-vault interactions go through this server — never through ad-hoc file paths or system prompt injection. Claude CLI connects to the MCP server as a client; `agentonomous` agents connect to the same server in v2.0.
+
+See [mcp-server.md](./mcp-server.md) for the full tool surface.
+
+## Why this matters
+
+Because agents interact with the vault through Obsidian's own data model, every agent output:
+
+- Is a valid Obsidian note that works without the plugin installed
+- Enters the knowledge graph as first-class content with backlinks
+- Is queryable by Bases without special configuration
+- Respects the vault's existing structure and conventions
+
+The vault grows richer with every agent interaction — not as a side effect, but as a design requirement.

--- a/docs/glossary/workflow-encapsulation.md
+++ b/docs/glossary/workflow-encapsulation.md
@@ -1,0 +1,43 @@
+---
+term: "Workflow encapsulation"
+aliases: []
+category: governance
+status: stable
+version: "v1 and v2.0"
+related:
+  - h-acd.md
+  - human-authority.md
+  - intent-first.md
+  - workflow-stage.md
+  - adlc.md
+issues:
+  - "#164"
+last_updated: 2026-05-05
+---
+
+# Workflow encapsulation
+
+One of the four H-ACD principles. The methodology complexity of the ADLC — stage slugs, artifact types, frontmatter schema, agent routing, quality gate logic — is hidden inside Specorator. The user experiences the outcomes of the methodology without touching its machinery.
+
+## What this means in practice
+
+The user says "I want to figure out what to build." Specorator determines the current stage, assembles the appropriate context, routes to the right agent capability, and returns "here's a draft of what you described — what do you think?" The twelve-stage ADLC executed; the user never saw it.
+
+From the user's perspective, they are having a conversation about their work. From Specorator's perspective, every message is contextualised by stage, feature, persona, vault state, and workflow expectations — none of which the user had to specify.
+
+## What encapsulation forbids
+
+Any feature, interaction, or piece of copy that exposes the following to the user violates workflow encapsulation and must be redesigned:
+
+- Stage slugs (`idea`, `requirements`, `implementation-log`) in user-facing text
+- Artifact type names or frontmatter keys
+- Agent role names, model names, or prompt engineering terminology
+- Workflow state machine transitions or gate logic
+
+## Encapsulation vs hiding
+
+Encapsulation is not about deceiving the user. Users who want to understand the methodology can read the `agentic-workflow` documentation. The plugin simply does not require them to. The goal is that the methodology serves the user — the user does not serve the methodology.
+
+## Reference
+
+[Workflow Encapsulation in H-ACD](https://www.designative.info/2025/12/16/workflow-encapsulation-in-human-agent-centered-design-from-doing-work-to-governing-outcomes/)

--- a/docs/glossary/workflow-navigator.md
+++ b/docs/glossary/workflow-navigator.md
@@ -1,0 +1,35 @@
+---
+term: "Workflow navigator"
+aliases: ["navigator", "workflow navigation view"]
+category: ui
+status: stable
+version: "v1"
+related:
+  - cockpit.md
+  - fleet-dashboard.md
+  - workflow-stage.md
+  - workflow-state.md
+issues:
+  - "#47"
+  - "#1"
+last_updated: 2026-05-05
+---
+
+# Workflow navigator
+
+The v1 sidebar or panel view that surfaces workflow state for a single feature: active project, current stage (in plain language), which artifacts are present, next required artifacts, and controls for opening or creating workflow files. Implemented as a Vue 3 component in the isolated browser runtime.
+
+## What the navigator shows
+
+- The active feature's name and its current stage as a plain-language label (never a slug)
+- A visual progress strip showing which stages are done, current, and upcoming
+- Quick-access links to the current stage's artifact and related notes
+- A "what comes next?" prompt tailored to the current stage
+
+## Relationship to the fleet dashboard
+
+The workflow navigator is the **per-feature pipeline view** — it shows one feature at a time. The fleet dashboard (v2.0, #168) extends this concept to N features simultaneously. The navigator is the v1 foundation; the fleet dashboard is the v2.0 evolution. The data model and visual conventions established in the navigator carry forward unchanged.
+
+## Roadmap
+
+The workflow navigator ships in Phase 4 Increment 2 (see #47). It is the Specorator UI component that first establishes the "pipeline" mental model for users.

--- a/docs/glossary/workflow-stage.md
+++ b/docs/glossary/workflow-stage.md
@@ -1,0 +1,50 @@
+---
+term: "Workflow stage"
+aliases: ["stage", "ADLC stage"]
+category: workflow
+status: stable
+version: "v1 and v2.0"
+related:
+  - adlc.md
+  - pipeline.md
+  - gate.md
+  - artifact.md
+  - workflow-state.md
+issues:
+  - "#1"
+  - "#161"
+last_updated: 2026-05-05
+---
+
+# Workflow stage
+
+One of the twelve named phases in the ADLC through which a feature progresses. Each stage has a slug (the internal identifier), a plain-language label (what users see), an agent role, expected artifacts, and a quality gate before the next stage begins.
+
+## Stage slugs and plain labels
+
+| Slug | Plain label |
+|---|---|
+| `idea` | Exploring the idea |
+| `research` | Understanding the space |
+| `requirements` | Defining what to build |
+| `design` | Figuring out how it works |
+| `spec` | Writing it all down |
+| `tasks` | Planning the work |
+| `implementation-log` | Building it |
+| `test-plan` | Making sure it works |
+| `test-report` | What we found |
+| `review` | Getting a second opinion |
+| `release-notes` | Telling people what changed |
+| `retrospective` | What we learned |
+
+## User-facing rule
+
+Stage slugs **never appear in user-facing text**. The UI always uses plain labels. This is a workflow encapsulation requirement enforced via ESLint and design review.
+
+## Stage artifacts
+
+Each stage has one canonical artifact file created lazily when the user advances to that stage. The file lives at `specs/{slug}/{stage-slug}.md`. If the file already exists when a stage begins, Specorator shows a notice and skips creation without overwriting (overwrite protection, REQ-AVS-005).
+
+## Ambiguity note
+
+"Stage" and "step" are sometimes used interchangeably in older documentation. Prefer "stage" for the twelve ADLC phases; "step" is a deprecated synonym from an earlier design iteration.

--- a/docs/glossary/workflow-state.md
+++ b/docs/glossary/workflow-state.md
@@ -1,0 +1,52 @@
+---
+term: "Workflow state"
+aliases: ["workflow-state.md", "feature state"]
+category: workflow
+status: stable
+version: "v1 and v2.0"
+related:
+  - feature.md
+  - artifact.md
+  - traceability-chain.md
+  - workflow-stage.md
+  - gate.md
+issues:
+  - "#165"
+  - "#169"
+last_updated: 2026-05-05
+---
+
+# Workflow state
+
+The current status of a feature as derived from vault Markdown content: which stage it is in, which artifacts are present, which gates have passed, and how it connects to related features and its root issue. Workflow state is read from the vault, not from plugin-private storage.
+
+## The canonical state file
+
+Every feature has a `workflow-state.md` file at `specs/{slug}/workflow-state.md`. This file's YAML frontmatter is the anchor of the feature's traceability chain:
+
+```yaml
+---
+feature: auth-flow
+slug: auth-flow
+current_stage: requirements
+root_issue: "161"
+parent_feature: ""
+child_features: []
+artifacts:
+  idea:         { status: accepted, path: idea.md, session: sessions/idea-session-20260504.md }
+  research:     { status: accepted, path: research.md, session: sessions/research-session-20260504.md }
+  requirements: { status: proposed, path: requirements.md, session: sessions/requirements-session-20260505.md }
+quality_gate_status:
+  idea: passed
+  research: passed
+  requirements: pending
+---
+```
+
+## Why state lives in the vault
+
+Plugin-private state (Obsidian's `data.json`) is opaque to agents and unavailable in browser mode. Vault-derived state is readable by any agent through `workflow_get_state` and `frontmatter_get`, queryable by Bases, and inspectable by the user as plain Markdown. It is also portable: copying the `specs/` folder moves the full feature state with it.
+
+## Ambiguity note
+
+"State" can mean workflow state (vault-derived feature status) or plugin settings state (stored in Obsidian's `loadData`/`saveData`). Always use "workflow state" for vault-derived feature status and "plugin settings" or "plugin data" for stored configuration.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

This PR captures the CI/CD pipeline monitoring vision — the idea that N active features each run through the 12-stage ADLC like a pipeline, the user can see and steer all of them from a single cockpit, and everything traces back to one root issue.

### New GitHub issues created

- **#168 — Epic: Workflow Fleet Dashboard — Mission Control for the Agentic Workforce**
  The multi-project cockpit: features × stages pipeline matrix, live agent session indicators, HITL/HOTL mode per row, inline intervention controls (approve, redirect, pause, resume, abandon), health signals (stuck, drift, backlog, failure), recursive epic → feature tree, and traceability drill-down. The v1 foundation is the Increment 2 workflow navigator; the full cockpit is v2.0.

- **#169 — Requirement: End-to-End Traceability — Root Issue as the Source of Truth Chain**
  Specifies the complete traceability chain (root issue → idea → … → retrospective), the agent session log schema and vault storage at `specs/{slug}/sessions/`, the extended `workflow-state.md` frontmatter (`root_issue`, `parent_feature`, `child_features`, per-stage artifacts map), and the `workflow_list_features` MCP response needed to build the fleet matrix in one query.

### Existing issues updated

- **#23 (v2.0 epic)** — Added Fleet Dashboard, HITL/HOTL distinction with explicit UI mode indicators, session log as first-class artifact, and cross-references to #168 and #169.
- **#164 (H-ACD philosophy)** — Added "The ADLC as a Pipeline" section framing the 12 stages as a pipeline with human gate approval, introduced HITL vs HOTL as named H-ACD concepts, and added criteria 7 and 8 to the design evaluation checklist.
- **#47 (Roadmap)** — Clarified that Increment 2's workflow navigation is the per-feature view; added Increment 3 for quality gates and session log display; documented fleet dashboard and traceability as v2.0 additions.

### New: docs/glossary/ — per-term definition files

Converts the flat `docs/glossary.md` into 37 individual Markdown files under `docs/glossary/`, one per term. Each file has structured YAML frontmatter (`term`, `aliases`, `category`, `status`, `version`, `related`, `issues`, `last_updated`) and a focused body with definition, practical guidance, and cross-references.

**New terms** (not in the old glossary): `h-acd`, `adlc`, `pipeline`, `hitl`, `hotl`, `oversight-mode`, `fleet-dashboard`, `session-log`, `traceability-chain`, `vault-as-operating-environment`, `mcp-server`, `runtime-port`, `specorator-runtime`, `workflow-encapsulation`, `human-authority`, `intent-first`

**Promoted from monolith**: all established terms (artifact, gate, gate-check, scaffold, feature, workflow-stage, workflow-state, open-question, decision-note, cockpit, workflow-navigator, chat-sidebar, proposed-output, accepted-output, companion-app, agentic-coworker, agentic-workflow, agentonomous, narrow-port, claude-cli-port, specorator)

Index at `docs/glossary/README.md` groups all terms by category with version scope.

## Test plan

- [ ] Read `docs/glossary/README.md` — all 37 term files listed by category
- [ ] Spot-check 3–4 term files: confirm frontmatter schema is consistent (`term`, `aliases`, `category`, `status`, `version`, `related`, `issues`, `last_updated`)
- [ ] Confirm HITL and HOTL files cross-reference each other correctly
- [ ] Confirm fleet-dashboard.md references #168 and session-log.md references #169
- [ ] `npm run typecheck && npm run lint && npm run test` all pass (no source code changes in this PR)

https://claude.ai/code/session_015FDEt1TvwJ3NvgwyBZ87qz
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015FDEt1TvwJ3NvgwyBZ87qz)_