### PR TITLE
feat(plugin-shell): URI dispatch — obsidian://specorator protocol handler

### DIFF
--- a/src/core/plugin-core.ts
+++ b/src/core/plugin-core.ts
@@ -17,6 +17,18 @@ export interface CorePorts {
 
 // ── Validation helpers ────────────────────────────────────────────────────────
 
+function validateUriActions(modules: ReadonlyArray<ModuleDescriptor>): void {
+  const seen = new Set<string>()
+  for (const mod of modules) {
+    for (const uriAction of mod.uriActions ?? []) {
+      if (seen.has(uriAction.action)) {
+        throw new Error(`duplicate URI action "${uriAction.action}" in module "${mod.id}"`)
+      }
+      seen.add(uriAction.action)
+    }
+  }
+}
+
 function validateSettingsKeys(modules: ReadonlyArray<ModuleDescriptor>): void {
   const seen = new Set<string>()
   for (const mod of modules) {
@@ -42,6 +54,7 @@ function validateModules(modules: ReadonlyArray<ModuleDescriptor>): void {
   }
 
   validateSettingsKeys(modules)
+  validateUriActions(modules)
 
   for (const mod of modules) {
     const deps = mod.dependsOn ?? []
@@ -169,6 +182,7 @@ export class PluginCore {
   private sorted: ModuleDescriptor[] = []
   private readonly leakMap = new Map<string, number>()
   private readonly moduleSettingsMap = new Map<string, unknown>()
+  private readonly uriDispatch = new Map<string, (params: URLSearchParams) => void>()
   private _initCalled = false
 
   constructor(
@@ -204,6 +218,19 @@ export class PluginCore {
   /** Returns the migrated, validated settings slice for a module by settingsKey. */
   getModuleSettings(settingsKey: string): unknown {
     return this.moduleSettingsMap.get(settingsKey)
+  }
+
+  /** Dispatch an obsidian://specorator URI to the matching module handler. Returns true if handled. */
+  handleUri(params: URLSearchParams): boolean {
+    const action = params.get('action')
+    if (action === null) return false
+    const handler = this.uriDispatch.get(action)
+    if (handler === undefined) return false
+    const result = trySync(() => { handler(params) })
+    if (!result.ok) {
+      this.ports.logger.error('URI action handler failed', result.error, { action })
+    }
+    return true
   }
 
   /**
@@ -248,6 +275,12 @@ export class PluginCore {
 
     validateModules(this.modules)
     this.sorted = topoSort(this.modules)
+
+    for (const mod of this.modules) {
+      for (const uriAction of mod.uriActions ?? []) {
+        this.uriDispatch.set(uriAction.action, uriAction.handler)
+      }
+    }
 
     migrateSettings(this.sorted, rawSettings, this.ports.logger)
     const settings = rawSettings

--- a/src/modules/module.ts
+++ b/src/modules/module.ts
@@ -20,6 +20,11 @@ export interface ModuleCommandDescriptor {
 	readonly callback: () => void
 }
 
+export interface ModuleUriAction {
+	readonly action: string
+	readonly handler: (params: URLSearchParams) => void
+}
+
 export interface ModuleViewIntent {
 	readonly id: string
 	readonly label: string
@@ -39,6 +44,7 @@ export interface ModuleDescriptor<S = Record<string, unknown>> {
 	readonly id: string
 	readonly dependsOn?: ReadonlyArray<string>
 	readonly commands?: ReadonlyArray<ModuleCommandDescriptor>
+	readonly uriActions?: ReadonlyArray<ModuleUriAction>
 	readonly views?: ReadonlyArray<ModuleViewIntent>
 	readonly settingsSchema?: ModuleSettingsSchema
 	/** Unique key used to read/write this module's settings slice in the stored blob. Omit if the module has no persistent settings. */

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -76,6 +76,23 @@ export default class SpecoratorPlugin extends Plugin {
 
     this.addSettingTab(new SpecoratorSettingTab(this.app, this))
     this.detectLegacyVaultLayout()
+
+    this.registerObsidianProtocolHandler('specorator', (params) => {
+      const searchParams = new URLSearchParams(Object.entries(params))
+      if (this.core?.handleUri(searchParams) === true) return
+
+      // v1 stub handlers — replaced by module uriActions when the owning module is built
+      const action = params.action
+      if (action === 'open-chat' || action === 'focus-chat') {
+        void this.activateView()
+        return
+      }
+      if (action === 'send-message' || action === 'open-workflow') {
+        this.bridge?.showInfo(`URI action "${action}" is not yet implemented.`)
+        return
+      }
+      this.bridge?.showWarning(`Unknown Specorator URI action: "${action}"`)
+    })
   }
 
   // eslint-disable-next-line obsidianmd/detach-leaves

--- a/tests/core/plugin-core.test.ts
+++ b/tests/core/plugin-core.test.ts
@@ -588,3 +588,88 @@ describe('PluginCore.notifySettingsChanged', () => {
     expect(onSettingsChange).not.toHaveBeenCalled()
   })
 })
+
+// ── URI dispatch ──────────────────────────────────────────────────────────────
+
+describe('PluginCore.handleUri', () => {
+  it('dispatches to the matching module handler and returns true', async () => {
+    const ports = makePorts()
+    const handler = vi.fn()
+    const mod = makeModule('a', {
+      uriActions: [{ action: 'open-chat', handler }],
+    })
+    const core = new PluginCore([mod], ports)
+    await core.init({})
+
+    const handled = core.handleUri(new URLSearchParams('action=open-chat'))
+
+    expect(handled).toBe(true)
+    expect(handler).toHaveBeenCalledWith(expect.any(URLSearchParams))
+  })
+
+  it('passes URLSearchParams including extra params to handler', async () => {
+    const ports = makePorts()
+    const handler = vi.fn()
+    const mod = makeModule('a', {
+      uriActions: [{ action: 'send-message', handler }],
+    })
+    const core = new PluginCore([mod], ports)
+    await core.init({})
+
+    core.handleUri(new URLSearchParams('action=send-message&text=hello'))
+
+    const received: URLSearchParams = handler.mock.calls[0][0]
+    expect(received.get('text')).toBe('hello')
+  })
+
+  it('returns false for unknown action without throwing', async () => {
+    const ports = makePorts()
+    const core = new PluginCore([], ports)
+    await core.init({})
+
+    let handled: boolean | undefined
+    expect(() => { handled = core.handleUri(new URLSearchParams('action=ghost')) }).not.toThrow()
+    expect(handled).toBe(false)
+  })
+
+  it('detects duplicate action across modules and throws on init', async () => {
+    const ports = makePorts()
+    const handler = vi.fn()
+    const a = makeModule('a', { uriActions: [{ action: 'open-chat', handler }] })
+    const b = makeModule('b', { uriActions: [{ action: 'open-chat', handler }] })
+    const core = new PluginCore([a, b], ports)
+
+    await expect(core.init({})).rejects.toThrow(/duplicate.*open-chat/i)
+  })
+
+  it('returns false when no action param is present', async () => {
+    const ports = makePorts()
+    const handler = vi.fn()
+    const mod = makeModule('a', { uriActions: [{ action: 'open-chat', handler }] })
+    const core = new PluginCore([mod], ports)
+    await core.init({})
+
+    let handled: boolean | undefined
+    expect(() => { handled = core.handleUri(new URLSearchParams('')) }).not.toThrow()
+    expect(handled).toBe(false)
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('catches and logs handler errors without throwing', async () => {
+    const ports = makePorts()
+    const mod = makeModule('a', {
+      uriActions: [{ action: 'boom', handler: () => { throw new Error('handler exploded') } }],
+    })
+    const core = new PluginCore([mod], ports)
+    await core.init({})
+
+    let handled: boolean | undefined
+    expect(() => { handled = core.handleUri(new URLSearchParams('action=boom')) }).not.toThrow()
+    expect(handled).toBe(true)
+    expect(ports.logger.error).toHaveBeenCalledWith(
+      'URI action handler failed',
+      expect.any(Error),
+      expect.objectContaining({ action: 'boom' }),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `ModuleUriAction` interface and `uriActions` field to `ModuleDescriptor` — modules declare URI handlers declaratively
- Adds `PluginCore.handleUri(params): boolean` — dispatches to matching module handler, returns true if handled; errors caught and logged via `trySync`
- Validates duplicate action names at `init()` time (throws like other duplicate checks)
- Wires `registerObsidianProtocolHandler('specorator', ...)` in `main.ts`; module dispatch takes priority over v1 stub routes

## Design notes

`handleUri` returns `boolean` so `main.ts` can try module dispatch first and fall through to v1 stubs only when no module owns the action. When the chat module ships and declares `open-chat` via `uriActions`, the stub in `main.ts` is removed — no silent shadowing.

v1 stubs (`open-chat`, `focus-chat` → `activateView()`; `send-message`, `open-workflow` → info notice) live in `main.ts` until the owning modules are built.

## Test Plan

- [x] Dispatch routing — handler called with correct `URLSearchParams`
- [x] Extra params passed through to handler
- [x] Unknown action returns `false`, no throw
- [x] No-action param returns `false`, no throw
- [x] Duplicate action across modules throws on `init()`
- [x] Handler errors caught and logged, do not propagate
- [x] `npm run typecheck` + `npm run lint` clean
- [x] 44/44 tests pass

Closes #183

🤖 Generated with [Claude Code](https://claude.ai/claude-code)