### PR TITLE
feat(mcp): vault + frontmatter tools — 10 tools (#190)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
 				"pinia": "^3.0.4",
 				"vue": "^3.5.33",
 				"vue-i18n": "^11.4.0",
-				"vue-router": "^5.0.6"
+				"vue-router": "^5.0.6",
+				"yaml": "^2.8.4",
+				"zod": "^4.4.3"
 			},
 			"devDependencies": {
 				"@eslint/js": "^10.0.1",
@@ -11333,9 +11335,9 @@
 			"license": "MIT"
 		},
 		"node_modules/yaml": {
-			"version": "2.8.3",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+			"version": "2.8.4",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+			"integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
 			"license": "ISC",
 			"bin": {
 				"yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
 		"pinia": "^3.0.4",
 		"vue": "^3.5.33",
 		"vue-i18n": "^11.4.0",
-		"vue-router": "^5.0.6"
+		"vue-router": "^5.0.6",
+		"yaml": "^2.8.4",
+		"zod": "^4.4.3"
 	},
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",

--- a/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+++ b/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
@@ -21,9 +21,14 @@ function parseFrontmatter(content: string): Record<string, unknown> {
   }
 }
 
+function joinVaultPath(parent: string, child: string): string {
+  const p = parent.replace(/\/+$/, '')
+  return p ? `${p}/${child}` : child
+}
+
 async function collectFiles(vault: VaultPort, folder: string): Promise<string[]> {
   const [files, subfolders] = await Promise.all([vault.listFiles(folder), vault.listFolders(folder)])
-  const nested = await Promise.all(subfolders.map((sub) => collectFiles(vault, `${folder}/${sub}`)))
+  const nested = await Promise.all(subfolders.map((sub) => collectFiles(vault, joinVaultPath(folder, sub))))
   return [...files, ...nested.flat()]
 }
 
@@ -100,7 +105,7 @@ function registerTools(mcp: McpServer, vault: VaultPort): void {
         vault.listFiles(folder),
         vault.listFolders(folder),
       ])
-      const folders = subfolderNames.map((sub) => `${folder}/${sub}`)
+      const folders = subfolderNames.map((sub) => joinVaultPath(folder, sub))
       return ok({ files, folders })
     },
   )

--- a/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+++ b/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
@@ -214,7 +214,11 @@ export class ObsidianMcpServerAdapter implements ObsidianMcpServerPort {
     registerTools(mcp, this.vault)
     const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined })
     await mcp.connect(transport)
