### PR TITLE
feat(mcp): implement PendingProposal queue — write tools return receipts, accept/reject apply or discard mutations

### DIFF
--- a/docs/superpowers/plans/2026-05-10-pending-proposal.md
+++ b/docs/superpowers/plans/2026-05-10-pending-proposal.md
@@ -1,0 +1,1034 @@
+# PendingProposal Mechanism Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace write-tool stubs in `ObsidianMcpServerAdapter` with a real proposal queue so MCP write tools return a receipt instead of mutating the vault directly, and accept/reject calls apply or discard the mutation.
+
+**Architecture:** A new `ProposalStore` class (instance-level on the adapter) holds a `Map<proposalId, ProposalEntry>` where each entry captures a `mutate` closure at queue time. Write tools call `store.queue()` and return `{ proposalId, status: 'pending' }`. The adapter exposes `acceptProposal`, `rejectProposal`, and `getProposals` as public methods (not on the port interface).
+
+**Tech Stack:** TypeScript, `node:crypto` (randomUUID), `yaml` (parse + stringify, already a dependency), Vitest, `@modelcontextprotocol/sdk`.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/infrastructure/obsidian/ProposalStore.ts` | **Create** | `PendingProposal` type, `ProposalStore` class |
+| `src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts` | **Modify** | Wire store, update write tools, add public methods, add `applyFrontmatterUpdate` |
+| `tests/infrastructure/proposal-store.test.ts` | **Create** | Pure unit tests for `ProposalStore` (no HTTP) |
+| `tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts` | **Modify** | Replace stub assertions with real accept/reject behavior tests |
+
+---
+
+## Task 1: Write failing `ProposalStore` unit tests
+
+**Files:**
+- Create: `tests/infrastructure/proposal-store.test.ts`
+
+- [ ] **Step 1.1: Create the test file**
+
+```ts
+import { describe, it, expect, vi } from 'vitest'
+import { ProposalStore } from '@/infrastructure/obsidian/ProposalStore'
+
+describe('ProposalStore', () => {
+  describe('queue()', () => {
+    it('returns a non-empty string proposalId', () => {
+      const store = new ProposalStore()
+      const id = store.queue('vault_write_note', { path: 'a.md' }, async () => {})
+      expect(typeof id).toBe('string')
+      expect(id.length).toBeGreaterThan(0)
+    })
+
+    it('returns a unique id for each call', () => {
+      const store = new ProposalStore()
+      const id1 = store.queue('vault_write_note', {}, async () => {})
+      const id2 = store.queue('vault_write_note', {}, async () => {})
+      expect(id1).not.toBe(id2)
+    })
+  })
+
+  describe('getAll()', () => {
+    it('returns queued proposal with status pending and correct shape', () => {
+      const store = new ProposalStore()
+      const params = { path: 'a.md', content: 'hi' }
+      const id = store.queue('vault_write_note', params, async () => {})
+      const all = store.getAll()
+      expect(all).toHaveLength(1)
+      expect(all[0]).toEqual({
+        proposalId: id,
+        toolName: 'vault_write_note',
+        params,
+        status: 'pending',
+      })
+    })
+
+    it('does not expose mutate closure', () => {
+      const store = new ProposalStore()
+      store.queue('vault_write_note', {}, async () => {})
+      const all = store.getAll()
+      expect('mutate' in all[0]).toBe(false)
+    })
+
+    it('returns all queued proposals', () => {
+      const store = new ProposalStore()
+      store.queue('vault_write_note', {}, async () => {})
+      store.queue('vault_append_to_note', {}, async () => {})
+      expect(store.getAll()).toHaveLength(2)
+    })
+  })
+
+  describe('get()', () => {
+    it('returns the proposal for a known id', () => {
+      const store = new ProposalStore()
+      const id = store.queue('vault_write_note', { path: 'x.md' }, async () => {})
+      const p = store.get(id)
+      expect(p?.proposalId).toBe(id)
+      expect(p?.status).toBe('pending')
+    })
+
+    it('returns undefined for unknown id', () => {
+      const store = new ProposalStore()
+      expect(store.get('no-such-id')).toBeUndefined()
+    })
+
+    it('does not expose mutate closure', () => {
+      const store = new ProposalStore()
+      const id = store.queue('vault_write_note', {}, async () => {})
+      expect('mutate' in store.get(id)!).toBe(false)
+    })
+  })
+
+  describe('accept()', () => {
+    it('calls mutate fn exactly once and sets status to accepted', async () => {
+      const store = new ProposalStore()
+      const mutate = vi.fn().mockResolvedValue(undefined)
+      const id = store.queue('vault_write_note', {}, mutate)
+      await store.accept(id)
+      expect(mutate).toHaveBeenCalledOnce()
+      expect(store.get(id)?.status).toBe('accepted')
+    })
+
+    it('throws on unknown id', async () => {
+      const store = new ProposalStore()
+      await expect(store.accept('no-such-id')).rejects.toThrow('no-such-id')
+    })
+
+    it('throws when already accepted', async () => {
+      const store = new ProposalStore()
+      const id = store.queue('vault_write_note', {}, async () => {})
+      await store.accept(id)
+      await expect(store.accept(id)).rejects.toThrow(id)
+    })
+
+    it('throws when already rejected', async () => {
+      const store = new ProposalStore()
+      const id = store.queue('vault_write_note', {}, async () => {})
+      store.reject(id)
+      await expect(store.accept(id)).rejects.toThrow(id)
+    })
+  })
+
+  describe('reject()', () => {
+    it('sets status to rejected without calling mutate', () => {
+      const store = new ProposalStore()
+      const mutate = vi.fn().mockResolvedValue(undefined)
+      const id = store.queue('vault_write_note', {}, mutate)
+      store.reject(id)
+      expect(mutate).not.toHaveBeenCalled()
+      expect(store.get(id)?.status).toBe('rejected')
+    })
+
+    it('throws on unknown id', () => {
+      const store = new ProposalStore()
+      expect(() => store.reject('no-such-id')).toThrow('no-such-id')
+    })
+
+    it('throws when already accepted', async () => {
+      const store = new ProposalStore()
+      const id = store.queue('vault_write_note', {}, async () => {})
+      await store.accept(id)
+      expect(() => store.reject(id)).toThrow(id)
+    })
+
+    it('throws when already rejected', () => {
+      const store = new ProposalStore()
+      const id = store.queue('vault_write_note', {}, async () => {})
+      store.reject(id)
+      expect(() => store.reject(id)).toThrow(id)
+    })
+  })
+})
+```
+
+- [ ] **Step 1.2: Run tests — confirm they fail**
+
+```
+npx vitest run tests/infrastructure/proposal-store.test.ts
+```
+
+Expected: all tests FAIL with `Cannot find module '@/infrastructure/obsidian/ProposalStore'`.
+
+---
+
+## Task 2: Implement `ProposalStore`
+
+**Files:**
+- Create: `src/infrastructure/obsidian/ProposalStore.ts`
+
+- [ ] **Step 2.1: Create the implementation**
+
+```ts
+import { randomUUID } from 'node:crypto'
+
+export type PendingProposal = {
+  proposalId: string
+  toolName: string
+  params: unknown
+  status: 'pending' | 'accepted' | 'rejected'
+}
+
+type ProposalEntry = PendingProposal & { mutate: () => Promise<void> }
+
+export class ProposalStore {
+  private readonly entries = new Map<string, ProposalEntry>()
+
+  queue(toolName: string, params: unknown, mutate: () => Promise<void>): string {
+    const proposalId = randomUUID()
+    this.entries.set(proposalId, { proposalId, toolName, params, status: 'pending', mutate })
+    return proposalId
+  }
+
+  async accept(proposalId: string): Promise<void> {
+    const entry = this.#getOrThrow(proposalId)
+    this.#assertPending(entry)
+    await entry.mutate()
+    entry.status = 'accepted'
+  }
+
+  reject(proposalId: string): void {
+    const entry = this.#getOrThrow(proposalId)
+    this.#assertPending(entry)
+    entry.status = 'rejected'
+  }
+
+  getAll(): ReadonlyArray<PendingProposal> {
+    return Array.from(this.entries.values()).map(({ mutate: _m, ...rest }) => rest)
+  }
+
+  get(proposalId: string): PendingProposal | undefined {
+    const entry = this.entries.get(proposalId)
+    if (!entry) return undefined
+    const { mutate: _m, ...rest } = entry
+    return rest
+  }
+
+  #getOrThrow(proposalId: string): ProposalEntry {
+    const entry = this.entries.get(proposalId)
+    if (!entry) throw new Error(`Unknown proposal: ${proposalId}`)
+    return entry
+  }
+
+  #assertPending(entry: ProposalEntry): void {
+    if (entry.status !== 'pending')
+      throw new Error(`Proposal not pending: ${entry.proposalId} (${entry.status})`)
+  }
+}
+```
+
+- [ ] **Step 2.2: Run tests — confirm they pass**
+
+```
+npx vitest run tests/infrastructure/proposal-store.test.ts
+```
+
+Expected: all 14 tests PASS.
+
+- [ ] **Step 2.3: Commit**
+
+```
+git add src/infrastructure/obsidian/ProposalStore.ts tests/infrastructure/proposal-store.test.ts
+git commit -m "feat(mcp): add ProposalStore — queue/accept/reject for write tool proposals"
+```
+
+---
+
+## Task 3: Update `ObsidianMcpServerAdapter`
+
+**Files:**
+- Modify: `src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts`
+
+Replace the entire file content. Changes from the current version:
+- Delete `STUB_PROPOSAL_ID` constant
+- Import `stringify as stringifyYaml` from `yaml`
+- Import `ProposalStore` and `PendingProposal` from `./ProposalStore`
+- Add `applyFrontmatterUpdate` module-level async function
+- Add `private readonly proposalStore = new ProposalStore()` field on the class
+- Add `acceptProposal`, `rejectProposal`, `getProposals` public methods
+- Update `registerTools` signature to accept `store: ProposalStore` as third param
+- Replace stub returns in write tools with `store.queue(...)` calls
+- Pass `this.proposalStore` to `registerTools` in `_handleMcpRequest`
+
+- [ ] **Step 3.1: Replace file content**
+
+```ts
+import * as http from 'node:http'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import { z } from 'zod'
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
+import type { ObsidianMcpServerPort, McpConnectionConfig, VaultPort } from '@/domain/ports'
+import { ProposalStore, type PendingProposal } from './ProposalStore'
+
+function parseFrontmatter(content: string): Record<string, unknown> {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content)
+  if (!match) return {}
+  try {
+    const result = parseYaml(match[1]) as unknown
+    if (result !== null && typeof result === 'object' && !Array.isArray(result)) {
+      return result as Record<string, unknown>
+    }
+    return {}
+  } catch {
+    return {}
+  }
+}
+
+async function applyFrontmatterUpdate(
+  vault: VaultPort,
+  path: string,
+  updates: Record<string, unknown>,
+): Promise<void> {
+  const content = await vault.readFile(path)
+  const existing = parseFrontmatter(content)
+  const merged = { ...existing, ...updates }
+  const body = content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '')
+  await vault.writeFile(path, `---\n${stringifyYaml(merged)}---\n${body}`)
+}
+
+function joinVaultPath(parent: string, child: string): string {
+  const p = parent.replace(/\/+$/, '')
+  return p ? `${p}/${child}` : child
+}
+
+async function collectFiles(vault: VaultPort, folder: string): Promise<string[]> {
+  const [files, subfolders] = await Promise.all([vault.listFiles(folder), vault.listFolders(folder)])
+  const nested = await Promise.all(
+    subfolders.map((sub) => collectFiles(vault, joinVaultPath(folder, sub))),
+  )
+  return [...files, ...nested.flat()]
+}
+
+function ok(data: unknown): { content: [{ type: 'text'; text: string }] } {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(data) }] }
+}
+
+function registerTools(mcp: McpServer, vault: VaultPort, store: ProposalStore): void {
+  mcp.registerTool(
+    'vault_read_note',
+    {
+      description: 'Read the full content of a vault note',
+      inputSchema: { path: z.string().describe('Vault-relative path') },
+    },
+    async ({ path }) => ok({ content: await vault.readFile(path) }),
+  )
+
+  mcp.registerTool(
+    'vault_write_note',
+    {
+      description: 'Overwrite a vault note — queued for proposal review',
+      inputSchema: { path: z.string(), content: z.string() },
+    },
+    async ({ path, content }) => {
+      const proposalId = store.queue('vault_write_note', { path, content }, () =>
+        vault.writeFile(path, content),
+      )
+      return ok({ proposalId, status: 'pending' })
+    },
+  )
+
+  mcp.registerTool(
+    'vault_append_to_note',
+    {
+      description: 'Append text to a vault note — queued for proposal review',
+      inputSchema: { path: z.string(), content: z.string().describe('Text to append') },
+    },
+    async ({ path, content }) => {
+      const proposalId = store.queue('vault_append_to_note', { path, content }, async () => {
+        const existing = await vault.readFile(path)
+        await vault.writeFile(path, existing + content)
+      })
+      return ok({ proposalId, status: 'pending' })
+    },
+  )
+
+  mcp.registerTool(
+    'vault_search',
+    {
+      description: 'Search vault notes for a query string (case-insensitive, recursive)',
+      inputSchema: {
+        query: z.string().describe('Substring to search for'),
+        folder: z.string().describe('Vault-relative folder to search in'),
+      },
+    },
+    async ({ query, folder }) => {
+      const files = await collectFiles(vault, folder)
+      const lower = query.toLowerCase()
+      const matches: Array<{ path: string; excerpt: string }> = []
+      for (const path of files) {
+        try {
+          const content = await vault.readFile(path)
+          const idx = content.toLowerCase().indexOf(lower)
+          if (idx !== -1) {
+            const start = Math.max(0, idx - 60)
+            const end = Math.min(content.length, idx + query.length + 60)
+            matches.push({ path, excerpt: content.slice(start, end).trim() })
+          }
+        } catch {
+          // skip unreadable files
+        }
+      }
+      return ok({ matches })
+    },
+  )
+
+  mcp.registerTool(
+    'vault_list_folder',
+    {
+      description: 'List files and immediate subfolders in a vault folder',
+      inputSchema: { folder: z.string().describe('Vault-relative folder path') },
+    },
+    async ({ folder }) => {
+      const [files, subfolderNames] = await Promise.all([
+        vault.listFiles(folder),
+        vault.listFolders(folder),
+      ])
+      const folders = subfolderNames.map((sub) => joinVaultPath(folder, sub))
+      return ok({ files, folders })
+    },
+  )
+
+  mcp.registerTool(
+    'vault_create_folder',
+    {
+      description: 'Create a folder in the vault',
+      inputSchema: { path: z.string().describe('Vault-relative path to create') },
+    },
+    async ({ path }) => {
+      await vault.createFolder(path)
+      return ok({ created: true })
+    },
+  )
+
+  mcp.registerTool(
+    'frontmatter_get',
+    {
+      description: 'Get all YAML frontmatter fields from a vault note',
+      inputSchema: { path: z.string() },
+    },
+    async ({ path }) => {
+      const content = await vault.readFile(path)
+      return ok({ frontmatter: parseFrontmatter(content) })
+    },
+  )
+
+  mcp.registerTool(
+    'frontmatter_get_field',
+    {
+      description: 'Get a single frontmatter field from a vault note',
+      inputSchema: { path: z.string(), field: z.string().describe('Frontmatter key') },
+    },
+    async ({ path, field }) => {
+      const content = await vault.readFile(path)
+      const fm = parseFrontmatter(content)
+      const value = Object.prototype.hasOwnProperty.call(fm, field) ? fm[field] : null
+      return ok({ field, value })
+    },
+  )
+
+  mcp.registerTool(
+    'frontmatter_set_field',
+    {
+      description: 'Set a frontmatter field — queued for proposal review',
+      inputSchema: { path: z.string(), field: z.string(), value: z.any() },
+    },
+    async ({ path, field, value }) => {
+      const proposalId = store.queue('frontmatter_set_field', { path, field, value }, () =>
+        applyFrontmatterUpdate(vault, path, { [field]: value }),
+      )
+      return ok({ proposalId, status: 'pending' })
+    },
+  )
+
+  mcp.registerTool(
+    'frontmatter_set_many',
+    {
+      description: 'Set multiple frontmatter fields at once — queued for proposal review',
+      inputSchema: {
+        path: z.string(),
+        fields: z.record(z.string(), z.any()).describe('Key-value pairs to set'),
+      },
+    },
+    async ({ path, fields }) => {
+      const proposalId = store.queue('frontmatter_set_many', { path, fields }, () =>
+        applyFrontmatterUpdate(vault, path, fields),
+      )
+      return ok({ proposalId, status: 'pending' })
+    },
+  )
+}
+
+export class ObsidianMcpServerAdapter implements ObsidianMcpServerPort {
+  private readonly proposalStore = new ProposalStore()
+  private httpServer: http.Server | null = null
+  private assignedPort = 0
+
+  constructor(private readonly vault: VaultPort) {}
+
+  async acceptProposal(proposalId: string): Promise<void> {
+    await this.proposalStore.accept(proposalId)
+  }
+
+  rejectProposal(proposalId: string): void {
+    this.proposalStore.reject(proposalId)
+  }
+
+  getProposals(): ReadonlyArray<PendingProposal> {
+    return this.proposalStore.getAll()
+  }
+
+  async start(): Promise<{ port: number }> {
+    const server = http.createServer((req, res) => {
+      const host = req.headers.host?.split(':')[0] ?? ''
+      if (host !== '127.0.0.1' && host !== 'localhost') {
+        res.writeHead(421).end()
+        return
+      }
+      if (req.url === '/mcp') {
+        void this._handleMcpRequest(req, res).catch(() => {
+          if (!res.headersSent) res.writeHead(500).end()
+        })
+      } else {
+        res.writeHead(404).end()
+      }
+    })
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+
+    const addr = server.address()
+    const port = addr !== null && typeof addr === 'object' ? addr.port : 0
+
+    this.httpServer = server
+    this.assignedPort = port
+
+    return { port }
+  }
+
+  private async _handleMcpRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ): Promise<void> {
+    const mcp = new McpServer({ name: 'specorator', version: '1.0.0' })
+    registerTools(mcp, this.vault, this.proposalStore)
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined })
+    await mcp.connect(transport)
+    try {
+      await transport.handleRequest(req, res)
+    } finally {
+      await transport.close()
+    }
+  }
+
+  async stop(): Promise<void> {
+    const server = this.httpServer
+    if (server !== null) {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err !== undefined) reject(err)
+          else resolve()
+        })
+      })
+    }
+    this.httpServer = null
+    this.assignedPort = 0
+  }
+
+  getConnectionConfig(): McpConnectionConfig {
+    if (this.assignedPort === 0) {
+      throw new Error('MCP server not started — call start() first')
+    }
+    return { transport: 'http', url: `http://127.0.0.1:${this.assignedPort}/mcp` }
+  }
+}
+```
+
+- [ ] **Step 3.2: Run typecheck**
+
+```
+npm run typecheck
+```
+
+Expected: no errors.
+
+---
+
+## Task 4: Update integration tests
+
+**Files:**
+- Modify: `tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts`
+
+Replace the entire file. Key changes from current version:
+- Delete `const STUB_PROPOSAL_ID` constant
+- Add `parseFrontmatter` helper (copy of the module-level one — needed to verify accept results)
+- Replace stub-assertion write tool tests with real vault-mutation tests
+- Keep all read tool tests and `tools/list` test unchanged
+
+- [ ] **Step 4.1: Replace file content**
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { ObsidianMcpServerAdapter } from '@/infrastructure/obsidian/ObsidianMcpServerAdapter'
+import { MockBridge } from '@/infrastructure/mock/MockBridge'
+import { parse as parseYaml } from 'yaml'
+
+async function mcpPost(port: number, body: unknown): Promise<unknown> {
+  const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      Host: '127.0.0.1',
+    },
+    body: JSON.stringify(body),
+  })
+  const text = await res.text()
+  const dataLine = text.split('\n').find((line) => line.startsWith('data: '))
+  if (dataLine) return JSON.parse(dataLine.slice(6))
+  return JSON.parse(text)
+}
+
+async function initMcp(port: number): Promise<void> {
+  await mcpPost(port, {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'test', version: '0.0.0' },
+    },
+  })
+}
+
+interface ToolResponse {
+  result: {
+    content: Array<{ type: string; text: string }>
+    isError?: boolean
+  }
+}
+
+async function callTool(
+  port: number,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ToolResponse> {
+  return mcpPost(port, {
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/call',
+    params: { name, arguments: args },
+  }) as Promise<ToolResponse>
+}
+
+function parseToolResult(resp: ToolResponse): unknown {
+  return JSON.parse(resp.result.content[0].text)
+}
+
+function parseFrontmatter(content: string): Record<string, unknown> {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content)
+  if (!match) return {}
+  try {
+    const result = parseYaml(match[1]) as unknown
+    if (result !== null && typeof result === 'object' && !Array.isArray(result)) {
+      return result as Record<string, unknown>
+    }
+    return {}
+  } catch {
+    return {}
+  }
+}
+
+const VAULT_FILES = {
+  'notes/hello.md': '# Hello\n\nWorld content here',
+  'notes/another.md': '# Another\n\nSome other stuff',
+  'specs/dark-mode/workflow-state.md':
+    '---\nid: abc123\nslug: dark-mode\nstatus: active\ncurrentStep: 3\n---\nBody content',
+  'specs/dark-mode/idea.md': '# Idea\n\nSome idea content',
+}
+
+describe('ObsidianMcpServerAdapter — vault + frontmatter tools', () => {
+  let adapter: ObsidianMcpServerAdapter
+  let vault: MockBridge
+  let port: number
+
+  beforeEach(async () => {
+    vault = new MockBridge(VAULT_FILES)
+    adapter = new ObsidianMcpServerAdapter(vault)
+    ;({ port } = await adapter.start())
+    await initMcp(port)
+  })
+
+  afterEach(async () => {
+    await adapter.stop()
+  })
+
+  describe('tools/list', () => {
+    it('registers all 10 tools', async () => {
+      const resp = (await mcpPost(port, {
+        jsonrpc: '2.0',
+        id: 99,
+        method: 'tools/list',
+        params: {},
+      })) as { result: { tools: Array<{ name: string }> } }
+      const names = resp.result.tools.map((t) => t.name).sort()
+      expect(names).toEqual([
+        'frontmatter_get',
+        'frontmatter_get_field',
+        'frontmatter_set_field',
+        'frontmatter_set_many',
+        'vault_append_to_note',
+        'vault_create_folder',
+        'vault_list_folder',
+        'vault_read_note',
+        'vault_search',
+        'vault_write_note',
+      ])
+    })
+  })
+
+  describe('vault_read_note', () => {
+    it('returns file content for existing path', async () => {
+      const resp = await callTool(port, 'vault_read_note', { path: 'notes/hello.md' })
+      expect(resp.result.isError).toBeFalsy()
+      expect(parseToolResult(resp)).toEqual({ content: '# Hello\n\nWorld content here' })
+    })
+
+    it('returns isError when file not found', async () => {
+      const resp = await callTool(port, 'vault_read_note', { path: 'missing.md' })
+      expect(resp.result.isError).toBe(true)
+    })
+  })
+
+  describe('vault_write_note', () => {
+    it('returns a pending proposal receipt without mutating the vault', async () => {
+      const resp = await callTool(port, 'vault_write_note', {
+        path: 'notes/new.md',
+        content: '# New note',
+      })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { proposalId: string; status: string }
+      expect(result.status).toBe('pending')
+      expect(typeof result.proposalId).toBe('string')
+      expect(result.proposalId.length).toBeGreaterThan(0)
+      expect(await vault.fileExists('notes/new.md')).toBe(false)
+    })
+
+    it('accept writes the note content to the vault', async () => {
+      const resp = await callTool(port, 'vault_write_note', {
+        path: 'notes/new.md',
+        content: '# New note',
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      await adapter.acceptProposal(proposalId)
+      expect(await vault.readFile('notes/new.md')).toBe('# New note')
+    })
+
+    it('reject leaves the vault unchanged', async () => {
+      const resp = await callTool(port, 'vault_write_note', {
+        path: 'notes/new.md',
+        content: '# New note',
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      adapter.rejectProposal(proposalId)
+      expect(await vault.fileExists('notes/new.md')).toBe(false)
+    })
+  })
+
+  describe('vault_append_to_note', () => {
+    it('returns a pending proposal receipt without mutating the vault', async () => {
+      const resp = await callTool(port, 'vault_append_to_note', {
+        path: 'notes/hello.md',
+        content: '\n\nAppended text',
+      })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { proposalId: string; status: string }
+      expect(result.status).toBe('pending')
+      expect(await vault.readFile('notes/hello.md')).toBe('# Hello\n\nWorld content here')
+    })
+
+    it('accept appends the content to the existing file', async () => {
+      const resp = await callTool(port, 'vault_append_to_note', {
+        path: 'notes/hello.md',
+        content: '\n\nAppended text',
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      await adapter.acceptProposal(proposalId)
+      expect(await vault.readFile('notes/hello.md')).toBe(
+        '# Hello\n\nWorld content here\n\nAppended text',
+      )
+    })
+
+    it('reject leaves the vault unchanged', async () => {
+      const resp = await callTool(port, 'vault_append_to_note', {
+        path: 'notes/hello.md',
+        content: '\n\nAppended text',
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      adapter.rejectProposal(proposalId)
+      expect(await vault.readFile('notes/hello.md')).toBe('# Hello\n\nWorld content here')
+    })
+  })
+
+  describe('vault_search', () => {
+    it('returns files containing the query string (case-insensitive)', async () => {
+      const resp = await callTool(port, 'vault_search', { query: 'world', folder: 'notes' })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { matches: Array<{ path: string; excerpt: string }> }
+      const paths = result.matches.map((m) => m.path)
+      expect(paths).toContain('notes/hello.md')
+      expect(paths).not.toContain('notes/another.md')
+    })
+
+    it('returns empty matches when nothing found', async () => {
+      const resp = await callTool(port, 'vault_search', {
+        query: 'zzz-no-match',
+        folder: 'notes',
+      })
+      expect(parseToolResult(resp)).toEqual({ matches: [] })
+    })
+
+    it('searches recursively across subfolders', async () => {
+      const resp = await callTool(port, 'vault_search', { query: 'idea', folder: 'specs' })
+      const result = parseToolResult(resp) as { matches: Array<{ path: string }> }
+      expect(result.matches.map((m) => m.path)).toContain('specs/dark-mode/idea.md')
+    })
+
+    it('produces no double-slash paths when folder has trailing slash', async () => {
+      const resp = await callTool(port, 'vault_search', { query: 'idea', folder: 'specs/' })
+      const result = parseToolResult(resp) as { matches: Array<{ path: string }> }
+      expect(result.matches.every((m) => !m.path.includes('//'))).toBe(true)
+      expect(result.matches.map((m) => m.path)).toContain('specs/dark-mode/idea.md')
+    })
+  })
+
+  describe('vault_list_folder', () => {
+    it('returns files in the given folder', async () => {
+      const resp = await callTool(port, 'vault_list_folder', { folder: 'notes' })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { files: string[]; folders: string[] }
+      expect(result.files).toContain('notes/hello.md')
+      expect(result.files).toContain('notes/another.md')
+    })
+
+    it('returns subfolders as full paths', async () => {
+      const resp = await callTool(port, 'vault_list_folder', { folder: 'specs' })
+      const result = parseToolResult(resp) as { files: string[]; folders: string[] }
+      expect(result.folders).toContain('specs/dark-mode')
+    })
+
+    it('produces no double-slash paths when folder has trailing slash', async () => {
+      const resp = await callTool(port, 'vault_list_folder', { folder: 'specs/' })
+      const result = parseToolResult(resp) as { files: string[]; folders: string[] }
+      expect(result.folders.every((f) => !f.includes('//'))).toBe(true)
+      expect(result.folders).toContain('specs/dark-mode')
+    })
+  })
+
+  describe('vault_create_folder', () => {
+    it('returns created: true', async () => {
+      const resp = await callTool(port, 'vault_create_folder', { path: 'new-folder' })
+      expect(resp.result.isError).toBeFalsy()
+      expect(parseToolResult(resp)).toEqual({ created: true })
+    })
+  })
+
+  describe('frontmatter_get', () => {
+    it('returns all frontmatter fields', async () => {
+      const resp = await callTool(port, 'frontmatter_get', {
+        path: 'specs/dark-mode/workflow-state.md',
+      })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { frontmatter: Record<string, unknown> }
+      expect(result.frontmatter).toMatchObject({
+        id: 'abc123',
+        slug: 'dark-mode',
+        status: 'active',
+      })
+    })
+
+    it('returns empty frontmatter for note without frontmatter', async () => {
+      const resp = await callTool(port, 'frontmatter_get', { path: 'notes/hello.md' })
+      expect(resp.result.isError).toBeFalsy()
+      expect(parseToolResult(resp)).toEqual({ frontmatter: {} })
+    })
+
+    it('returns isError when file not found', async () => {
+      const resp = await callTool(port, 'frontmatter_get', { path: 'missing.md' })
+      expect(resp.result.isError).toBe(true)
+    })
+  })
+
+  describe('frontmatter_get_field', () => {
+    it('returns value for existing field', async () => {
+      const resp = await callTool(port, 'frontmatter_get_field', {
+        path: 'specs/dark-mode/workflow-state.md',
+        field: 'slug',
+      })
+      expect(resp.result.isError).toBeFalsy()
+      expect(parseToolResult(resp)).toEqual({ field: 'slug', value: 'dark-mode' })
+    })
+
+    it('returns null for field not present in frontmatter', async () => {
+      const resp = await callTool(port, 'frontmatter_get_field', {
+        path: 'specs/dark-mode/workflow-state.md',
+        field: 'nonexistent',
+      })
+      expect(parseToolResult(resp)).toEqual({ field: 'nonexistent', value: null })
+    })
+
+    it('returns isError when file not found', async () => {
+      const resp = await callTool(port, 'frontmatter_get_field', {
+        path: 'missing.md',
+        field: 'slug',
+      })
+      expect(resp.result.isError).toBe(true)
+    })
+  })
+
+  describe('frontmatter_set_field', () => {
+    it('returns a pending proposal receipt without mutating the vault', async () => {
+      const resp = await callTool(port, 'frontmatter_set_field', {
+        path: 'specs/dark-mode/workflow-state.md',
+        field: 'status',
+        value: 'draft',
+      })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { proposalId: string; status: string }
+      expect(result.status).toBe('pending')
+      const unchanged = await vault.readFile('specs/dark-mode/workflow-state.md')
+      expect(parseFrontmatter(unchanged).status).toBe('active')
+    })
+
+    it('accept merges the field while preserving other frontmatter and body', async () => {
+      const resp = await callTool(port, 'frontmatter_set_field', {
+        path: 'specs/dark-mode/workflow-state.md',
+        field: 'status',
+        value: 'draft',
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      await adapter.acceptProposal(proposalId)
+      const updated = await vault.readFile('specs/dark-mode/workflow-state.md')
+      const fm = parseFrontmatter(updated)
+      expect(fm.status).toBe('draft')
+      expect(fm.id).toBe('abc123')
+      expect(fm.slug).toBe('dark-mode')
+      expect(updated).toContain('Body content')
+    })
+
+    it('reject leaves the vault unchanged', async () => {
+      const resp = await callTool(port, 'frontmatter_set_field', {
+        path: 'specs/dark-mode/workflow-state.md',
+        field: 'status',
+        value: 'draft',
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      adapter.rejectProposal(proposalId)
+      const unchanged = await vault.readFile('specs/dark-mode/workflow-state.md')
+      expect(parseFrontmatter(unchanged).status).toBe('active')
+    })
+  })
+
+  describe('frontmatter_set_many', () => {
+    it('returns a pending proposal receipt without mutating the vault', async () => {
+      const resp = await callTool(port, 'frontmatter_set_many', {
+        path: 'specs/dark-mode/workflow-state.md',
+        fields: { status: 'done', newField: 42 },
+      })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { proposalId: string; status: string }
+      expect(result.status).toBe('pending')
+      const unchanged = await vault.readFile('specs/dark-mode/workflow-state.md')
+      expect(parseFrontmatter(unchanged).status).toBe('active')
+    })
+
+    it('accept merges all fields while preserving other frontmatter and body', async () => {
+      const resp = await callTool(port, 'frontmatter_set_many', {
+        path: 'specs/dark-mode/workflow-state.md',
+        fields: { status: 'done', newField: 42 },
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      await adapter.acceptProposal(proposalId)
+      const updated = await vault.readFile('specs/dark-mode/workflow-state.md')
+      const fm = parseFrontmatter(updated)
+      expect(fm.status).toBe('done')
+      expect(fm.newField).toBe(42)
+      expect(fm.id).toBe('abc123')
+      expect(updated).toContain('Body content')
+    })
+
+    it('reject leaves the vault unchanged', async () => {
+      const resp = await callTool(port, 'frontmatter_set_many', {
+        path: 'specs/dark-mode/workflow-state.md',
+        fields: { status: 'done', newField: 42 },
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      adapter.rejectProposal(proposalId)
+      const unchanged = await vault.readFile('specs/dark-mode/workflow-state.md')
+      expect(parseFrontmatter(unchanged).status).toBe('active')
+    })
+  })
+})
+```
+
+- [ ] **Step 4.2: Run all MCP tests — confirm they pass**
+
+```
+npx vitest run tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts tests/infrastructure/obsidian-mcp-server-adapter.test.ts tests/infrastructure/proposal-store.test.ts tests/core/plugin-core-mcp.test.ts
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 4.3: Commit**
+
+```
+git add src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
+git commit -m "feat(mcp): wire ProposalStore into adapter — write tools queue proposals, accept/reject apply or discard mutations"
+```
+
+---
+
+## Task 5: Verify and close
+
+- [ ] **Step 5.1: Run full verify gate**
+
+```
+npm run verify
+```
+
+Expected: typecheck, lint, all tests, coverage thresholds — all green. If coverage drops below threshold (80/70/80/80), it means a branch in `ProposalStore` or `applyFrontmatterUpdate` is untested — add the missing test case and re-run.
+
+- [ ] **Step 5.2: Confirm issue acceptance criteria**
+
+Check each item from issue #191:
+- `PendingProposal` type defined → `src/infrastructure/obsidian/ProposalStore.ts`
+- In-memory store inside adapter layer → `ProposalStore` held on `ObsidianMcpServerAdapter`
+- Write tools return `{ proposalId, status: 'pending' }` with no vault mutation → verified by integration tests
+- `acceptProposal()` applies mutation, status `'accepted'` → verified by integration + unit tests
+- `rejectProposal()` sets `'rejected'`, vault unchanged → verified by integration + unit tests
+- Store accessible to sidebar module (read-only accessor) → `adapter.getProposals()` exists
+- Unit tests: queue, accept, reject flows → `tests/infrastructure/proposal-store.test.ts`
+- `npm run verify` green → Step 5.1

--- a/docs/superpowers/specs/2026-05-10-pending-proposal-design.md
+++ b/docs/superpowers/specs/2026-05-10-pending-proposal-design.md
@@ -1,0 +1,269 @@
+# PendingProposal Mechanism — Design
+
+**Issue:** #191  
+**Date:** 2026-05-10  
+**Status:** Approved
+
+---
+
+## Problem
+
+MCP write tools must not mutate the vault directly. Every write must be queued as a proposal, reviewed by the user in the chat sidebar, and either accepted (vault mutated) or rejected (vault unchanged).
+
+---
+
+## Scope
+
+This issue delivers the queue/accept/reject infrastructure for the four write tools currently stubbed in `ObsidianMcpServerAdapter`:
+
+- `vault_write_note`
+- `vault_append_to_note`
+- `frontmatter_set_field`
+- `frontmatter_set_many`
+
+Future write tool groups (#190, #192, #193) follow the same pattern.
+
+---
+
+## Architecture
+
+### Approach: `ProposalStore` class (Approach B)
+
+The proposal store is extracted to its own class (`ProposalStore`) rather than inlined on the adapter. This keeps the adapter responsible for HTTP/transport only, and makes the store unit-testable without spinning up an HTTP server.
+
+```
+ObsidianMcpServerAdapter
+  └─ ProposalStore (private, instance-level)
+       └─ Map<proposalId, ProposalEntry>
+
+registerTools(mcp, vault, store)
+  └─ write tools call store.queue(toolName, params, mutateFn)
+```
+
+The store is instance-level on `ObsidianMcpServerAdapter` — shared across all requests. Each HTTP request creates a fresh `McpServer` but passes the same store, so proposals queued in one request are accessible to `acceptProposal` / `rejectProposal` called from outside (e.g. the chat sidebar).
+
+---
+
+## Types
+
+### `PendingProposal` (exported)
+
+```ts
+export type PendingProposal = {
+  proposalId: string
+  toolName: string
+  params: unknown
+  status: 'pending' | 'accepted' | 'rejected'
+}
+```
+
+Defined in `src/infrastructure/obsidian/ProposalStore.ts`. Exported for sidebar consumption. Not added to `ObsidianMcpServerPort` — internal to the adapter layer.
+
+### `ProposalEntry` (internal)
+
+```ts
+type ProposalEntry = PendingProposal & { mutate: () => Promise<void> }
+```
+
+Not exported. The `mutate` closure is captured at queue time and called on accept. Never surfaces to callers of `getAll()` or `get()`.
+
+---
+
+## `ProposalStore`
+
+**File:** `src/infrastructure/obsidian/ProposalStore.ts`
+
+```ts
+import { randomUUID } from 'node:crypto'
+
+export class ProposalStore {
+  private readonly entries = new Map<string, ProposalEntry>()
+
+  queue(toolName: string, params: unknown, mutate: () => Promise<void>): string {
+    const proposalId = randomUUID()
+    this.entries.set(proposalId, { proposalId, toolName, params, status: 'pending', mutate })
+    return proposalId
+  }
+
+  async accept(proposalId: string): Promise<void> {
+    const entry = this.#getOrThrow(proposalId)
+    this.#assertPending(entry)
+    await entry.mutate()
+    entry.status = 'accepted'
+  }
+
+  reject(proposalId: string): void {
+    const entry = this.#getOrThrow(proposalId)
+    this.#assertPending(entry)
+    entry.status = 'rejected'
+  }
+
+  getAll(): ReadonlyArray<PendingProposal> {
+    return Array.from(this.entries.values()).map(({ mutate: _m, ...rest }) => rest)
+  }
+
+  get(proposalId: string): PendingProposal | undefined {
+    const entry = this.entries.get(proposalId)
+    if (!entry) return undefined
+    const { mutate: _m, ...rest } = entry
+    return rest
+  }
+
+  #getOrThrow(proposalId: string): ProposalEntry {
+    const entry = this.entries.get(proposalId)
+    if (!entry) throw new Error(`Unknown proposal: ${proposalId}`)
+    return entry
+  }
+
+  #assertPending(entry: ProposalEntry): void {
+    if (entry.status !== 'pending')
+      throw new Error(`Proposal not pending: ${entry.proposalId} (${entry.status})`)
+  }
+}
+```
+
+---
+
+## `registerTools` changes
+
+Signature gains a third param: `store: ProposalStore`.
+
+Write tools replace the hardcoded stub with `store.queue()`, capturing the vault mutation as a closure:
+
+```ts
+// vault_write_note
+async ({ path, content }) => {
+  const proposalId = store.queue('vault_write_note', { path, content },
+    () => vault.writeFile(path, content))
+  return ok({ proposalId, status: 'pending' })
+}
+
+// vault_append_to_note
+async ({ path, content }) => {
+  const proposalId = store.queue('vault_append_to_note', { path, content }, async () => {
+    const existing = await vault.readFile(path)
+    await vault.writeFile(path, existing + content)
+  })
+  return ok({ proposalId, status: 'pending' })
+}
+
+// frontmatter_set_field
+async ({ path, field, value }) => {
+  const proposalId = store.queue('frontmatter_set_field', { path, field, value },
+    () => applyFrontmatterUpdate(vault, path, { [field]: value }))
+  return ok({ proposalId, status: 'pending' })
+}
+
+// frontmatter_set_many
+async ({ path, fields }) => {
+  const proposalId = store.queue('frontmatter_set_many', { path, fields },
+    () => applyFrontmatterUpdate(vault, path, fields))
+  return ok({ proposalId, status: 'pending' })
+}
+```
+
+### `applyFrontmatterUpdate` helper
+
+Module-level in `ObsidianMcpServerAdapter.ts`:
+
+```ts
+async function applyFrontmatterUpdate(
+  vault: VaultPort,
+  path: string,
+  updates: Record<string, unknown>,
+): Promise<void> {
+  const content = await vault.readFile(path)
+  const existing = parseFrontmatter(content)
+  const merged = { ...existing, ...updates }
+  const body = content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '')
+  await vault.writeFile(path, `---\n${stringifyYaml(merged)}---\n${body}`)
+}
+```
+
+Import `stringify as stringifyYaml` from `yaml` (already a dependency).
+
+---
+
+## `ObsidianMcpServerAdapter` changes
+
+```ts
+export class ObsidianMcpServerAdapter implements ObsidianMcpServerPort {
+  private readonly proposalStore = new ProposalStore()
+  // ... existing fields
+
+  async acceptProposal(proposalId: string): Promise<void> {
+    await this.proposalStore.accept(proposalId)
+  }
+
+  rejectProposal(proposalId: string): void {
+    this.proposalStore.reject(proposalId)
+  }
+
+  getProposals(): ReadonlyArray<PendingProposal> {
+    return this.proposalStore.getAll()
+  }
+
+  // _handleMcpRequest: registerTools(mcp, this.vault, this.proposalStore)
+  // start / stop / getConnectionConfig: unchanged
+}
+```
+
+`acceptProposal`, `rejectProposal`, `getProposals` are public on the concrete class but NOT added to `ObsidianMcpServerPort`. The `STUB_PROPOSAL_ID` constant is deleted.
+
+---
+
+## Files changed
+
+| File | Action |
+|---|---|
+| `src/infrastructure/obsidian/ProposalStore.ts` | New |
+| `src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts` | Updated |
+| `tests/infrastructure/proposal-store.test.ts` | New |
+| `tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts` | Updated |
+
+---
+
+## Testing
+
+### `tests/infrastructure/proposal-store.test.ts` (pure, no HTTP)
+
+| Test | Assertion |
+|---|---|
+| `queue()` returns string id | `typeof id === 'string'` |
+| `getAll()` returns proposal with status `'pending'` | shape matches `PendingProposal` |
+| `get(id)` returns proposal; `get(unknown)` → `undefined` | lookup correctness |
+| `accept()` calls mutate fn, status → `'accepted'` | spy on mutate called once |
+| `reject()` status → `'rejected'`, mutate NOT called | spy on mutate never called |
+| `accept()` on already-accepted throws | error message contains id |
+| `reject()` on already-rejected throws | error message contains id |
+| `accept()` / `reject()` on unknown id throw | error message contains id |
+| `getAll()` does not expose `mutate` property | key not present in result |
+
+### `tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts` (HTTP integration)
+
+Write tool tests updated — stop asserting stub constant, start asserting real behavior:
+
+```ts
+// Pattern for each write tool:
+// 1. call tool → get proposalId, assert status 'pending'
+// 2. assert vault NOT yet mutated
+// 3. adapter.acceptProposal(proposalId) → assert vault IS mutated
+// 4. (separate test) adapter.rejectProposal(proposalId) → assert vault unchanged
+```
+
+Frontmatter tests verify merged fields via `parseFrontmatter` after accept.
+
+---
+
+## Acceptance criteria mapping
+
+| AC | Covered by |
+|---|---|
+| `PendingProposal` type defined | `ProposalStore.ts` export |
+| In-memory store inside adapter layer | `ProposalStore` held on adapter instance |
+| Write tools return `{ proposalId, status: 'pending' }` | `registerTools` update |
+| `acceptProposal()` applies mutation, status `'accepted'` | `ProposalStore.accept()` + adapter method |
+| `rejectProposal()` sets `'rejected'`, vault unchanged | `ProposalStore.reject()` + adapter method |
+| Store accessible to sidebar (read-only accessor) | `adapter.getProposals()` |
+| Unit tests: queue, accept, reject | `proposal-store.test.ts` |
+| `npm run verify` green | all tests + typecheck + lint |

--- a/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+++ b/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
@@ -2,10 +2,9 @@ import * as http from 'node:http'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import { z } from 'zod'
-import { parse as parseYaml } from 'yaml'
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
 import type { ObsidianMcpServerPort, McpConnectionConfig, VaultPort } from '@/domain/ports'
-
-const STUB_PROPOSAL_ID = 'stub-00000000-0000-0000-0000-000000000000'
+import { ProposalStore, type PendingProposal } from './ProposalStore'
 
 function parseFrontmatter(content: string): Record<string, unknown> {
   const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content)
@@ -21,6 +20,18 @@ function parseFrontmatter(content: string): Record<string, unknown> {
   }
 }
 
+async function applyFrontmatterUpdate(
+  vault: VaultPort,
+  path: string,
+  updates: Record<string, unknown>,
+): Promise<void> {
+  const content = await vault.readFile(path)
+  const existing = parseFrontmatter(content)
+  const merged = { ...existing, ...updates }
+  const body = content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '')
+  await vault.writeFile(path, `---\n${stringifyYaml(merged)}---\n${body}`)
+}
+
 function joinVaultPath(parent: string, child: string): string {
   const p = parent.replace(/\/+$/, '')
   return p ? `${p}/${child}` : child
@@ -28,7 +39,9 @@ function joinVaultPath(parent: string, child: string): string {
 
 async function collectFiles(vault: VaultPort, folder: string): Promise<string[]> {
   const [files, subfolders] = await Promise.all([vault.listFiles(folder), vault.listFolders(folder)])
-  const nested = await Promise.all(subfolders.map((sub) => collectFiles(vault, joinVaultPath(folder, sub))))
+  const nested = await Promise.all(
+    subfolders.map((sub) => collectFiles(vault, joinVaultPath(folder, sub))),
+  )
   return [...files, ...nested.flat()]
 }
 
@@ -36,7 +49,7 @@ function ok(data: unknown): { content: [{ type: 'text'; text: string }] } {
   return { content: [{ type: 'text' as const, text: JSON.stringify(data) }] }
 }
 
-function registerTools(mcp: McpServer, vault: VaultPort): void {
+function registerTools(mcp: McpServer, vault: VaultPort, store: ProposalStore): void {
   mcp.registerTool(
     'vault_read_note',
     {
@@ -52,7 +65,12 @@ function registerTools(mcp: McpServer, vault: VaultPort): void {
       description: 'Overwrite a vault note — queued for proposal review',
       inputSchema: { path: z.string(), content: z.string() },
     },
-    async () => ok({ proposalId: STUB_PROPOSAL_ID, status: 'pending' }),
+    async ({ path, content }) => {
+      const proposalId = store.queue('vault_write_note', { path, content }, () =>
+        vault.writeFile(path, content),
+      )
+      return ok({ proposalId, status: 'pending' })
+    },
   )
 
   mcp.registerTool(
@@ -61,7 +79,13 @@ function registerTools(mcp: McpServer, vault: VaultPort): void {
       description: 'Append text to a vault note — queued for proposal review',
       inputSchema: { path: z.string(), content: z.string().describe('Text to append') },
     },
-    async () => ok({ proposalId: STUB_PROPOSAL_ID, status: 'pending' }),
+    async ({ path, content }) => {
+      const proposalId = store.queue('vault_append_to_note', { path, content }, async () => {
+        const existing = await vault.readFile(path)
+        await vault.writeFile(path, existing + content)
+      })
+      return ok({ proposalId, status: 'pending' })
+    },
   )
 
   mcp.registerTool(
@@ -87,7 +111,7 @@ function registerTools(mcp: McpServer, vault: VaultPort): void {
             matches.push({ path, excerpt: content.slice(start, end).trim() })
           }
         } catch {
-          // Skip unreadable files
+          // skip unreadable files
         }
       }
       return ok({ matches })
@@ -154,7 +178,12 @@ function registerTools(mcp: McpServer, vault: VaultPort): void {
       description: 'Set a frontmatter field — queued for proposal review',
       inputSchema: { path: z.string(), field: z.string(), value: z.any() },
     },
-    async () => ok({ proposalId: STUB_PROPOSAL_ID, status: 'pending' }),
+    async ({ path, field, value }) => {
+      const proposalId = store.queue('frontmatter_set_field', { path, field, value }, () =>
+        applyFrontmatterUpdate(vault, path, { [field]: value }),
+      )
+      return ok({ proposalId, status: 'pending' })
+    },
   )
 
   mcp.registerTool(
@@ -166,15 +195,33 @@ function registerTools(mcp: McpServer, vault: VaultPort): void {
         fields: z.record(z.string(), z.any()).describe('Key-value pairs to set'),
       },
     },
-    async () => ok({ proposalId: STUB_PROPOSAL_ID, status: 'pending' }),
+    async ({ path, fields }) => {
+      const proposalId = store.queue('frontmatter_set_many', { path, fields }, () =>
+        applyFrontmatterUpdate(vault, path, fields),
+      )
+      return ok({ proposalId, status: 'pending' })
+    },
   )
 }
 
 export class ObsidianMcpServerAdapter implements ObsidianMcpServerPort {
+  private readonly proposalStore = new ProposalStore()
   private httpServer: http.Server | null = null
   private assignedPort = 0
 
   constructor(private readonly vault: VaultPort) {}
+
+  async acceptProposal(proposalId: string): Promise<void> {
+    await this.proposalStore.accept(proposalId)
+  }
+
+  rejectProposal(proposalId: string): void {
+    this.proposalStore.reject(proposalId)
+  }
+
+  getProposals(): ReadonlyArray<PendingProposal> {
+    return this.proposalStore.getAll()
+  }
 
   async start(): Promise<{ port: number }> {
     const server = http.createServer((req, res) => {
@@ -211,7 +258,7 @@ export class ObsidianMcpServerAdapter implements ObsidianMcpServerPort {
     res: http.ServerResponse,
   ): Promise<void> {
     const mcp = new McpServer({ name: 'specorator', version: '1.0.0' })
-    registerTools(mcp, this.vault)
+    registerTools(mcp, this.vault, this.proposalStore)
     const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined })
     await mcp.connect(transport)
     try {

--- a/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+++ b/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
@@ -176,12 +176,11 @@ function registerTools(mcp: McpServer, vault: VaultPort, store: ProposalStore): 
     'frontmatter_set_field',
     {
       description: 'Set a frontmatter field — queued for proposal review',
-      inputSchema: { path: z.string(), field: z.string(), value: z.any() },
+      inputSchema: { path: z.string(), field: z.string(), value: z.unknown() },
     },
     async ({ path, field, value }) => {
-      const safeValue: unknown = value
-      const proposalId = store.queue('frontmatter_set_field', { path, field, value: safeValue }, () =>
-        applyFrontmatterUpdate(vault, path, { [field]: safeValue }),
+      const proposalId = store.queue('frontmatter_set_field', { path, field, value }, () =>
+        applyFrontmatterUpdate(vault, path, { [field]: value }),
       )
       return ok({ proposalId, status: 'pending' })
     },
@@ -212,6 +211,7 @@ export class ObsidianMcpServerAdapter implements ObsidianMcpServerPort {
 
   constructor(private readonly vault: VaultPort) {}
 
+  // Off-port by design: called directly by the sidebar module, not via MCP.
   async acceptProposal(proposalId: string): Promise<void> {
     await this.proposalStore.accept(proposalId)
   }

--- a/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+++ b/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
@@ -179,8 +179,9 @@ function registerTools(mcp: McpServer, vault: VaultPort, store: ProposalStore): 
       inputSchema: { path: z.string(), field: z.string(), value: z.any() },
     },
     async ({ path, field, value }) => {
-      const proposalId = store.queue('frontmatter_set_field', { path, field, value }, () =>
-        applyFrontmatterUpdate(vault, path, { [field]: value }),
+      const safeValue: unknown = value
+      const proposalId = store.queue('frontmatter_set_field', { path, field, value: safeValue }, () =>
+        applyFrontmatterUpdate(vault, path, { [field]: safeValue }),
       )
       return ok({ proposalId, status: 'pending' })
     },

--- a/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+++ b/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
@@ -26,10 +26,22 @@ async function applyFrontmatterUpdate(
   updates: Record<string, unknown>,
 ): Promise<void> {
   const content = await vault.readFile(path)
-  const existing = parseFrontmatter(content)
+  const fmMatch = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/.exec(content)
+  let existing: Record<string, unknown> = {}
+  let bodyStart = 0
+  if (fmMatch) {
+    try {
+      const parsed = parseYaml(fmMatch[1]) as unknown
+      if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        existing = parsed as Record<string, unknown>
+        bodyStart = fmMatch[0].length
+      }
+    } catch {
+      // non-YAML block — leave bodyStart at 0 so content is preserved
+    }
+  }
   const merged = { ...existing, ...updates }
-  const body = content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '')
-  await vault.writeFile(path, `---\n${stringifyYaml(merged)}---\n${body}`)
+  await vault.writeFile(path, `---\n${stringifyYaml(merged)}---\n${content.slice(bodyStart)}`)
 }
 
 function joinVaultPath(parent: string, child: string): string {

--- a/src/infrastructure/obsidian/ProposalStore.ts
+++ b/src/infrastructure/obsidian/ProposalStore.ts
@@ -40,7 +40,7 @@ export class ProposalStore {
     return Array.from(this.entries.values()).map(({ proposalId, toolName, params, status }) => ({
       proposalId,
       toolName,
-      params,
+      params: structuredClone(params),
       status,
     }))
   }
@@ -48,7 +48,12 @@ export class ProposalStore {
   get(proposalId: string): PendingProposal | undefined {
     const entry = this.entries.get(proposalId)
     if (!entry) return undefined
-    return { proposalId: entry.proposalId, toolName: entry.toolName, params: entry.params, status: entry.status }
+    return {
+      proposalId: entry.proposalId,
+      toolName: entry.toolName,
+      params: structuredClone(entry.params),
+      status: entry.status,
+    }
   }
 
   #getOrThrow(proposalId: string): ProposalEntry {

--- a/src/infrastructure/obsidian/ProposalStore.ts
+++ b/src/infrastructure/obsidian/ProposalStore.ts
@@ -21,8 +21,13 @@ export class ProposalStore {
   async accept(proposalId: string): Promise<void> {
     const entry = this.#getOrThrow(proposalId)
     this.#assertPending(entry)
-    await entry.mutate()
     entry.status = 'accepted'
+    try {
+      await entry.mutate()
+    } catch (e) {
+      entry.status = 'pending'
+      throw e
+    }
   }
 
   reject(proposalId: string): void {

--- a/src/infrastructure/obsidian/ProposalStore.ts
+++ b/src/infrastructure/obsidian/ProposalStore.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 
-export type PendingProposal = {
+export interface PendingProposal {
   proposalId: string
   toolName: string
   params: unknown
@@ -32,14 +32,18 @@ export class ProposalStore {
   }
 
   getAll(): ReadonlyArray<PendingProposal> {
-    return Array.from(this.entries.values()).map(({ mutate: _m, ...rest }) => rest)
+    return Array.from(this.entries.values()).map(({ proposalId, toolName, params, status }) => ({
+      proposalId,
+      toolName,
+      params,
+      status,
+    }))
   }
 
   get(proposalId: string): PendingProposal | undefined {
     const entry = this.entries.get(proposalId)
     if (!entry) return undefined
-    const { mutate: _m, ...rest } = entry
-    return rest
+    return { proposalId: entry.proposalId, toolName: entry.toolName, params: entry.params, status: entry.status }
   }
 
   #getOrThrow(proposalId: string): ProposalEntry {

--- a/src/infrastructure/obsidian/ProposalStore.ts
+++ b/src/infrastructure/obsidian/ProposalStore.ts
@@ -1,0 +1,55 @@
+import { randomUUID } from 'node:crypto'
+
+export type PendingProposal = {
+  proposalId: string
+  toolName: string
+  params: unknown
+  status: 'pending' | 'accepted' | 'rejected'
+}
+
+type ProposalEntry = PendingProposal & { mutate: () => Promise<void> }
+
+export class ProposalStore {
+  private readonly entries = new Map<string, ProposalEntry>()
+
+  queue(toolName: string, params: unknown, mutate: () => Promise<void>): string {
+    const proposalId = randomUUID()
+    this.entries.set(proposalId, { proposalId, toolName, params, status: 'pending', mutate })
+    return proposalId
+  }
+
+  async accept(proposalId: string): Promise<void> {
+    const entry = this.#getOrThrow(proposalId)
+    this.#assertPending(entry)
+    await entry.mutate()
+    entry.status = 'accepted'
+  }
+
+  reject(proposalId: string): void {
+    const entry = this.#getOrThrow(proposalId)
+    this.#assertPending(entry)
+    entry.status = 'rejected'
+  }
+
+  getAll(): ReadonlyArray<PendingProposal> {
+    return Array.from(this.entries.values()).map(({ mutate: _m, ...rest }) => rest)
+  }
+
+  get(proposalId: string): PendingProposal | undefined {
+    const entry = this.entries.get(proposalId)
+    if (!entry) return undefined
+    const { mutate: _m, ...rest } = entry
+    return rest
+  }
+
+  #getOrThrow(proposalId: string): ProposalEntry {
+    const entry = this.entries.get(proposalId)
+    if (!entry) throw new Error(`Unknown proposal: ${proposalId}`)
+    return entry
+  }
+
+  #assertPending(entry: ProposalEntry): void {
+    if (entry.status !== 'pending')
+      throw new Error(`Proposal not pending: ${entry.proposalId} (${entry.status})`)
+  }
+}

--- a/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { ObsidianMcpServerAdapter } from '@/infrastructure/obsidian/ObsidianMcpServerAdapter'
 import { MockBridge } from '@/infrastructure/mock/MockBridge'
-
-const STUB_PROPOSAL_ID = 'stub-00000000-0000-0000-0000-000000000000'
+import { parse as parseYaml } from 'yaml'
 
 async function mcpPost(port: number, body: unknown): Promise<unknown> {
   const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
@@ -15,7 +14,6 @@ async function mcpPost(port: number, body: unknown): Promise<unknown> {
     body: JSON.stringify(body),
   })
   const text = await res.text()
-  // SSE format: each event is "event: message\ndata: {...}\n\n"
   const dataLine = text.split('\n').find((line) => line.startsWith('data: '))
   if (dataLine) return JSON.parse(dataLine.slice(6))
   return JSON.parse(text)
@@ -41,7 +39,11 @@ interface ToolResponse {
   }
 }
 
-async function callTool(port: number, name: string, args: Record<string, unknown>): Promise<ToolResponse> {
+async function callTool(
+  port: number,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ToolResponse> {
   return mcpPost(port, {
     jsonrpc: '2.0',
     id: 2,
@@ -52,6 +54,20 @@ async function callTool(port: number, name: string, args: Record<string, unknown
 
 function parseToolResult(resp: ToolResponse): unknown {
   return JSON.parse(resp.result.content[0].text)
+}
+
+function parseFrontmatter(content: string): Record<string, unknown> {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content)
+  if (!match) return {}
+  try {
+    const result = parseYaml(match[1]) as unknown
+    if (result !== null && typeof result === 'object' && !Array.isArray(result)) {
+      return result as Record<string, unknown>
+    }
+    return {}
+  } catch {
+    return {}
+  }
 }
 
 const VAULT_FILES = {
@@ -116,24 +132,72 @@ describe('ObsidianMcpServerAdapter — vault + frontmatter tools', () => {
   })
 
   describe('vault_write_note', () => {
-    it('returns pending proposal stub without mutating vault', async () => {
+    it('returns a pending proposal receipt without mutating the vault', async () => {
       const resp = await callTool(port, 'vault_write_note', {
         path: 'notes/new.md',
         content: '# New note',
       })
       expect(resp.result.isError).toBeFalsy()
-      expect(parseToolResult(resp)).toEqual({ proposalId: STUB_PROPOSAL_ID, status: 'pending' })
+      const result = parseToolResult(resp) as { proposalId: string; status: string }
+      expect(result.status).toBe('pending')
+      expect(typeof result.proposalId).toBe('string')
+      expect(result.proposalId.length).toBeGreaterThan(0)
+      expect(await vault.fileExists('notes/new.md')).toBe(false)
+    })
+
+    it('accept writes the note content to the vault', async () => {
+      const resp = await callTool(port, 'vault_write_note', {
+        path: 'notes/new.md',
+        content: '# New note',
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      await adapter.acceptProposal(proposalId)
+      expect(await vault.readFile('notes/new.md')).toBe('# New note')
+    })
+
+    it('reject leaves the vault unchanged', async () => {
+      const resp = await callTool(port, 'vault_write_note', {
+        path: 'notes/new.md',
+        content: '# New note',
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      adapter.rejectProposal(proposalId)
+      expect(await vault.fileExists('notes/new.md')).toBe(false)
     })
   })
 
   describe('vault_append_to_note', () => {
-    it('returns pending proposal stub without mutating vault', async () => {
+    it('returns a pending proposal receipt without mutating the vault', async () => {
       const resp = await callTool(port, 'vault_append_to_note', {
         path: 'notes/hello.md',
         content: '\n\nAppended text',
       })
       expect(resp.result.isError).toBeFalsy()
-      expect(parseToolResult(resp)).toEqual({ proposalId: STUB_PROPOSAL_ID, status: 'pending' })
+      const result = parseToolResult(resp) as { proposalId: string; status: string }
+      expect(result.status).toBe('pending')
+      expect(await vault.readFile('notes/hello.md')).toBe('# Hello\n\nWorld content here')
+    })
+
+    it('accept appends the content to the existing file', async () => {
+      const resp = await callTool(port, 'vault_append_to_note', {
+        path: 'notes/hello.md',
+        content: '\n\nAppended text',
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      await adapter.acceptProposal(proposalId)
+      expect(await vault.readFile('notes/hello.md')).toBe(
+        '# Hello\n\nWorld content here\n\nAppended text',
+      )
+    })
+
+    it('reject leaves the vault unchanged', async () => {
+      const resp = await callTool(port, 'vault_append_to_note', {
+        path: 'notes/hello.md',
+        content: '\n\nAppended text',
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      adapter.rejectProposal(proposalId)
+      expect(await vault.readFile('notes/hello.md')).toBe('# Hello\n\nWorld content here')
     })
   })
 
@@ -148,7 +212,10 @@ describe('ObsidianMcpServerAdapter — vault + frontmatter tools', () => {
     })
 
     it('returns empty matches when nothing found', async () => {
-      const resp = await callTool(port, 'vault_search', { query: 'zzz-no-match', folder: 'notes' })
+      const resp = await callTool(port, 'vault_search', {
+        query: 'zzz-no-match',
+        folder: 'notes',
+      })
       expect(parseToolResult(resp)).toEqual({ matches: [] })
     })
 
@@ -204,7 +271,11 @@ describe('ObsidianMcpServerAdapter — vault + frontmatter tools', () => {
       })
       expect(resp.result.isError).toBeFalsy()
       const result = parseToolResult(resp) as { frontmatter: Record<string, unknown> }
-      expect(result.frontmatter).toMatchObject({ id: 'abc123', slug: 'dark-mode', status: 'active' })
+      expect(result.frontmatter).toMatchObject({
+        id: 'abc123',
+        slug: 'dark-mode',
+        status: 'active',
+      })
     })
 
     it('returns empty frontmatter for note without frontmatter', async () => {
@@ -247,25 +318,85 @@ describe('ObsidianMcpServerAdapter — vault + frontmatter tools', () => {
   })
 
   describe('frontmatter_set_field', () => {
-    it('returns pending proposal stub without mutating vault', async () => {
+    it('returns a pending proposal receipt without mutating the vault', async () => {
       const resp = await callTool(port, 'frontmatter_set_field', {
         path: 'specs/dark-mode/workflow-state.md',
         field: 'status',
         value: 'draft',
       })
       expect(resp.result.isError).toBeFalsy()
-      expect(parseToolResult(resp)).toEqual({ proposalId: STUB_PROPOSAL_ID, status: 'pending' })
+      const result = parseToolResult(resp) as { proposalId: string; status: string }
+      expect(result.status).toBe('pending')
+      const unchanged = await vault.readFile('specs/dark-mode/workflow-state.md')
+      expect(parseFrontmatter(unchanged).status).toBe('active')
+    })
+
+    it('accept merges the field while preserving other frontmatter and body', async () => {
+      const resp = await callTool(port, 'frontmatter_set_field', {
+        path: 'specs/dark-mode/workflow-state.md',
+        field: 'status',
+        value: 'draft',
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      await adapter.acceptProposal(proposalId)
+      const updated = await vault.readFile('specs/dark-mode/workflow-state.md')
+      const fm = parseFrontmatter(updated)
+      expect(fm.status).toBe('draft')
+      expect(fm.id).toBe('abc123')
+      expect(fm.slug).toBe('dark-mode')
+      expect(updated).toContain('Body content')
+    })
+
+    it('reject leaves the vault unchanged', async () => {
+      const resp = await callTool(port, 'frontmatter_set_field', {
+        path: 'specs/dark-mode/workflow-state.md',
+        field: 'status',
+        value: 'draft',
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      adapter.rejectProposal(proposalId)
+      const unchanged = await vault.readFile('specs/dark-mode/workflow-state.md')
+      expect(parseFrontmatter(unchanged).status).toBe('active')
     })
   })
 
   describe('frontmatter_set_many', () => {
-    it('returns pending proposal stub without mutating vault', async () => {
+    it('returns a pending proposal receipt without mutating the vault', async () => {
       const resp = await callTool(port, 'frontmatter_set_many', {
         path: 'specs/dark-mode/workflow-state.md',
-        fields: { status: 'draft', slug: 'dm' },
+        fields: { status: 'done', newField: 42 },
       })
       expect(resp.result.isError).toBeFalsy()
-      expect(parseToolResult(resp)).toEqual({ proposalId: STUB_PROPOSAL_ID, status: 'pending' })
+      const result = parseToolResult(resp) as { proposalId: string; status: string }
+      expect(result.status).toBe('pending')
+      const unchanged = await vault.readFile('specs/dark-mode/workflow-state.md')
+      expect(parseFrontmatter(unchanged).status).toBe('active')
+    })
+
+    it('accept merges all fields while preserving other frontmatter and body', async () => {
+      const resp = await callTool(port, 'frontmatter_set_many', {
+        path: 'specs/dark-mode/workflow-state.md',
+        fields: { status: 'done', newField: 42 },
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      await adapter.acceptProposal(proposalId)
+      const updated = await vault.readFile('specs/dark-mode/workflow-state.md')
+      const fm = parseFrontmatter(updated)
+      expect(fm.status).toBe('done')
+      expect(fm.newField).toBe(42)
+      expect(fm.id).toBe('abc123')
+      expect(updated).toContain('Body content')
+    })
+
+    it('reject leaves the vault unchanged', async () => {
+      const resp = await callTool(port, 'frontmatter_set_many', {
+        path: 'specs/dark-mode/workflow-state.md',
+        fields: { status: 'done', newField: 42 },
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      adapter.rejectProposal(proposalId)
+      const unchanged = await vault.readFile('specs/dark-mode/workflow-state.md')
+      expect(parseFrontmatter(unchanged).status).toBe('active')
     })
   })
 })

--- a/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
@@ -73,6 +73,7 @@ function parseFrontmatter(content: string): Record<string, unknown> {
 const VAULT_FILES = {
   'notes/hello.md': '# Hello\n\nWorld content here',
   'notes/another.md': '# Another\n\nSome other stuff',
+  'notes/non-yaml-fence.md': '---\nnot: [valid: yaml\n---\nBody stays',
   'specs/dark-mode/workflow-state.md':
     '---\nid: abc123\nslug: dark-mode\nstatus: active\ncurrentStep: 3\n---\nBody content',
   'specs/dark-mode/idea.md': '# Idea\n\nSome idea content',
@@ -397,6 +398,19 @@ describe('ObsidianMcpServerAdapter — vault + frontmatter tools', () => {
       adapter.rejectProposal(proposalId)
       const unchanged = await vault.readFile('specs/dark-mode/workflow-state.md')
       expect(parseFrontmatter(unchanged).status).toBe('active')
+    })
+
+    it('accept does not strip content when note starts with non-YAML --- block', async () => {
+      const resp = await callTool(port, 'frontmatter_set_field', {
+        path: 'notes/non-yaml-fence.md',
+        field: 'tag',
+        value: 'test',
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      await adapter.acceptProposal(proposalId)
+      const result = await vault.readFile('notes/non-yaml-fence.md')
+      expect(result).toContain('Body stays')
+      expect(result).toContain('not: [valid: yaml')
     })
 
     it('accept creates frontmatter block on note with no existing frontmatter', async () => {

--- a/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
@@ -398,5 +398,36 @@ describe('ObsidianMcpServerAdapter — vault + frontmatter tools', () => {
       const unchanged = await vault.readFile('specs/dark-mode/workflow-state.md')
       expect(parseFrontmatter(unchanged).status).toBe('active')
     })
+
+    it('accept creates frontmatter block on note with no existing frontmatter', async () => {
+      const resp = await callTool(port, 'frontmatter_set_field', {
+        path: 'notes/hello.md',
+        field: 'tag',
+        value: 'greeting',
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      await adapter.acceptProposal(proposalId)
+      const updated = await vault.readFile('notes/hello.md')
+      expect(parseFrontmatter(updated).tag).toBe('greeting')
+      expect(updated).toContain('# Hello')
+    })
+  })
+
+  describe('getProposals()', () => {
+    it('returns pending proposal with correct shape after write tool call', async () => {
+      const resp = await callTool(port, 'vault_write_note', {
+        path: 'notes/new.md',
+        content: '# New',
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      const proposals = adapter.getProposals()
+      expect(proposals).toHaveLength(1)
+      expect(proposals[0]).toEqual({
+        proposalId,
+        toolName: 'vault_write_note',
+        params: { path: 'notes/new.md', content: '# New' },
+        status: 'pending',
+      })
+    })
   })
 })

--- a/tests/infrastructure/proposal-store.test.ts
+++ b/tests/infrastructure/proposal-store.test.ts
@@ -67,6 +67,17 @@ describe('ProposalStore', () => {
       const id = store.queue('vault_write_note', {}, async () => {})
       expect('mutate' in store.get(id)!).toBe(false)
     })
+
+    it('returns a deep copy of params — mutating returned value does not affect queued closure', async () => {
+      const params = { fields: { status: 'pending' } }
+      const captured: Record<string, unknown>[] = []
+      const store = new ProposalStore()
+      const id = store.queue('frontmatter_set_many', params, async () => { captured.push(params.fields) })
+      const snapshot = store.get(id)!.params as typeof params
+      snapshot.fields.status = 'mutated'
+      await store.accept(id)
+      expect(captured[0].status).toBe('pending')
+    })
   })
 
   describe('accept()', () => {

--- a/tests/infrastructure/proposal-store.test.ts
+++ b/tests/infrastructure/proposal-store.test.ts
@@ -111,21 +111,21 @@ describe('ProposalStore', () => {
 
     it('throws on unknown id', () => {
       const store = new ProposalStore()
-      expect(() => store.reject('no-such-id')).toThrow('no-such-id')
+      expect(() => { store.reject('no-such-id') }).toThrow('no-such-id')
     })
 
     it('throws when already accepted', async () => {
       const store = new ProposalStore()
       const id = store.queue('vault_write_note', {}, async () => {})
       await store.accept(id)
-      expect(() => store.reject(id)).toThrow(id)
+      expect(() => { store.reject(id) }).toThrow(id)
     })
 
     it('throws when already rejected', () => {
       const store = new ProposalStore()
       const id = store.queue('vault_write_note', {}, async () => {})
       store.reject(id)
-      expect(() => store.reject(id)).toThrow(id)
+      expect(() => { store.reject(id) }).toThrow(id)
     })
   })
 })

--- a/tests/infrastructure/proposal-store.test.ts
+++ b/tests/infrastructure/proposal-store.test.ts
@@ -97,6 +97,17 @@ describe('ProposalStore', () => {
       store.reject(id)
       await expect(store.accept(id)).rejects.toThrow(id)
     })
+
+    it('leaves status pending and allows retry when mutate throws', async () => {
+      const store = new ProposalStore()
+      const mutate = vi.fn().mockRejectedValueOnce(new Error('vault error')).mockResolvedValue(undefined)
+      const id = store.queue('vault_write_note', {}, mutate)
+      await expect(store.accept(id)).rejects.toThrow('vault error')
+      expect(store.get(id)?.status).toBe('pending')
+      await store.accept(id)
+      expect(store.get(id)?.status).toBe('accepted')
+      expect(mutate).toHaveBeenCalledTimes(2)
+    })
   })
 
   describe('reject()', () => {

--- a/tests/infrastructure/proposal-store.test.ts
+++ b/tests/infrastructure/proposal-store.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ProposalStore } from '@/infrastructure/obsidian/ProposalStore'
+
+describe('ProposalStore', () => {
+  describe('queue()', () => {
+    it('returns a non-empty string proposalId', () => {
+      const store = new ProposalStore()
+      const id = store.queue('vault_write_note', { path: 'a.md' }, async () => {})
+      expect(typeof id).toBe('string')
+      expect(id.length).toBeGreaterThan(0)
+    })
+
+    it('returns a unique id for each call', () => {
+      const store = new ProposalStore()
+      const id1 = store.queue('vault_write_note', {}, async () => {})
+      const id2 = store.queue('vault_write_note', {}, async () => {})
+      expect(id1).not.toBe(id2)
+    })
+  })
+
+  describe('getAll()', () => {
+    it('returns queued proposal with status pending and correct shape', () => {
+      const store = new ProposalStore()
+      const params = { path: 'a.md', content: 'hi' }
+      const id = store.queue('vault_write_note', params, async () => {})
+      const all = store.getAll()
+      expect(all).toHaveLength(1)
+      expect(all[0]).toEqual({
+        proposalId: id,
+        toolName: 'vault_write_note',
+        params,
+        status: 'pending',
+      })
+    })
+
+    it('does not expose mutate closure', () => {
+      const store = new ProposalStore()
+      store.queue('vault_write_note', {}, async () => {})
+      const all = store.getAll()
+      expect('mutate' in all[0]).toBe(false)
+    })
+
+    it('returns all queued proposals', () => {
+      const store = new ProposalStore()
+      store.queue('vault_write_note', {}, async () => {})
+      store.queue('vault_append_to_note', {}, async () => {})
+      expect(store.getAll()).toHaveLength(2)
+    })
+  })
+
+  describe('get()', () => {
+    it('returns the proposal for a known id', () => {
+      const store = new ProposalStore()
+      const id = store.queue('vault_write_note', { path: 'x.md' }, async () => {})
+      const p = store.get(id)
+      expect(p?.proposalId).toBe(id)
+      expect(p?.status).toBe('pending')
+    })
+
+    it('returns undefined for unknown id', () => {
+      const store = new ProposalStore()
+      expect(store.get('no-such-id')).toBeUndefined()
+    })
+
+    it('does not expose mutate closure', () => {
+      const store = new ProposalStore()
+      const id = store.queue('vault_write_note', {}, async () => {})
+      expect('mutate' in store.get(id)!).toBe(false)
+    })
+  })
+
+  describe('accept()', () => {
+    it('calls mutate fn exactly once and sets status to accepted', async () => {
+      const store = new ProposalStore()
+      const mutate = vi.fn().mockResolvedValue(undefined)
+      const id = store.queue('vault_write_note', {}, mutate)
+      await store.accept(id)
+      expect(mutate).toHaveBeenCalledOnce()
+      expect(store.get(id)?.status).toBe('accepted')
+    })
+
+    it('throws on unknown id', async () => {
+      const store = new ProposalStore()
+      await expect(store.accept('no-such-id')).rejects.toThrow('no-such-id')
+    })
+
+    it('throws when already accepted', async () => {
+      const store = new ProposalStore()
+      const id = store.queue('vault_write_note', {}, async () => {})
+      await store.accept(id)
+      await expect(store.accept(id)).rejects.toThrow(id)
+    })
+
+    it('throws when already rejected', async () => {
+      const store = new ProposalStore()
+      const id = store.queue('vault_write_note', {}, async () => {})
+      store.reject(id)
+      await expect(store.accept(id)).rejects.toThrow(id)
+    })
+  })
+
+  describe('reject()', () => {
+    it('sets status to rejected without calling mutate', () => {
+      const store = new ProposalStore()
+      const mutate = vi.fn().mockResolvedValue(undefined)
+      const id = store.queue('vault_write_note', {}, mutate)
+      store.reject(id)
+      expect(mutate).not.toHaveBeenCalled()
+      expect(store.get(id)?.status).toBe('rejected')
+    })
+
+    it('throws on unknown id', () => {
+      const store = new ProposalStore()
+      expect(() => store.reject('no-such-id')).toThrow('no-such-id')
+    })
+
+    it('throws when already accepted', async () => {
+      const store = new ProposalStore()
+      const id = store.queue('vault_write_note', {}, async () => {})
+      await store.accept(id)
+      expect(() => store.reject(id)).toThrow(id)
+    })
+
+    it('throws when already rejected', () => {
+      const store = new ProposalStore()
+      const id = store.queue('vault_write_note', {}, async () => {})
+      store.reject(id)
+      expect(() => store.reject(id)).toThrow(id)
+    })
+  })
+})


### PR DESCRIPTION
Closes #191

## Summary

- Add `ProposalStore` class (`src/infrastructure/obsidian/ProposalStore.ts`) — in-memory `Map<proposalId, entry>` with a captured `mutate` closure per entry; exposes `queue`, `accept`, `reject`, `get`, `getAll`
- Wire `ProposalStore` into `ObsidianMcpServerAdapter` — write tools (`vault_write_note`, `vault_append_to_note`, `frontmatter_set_field`, `frontmatter_set_many`) now return `{ proposalId, status: 'pending' }` without touching the vault; `applyFrontmatterUpdate` handles merge-on-accept for frontmatter tools
- Expose `acceptProposal`, `rejectProposal`, `getProposals` as public methods on the adapter for the sidebar module to consume

## Test Plan

- [x] `tests/infrastructure/proposal-store.test.ts` — 16 unit tests covering queue uniqueness, `getAll`/`get` shape (no mutate leakage), accept/reject flows, and double-transition guards
- [x] `tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts` — stub assertions replaced with real vault-mutation tests: pending receipt without vault change, accept applies, reject preserves
- [x] `npm run verify` green — 420 tests, 0 lint errors, coverage 91.77/80.32/89.62/92.8 (thresholds 80/70/80/80)

🤖 Generated with [Claude Code](https://claude.com/claude-code)