### PR TITLE
feat(ui): W11 layout system — MainLayout/DashboardLayout/PanelLayout (closes #109)

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,12 +1,39 @@
 import type { Preview } from '@storybook/vue3-vite'
 import { setup } from '@storybook/vue3-vite'
 import { createPinia } from 'pinia'
+import { createMemoryHistory, createRouter } from 'vue-router'
 import { i18n, setLocale } from '../src/ui/i18n'
+import {
+  LOGGER_PORT,
+  NOTIFICATION_PORT,
+  SETTINGS_PORT,
+  VAULT_PORT,
+  WORKSPACE_PORT,
+} from '../src/infrastructure/bridge/ports'
+import { MockBridge } from '../src/infrastructure/mock/MockBridge'
 import './obsidian-theme.css'
+
+const storyRouter = createRouter({
+  history: createMemoryHistory(),
+  routes: [
+    { path: '/', name: 'home', component: { template: '<div />' } },
+    { path: '/features', name: 'features', component: { template: '<div />' } },
+    { path: '/settings', name: 'settings', component: { template: '<div />' } },
+    { path: '/file/:filePath(.*)', name: 'file', component: { template: '<div />' } },
+  ],
+})
+
+const storyBridge = new MockBridge()
 
 setup((app) => {
   app.use(createPinia())
   app.use(i18n)
+  app.use(storyRouter)
+  app.provide(SETTINGS_PORT, storyBridge)
+  app.provide(VAULT_PORT, storyBridge)
+  app.provide(WORKSPACE_PORT, storyBridge)
+  app.provide(NOTIFICATION_PORT, storyBridge)
+  app.provide(LOGGER_PORT, storyBridge)
 })
 
 const preview: Preview = {

--- a/src/plugin/SpecoratorView.ts
+++ b/src/plugin/SpecoratorView.ts
@@ -3,7 +3,7 @@ import { createApp, type App as VueApp } from 'vue'
 import { createPinia } from 'pinia'
 import { router } from '@/ui/router'
 import { i18n, setLocale, type SupportedLocale } from '@/ui/i18n'
-import App from '@/ui/App.vue'
+import AppRoot from '@/ui/AppRoot.vue'
 import {
   SETTINGS_PORT,
   VAULT_PORT,
@@ -44,7 +44,7 @@ export class SpecoratorView extends ItemView {
 
     setLocale(this.plugin.settings.locale as SupportedLocale)
 
-    this.vueApp = createApp(App)
+    this.vueApp = createApp(AppRoot)
     this.vueApp.use(createPinia())
     this.vueApp.use(router)
     this.vueApp.use(i18n)

--- a/src/ui/AppRoot.vue
+++ b/src/ui/AppRoot.vue
@@ -1,14 +1,15 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted } from 'vue'
-import { useI18n } from 'vue-i18n'
-import { RouterView, RouterLink, useRouter } from 'vue-router'
+import { computed, onMounted, onUnmounted, type Component } from 'vue'
+import { RouterView, useRoute, useRouter } from 'vue-router'
 import AppToast from './components/common/AppToast.vue'
-import ErrorBoundary from './components/ErrorBoundary.vue'
+import MainLayout from './layouts/MainLayout.vue'
 import { useNotificationStore } from './stores/notificationStore'
 
-const { t } = useI18n()
+const route = useRoute()
 const router = useRouter()
 const notificationStore = useNotificationStore()
+
+const layout = computed<Component>(() => route.meta.layout ?? MainLayout)
 
 function onNotice(e: Event) {
   const { message, durationMs } = (e as CustomEvent<{
@@ -36,23 +37,10 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="sp-app">
-    <nav class="sp-nav">
-      <RouterLink class="sp-nav__link" to="/" active-class="sp-nav__link--active" exact>
-        {{ t('nav.home') }}
-      </RouterLink>
-      <RouterLink class="sp-nav__link" to="/features" active-class="sp-nav__link--active">
-        {{ t('nav.features') }}
-      </RouterLink>
-      <RouterLink class="sp-nav__link" to="/settings" active-class="sp-nav__link--active">
-        {{ t('nav.settings') }}
-      </RouterLink>
-    </nav>
-    <main class="sp-main">
-      <ErrorBoundary>
-        <RouterView />
-      </ErrorBoundary>
-    </main>
+  <div class="sp-app" data-testid="app-root">
+    <component :is="layout">
+      <RouterView />
+    </component>
     <AppToast />
   </div>
 </template>
@@ -77,38 +65,5 @@ onUnmounted(() => {
   flex-direction: column;
   height: 100vh;
   overflow: hidden;
-}
-
-.sp-nav {
-  display: flex;
-  gap: 0;
-  border-bottom: 1px solid var(--background-modifier-border);
-  background: var(--background-secondary);
-  padding: 0 0.5rem;
-  flex-shrink: 0;
-}
-
-.sp-nav__link {
-  padding: 0.5rem 0.875rem;
-  font-size: 0.8125rem;
-  font-weight: 500;
-  color: var(--text-muted);
-  text-decoration: none;
-  border-bottom: 2px solid transparent;
-  transition: color 0.15s, border-color 0.15s;
-}
-
-.sp-nav__link:hover {
-  color: var(--text-normal);
-}
-
-.sp-nav__link--active {
-  color: var(--text-normal);
-  border-bottom-color: var(--interactive-accent);
-}
-
-.sp-main {
-  flex: 1;
-  overflow-y: auto;
 }
 </style>

--- a/src/ui/layouts/DashboardLayout.vue
+++ b/src/ui/layouts/DashboardLayout.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import ErrorBoundary from '../components/ErrorBoundary.vue'
+</script>
+
+<template>
+  <div class="sp-layout sp-layout--dashboard" data-testid="layout-dashboard">
+    <header v-if="$slots.header" class="sp-layout__header" data-testid="layout-dashboard-header">
+      <slot name="header" />
+    </header>
+
+    <main class="sp-layout__body" data-testid="layout-dashboard-body">
+      <ErrorBoundary>
+        <slot />
+      </ErrorBoundary>
+    </main>
+
+    <footer v-if="$slots.footer" class="sp-layout__footer" data-testid="layout-dashboard-footer">
+      <slot name="footer" />
+    </footer>
+  </div>
+</template>
+
+<style scoped>
+.sp-layout--dashboard {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  background: var(--background-primary);
+}
+
+.sp-layout__header {
+  flex-shrink: 0;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.sp-layout__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  align-content: start;
+}
+
+.sp-layout__footer {
+  flex-shrink: 0;
+  padding: 0.75rem 1.5rem;
+  border-top: 1px solid var(--background-modifier-border);
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+}
+</style>

--- a/src/ui/layouts/MainLayout.vue
+++ b/src/ui/layouts/MainLayout.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { RouterLink } from 'vue-router'
+import ErrorBoundary from '../components/ErrorBoundary.vue'
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <div class="sp-layout sp-layout--main" data-testid="layout-main">
+    <nav class="sp-layout__nav">
+      <RouterLink class="sp-layout__nav-link" to="/" active-class="sp-layout__nav-link--active" exact>
+        {{ t('nav.home') }}
+      </RouterLink>
+      <RouterLink class="sp-layout__nav-link" to="/features" active-class="sp-layout__nav-link--active">
+        {{ t('nav.features') }}
+      </RouterLink>
+      <RouterLink class="sp-layout__nav-link" to="/settings" active-class="sp-layout__nav-link--active">
+        {{ t('nav.settings') }}
+      </RouterLink>
+    </nav>
+
+    <header v-if="$slots.header" class="sp-layout__header" data-testid="layout-main-header">
+      <slot name="header" />
+    </header>
+
+    <main class="sp-layout__body" data-testid="layout-main-body">
+      <ErrorBoundary>
+        <slot />
+      </ErrorBoundary>
+    </main>
+
+    <footer v-if="$slots.footer" class="sp-layout__footer" data-testid="layout-main-footer">
+      <slot name="footer" />
+    </footer>
+  </div>
+</template>
+
+<style scoped>
+.sp-layout--main {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.sp-layout__nav {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--background-modifier-border);
+  background: var(--background-secondary);
+  padding: 0 0.5rem;
+  flex-shrink: 0;
+}
+
+.sp-layout__nav-link {
+  padding: 0.5rem 0.875rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.sp-layout__nav-link:hover {
+  color: var(--text-normal);
+}
+
+.sp-layout__nav-link--active {
+  color: var(--text-normal);
+  border-bottom-color: var(--interactive-accent);
+}
+
+.sp-layout__header {
+  flex-shrink: 0;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--background-modifier-border);
+  background: var(--background-primary);
+}
+
+.sp-layout__body {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.sp-layout__footer {
+  flex-shrink: 0;
+  padding: 0.5rem 1rem;
+  border-top: 1px solid var(--background-modifier-border);
+  background: var(--background-secondary);
+}
+</style>

--- a/src/ui/layouts/PanelLayout.vue
+++ b/src/ui/layouts/PanelLayout.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import ErrorBoundary from '../components/ErrorBoundary.vue'
+</script>
+
+<template>
+  <div class="sp-layout sp-layout--panel" data-testid="layout-panel">
+    <header v-if="$slots.header" class="sp-layout__header" data-testid="layout-panel-header">
+      <slot name="header" />
+    </header>
+
+    <div class="sp-layout__body" data-testid="layout-panel-body">
+      <ErrorBoundary>
+        <slot />
+      </ErrorBoundary>
+    </div>
+
+    <footer v-if="$slots.footer" class="sp-layout__footer" data-testid="layout-panel-footer">
+      <slot name="footer" />
+    </footer>
+  </div>
+</template>
+
+<style scoped>
+.sp-layout--panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  background: var(--background-secondary);
+}
+
+.sp-layout__header {
+  flex-shrink: 0;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--background-modifier-border);
+  background: var(--background-primary);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-normal);
+}
+
+.sp-layout__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.75rem;
+}
+
+.sp-layout__footer {
+  flex-shrink: 0;
+  padding: 0.5rem 0.75rem;
+  border-top: 1px solid var(--background-modifier-border);
+  background: var(--background-primary);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+</style>

--- a/src/ui/layouts/index.ts
+++ b/src/ui/layouts/index.ts
@@ -1,0 +1,3 @@
+export { default as MainLayout } from './MainLayout.vue'
+export { default as DashboardLayout } from './DashboardLayout.vue'
+export { default as PanelLayout } from './PanelLayout.vue'

--- a/src/ui/main.ts
+++ b/src/ui/main.ts
@@ -8,7 +8,7 @@
 import './standalone.css'
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
-import App from './App.vue'
+import AppRoot from './AppRoot.vue'
 import { router } from './router'
 import { i18n, i18nMerge, i18nTranslate, setLocale, type SupportedLocale } from './i18n'
 import {
@@ -31,7 +31,7 @@ const mountPoint = document.querySelector('#app')
 
 mountPoint?.classList.add('specorator-root')
 
-const app = createApp(App)
+const app = createApp(AppRoot)
 app.use(createPinia())
 app.use(router)
 app.use(i18n)

--- a/src/ui/router/index.ts
+++ b/src/ui/router/index.ts
@@ -1,15 +1,23 @@
+import type { Component } from 'vue'
 import { createRouter, createWebHashHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
 import FeaturesView from '../views/FeaturesView.vue'
 import SettingsView from '../views/SettingsView.vue'
 import FileView from '../views/FileView.vue'
+import MainLayout from '../layouts/MainLayout.vue'
+
+declare module 'vue-router' {
+  interface RouteMeta {
+    layout?: Component
+  }
+}
 
 export const router = createRouter({
   history: createWebHashHistory(),
   routes: [
-    { path: '/', name: 'home', component: HomeView },
-    { path: '/features', name: 'features', component: FeaturesView },
-    { path: '/settings', name: 'settings', component: SettingsView },
-    { path: '/file/:filePath(.*)', name: 'file', component: FileView },
+    { path: '/', name: 'home', component: HomeView, meta: { layout: MainLayout } },
+    { path: '/features', name: 'features', component: FeaturesView, meta: { layout: MainLayout } },
+    { path: '/settings', name: 'settings', component: SettingsView, meta: { layout: MainLayout } },
+    { path: '/file/:filePath(.*)', name: 'file', component: FileView, meta: { layout: MainLayout } },
   ],
 })

--- a/stories/layouts/DashboardLayout.stories.ts
+++ b/stories/layouts/DashboardLayout.stories.ts
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import DashboardLayout from '@/ui/layouts/DashboardLayout.vue'
+
+const meta: Meta<typeof DashboardLayout> = {
+  title: 'Layouts/DashboardLayout',
+  component: DashboardLayout,
+}
+export default meta
+type Story = StoryObj<typeof DashboardLayout>
+
+const cardStyle =
+  'background:var(--background-secondary);border:1px solid var(--background-modifier-border);border-radius:6px;padding:1rem;'
+
+export const Default: Story = {
+  render: () => ({
+    components: { DashboardLayout },
+    template: `
+      <DashboardLayout>
+        <div style="${cardStyle}"><h3 style="margin:0 0 0.5rem;">Active features</h3><p style="margin:0;font-size:1.5rem;">12</p></div>
+        <div style="${cardStyle}"><h3 style="margin:0 0 0.5rem;">In review</h3><p style="margin:0;font-size:1.5rem;">3</p></div>
+        <div style="${cardStyle}"><h3 style="margin:0 0 0.5rem;">Archived</h3><p style="margin:0;font-size:1.5rem;">47</p></div>
+        <div style="${cardStyle}"><h3 style="margin:0 0 0.5rem;">Decisions</h3><p style="margin:0;font-size:1.5rem;">9</p></div>
+      </DashboardLayout>
+    `,
+  }),
+}
+
+export const WithHeaderAndFooter: Story = {
+  render: () => ({
+    components: { DashboardLayout },
+    template: `
+      <DashboardLayout>
+        <template #header>
+          <h1 style="margin:0;font-size:1.125rem;">Workflow overview</h1>
+        </template>
+        <div style="${cardStyle}"><h3 style="margin:0 0 0.5rem;">KPI 1</h3><p style="margin:0;font-size:1.5rem;">42</p></div>
+        <div style="${cardStyle}"><h3 style="margin:0 0 0.5rem;">KPI 2</h3><p style="margin:0;font-size:1.5rem;">17</p></div>
+        <template #footer>
+          <small>Updated just now</small>
+        </template>
+      </DashboardLayout>
+    `,
+  }),
+}

--- a/stories/layouts/MainLayout.stories.ts
+++ b/stories/layouts/MainLayout.stories.ts
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import MainLayout from '@/ui/layouts/MainLayout.vue'
+
+const meta: Meta<typeof MainLayout> = {
+  title: 'Layouts/MainLayout',
+  component: MainLayout,
+}
+export default meta
+type Story = StoryObj<typeof MainLayout>
+
+export const Default: Story = {
+  render: () => ({
+    components: { MainLayout },
+    template: `
+      <MainLayout>
+        <div style="padding:1rem;">
+          <p>Default body content lives in the unnamed slot.</p>
+        </div>
+      </MainLayout>
+    `,
+  }),
+}
+
+export const WithHeaderAndFooter: Story = {
+  render: () => ({
+    components: { MainLayout },
+    template: `
+      <MainLayout>
+        <template #header>
+          <h1 style="margin:0;font-size:1rem;">Page header</h1>
+        </template>
+        <div style="padding:1rem;">
+          <p>Body content rendered between the header and footer slots.</p>
+        </div>
+        <template #footer>
+          <small>Layout footer slot</small>
+        </template>
+      </MainLayout>
+    `,
+  }),
+}

--- a/stories/layouts/PanelLayout.stories.ts
+++ b/stories/layouts/PanelLayout.stories.ts
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import PanelLayout from '@/ui/layouts/PanelLayout.vue'
+
+const meta: Meta<typeof PanelLayout> = {
+  title: 'Layouts/PanelLayout',
+  component: PanelLayout,
+  decorators: [
+    (story) => ({
+      components: { story },
+      template: '<div style="width:320px;height:480px;border:1px solid var(--background-modifier-border);"><story /></div>',
+    }),
+  ],
+}
+export default meta
+type Story = StoryObj<typeof PanelLayout>
+
+export const Default: Story = {
+  render: () => ({
+    components: { PanelLayout },
+    template: `
+      <PanelLayout>
+        <p>Panel body content. Designed for narrow widths used by Obsidian sidebar leaves.</p>
+      </PanelLayout>
+    `,
+  }),
+}
+
+export const WithHeaderAndFooter: Story = {
+  render: () => ({
+    components: { PanelLayout },
+    template: `
+      <PanelLayout>
+        <template #header>Chat session</template>
+        <p>Each panel mounts <code>PanelLayout</code> directly without a router.</p>
+        <p>Use the slots for compact sidebar UIs.</p>
+        <template #footer>3 messages · synced</template>
+      </PanelLayout>
+    `,
+  }),
+}

--- a/styles.css
+++ b/styles.css
@@ -333,6 +333,53 @@ to { transform: rotate(360deg);
   margin: 0;
 }
 
+.specorator-root :where(.sp-layout--main[data-v-d03ebfab]) {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+.specorator-root :where(.sp-layout__nav[data-v-d03ebfab]) {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--background-modifier-border);
+  background: var(--background-secondary);
+  padding: 0 0.5rem;
+  flex-shrink: 0;
+}
+.specorator-root :where(.sp-layout__nav-link[data-v-d03ebfab]) {
+  padding: 0.5rem 0.875rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+}
+.specorator-root :where(.sp-layout__nav-link[data-v-d03ebfab]:hover) {
+  color: var(--text-normal);
+}
+.specorator-root :where(.sp-layout__nav-link--active[data-v-d03ebfab]) {
+  color: var(--text-normal);
+  border-bottom-color: var(--interactive-accent);
+}
+.specorator-root :where(.sp-layout__header[data-v-d03ebfab]) {
+  flex-shrink: 0;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--background-modifier-border);
+  background: var(--background-primary);
+}
+.specorator-root :where(.sp-layout__body[data-v-d03ebfab]) {
+  flex: 1;
+  overflow-y: auto;
+}
+.specorator-root :where(.sp-layout__footer[data-v-d03ebfab]) {
+  flex-shrink: 0;
+  padding: 0.5rem 1rem;
+  border-top: 1px solid var(--background-modifier-border);
+  background: var(--background-secondary);
+}
+
 .specorator-root :where(.sp-toast-container[data-v-0721de72]) {
   position: fixed;
   bottom: 1.5rem;
@@ -389,38 +436,10 @@ to   { opacity: 1; transform: translateY(0);
   box-sizing: border-box;
 }
 
-.specorator-root :where(.sp-app[data-v-b59384b3]) {
+.specorator-root :where(.sp-app[data-v-1830bd0f]) {
   display: flex;
   flex-direction: column;
   height: 100vh;
   overflow: hidden;
-}
-.specorator-root :where(.sp-nav[data-v-b59384b3]) {
-  display: flex;
-  gap: 0;
-  border-bottom: 1px solid var(--background-modifier-border);
-  background: var(--background-secondary);
-  padding: 0 0.5rem;
-  flex-shrink: 0;
-}
-.specorator-root :where(.sp-nav__link[data-v-b59384b3]) {
-  padding: 0.5rem 0.875rem;
-  font-size: 0.8125rem;
-  font-weight: 500;
-  color: var(--text-muted);
-  text-decoration: none;
-  border-bottom: 2px solid transparent;
-  transition: color 0.15s, border-color 0.15s;
-}
-.specorator-root :where(.sp-nav__link[data-v-b59384b3]:hover) {
-  color: var(--text-normal);
-}
-.specorator-root :where(.sp-nav__link--active[data-v-b59384b3]) {
-  color: var(--text-normal);
-  border-bottom-color: var(--interactive-accent);
-}
-.specorator-root :where(.sp-main[data-v-b59384b3]) {
-  flex: 1;
-  overflow-y: auto;
 }
 /*$vite$:1*/

--- a/tests/ui/AppRoot.po.ts
+++ b/tests/ui/AppRoot.po.ts
@@ -1,0 +1,32 @@
+import type { VueWrapper } from '@vue/test-utils'
+
+const TID = {
+	root: 'app-root',
+	mainLayout: 'layout-main',
+	dashboardLayout: 'layout-dashboard',
+	panelLayout: 'layout-panel',
+} as const
+
+export class AppRootPageObject {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	private byTid(tid: string) {
+		return `[data-testid="${tid}"]`
+	}
+
+	get root() {
+		return this.wrapper.get(this.byTid(TID.root))
+	}
+
+	mainLayout() {
+		return this.wrapper.find(this.byTid(TID.mainLayout))
+	}
+
+	dashboardLayout() {
+		return this.wrapper.find(this.byTid(TID.dashboardLayout))
+	}
+
+	panelLayout() {
+		return this.wrapper.find(this.byTid(TID.panelLayout))
+	}
+}

--- a/tests/ui/AppRoot.test.ts
+++ b/tests/ui/AppRoot.test.ts
@@ -1,0 +1,80 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { createPinia } from 'pinia'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import AppRoot from '@/ui/AppRoot.vue'
+import DashboardLayout from '@/ui/layouts/DashboardLayout.vue'
+import { i18n } from '@/ui/i18n'
+import { LOGGER_PORT, NOTIFICATION_PORT } from '@/infrastructure/bridge/ports'
+import { fakeModulePorts } from '../__fakes__/fake-ports'
+import { AppRootPageObject } from './AppRoot.po'
+
+async function mountAppRoot(initialPath: string) {
+	const router = createRouter({
+		history: createMemoryHistory(),
+		routes: [
+			{
+				path: '/',
+				name: 'home',
+				component: { template: '<div data-testid="home" />' },
+				meta: { layout: DashboardLayout },
+			},
+			{
+				path: '/features',
+				name: 'features',
+				component: { template: '<div data-testid="features" />' },
+			},
+			{
+				path: '/settings',
+				name: 'settings',
+				component: { template: '<div />' },
+			},
+			{
+				path: '/file/:filePath(.*)',
+				name: 'file',
+				component: { template: '<div />' },
+			},
+		],
+	})
+	await router.push(initialPath)
+	await router.isReady()
+	const ports = fakeModulePorts()
+	const wrapper = mount(AppRoot, {
+		global: {
+			plugins: [i18n, router, createPinia()],
+			provide: {
+				[LOGGER_PORT as unknown as symbol]: ports.logger,
+				[NOTIFICATION_PORT as unknown as symbol]: ports.notifications,
+			},
+		},
+	})
+	return { po: new AppRootPageObject(wrapper), wrapper }
+}
+
+describe('AppRoot', () => {
+	it('falls back to MainLayout when route.meta.layout is absent', async () => {
+		const { po } = await mountAppRoot('/features')
+		await flushPromises()
+		expect(po.mainLayout().exists()).toBe(true)
+		expect(po.dashboardLayout().exists()).toBe(false)
+	})
+
+	it('resolves the active layout from route.meta.layout', async () => {
+		const { po } = await mountAppRoot('/')
+		await flushPromises()
+		expect(po.dashboardLayout().exists()).toBe(true)
+		expect(po.mainLayout().exists()).toBe(false)
+	})
+
+	it('swaps layouts when navigating between routes', async () => {
+		const { po, wrapper } = await mountAppRoot('/')
+		await flushPromises()
+		expect(po.dashboardLayout().exists()).toBe(true)
+
+		const router = wrapper.vm.$router
+		await router.push('/features')
+		await flushPromises()
+		expect(po.mainLayout().exists()).toBe(true)
+		expect(po.dashboardLayout().exists()).toBe(false)
+	})
+})

--- a/tests/ui/layouts/DashboardLayout.po.ts
+++ b/tests/ui/layouts/DashboardLayout.po.ts
@@ -1,0 +1,32 @@
+import type { VueWrapper } from '@vue/test-utils'
+
+const TID = {
+	root: 'layout-dashboard',
+	header: 'layout-dashboard-header',
+	body: 'layout-dashboard-body',
+	footer: 'layout-dashboard-footer',
+} as const
+
+export class DashboardLayoutPageObject {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	private byTid(tid: string) {
+		return `[data-testid="${tid}"]`
+	}
+
+	get root() {
+		return this.wrapper.get(this.byTid(TID.root))
+	}
+
+	header() {
+		return this.wrapper.find(this.byTid(TID.header))
+	}
+
+	get body() {
+		return this.wrapper.get(this.byTid(TID.body))
+	}
+
+	footer() {
+		return this.wrapper.find(this.byTid(TID.footer))
+	}
+}

--- a/tests/ui/layouts/DashboardLayout.test.ts
+++ b/tests/ui/layouts/DashboardLayout.test.ts
@@ -1,0 +1,44 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import DashboardLayout from '@/ui/layouts/DashboardLayout.vue'
+import { LOGGER_PORT, NOTIFICATION_PORT } from '@/infrastructure/bridge/ports'
+import { fakeModulePorts } from '../../__fakes__/fake-ports'
+import { DashboardLayoutPageObject } from './DashboardLayout.po'
+
+function mountLayout(slots: Record<string, string> = {}) {
+	const ports = fakeModulePorts()
+	const wrapper = mount(DashboardLayout, {
+		global: {
+			provide: {
+				[LOGGER_PORT as unknown as symbol]: ports.logger,
+				[NOTIFICATION_PORT as unknown as symbol]: ports.notifications,
+			},
+		},
+		slots,
+	})
+	return new DashboardLayoutPageObject(wrapper)
+}
+
+describe('DashboardLayout', () => {
+	it('renders root and default body', () => {
+		const po = mountLayout({ default: '<div data-testid="kpi">42</div>' })
+		expect(po.root.element.tagName).toBe('DIV')
+		expect(po.body.find('[data-testid="kpi"]').text()).toBe('42')
+	})
+
+	it('omits header and footer when slots are empty', () => {
+		const po = mountLayout({ default: '<div />' })
+		expect(po.header().exists()).toBe(false)
+		expect(po.footer().exists()).toBe(false)
+	})
+
+	it('renders header and footer slots when provided', () => {
+		const po = mountLayout({
+			default: '<div />',
+			header: '<h1 data-testid="hdr">Overview</h1>',
+			footer: '<small data-testid="ftr">Updated</small>',
+		})
+		expect(po.header().find('[data-testid="hdr"]').text()).toBe('Overview')
+		expect(po.footer().find('[data-testid="ftr"]').text()).toBe('Updated')
+	})
+})

--- a/tests/ui/layouts/MainLayout.po.ts
+++ b/tests/ui/layouts/MainLayout.po.ts
@@ -1,0 +1,32 @@
+import type { VueWrapper } from '@vue/test-utils'
+
+const TID = {
+	root: 'layout-main',
+	header: 'layout-main-header',
+	body: 'layout-main-body',
+	footer: 'layout-main-footer',
+} as const
+
+export class MainLayoutPageObject {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	private byTid(tid: string) {
+		return `[data-testid="${tid}"]`
+	}
+
+	get root() {
+		return this.wrapper.get(this.byTid(TID.root))
+	}
+
+	header() {
+		return this.wrapper.find(this.byTid(TID.header))
+	}
+
+	get body() {
+		return this.wrapper.get(this.byTid(TID.body))
+	}
+
+	footer() {
+		return this.wrapper.find(this.byTid(TID.footer))
+	}
+}

--- a/tests/ui/layouts/MainLayout.test.ts
+++ b/tests/ui/layouts/MainLayout.test.ts
@@ -1,0 +1,72 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import MainLayout from '@/ui/layouts/MainLayout.vue'
+import { i18n } from '@/ui/i18n'
+import { LOGGER_PORT, NOTIFICATION_PORT } from '@/infrastructure/bridge/ports'
+import { fakeModulePorts } from '../../__fakes__/fake-ports'
+import { MainLayoutPageObject } from './MainLayout.po'
+
+function mountLayout(slots: Record<string, string> = {}) {
+	const ports = fakeModulePorts()
+	const router = createRouter({
+		history: createMemoryHistory(),
+		routes: [
+			{ path: '/', name: 'home', component: { template: '<div />' } },
+			{ path: '/features', name: 'features', component: { template: '<div />' } },
+			{ path: '/settings', name: 'settings', component: { template: '<div />' } },
+		],
+	})
+	const wrapper = mount(MainLayout, {
+		global: {
+			plugins: [i18n, router],
+			provide: {
+				[LOGGER_PORT as unknown as symbol]: ports.logger,
+				[NOTIFICATION_PORT as unknown as symbol]: ports.notifications,
+			},
+		},
+		slots,
+	})
+	return new MainLayoutPageObject(wrapper)
+}
+
+describe('MainLayout', () => {
+	it('renders root and default body', () => {
+		const po = mountLayout({ default: '<p data-testid="payload">body</p>' })
+		expect(po.root.element.tagName).toBe('DIV')
+		expect(po.body.find('[data-testid="payload"]').text()).toBe('body')
+	})
+
+	it('hides header when slot is empty', () => {
+		const po = mountLayout({ default: '<div />' })
+		expect(po.header().exists()).toBe(false)
+	})
+
+	it('renders header slot when provided', () => {
+		const po = mountLayout({
+			default: '<div />',
+			header: '<h1 data-testid="hdr">Title</h1>',
+		})
+		expect(po.header().exists()).toBe(true)
+		expect(po.header().find('[data-testid="hdr"]').text()).toBe('Title')
+	})
+
+	it('hides footer when slot is empty', () => {
+		const po = mountLayout({ default: '<div />' })
+		expect(po.footer().exists()).toBe(false)
+	})
+
+	it('renders footer slot when provided', () => {
+		const po = mountLayout({
+			default: '<div />',
+			footer: '<small data-testid="ftr">Footer</small>',
+		})
+		expect(po.footer().exists()).toBe(true)
+		expect(po.footer().find('[data-testid="ftr"]').text()).toBe('Footer')
+	})
+
+	it('renders the top nav links', () => {
+		const po = mountLayout({ default: '<div />' })
+		expect(po.root.findAll('a').length).toBe(3)
+	})
+})

--- a/tests/ui/layouts/PanelLayout.po.ts
+++ b/tests/ui/layouts/PanelLayout.po.ts
@@ -1,0 +1,32 @@
+import type { VueWrapper } from '@vue/test-utils'
+
+const TID = {
+	root: 'layout-panel',
+	header: 'layout-panel-header',
+	body: 'layout-panel-body',
+	footer: 'layout-panel-footer',
+} as const
+
+export class PanelLayoutPageObject {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	private byTid(tid: string) {
+		return `[data-testid="${tid}"]`
+	}
+
+	get root() {
+		return this.wrapper.get(this.byTid(TID.root))
+	}
+
+	header() {
+		return this.wrapper.find(this.byTid(TID.header))
+	}
+
+	get body() {
+		return this.wrapper.get(this.byTid(TID.body))
+	}
+
+	footer() {
+		return this.wrapper.find(this.byTid(TID.footer))
+	}
+}

--- a/tests/ui/layouts/PanelLayout.test.ts
+++ b/tests/ui/layouts/PanelLayout.test.ts
@@ -1,0 +1,44 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import PanelLayout from '@/ui/layouts/PanelLayout.vue'
+import { LOGGER_PORT, NOTIFICATION_PORT } from '@/infrastructure/bridge/ports'
+import { fakeModulePorts } from '../../__fakes__/fake-ports'
+import { PanelLayoutPageObject } from './PanelLayout.po'
+
+function mountLayout(slots: Record<string, string> = {}) {
+	const ports = fakeModulePorts()
+	const wrapper = mount(PanelLayout, {
+		global: {
+			provide: {
+				[LOGGER_PORT as unknown as symbol]: ports.logger,
+				[NOTIFICATION_PORT as unknown as symbol]: ports.notifications,
+			},
+		},
+		slots,
+	})
+	return new PanelLayoutPageObject(wrapper)
+}
+
+describe('PanelLayout', () => {
+	it('renders without a router (no router plugin installed)', () => {
+		const po = mountLayout({ default: '<p data-testid="payload">panel</p>' })
+		expect(po.root.element.tagName).toBe('DIV')
+		expect(po.body.find('[data-testid="payload"]').text()).toBe('panel')
+	})
+
+	it('omits header and footer when slots are empty', () => {
+		const po = mountLayout({ default: '<div />' })
+		expect(po.header().exists()).toBe(false)
+		expect(po.footer().exists()).toBe(false)
+	})
+
+	it('renders header and footer slots when provided', () => {
+		const po = mountLayout({
+			default: '<div />',
+			header: '<span data-testid="hdr">Chat</span>',
+			footer: '<span data-testid="ftr">Synced</span>',
+		})
+		expect(po.header().find('[data-testid="hdr"]').text()).toBe('Chat')
+		expect(po.footer().find('[data-testid="ftr"]').text()).toBe('Synced')
+	})
+})


### PR DESCRIPTION
## Summary
- Three layouts under `src/ui/layouts/` (`MainLayout`, `DashboardLayout`, `PanelLayout`) with consistent `#header` / `#default` / `#footer` slot API.
- `App.vue` → `AppRoot.vue`: resolves `route.meta.layout` (component ref → fallback `MainLayout`); hosts global `AppToast` + `sp:notice` / `sp:open-file` listeners above any layout.
- `MainLayout` owns the top nav previously in `App.vue`; `PanelLayout` has no router dependency and is ready to be mounted directly by future panel components (e.g. `ChatSidebar` from #161).
- Storybook gains a story per layout under "Layouts/"; `.storybook/preview.ts` wires a memory router and provides the four narrow ports so layouts that wrap content in `ErrorBoundary` render cleanly.
- Tests cover slot rendering, header/footer omission, and `AppRoot` layout resolution + fallback (PageObjects per ADR-009; `data-testid` only).

Closes #109. Part of epic #85 (W11).

## Acceptance criteria status
- [x] Three layout components exist as Vue SFCs with consistent slot API (`#header`, `#default`, `#footer`)
- [x] `route.meta.layout` resolution wired in `AppRoot.vue` (with `MainLayout` fallback)
- [x] Existing pages migrated to the layout system without cross-module UI imports (rendered inside `MainLayout` slot; views unchanged)
- [x] Extracted reusable UI represented as isolated `.vue` SFCs with scoped/token-based styling
- [x] Storybook stories cover each layout

## Out of scope (called out in plan)
- Real `ChatSidebar` consumer for `PanelLayout` (#161).
- Migrating Home onto `DashboardLayout` (Home is a welcome page today, not a KPI dashboard — wait until KPIs are defined).

## Test plan
- [x] `npm run verify` — green end-to-end (typecheck + lint + 273 tests + plugin/standalone build + docs:api + manifest + workflows + git diff --check)
- [ ] `npm run dev` — visit `/`, `/features`, `/settings`, `/file/...` in standalone browser. Confirm nav still works, toast still appears globally, ErrorBoundary intact.
- [ ] `npm run dev:plugin` — load in Obsidian sandbox vault. Same paths, plus `obsidian://` protocol.
- [ ] `npm run storybook` — three new stories visible under `Layouts/`. A11y panel populated. Theme toolbar toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)