-    await transport.handleRequest(req, res)
+    try {
+      await transport.handleRequest(req, res)
+    } finally {
+      await transport.close()
+    }
   }
 
   async stop(): Promise<void> {

--- a/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+++ b/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
@@ -1,18 +1,177 @@
 import * as http from 'node:http'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
-import type { ObsidianMcpServerPort, McpConnectionConfig } from '@/domain/ports'
+import { z } from 'zod'
+import { parse as parseYaml } from 'yaml'
+import type { ObsidianMcpServerPort, McpConnectionConfig, VaultPort } from '@/domain/ports'
+
+const STUB_PROPOSAL_ID = 'stub-00000000-0000-0000-0000-000000000000'
+
+function parseFrontmatter(content: string): Record<string, unknown> {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content)
+  if (!match) return {}
+  try {
+    const result = parseYaml(match[1]) as unknown
+    if (result !== null && typeof result === 'object' && !Array.isArray(result)) {
+      return result as Record<string, unknown>
+    }
+    return {}
+  } catch {
+    return {}
+  }
+}
+
+async function collectFiles(vault: VaultPort, folder: string): Promise<string[]> {
+  const [files, subfolders] = await Promise.all([vault.listFiles(folder), vault.listFolders(folder)])
+  const nested = await Promise.all(subfolders.map((sub) => collectFiles(vault, `${folder}/${sub}`)))
+  return [...files, ...nested.flat()]
+}
+
+function ok(data: unknown): { content: [{ type: 'text'; text: string }] } {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(data) }] }
+}
+
+function registerTools(mcp: McpServer, vault: VaultPort): void {
+  mcp.registerTool(
+    'vault_read_note',
+    {
+      description: 'Read the full content of a vault note',
+      inputSchema: { path: z.string().describe('Vault-relative path') },
+    },
+    async ({ path }) => ok({ content: await vault.readFile(path) }),
+  )
+
+  mcp.registerTool(
+    'vault_write_note',
+    {
+      description: 'Overwrite a vault note — queued for proposal review',
+      inputSchema: { path: z.string(), content: z.string() },
+    },
+    async () => ok({ proposalId: STUB_PROPOSAL_ID, status: 'pending' }),
+  )
+
+  mcp.registerTool(
+    'vault_append_to_note',
+    {
+      description: 'Append text to a vault note — queued for proposal review',
+      inputSchema: { path: z.string(), content: z.string().describe('Text to append') },
+    },
+    async () => ok({ proposalId: STUB_PROPOSAL_ID, status: 'pending' }),
+  )
+
+  mcp.registerTool(
+    'vault_search',
+    {
+      description: 'Search vault notes for a query string (case-insensitive, recursive)',
+      inputSchema: {
+        query: z.string().describe('Substring to search for'),
+        folder: z.string().describe('Vault-relative folder to search in'),
+      },
+    },
+    async ({ query, folder }) => {
+      const files = await collectFiles(vault, folder)
+      const lower = query.toLowerCase()
+      const matches: Array<{ path: string; excerpt: string }> = []
+      for (const path of files) {
+        try {
+          const content = await vault.readFile(path)
+          const idx = content.toLowerCase().indexOf(lower)
+          if (idx !== -1) {
+            const start = Math.max(0, idx - 60)
+            const end = Math.min(content.length, idx + query.length + 60)
+            matches.push({ path, excerpt: content.slice(start, end).trim() })
+          }
+        } catch {
+          // Skip unreadable files
+        }
+      }
+      return ok({ matches })
+    },
+  )
+
+  mcp.registerTool(
+    'vault_list_folder',
+    {
+      description: 'List files and immediate subfolders in a vault folder',
+      inputSchema: { folder: z.string().describe('Vault-relative folder path') },
+    },
+    async ({ folder }) => {
+      const [files, subfolderNames] = await Promise.all([
+        vault.listFiles(folder),
+        vault.listFolders(folder),
+      ])
+      const folders = subfolderNames.map((sub) => `${folder}/${sub}`)
+      return ok({ files, folders })
+    },
+  )
+
+  mcp.registerTool(
+    'vault_create_folder',
+    {
+      description: 'Create a folder in the vault',
+      inputSchema: { path: z.string().describe('Vault-relative path to create') },
+    },
+    async ({ path }) => {
+      await vault.createFolder(path)
+      return ok({ created: true })
+    },
+  )
+
+  mcp.registerTool(
+    'frontmatter_get',
+    {
+      description: 'Get all YAML frontmatter fields from a vault note',
+      inputSchema: { path: z.string() },
+    },
+    async ({ path }) => {
+      const content = await vault.readFile(path)
+      return ok({ frontmatter: parseFrontmatter(content) })
+    },
+  )
+
+  mcp.registerTool(
+    'frontmatter_get_field',
+    {
+      description: 'Get a single frontmatter field from a vault note',
+      inputSchema: { path: z.string(), field: z.string().describe('Frontmatter key') },
+    },
+    async ({ path, field }) => {
+      const content = await vault.readFile(path)
+      const fm = parseFrontmatter(content)
+      const value = Object.prototype.hasOwnProperty.call(fm, field) ? fm[field] : null
+      return ok({ field, value })
+    },
+  )
+
+  mcp.registerTool(
+    'frontmatter_set_field',
+    {
+      description: 'Set a frontmatter field — queued for proposal review',
+      inputSchema: { path: z.string(), field: z.string(), value: z.any() },
+    },
+    async () => ok({ proposalId: STUB_PROPOSAL_ID, status: 'pending' }),
+  )
+
+  mcp.registerTool(
+    'frontmatter_set_many',
+    {
+      description: 'Set multiple frontmatter fields at once — queued for proposal review',
+      inputSchema: {
+        path: z.string(),
+        fields: z.record(z.string(), z.any()).describe('Key-value pairs to set'),
+      },
+    },
+    async () => ok({ proposalId: STUB_PROPOSAL_ID, status: 'pending' }),
+  )
+}
 
 export class ObsidianMcpServerAdapter implements ObsidianMcpServerPort {
   private httpServer: http.Server | null = null
-  private transport: StreamableHTTPServerTransport | null = null
   private assignedPort = 0
 
-  async start(): Promise<{ port: number }> {
-    const mcp = new McpServer({ name: 'specorator', version: '1.0.0' })
-    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined })
-    await mcp.connect(transport)
+  constructor(private readonly vault: VaultPort) {}
 
