### PR TITLE
fix(ci): replace remote installer script with verified release download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install actionlint
         run: |
-          curl -sSfL -o actionlint.tar.gz \
+          curl -sSfL -o actionlint_1.7.12_linux_amd64.tar.gz \
             https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
           curl -sSfL -o actionlint_checksums.txt \
             https://github.com/rhysd/actionlint/releases/download/v1.7.12/checksums.txt
           sha256sum --check --ignore-missing actionlint_checksums.txt
-          tar -xzf actionlint.tar.gz actionlint
-          rm actionlint.tar.gz actionlint_checksums.txt
+          tar -xzf actionlint_1.7.12_linux_amd64.tar.gz actionlint
+          rm actionlint_1.7.12_linux_amd64.tar.gz actionlint_checksums.txt
       - name: Run actionlint
         run: ./actionlint -color
       - name: Set up Node.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install actionlint
         run: |
-          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
+          curl -sSfL -o actionlint.tar.gz \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
+          curl -sSfL -o actionlint_checksums.txt \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.12/checksums.txt
+          sha256sum --check --ignore-missing actionlint_checksums.txt
+          tar -xzf actionlint.tar.gz actionlint
+          rm actionlint.tar.gz actionlint_checksums.txt
       - name: Run actionlint
         run: ./actionlint -color
       - name: Set up Node.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}  
 
 jobs:
   workflow-lint:
@@ -23,13 +23,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install actionlint
         run: |
-          curl -sSfL -o actionlint_1.7.12_linux_amd64.tar.gz \
+          curl -L -o actionlint_1.7.12_linux_amd64.tar.gz \
             https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
-          curl -sSfL -o actionlint_checksums.txt \
-            https://github.com/rhysd/actionlint/releases/download/v1.7.12/checksums.txt
-          sha256sum --check --ignore-missing actionlint_checksums.txt
+          echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint_1.7.12_linux_amd64.tar.gz" | sha256sum --check
           tar -xzf actionlint_1.7.12_linux_amd64.tar.gz actionlint
-          rm actionlint_1.7.12_linux_amd64.tar.gz actionlint_checksums.txt
+          rm actionlint_1.7.12_linux_amd64.tar.gz
       - name: Run actionlint
         run: ./actionlint -color
       - name: Set up Node.js


### PR DESCRIPTION
Addresses the P1 supply-chain finding raised in PR #204 (Codex review on `.github/workflows/ci.yml` line 26).

## Problem

The previous install step executed a remote script without any integrity check:
```sh
bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
```
If the upstream script at that URL were changed (raw file paths are mutable even when a tag is specified), arbitrary code would run in CI with the repository token — defeating the repo's own SHA-pinning supply-chain controls.

## Fix

Download the release tarball and its `checksums.txt` directly from the immutable GitHub release artifact, verify with `sha256sum`, then extract:
```sh
curl -sSfL -o actionlint.tar.gz \
  https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
curl -sSfL -o actionlint_checksums.txt \
  https://github.com/rhysd/actionlint/releases/download/v1.7.12/checksums.txt
sha256sum --check --ignore-missing actionlint_checksums.txt
tar -xzf actionlint.tar.gz actionlint
rm actionlint.tar.gz actionlint_checksums.txt
```
No remote code executes before the integrity check passes.

## Test plan
- [ ] `Lint workflow files (actionlint)` CI check passes on this PR

https://claude.ai/code/session_01W4CwHxP7mgwXPJD3GD4frG

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4CwHxP7mgwXPJD3GD4frG)_