+  async start(): Promise<{ port: number }> {
     const server = http.createServer((req, res) => {
       const host = req.headers.host?.split(':')[0] ?? ''
       if (host !== '127.0.0.1' && host !== 'localhost') {
@@ -20,7 +179,7 @@ export class ObsidianMcpServerAdapter implements ObsidianMcpServerPort {
         return
       }
       if (req.url === '/mcp') {
-        void transport.handleRequest(req, res).catch(() => {
+        void this._handleMcpRequest(req, res).catch(() => {
           if (!res.headersSent) res.writeHead(500).end()
         })
       } else {
@@ -37,28 +196,33 @@ export class ObsidianMcpServerAdapter implements ObsidianMcpServerPort {
     const port = addr !== null && typeof addr === 'object' ? addr.port : 0
 
     this.httpServer = server
-    this.transport = transport
     this.assignedPort = port
 
     return { port }
   }
 
+  private async _handleMcpRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ): Promise<void> {
+    const mcp = new McpServer({ name: 'specorator', version: '1.0.0' })
+    registerTools(mcp, this.vault)
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined })
+    await mcp.connect(transport)
+    await transport.handleRequest(req, res)
+  }
+
   async stop(): Promise<void> {
-    await this.transport?.close()
     const server = this.httpServer
     if (server !== null) {
       await new Promise<void>((resolve, reject) => {
         server.close((err) => {
-          if (err !== undefined) {
-            reject(err)
-          } else {
-            resolve()
-          }
+          if (err !== undefined) reject(err)
+          else resolve()
         })
       })
     }
     this.httpServer = null
-    this.transport = null
     this.assignedPort = 0
   }
 

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -46,7 +46,7 @@ export default class SpecoratorPlugin extends Plugin {
       logger: this.bridge,
       t: translationPort,
       i18nMerge,
-      mcpServer: new ObsidianMcpServerAdapter(),
+      mcpServer: new ObsidianMcpServerAdapter(this.bridge),
     })
 
     setLocale(this.settings.locale as SupportedLocale)

--- a/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
@@ -157,6 +157,13 @@ describe('ObsidianMcpServerAdapter — vault + frontmatter tools', () => {
       const result = parseToolResult(resp) as { matches: Array<{ path: string }> }
       expect(result.matches.map((m) => m.path)).toContain('specs/dark-mode/idea.md')
     })
+
+    it('produces no double-slash paths when folder has trailing slash', async () => {
+      const resp = await callTool(port, 'vault_search', { query: 'idea', folder: 'specs/' })
+      const result = parseToolResult(resp) as { matches: Array<{ path: string }> }
+      expect(result.matches.every((m) => !m.path.includes('//'))).toBe(true)
+      expect(result.matches.map((m) => m.path)).toContain('specs/dark-mode/idea.md')
+    })
   })
 
   describe('vault_list_folder', () => {
@@ -171,6 +178,13 @@ describe('ObsidianMcpServerAdapter — vault + frontmatter tools', () => {
     it('returns subfolders as full paths', async () => {
       const resp = await callTool(port, 'vault_list_folder', { folder: 'specs' })
       const result = parseToolResult(resp) as { files: string[]; folders: string[] }
+      expect(result.folders).toContain('specs/dark-mode')
+    })
+
+    it('produces no double-slash paths when folder has trailing slash', async () => {
+      const resp = await callTool(port, 'vault_list_folder', { folder: 'specs/' })
+      const result = parseToolResult(resp) as { files: string[]; folders: string[] }
+      expect(result.folders.every((f) => !f.includes('//'))).toBe(true)
       expect(result.folders).toContain('specs/dark-mode')
     })
   })

--- a/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { ObsidianMcpServerAdapter } from '@/infrastructure/obsidian/ObsidianMcpServerAdapter'
+import { MockBridge } from '@/infrastructure/mock/MockBridge'
+
+const STUB_PROPOSAL_ID = 'stub-00000000-0000-0000-0000-000000000000'
+
+async function mcpPost(port: number, body: unknown): Promise<unknown> {
+  const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      Host: '127.0.0.1',
+    },
+    body: JSON.stringify(body),
+  })
+  const text = await res.text()
+  // SSE format: each event is "event: message\ndata: {...}\n\n"
+  const dataLine = text.split('\n').find((line) => line.startsWith('data: '))
+  if (dataLine) return JSON.parse(dataLine.slice(6))
+  return JSON.parse(text)
+}
+
+async function initMcp(port: number): Promise<void> {
+  await mcpPost(port, {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'test', version: '0.0.0' },
+    },
+  })
+}
+
+interface ToolResponse {
+  result: {
+    content: Array<{ type: string; text: string }>
+    isError?: boolean
+  }
+}
+
+async function callTool(port: number, name: string, args: Record<string, unknown>): Promise<ToolResponse> {
+  return mcpPost(port, {
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/call',
+    params: { name, arguments: args },
+  }) as Promise<ToolResponse>
+}
+
+function parseToolResult(resp: ToolResponse): unknown {
+  return JSON.parse(resp.result.content[0].text)
+}
+
+const VAULT_FILES = {
+  'notes/hello.md': '# Hello\n\nWorld content here',
+  'notes/another.md': '# Another\n\nSome other stuff',
+  'specs/dark-mode/workflow-state.md':
+    '---\nid: abc123\nslug: dark-mode\nstatus: active\ncurrentStep: 3\n---\nBody content',
+  'specs/dark-mode/idea.md': '# Idea\n\nSome idea content',
+}
+
+describe('ObsidianMcpServerAdapter — vault + frontmatter tools', () => {
+  let adapter: ObsidianMcpServerAdapter
+  let vault: MockBridge
+  let port: number
+
+  beforeEach(async () => {
+    vault = new MockBridge(VAULT_FILES)
+    adapter = new ObsidianMcpServerAdapter(vault)
+    ;({ port } = await adapter.start())
+    await initMcp(port)
+  })
+
+  afterEach(async () => {
+    await adapter.stop()
+  })
+
+  describe('tools/list', () => {
+    it('registers all 10 tools', async () => {
+      const resp = (await mcpPost(port, {
+        jsonrpc: '2.0',
+        id: 99,
+        method: 'tools/list',
+        params: {},
+      })) as { result: { tools: Array<{ name: string }> } }
+      const names = resp.result.tools.map((t) => t.name).sort()
+      expect(names).toEqual([
+        'frontmatter_get',
+        'frontmatter_get_field',
+        'frontmatter_set_field',
+        'frontmatter_set_many',
+        'vault_append_to_note',
+        'vault_create_folder',
+        'vault_list_folder',
+        'vault_read_note',
+        'vault_search',
+        'vault_write_note',
+      ])
+    })
+  })
+
+  describe('vault_read_note', () => {
+    it('returns file content for existing path', async () => {
+      const resp = await callTool(port, 'vault_read_note', { path: 'notes/hello.md' })
+      expect(resp.result.isError).toBeFalsy()
+      expect(parseToolResult(resp)).toEqual({ content: '# Hello\n\nWorld content here' })
+    })
+
+    it('returns isError when file not found', async () => {
+      const resp = await callTool(port, 'vault_read_note', { path: 'missing.md' })
+      expect(resp.result.isError).toBe(true)
+    })
+  })
+
+  describe('vault_write_note', () => {
+    it('returns pending proposal stub without mutating vault', async () => {
+      const resp = await callTool(port, 'vault_write_note', {
+        path: 'notes/new.md',
+        content: '# New note',
+      })
+      expect(resp.result.isError).toBeFalsy()
+      expect(parseToolResult(resp)).toEqual({ proposalId: STUB_PROPOSAL_ID, status: 'pending' })
+    })
+  })
+
+  describe('vault_append_to_note', () => {
+    it('returns pending proposal stub without mutating vault', async () => {
+      const resp = await callTool(port, 'vault_append_to_note', {
+        path: 'notes/hello.md',
+        content: '\n\nAppended text',
+      })
+      expect(resp.result.isError).toBeFalsy()
+      expect(parseToolResult(resp)).toEqual({ proposalId: STUB_PROPOSAL_ID, status: 'pending' })
+    })
+  })
+
+  describe('vault_search', () => {
+    it('returns files containing the query string (case-insensitive)', async () => {
+      const resp = await callTool(port, 'vault_search', { query: 'world', folder: 'notes' })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { matches: Array<{ path: string; excerpt: string }> }
+      const paths = result.matches.map((m) => m.path)
+      expect(paths).toContain('notes/hello.md')
+      expect(paths).not.toContain('notes/another.md')
+    })
+
+    it('returns empty matches when nothing found', async () => {
+      const resp = await callTool(port, 'vault_search', { query: 'zzz-no-match', folder: 'notes' })
+      expect(parseToolResult(resp)).toEqual({ matches: [] })
+    })
+
+    it('searches recursively across subfolders', async () => {
+      const resp = await callTool(port, 'vault_search', { query: 'idea', folder: 'specs' })
+      const result = parseToolResult(resp) as { matches: Array<{ path: string }> }
+      expect(result.matches.map((m) => m.path)).toContain('specs/dark-mode/idea.md')
+    })
+  })
+
+  describe('vault_list_folder', () => {
+    it('returns files in the given folder', async () => {
+      const resp = await callTool(port, 'vault_list_folder', { folder: 'notes' })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { files: string[]; folders: string[] }
+      expect(result.files).toContain('notes/hello.md')
+      expect(result.files).toContain('notes/another.md')
+    })
+
+    it('returns subfolders as full paths', async () => {
+      const resp = await callTool(port, 'vault_list_folder', { folder: 'specs' })
+      const result = parseToolResult(resp) as { files: string[]; folders: string[] }
+      expect(result.folders).toContain('specs/dark-mode')
+    })
+  })
+
+  describe('vault_create_folder', () => {
+    it('returns created: true', async () => {
+      const resp = await callTool(port, 'vault_create_folder', { path: 'new-folder' })
+      expect(resp.result.isError).toBeFalsy()
+      expect(parseToolResult(resp)).toEqual({ created: true })
+    })
+  })
+
+  describe('frontmatter_get', () => {
+    it('returns all frontmatter fields', async () => {
+      const resp = await callTool(port, 'frontmatter_get', {
+        path: 'specs/dark-mode/workflow-state.md',
+      })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { frontmatter: Record<string, unknown> }
+      expect(result.frontmatter).toMatchObject({ id: 'abc123', slug: 'dark-mode', status: 'active' })
+    })
+
+    it('returns empty frontmatter for note without frontmatter', async () => {
+      const resp = await callTool(port, 'frontmatter_get', { path: 'notes/hello.md' })
+      expect(resp.result.isError).toBeFalsy()
+      expect(parseToolResult(resp)).toEqual({ frontmatter: {} })
+    })
+
+    it('returns isError when file not found', async () => {
+      const resp = await callTool(port, 'frontmatter_get', { path: 'missing.md' })
+      expect(resp.result.isError).toBe(true)
+    })
+  })
+
+  describe('frontmatter_get_field', () => {
+    it('returns value for existing field', async () => {
+      const resp = await callTool(port, 'frontmatter_get_field', {
+        path: 'specs/dark-mode/workflow-state.md',
+        field: 'slug',
+      })
+      expect(resp.result.isError).toBeFalsy()
+      expect(parseToolResult(resp)).toEqual({ field: 'slug', value: 'dark-mode' })
+    })
+
+    it('returns null for field not present in frontmatter', async () => {
+      const resp = await callTool(port, 'frontmatter_get_field', {
+        path: 'specs/dark-mode/workflow-state.md',
+        field: 'nonexistent',
+      })
+      expect(parseToolResult(resp)).toEqual({ field: 'nonexistent', value: null })
+    })
+
+    it('returns isError when file not found', async () => {
+      const resp = await callTool(port, 'frontmatter_get_field', {
+        path: 'missing.md',
+        field: 'slug',
+      })
+      expect(resp.result.isError).toBe(true)
+    })
+  })
+
+  describe('frontmatter_set_field', () => {
+    it('returns pending proposal stub without mutating vault', async () => {
+      const resp = await callTool(port, 'frontmatter_set_field', {
+        path: 'specs/dark-mode/workflow-state.md',
+        field: 'status',
+        value: 'draft',
+      })
+      expect(resp.result.isError).toBeFalsy()
+      expect(parseToolResult(resp)).toEqual({ proposalId: STUB_PROPOSAL_ID, status: 'pending' })
+    })
+  })
+
+  describe('frontmatter_set_many', () => {
+    it('returns pending proposal stub without mutating vault', async () => {
+      const resp = await callTool(port, 'frontmatter_set_many', {
+        path: 'specs/dark-mode/workflow-state.md',
+        fields: { status: 'draft', slug: 'dm' },
+      })
+      expect(resp.result.isError).toBeFalsy()
+      expect(parseToolResult(resp)).toEqual({ proposalId: STUB_PROPOSAL_ID, status: 'pending' })
+    })
+  })
+})

--- a/tests/infrastructure/obsidian-mcp-server-adapter.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter.test.ts
@@ -1,10 +1,11 @@
 import * as http from 'node:http'
 import { describe, it, expect } from 'vitest'
 import { ObsidianMcpServerAdapter } from '@/infrastructure/obsidian/ObsidianMcpServerAdapter'
+import { MockBridge } from '@/infrastructure/mock/MockBridge'
 
 describe('ObsidianMcpServerAdapter', () => {
   it('start() assigns a dynamic port in valid range', async () => {
-    const adapter = new ObsidianMcpServerAdapter()
+    const adapter = new ObsidianMcpServerAdapter(new MockBridge())
     const { port } = await adapter.start()
     expect(port).toBeGreaterThan(0)
     expect(port).toBeLessThanOrEqual(65535)
@@ -12,7 +13,7 @@ describe('ObsidianMcpServerAdapter', () => {
   })
 
   it('getConnectionConfig() returns 127.0.0.1 URL matching the assigned port', async () => {
-    const adapter = new ObsidianMcpServerAdapter()
+    const adapter = new ObsidianMcpServerAdapter(new MockBridge())
     const { port } = await adapter.start()
     expect(adapter.getConnectionConfig()).toEqual({
       transport: 'http',
@@ -22,25 +23,25 @@ describe('ObsidianMcpServerAdapter', () => {
   })
 
   it('getConnectionConfig() throws before start()', () => {
-    const adapter = new ObsidianMcpServerAdapter()
+    const adapter = new ObsidianMcpServerAdapter(new MockBridge())
     expect(() => adapter.getConnectionConfig()).toThrow(/not started/)
   })
 
   it('getConnectionConfig() throws after stop()', async () => {
-    const adapter = new ObsidianMcpServerAdapter()
+    const adapter = new ObsidianMcpServerAdapter(new MockBridge())
     await adapter.start()
     await adapter.stop()
     expect(() => adapter.getConnectionConfig()).toThrow(/not started/)
   })
 
   it('stop() closes the server cleanly', async () => {
-    const adapter = new ObsidianMcpServerAdapter()
+    const adapter = new ObsidianMcpServerAdapter(new MockBridge())
     await adapter.start()
     await expect(adapter.stop()).resolves.toBeUndefined()
   })
 
   it('returns 421 for requests with a non-localhost Host header (DNS rebinding guard)', async () => {
-    const adapter = new ObsidianMcpServerAdapter()
+    const adapter = new ObsidianMcpServerAdapter(new MockBridge())
     const { port } = await adapter.start()
 
     const statusCode = await new Promise<number>((resolve, reject) => {
@@ -59,7 +60,7 @@ describe('ObsidianMcpServerAdapter', () => {
   })
 
   it('returns 500 and stays alive when transport.handleRequest rejects', async () => {
-    const adapter = new ObsidianMcpServerAdapter()
+    const adapter = new ObsidianMcpServerAdapter(new MockBridge())
     const { port } = await adapter.start()
 
     // Send a request immediately after stop() is called on the transport
@@ -85,8 +86,8 @@ describe('ObsidianMcpServerAdapter', () => {
     expect([200, 202, 400, 404, 500, 0]).toContain(statusCode)
   })
 
-  it('server returns empty tool list at /mcp', async () => {
-    const adapter = new ObsidianMcpServerAdapter()
+  it('server responds to initialize at /mcp', async () => {
+    const adapter = new ObsidianMcpServerAdapter(new MockBridge())
     const { port } = await adapter.start()
 
     const response = await fetch(`http://localhost:${port}/mcp`, {


### PR DESCRIPTION
## Summary

- Registers 10 vault/frontmatter MCP tools on `ObsidianMcpServerAdapter` via `VaultPort`
- Switches adapter to **per-request `McpServer` pattern** — stateless HTTP transport closes after each SSE response, so reusing one `McpServer` breaks subsequent requests
- Adds `yaml` and `zod` as direct dependencies (were transitive)
- `vault_move_note` omitted — blocked on #203

## Tools

| Tool | Type | Behavior |
|---|---|---|
| `vault_read_note` | read | `VaultPort.readFile` → `{content}` |
| `vault_search` | read | recursive case-insensitive search |
| `vault_list_folder` | read | `{files, folders}` with full paths |
| `vault_create_folder` | read | `VaultPort.createFolder` → `{created: true}` |
| `frontmatter_get` | read | YAML frontmatter parsed via `yaml` pkg |
| `frontmatter_get_field` | read | single field or `null` |
| `vault_write_note` | write stub | `{proposalId, status: 'pending'}` |
| `vault_append_to_note` | write stub | `{proposalId, status: 'pending'}` |
| `frontmatter_set_field` | write stub | `{proposalId, status: 'pending'}` |
| `frontmatter_set_many` | write stub | `{proposalId, status: 'pending'}` |

Write stubs return a fixed `proposalId` pending #191 (write proposal queue).

## Test plan

- [x] 19 new tool tests in `tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts`
- [x] Existing lifecycle tests updated (constructor now requires `VaultPort`)
- [x] `npm run verify` green — 394 tests pass, coverage above all thresholds, typecheck + lint clean

Closes #190 (partial — `vault_move_note` pending #203)

🤖 Generated with [Claude Code](https://claude.com/claude-code)