### PR TITLE
feat(mcp): workflow tools — 6 tools (issue #192)

### DIFF
--- a/docs/superpowers/plans/2026-05-10-mcp-workflow-tools.md
+++ b/docs/superpowers/plans/2026-05-10-mcp-workflow-tools.md
@@ -1,0 +1,789 @@
+# MCP Workflow Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add 6 MCP workflow tools to `ObsidianMcpServerAdapter` — 4 read tools delegating to `IFeatureRepository` and 2 write stubs returning pending proposals.
+
+**Architecture:** Extend the existing `ObsidianMcpServerAdapter` with a new `registerWorkflowTools()` function (parallel to the existing `registerTools()`). The adapter constructor gains two new required params: `repo: IFeatureRepository` and `specsFolder: string`. All 6 tools are registered on the same MCP server instance per request.
+
+**Tech Stack:** TypeScript, MCP SDK (`@modelcontextprotocol/sdk`), Zod, Vitest, `MockBridge` for test isolation, `FeatureRepository` for domain access.
+
+---
+
+## File Map
+
+| Action | Path | Purpose |
+|---|---|---|
+| Modify | `src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts` | Add constructor params + `registerWorkflowTools()` |
+| Modify | `src/plugin/main.ts` | Update `ObsidianMcpServerAdapter` call site |
+| Modify | `tests/infrastructure/obsidian-mcp-server-adapter.test.ts` | Update 8 adapter instantiation sites |
+| Modify | `tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts` | Update `beforeEach` + fix `tools/list` count (10 → 16) |
+| Create | `tests/infrastructure/obsidian-mcp-server-adapter-workflow-tools.test.ts` | All 6 workflow tool tests |
+
+---
+
+## Task 1: Extend `ObsidianMcpServerAdapter` constructor + update call sites
+
+**Files:**
+- Modify: `src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts`
+- Modify: `src/plugin/main.ts`
+- Modify: `tests/infrastructure/obsidian-mcp-server-adapter.test.ts`
+- Modify: `tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts`
+
+- [ ] **Step 1: Add new imports + constructor params to adapter**
+
+In `src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts`, add these imports after the existing imports:
+
+```ts
+import type { IFeatureRepository } from '@/domain/feature/IFeatureRepository'
+import { getAllStepMeta, getStepMeta } from '@/domain/feature/FeatureStep'
+import { Slug } from '@/domain/shared/Slug'
+```
+
+Replace the class constructor:
+
+```ts
+export class ObsidianMcpServerAdapter implements ObsidianMcpServerPort {
+  private readonly proposalStore = new ProposalStore()
+  private httpServer: http.Server | null = null
+  private assignedPort = 0
+
+  constructor(
+    private readonly vault: VaultPort,
+    private readonly repo: IFeatureRepository,
+    private readonly specsFolder: string,
+  ) {}
+```
+
+In `_handleMcpRequest`, add the `registerWorkflowTools` call right after `registerTools`:
+
+```ts
+  private async _handleMcpRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ): Promise<void> {
+    const mcp = new McpServer({ name: 'specorator', version: '1.0.0' })
+    registerTools(mcp, this.vault, this.proposalStore)
+    registerWorkflowTools(mcp, this.repo, this.vault, this.proposalStore, this.specsFolder)
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined })
+    await mcp.connect(transport)
+    try {
+      await transport.handleRequest(req, res)
+    } finally {
+      await transport.close()
+    }
+  }
+```
+
+Add a skeleton `registerWorkflowTools` function (empty — tools added in later tasks) after `registerTools`:
+
+```ts
+function registerWorkflowTools(
+  mcp: McpServer,
+  repo: IFeatureRepository,
+  vault: VaultPort,
+  store: ProposalStore,
+  specsFolder: string,
+): void {
+  // tools added in Tasks 3–7
+}
+```
+
+- [ ] **Step 2: Update `main.ts` call site**
+
+In `src/plugin/main.ts`, add this import after the `ObsidianMcpServerAdapter` import:
+
+```ts
+import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
+```
+
+Replace the adapter instantiation inside `onload()`:
+
+```ts
+      mcpServer: new ObsidianMcpServerAdapter(
+        this.bridge,
+        new FeatureRepository(this.bridge, this.bridge, this.settings),
+        this.settings.specsFolder,
+      ),
+```
+
+- [ ] **Step 3: Update `tests/infrastructure/obsidian-mcp-server-adapter.test.ts`**
+
+Add imports at the top:
+
+```ts
+import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
+import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
+```
+
+Add a helper function before the `describe` block:
+
+```ts
+function makeAdapter(files: Record<string, string> = {}): ObsidianMcpServerAdapter {
+  const vault = new MockBridge(files)
+  const repo = new FeatureRepository(vault, vault, DEFAULT_SETTINGS)
+  return new ObsidianMcpServerAdapter(vault, repo, DEFAULT_SETTINGS.specsFolder)
+}
+```
+
+Replace every `new ObsidianMcpServerAdapter(new MockBridge())` with `makeAdapter()`. There are 8 occurrences (all in the file). The `http` import and all other code stays unchanged.
+
+- [ ] **Step 4: Update `beforeEach` in `tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts`**
+
+Add imports at the top of the file:
+
+```ts
+import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
+import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
+```
+
+Replace the `beforeEach` block:
+
+```ts
+  beforeEach(async () => {
+    vault = new MockBridge(VAULT_FILES)
+    const repo = new FeatureRepository(vault, vault, DEFAULT_SETTINGS)
+    adapter = new ObsidianMcpServerAdapter(vault, repo, DEFAULT_SETTINGS.specsFolder)
+    ;({ port } = await adapter.start())
+    await initMcp(port)
+  })
+```
+
+- [ ] **Step 5: Run typecheck — expect zero errors**
+
+```sh
+npm run typecheck
+```
+
+Expected: exits with code 0, no output.
+
+- [ ] **Step 6: Run existing adapter tests — expect all pass**
+
+```sh
+npx vitest run tests/infrastructure/obsidian-mcp-server-adapter.test.ts tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
+```
+
+Expected: all tests pass (8 + 32 = 40 tests).
+
+- [ ] **Step 7: Commit**
+
+```sh
+git add src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts src/plugin/main.ts tests/infrastructure/obsidian-mcp-server-adapter.test.ts tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
+git commit -m "refactor(mcp): extend adapter constructor with repo + specsFolder"
+```
+
+---
+
+## Task 2: Create failing test file for all 6 workflow tools
+
+**Files:**
+- Create: `tests/infrastructure/obsidian-mcp-server-adapter-workflow-tools.test.ts`
+
+- [ ] **Step 1: Create the test file**
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { ObsidianMcpServerAdapter } from '@/infrastructure/obsidian/ObsidianMcpServerAdapter'
+import { MockBridge } from '@/infrastructure/mock/MockBridge'
+import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
+import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const SPECS_FOLDER = 'specs'
+
+const DARK_MODE_WORKFLOW_STATE = [
+  '---',
+  'id: abc123',
+  'slug: dark-mode',
+  'feature: "Dark Mode"',
+  'area: "DM"',
+  'status: active',
+  'currentStep: 3',
+  'current_stage: requirements',
+  'last_updated: 2026-01-01',
+  'last_agent: ""',
+  'artifacts:',
+  '  idea: complete',
+  '  research: complete',
+  '  requirements: in-progress',
+  '  design: pending',
+  '  spec: pending',
+  '  tasks: pending',
+  '  implementation-log: pending',
+  '  test-plan: pending',
+  '  test-report: pending',
+  '  review: pending',
+  '  release-notes: pending',
+  '  retrospective: pending',
+  'createdAt: 2026-01-01T00:00:00.000Z',
+  'updatedAt: 2026-01-01T00:00:00.000Z',
+  '---',
+  '',
+].join('\n')
+
+const LIGHT_MODE_WORKFLOW_STATE = [
+  '---',
+  'id: def456',
+  'slug: light-mode',
+  'feature: "Light Mode"',
+  'area: "LM"',
+  'status: draft',
+  'currentStep: 1',
+  'current_stage: idea',
+  'last_updated: 2026-01-02',
+  'last_agent: ""',
+  'artifacts:',
+  '  idea: complete',
+  '  research: pending',
+  '  requirements: pending',
+  '  design: pending',
+  '  spec: pending',
+  '  tasks: pending',
+  '  implementation-log: pending',
+  '  test-plan: pending',
+  '  test-report: pending',
+  '  review: pending',
+  '  release-notes: pending',
+  '  retrospective: pending',
+  'createdAt: 2026-01-02T00:00:00.000Z',
+  'updatedAt: 2026-01-02T00:00:00.000Z',
+  '---',
+  '',
+].join('\n')
+
+const VAULT_FILES = {
+  'specs/dark-mode/workflow-state.md': DARK_MODE_WORKFLOW_STATE,
+  'specs/dark-mode/idea.md': '# Idea\n',
+  'specs/dark-mode/research.md': '# Research\n',
+  // requirements.md intentionally absent — tests exist: false
+  'specs/light-mode/workflow-state.md': LIGHT_MODE_WORKFLOW_STATE,
+  'specs/light-mode/idea.md': '# Light Mode Idea\n',
+}
+
+// ── Helpers (same pattern as obsidian-mcp-server-adapter-tools.test.ts) ───────
+
+async function mcpPost(port: number, body: unknown): Promise<unknown> {
+  const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      Host: '127.0.0.1',
+    },
+    body: JSON.stringify(body),
+  })
+  const text = await res.text()
+  const dataLine = text.split('\n').find((line) => line.startsWith('data: '))
+  if (dataLine) return JSON.parse(dataLine.slice(6))
+  return JSON.parse(text)
+}
+
+async function initMcp(port: number): Promise<void> {
+  await mcpPost(port, {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'test', version: '0.0.0' },
+    },
+  })
+}
+
+interface ToolResponse {
+  result: {
+    content: Array<{ type: string; text: string }>
+    isError?: boolean
+  }
+}
+
+async function callTool(
+  port: number,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ToolResponse> {
+  return mcpPost(port, {
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/call',
+    params: { name, arguments: args },
+  }) as Promise<ToolResponse>
+}
+
+function parseToolResult(resp: ToolResponse): unknown {
+  return JSON.parse(resp.result.content[0].text)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ObsidianMcpServerAdapter — workflow tools', () => {
+  let vault: MockBridge
+  let adapter: ObsidianMcpServerAdapter
+  let port: number
+
+  beforeEach(async () => {
+    vault = new MockBridge(VAULT_FILES)
+    const repo = new FeatureRepository(vault, vault, DEFAULT_SETTINGS)
+    adapter = new ObsidianMcpServerAdapter(vault, repo, SPECS_FOLDER)
+    ;({ port } = await adapter.start())
+    await initMcp(port)
+  })
+
+  afterEach(async () => {
+    await adapter.stop()
+  })
+
+  // ── workflow_get_state ────────────────────────────────────────────────────
+
+  describe('workflow_get_state', () => {
+    it('returns full feature DTO for existing slug', async () => {
+      const resp = await callTool(port, 'workflow_get_state', { slug: 'dark-mode' })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as Record<string, unknown>
+      expect(result.id).toBe('abc123')
+      expect(result.slug).toBe('dark-mode')
+      expect(result.title).toBe('Dark Mode')
+      expect(result.status).toBe('active')
+      expect(result.currentStep).toBe(3)
+    })
+
+    it('returns isError for unknown slug', async () => {
+      const resp = await callTool(port, 'workflow_get_state', { slug: 'not-found' })
+      expect(resp.result.isError).toBe(true)
+    })
+  })
+
+  // ── workflow_list_features ────────────────────────────────────────────────
+
+  describe('workflow_list_features', () => {
+    it('returns all features with slug, stage, and title', async () => {
+      const resp = await callTool(port, 'workflow_list_features', {})
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as {
+        features: Array<{ slug: string; stage: string; title: string }>
+      }
+      expect(result.features).toHaveLength(2)
+      const darkMode = result.features.find((f) => f.slug === 'dark-mode')
+      expect(darkMode).toBeDefined()
+      expect(darkMode?.stage).toBe('requirements')
+      expect(darkMode?.title).toBe('Dark Mode')
+    })
+
+    it('returns empty array when specs folder has no features', async () => {
+      const emptyVault = new MockBridge({})
+      const emptyRepo = new FeatureRepository(emptyVault, emptyVault, DEFAULT_SETTINGS)
+      const emptyAdapter = new ObsidianMcpServerAdapter(emptyVault, emptyRepo, SPECS_FOLDER)
+      const { port: emptyPort } = await emptyAdapter.start()
+      await initMcp(emptyPort)
+      const resp = await callTool(emptyPort, 'workflow_list_features', {})
+      const result = parseToolResult(resp) as { features: unknown[] }
+      expect(result.features).toHaveLength(0)
+      await emptyAdapter.stop()
+    })
+  })
+
+  // ── workflow_get_stage_artifacts ──────────────────────────────────────────
+
+  describe('workflow_get_stage_artifacts', () => {
+    it('returns all 12 artifacts with correct exists flags and current stage', async () => {
+      const resp = await callTool(port, 'workflow_get_stage_artifacts', { slug: 'dark-mode' })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as {
+        stage: string
+        artifacts: Array<{ slug: string; path: string; exists: boolean }>
+      }
+      expect(result.stage).toBe('requirements')
+      expect(result.artifacts).toHaveLength(12)
+      const idea = result.artifacts.find((a) => a.slug === 'idea')
+      expect(idea?.exists).toBe(true)
+      expect(idea?.path).toBe('specs/dark-mode/idea.md')
+      const research = result.artifacts.find((a) => a.slug === 'research')
+      expect(research?.exists).toBe(true)
+      const requirements = result.artifacts.find((a) => a.slug === 'requirements')
+      expect(requirements?.exists).toBe(false)
+      expect(requirements?.path).toBe('specs/dark-mode/requirements.md')
+    })
+
+    it('returns isError for unknown slug', async () => {
+      const resp = await callTool(port, 'workflow_get_stage_artifacts', { slug: 'not-found' })
+      expect(resp.result.isError).toBe(true)
+    })
+  })
+
+  // ── workflow_get_quality_gates ────────────────────────────────────────────
+
+  describe('workflow_get_quality_gates', () => {
+    it('returns all 12 gates in correct order', async () => {
+      const resp = await callTool(port, 'workflow_get_quality_gates', {})
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as {
+        gates: Array<{ number: number; slug: string; fileName: string }>
+      }
+      expect(result.gates).toHaveLength(12)
+      expect(result.gates[0]).toEqual({ number: 1, slug: 'idea', fileName: 'idea.md' })
+      expect(result.gates[11]).toEqual({
+        number: 12,
+        slug: 'retrospective',
+        fileName: 'retrospective.md',
+      })
+    })
+  })
+
+  // ── workflow_create_artifact ──────────────────────────────────────────────
+
+  describe('workflow_create_artifact', () => {
+    it('returns pending proposal receipt without mutating the vault', async () => {
+      const resp = await callTool(port, 'workflow_create_artifact', {
+        slug: 'dark-mode',
+        stage: 'design',
+      })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { proposalId: string; status: string }
+      expect(result.status).toBe('pending')
+      expect(typeof result.proposalId).toBe('string')
+      expect(result.proposalId.length).toBeGreaterThan(0)
+      expect(await vault.fileExists('specs/dark-mode/design.md')).toBe(false)
+    })
+  })
+
+  // ── workflow_propose_advance ──────────────────────────────────────────────
+
+  describe('workflow_propose_advance', () => {
+    it('returns pending proposal receipt without advancing the feature', async () => {
+      const resp = await callTool(port, 'workflow_propose_advance', { slug: 'dark-mode' })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { proposalId: string; status: string }
+      expect(result.status).toBe('pending')
+      expect(typeof result.proposalId).toBe('string')
+      expect(result.proposalId.length).toBeGreaterThan(0)
+      // workflow-state.md must remain unchanged
+      const state = await vault.readFile('specs/dark-mode/workflow-state.md')
+      expect(state).toContain('currentStep: 3')
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run tests — expect all to fail with "tool not found" errors**
+
+```sh
+npx vitest run tests/infrastructure/obsidian-mcp-server-adapter-workflow-tools.test.ts
+```
+
+Expected: all 8 tests fail. The `isError` tests will pass but others will fail because the tools don't exist yet. This confirms the test file wires up correctly.
+
+---
+
+## Task 3: Implement `workflow_get_state`
+
+**Files:**
+- Modify: `src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts`
+
+- [ ] **Step 1: Add the tool inside `registerWorkflowTools`**
+
+Replace the `// tools added in Tasks 3–7` comment in `registerWorkflowTools` with:
+
+```ts
+  mcp.registerTool(
+    'workflow_get_state',
+    {
+      description: 'Get the full workflow state for a feature by slug',
+      inputSchema: { slug: z.string().describe('Feature slug') },
+    },
+    async ({ slug }) => {
+      const feature = await repo.findBySlug(Slug.reconstitute(slug))
+      if (!feature) throw new Error(`Feature not found: ${slug}`)
+      return ok(feature.toPlainObject())
+    },
+  )
+
+  // tools added in Tasks 4–7
+```
+
+- [ ] **Step 2: Run the `workflow_get_state` tests — expect both to pass**
+
+```sh
+npx vitest run tests/infrastructure/obsidian-mcp-server-adapter-workflow-tools.test.ts -t "workflow_get_state"
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+git commit -m "feat(mcp): add workflow_get_state tool"
+```
+
+---
+
+## Task 4: Implement `workflow_list_features`
+
+**Files:**
+- Modify: `src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts`
+
+- [ ] **Step 1: Add the tool inside `registerWorkflowTools`**
+
+After the `workflow_get_state` registration, add:
+
+```ts
+  mcp.registerTool(
+    'workflow_list_features',
+    {
+      description: 'List all features with their current stage and title',
+      inputSchema: {},
+    },
+    async () => {
+      const features = await repo.findAll()
+      return ok({
+        features: features.map((f) => ({
+          slug: f.slug.toString(),
+          stage: getStepMeta(f.currentStep)?.slug ?? 'unknown',
+          title: f.title,
+        })),
+      })
+    },
+  )
+```
+
+- [ ] **Step 2: Run `workflow_list_features` tests — expect both to pass**
+
+```sh
+npx vitest run tests/infrastructure/obsidian-mcp-server-adapter-workflow-tools.test.ts -t "workflow_list_features"
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+git commit -m "feat(mcp): add workflow_list_features tool"
+```
+
+---
+
+## Task 5: Implement `workflow_get_stage_artifacts`
+
+**Files:**
+- Modify: `src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts`
+
+- [ ] **Step 1: Add the tool inside `registerWorkflowTools`**
+
+After the `workflow_list_features` registration, add:
+
+```ts
+  mcp.registerTool(
+    'workflow_get_stage_artifacts',
+    {
+      description: 'Get all stage artifact files for a feature and their vault existence status',
+      inputSchema: { slug: z.string().describe('Feature slug') },
+    },
+    async ({ slug }) => {
+      const feature = await repo.findBySlug(Slug.reconstitute(slug))
+      if (!feature) throw new Error(`Feature not found: ${slug}`)
+      const stage = getStepMeta(feature.currentStep)?.slug ?? 'unknown'
+      const artifacts = await Promise.all(
+        getAllStepMeta().map(async (meta) => {
+          const path = `${specsFolder}/${slug}/${meta.fileName}`
+          const exists = await vault.fileExists(path)
+          return { slug: meta.slug, path, exists }
+        }),
+      )
+      return ok({ stage, artifacts })
+    },
+  )
+```
+
+- [ ] **Step 2: Run `workflow_get_stage_artifacts` tests — expect both to pass**
+
+```sh
+npx vitest run tests/infrastructure/obsidian-mcp-server-adapter-workflow-tools.test.ts -t "workflow_get_stage_artifacts"
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+git commit -m "feat(mcp): add workflow_get_stage_artifacts tool"
+```
+
+---
+
+## Task 6: Implement `workflow_get_quality_gates`
+
+**Files:**
+- Modify: `src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts`
+
+- [ ] **Step 1: Add the tool inside `registerWorkflowTools`**
+
+After the `workflow_get_stage_artifacts` registration, add:
+
+```ts
+  mcp.registerTool(
+    'workflow_get_quality_gates',
+    {
+      description: 'Get all 12 workflow stage definitions (quality gates) in order',
+      inputSchema: {},
+    },
+    async () => ok({ gates: getAllStepMeta() }),
+  )
+```
+
+- [ ] **Step 2: Run `workflow_get_quality_gates` tests — expect 1 to pass**
+
+```sh
+npx vitest run tests/infrastructure/obsidian-mcp-server-adapter-workflow-tools.test.ts -t "workflow_get_quality_gates"
+```
+
+Expected: 1 test passes.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+git commit -m "feat(mcp): add workflow_get_quality_gates tool"
+```
+
+---
+
+## Task 7: Implement `workflow_create_artifact` and `workflow_propose_advance` stubs
+
+**Files:**
+- Modify: `src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts`
+
+- [ ] **Step 1: Add both stubs inside `registerWorkflowTools`**
+
+After the `workflow_get_quality_gates` registration, add both tools and remove the `// tools added in Tasks 4–7` comment:
+
+```ts
+  mcp.registerTool(
+    'workflow_create_artifact',
+    {
+      description: 'Queue a request to create a stage artifact — stub pending #191',
+      inputSchema: {
+        slug: z.string().describe('Feature slug'),
+        stage: z.string().describe('Stage slug (e.g. "design")'),
+      },
+    },
+    async ({ slug, stage }) => {
+      const proposalId = store.queue('workflow_create_artifact', { slug, stage }, async () => {})
+      return ok({ proposalId, status: 'pending' })
+    },
+  )
+
+  mcp.registerTool(
+    'workflow_propose_advance',
+    {
+      description: 'Queue a proposal to advance a feature to the next stage — stub pending #191',
+      inputSchema: { slug: z.string().describe('Feature slug') },
+    },
+    async ({ slug }) => {
+      const proposalId = store.queue('workflow_propose_advance', { slug }, async () => {})
+      return ok({ proposalId, status: 'pending' })
+    },
+  )
+```
+
+- [ ] **Step 2: Run write stub tests — expect both to pass**
+
+```sh
+npx vitest run tests/infrastructure/obsidian-mcp-server-adapter-workflow-tools.test.ts -t "workflow_create_artifact|workflow_propose_advance"
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 3: Run the full workflow tools test file — expect all 8 to pass**
+
+```sh
+npx vitest run tests/infrastructure/obsidian-mcp-server-adapter-workflow-tools.test.ts
+```
+
+Expected: 8 tests pass, 0 failures.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+git commit -m "feat(mcp): add workflow_create_artifact and workflow_propose_advance stubs"
+```
+
+---
+
+## Task 8: Update `tools/list` count assertion
+
+**Files:**
+- Modify: `tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts`
+
+- [ ] **Step 1: Update the assertion and expected list**
+
+Find the `tools/list` describe block. It currently asserts 10 tools. Replace the whole block:
+
+```ts
+  describe('tools/list', () => {
+    it('registers all 16 tools', async () => {
+      const resp = (await mcpPost(port, {
+        jsonrpc: '2.0',
+        id: 99,
+        method: 'tools/list',
+        params: {},
+      })) as { result: { tools: Array<{ name: string }> } }
+      const names = resp.result.tools.map((t) => t.name).sort()
+      expect(names).toEqual([
+        'frontmatter_get',
+        'frontmatter_get_field',
+        'frontmatter_set_field',
+        'frontmatter_set_many',
+        'vault_append_to_note',
+        'vault_create_folder',
+        'vault_list_folder',
+        'vault_read_note',
+        'vault_search',
+        'vault_write_note',
+        'workflow_create_artifact',
+        'workflow_get_quality_gates',
+        'workflow_get_stage_artifacts',
+        'workflow_get_state',
+        'workflow_list_features',
+        'workflow_propose_advance',
+      ])
+    })
+  })
+```
+
+- [ ] **Step 2: Run both existing adapter test files — expect all to pass**
+
+```sh
+npx vitest run tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts tests/infrastructure/obsidian-mcp-server-adapter.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
+git commit -m "test(mcp): update tools/list assertion to 16 tools"
+```
+
+---
+
+## Task 9: Final verification
+
+- [ ] **Step 1: Run full test suite and verify gate**
+
+```sh
+npm run verify
+```
+
+Expected: typecheck, lint, and all tests pass. Coverage thresholds met (80/70/80/80).
+
+- [ ] **Step 2: If verify passes — done**
+
+All 6 tools implemented, tests passing, `npm run verify` green.
+
+Open PR targeting `develop` with title: `feat(mcp): workflow tools — 6 tools (issue #192)`.

--- a/docs/superpowers/specs/2026-05-10-mcp-workflow-tools-design.md
+++ b/docs/superpowers/specs/2026-05-10-mcp-workflow-tools-design.md
@@ -1,0 +1,188 @@
+# Design: MCP Workflow Tools (Issue #192)
+
+**Date:** 2026-05-10  
+**Issue:** #192 — feat(plugin-shell): MCP server — workflow tools (6 tools)  
+**Parent:** #184 (Obsidian MCP server)  
+**Depends on:** #189 ✅ (scaffold — merged)  
+**Write tools blocked on:** #191 (PendingProposal mechanism)
+
+---
+
+## Scope
+
+Add 6 workflow tools to the existing `ObsidianMcpServerAdapter`. These tools expose Specorator's core domain to agents via the MCP HTTP endpoint at `http://127.0.0.1:{port}/mcp`.
+
+- 4 read tools: delegate to `IFeatureRepository` + `FEATURE_STEPS` metadata
+- 2 write tools: stub using `ProposalStore` no-op queue until #191 ships
+
+---
+
+## Architecture
+
+### Constructor change
+
+`ObsidianMcpServerAdapter` gains two new required constructor arguments:
+
+```ts
+constructor(
+  private readonly vault: VaultPort,
+  private readonly repo: IFeatureRepository,
+  private readonly specsFolder: string,
+)
+```
+
+**Call site in `main.ts`:**
+```ts
+new ObsidianMcpServerAdapter(
+  this.bridge,
+  new FeatureRepository(this.bridge, this.bridge, this.settings),
+  this.settings.specsFolder,
+)
+```
+
+`FeatureRepository` is already in the infrastructure layer — `main.ts` (infrastructure owner) is the correct place to instantiate it. Settings are snapshotted at plugin load time; `specsFolder` changes require a restart (acceptable for v1).
+
+### Tool registration
+
+A new `registerWorkflowTools(mcp, repo, vault, store, specsFolder)` function is added alongside the existing `registerTools()` in `ObsidianMcpServerAdapter.ts`. Both are called from `_handleMcpRequest`.
+
+`specsFolder` is passed as a plain string so `registerWorkflowTools` can build vault paths for `workflow_get_stage_artifacts` without duplicating `FeatureRepository`'s path logic.
+
+---
+
+## Tools
+
+### `workflow_get_state`
+
+| | |
+|---|---|
+| **Type** | Read |
+| **Input** | `{ slug: string }` |
+| **Output** | `FeaturePlainObject` |
+| **Delegates to** | `repo.findBySlug(slug)` → `feature.toPlainObject()` |
+| **Error** | Throws if slug not found → MCP `isError: true` |
+
+Returns the full feature DTO including `id`, `slug`, `title`, `area`, `status`, `currentStep`, `createdAt`, `updatedAt`.
+
+---
+
+### `workflow_list_features`
+
+| | |
+|---|---|
+| **Type** | Read |
+| **Input** | _(none)_ |
+| **Output** | `{ features: Array<{ slug: string, stage: string, title: string }> }` |
+| **Delegates to** | `repo.findAll()` |
+| **Error** | Infrastructure errors bubble naturally |
+
+`stage` is derived from `getStepMeta(feature.currentStep)?.slug ?? 'unknown'`.
+
+---
+
+### `workflow_get_stage_artifacts`
+
+| | |
+|---|---|
+| **Type** | Read |
+| **Input** | `{ slug: string }` |
+| **Output** | `{ stage: string, artifacts: Array<{ slug: string, path: string, exists: boolean }> }` |
+| **Delegates to** | `repo.findBySlug()` + `vault.fileExists()` per stage file |
+| **Error** | Throws if slug not found |
+
+Logic:
+1. `repo.findBySlug(slug)` → get feature, read `currentStep`
+2. `getStepMeta(currentStep)` → current stage slug (used as `stage` in response)
+3. For all 12 `FEATURE_STEPS`, build path `{specsFolder}/{slug}/{stepSlug}.md` and call `vault.fileExists()`
+4. Return full artifact map (all 12 stages, not just current)
+
+Path construction uses `specsFolder` (held by the adapter — see Architecture section) mirroring `FeatureRepository.stagePath()` without coupling to it.
+
+---
+
+### `workflow_get_quality_gates`
+
+| | |
+|---|---|
+| **Type** | Read |
+| **Input** | _(none)_ |
+| **Output** | `{ gates: Array<{ number: number, slug: string, fileName: string }> }` |
+| **Delegates to** | `getAllStepMeta()` from `FeatureStep.ts` — pure static data, no ports needed |
+| **Error** | None possible |
+
+Returns all 12 stage definitions as an ordered list. Agents use this to understand the full workflow shape.
+
+---
+
+### `workflow_create_artifact` _(stub)_
+
+| | |
+|---|---|
+| **Type** | Write → queue (no-op) |
+| **Input** | `{ slug: string, stage: string }` |
+| **Output** | `{ proposalId: string, status: 'pending' }` |
+| **Behavior** | `store.queue('workflow_create_artifact', { slug, stage }, async () => {})` |
+
+No-op mutate until #191 ships. The proposal is queryable via `getProposals()` and accept/reject work (accept runs the no-op).
+
+---
+
+### `workflow_propose_advance` _(stub)_
+
+| | |
+|---|---|
+| **Type** | Write → queue (no-op) |
+| **Input** | `{ slug: string }` |
+| **Output** | `{ proposalId: string, status: 'pending' }` |
+| **Behavior** | `store.queue('workflow_propose_advance', { slug }, async () => {})` |
+
+Same no-op pattern as `workflow_create_artifact`.
+
+---
+
+## Error Handling
+
+- Read tools: slug not found → `throw new Error(...)` inside handler; MCP SDK catches and returns `isError: true` response
+- No extra try/catch wrappers needed — SDK handles them
+- `workflow_list_features` and `workflow_get_quality_gates` have no domain errors; infrastructure errors bubble as MCP errors naturally
+
+---
+
+## Testing
+
+### New file
+
+`tests/infrastructure/obsidian-mcp-server-adapter-workflow-tools.test.ts`
+
+Pattern mirrors `obsidian-mcp-server-adapter-tools.test.ts`:
+- `MockBridge` seeded with valid `workflow-state.md` fixtures for at least 2 features
+- `beforeEach`: construct adapter with `MockBridge` + in-memory `FeatureRepository`, start, `initialize`
+- `afterEach`: stop adapter
+
+**Coverage per tool:**
+
+| Tool | Cases |
+|---|---|
+| `workflow_get_state` | happy path (returns correct DTO), slug not found (isError) |
+| `workflow_list_features` | returns correct shape for all features, empty vault returns `[]` |
+| `workflow_get_stage_artifacts` | returns all 12 artifacts with correct exists flags, slug not found (isError) |
+| `workflow_get_quality_gates` | returns all 12 gates in order |
+| `workflow_create_artifact` | returns pending receipt, vault unchanged |
+| `workflow_propose_advance` | returns pending receipt, vault unchanged |
+
+### Updated file
+
+`tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts` — update `tools/list` assertion from 10 to 16.
+
+### Acceptance criteria mapping
+
+| Criterion | Covered by |
+|---|---|
+| All 6 tools registered at `/mcp` | `tools/list` test (16 total) |
+| `workflow_get_state` returns full DTO | happy path test |
+| `workflow_list_features` returns `{ slug, stage, title }[]` | list test |
+| `workflow_get_stage_artifacts` returns `{ stage, artifacts }` | artifact test |
+| `workflow_get_quality_gates` returns gate defs from `FEATURE_STEPS` | gates test |
+| Write tools return `{ proposalId, status: 'pending' }` | stub tests |
+| Unit tests for each tool | all above |
+| `npm run verify` green | CI gate |

--- a/src/infrastructure/bridge/FeatureRepository.ts
+++ b/src/infrastructure/bridge/FeatureRepository.ts
@@ -39,7 +39,7 @@ export class FeatureRepository implements IFeatureRepository {
 	constructor(
 		private readonly vault: VaultPort,
 		private readonly notifications: NotificationPort,
-		private readonly settings: PluginSettings,
+		private readonly getSettings: () => PluginSettings,
 	) {}
 
 	private checkedPath(...segments: string[]): string {
@@ -49,19 +49,19 @@ export class FeatureRepository implements IFeatureRepository {
 	}
 
 	private folderPath(slugValue: string): string {
-		return this.checkedPath(this.settings.specsFolder, slugValue);
+		return this.checkedPath(this.getSettings().specsFolder, slugValue);
 	}
 
 	private metaPath(slugValue: string): string {
-		return this.checkedPath(this.settings.specsFolder, slugValue, META_FILE);
+		return this.checkedPath(this.getSettings().specsFolder, slugValue, META_FILE);
 	}
 
 	private stagePath(slugValue: string, stageName: string): string {
-		return this.checkedPath(this.settings.specsFolder, slugValue, `${stageName}.md`);
+		return this.checkedPath(this.getSettings().specsFolder, slugValue, `${stageName}.md`);
 	}
 
 	async findAll(): Promise<Feature[]> {
-		const specsFolder = this.checkedPath(this.settings.specsFolder);
+		const specsFolder = this.checkedPath(this.getSettings().specsFolder);
 		const folders = await this.vault.listFolders(specsFolder);
 		const features = await Promise.all(
 			folders.map(async (folder) => {

--- a/src/infrastructure/bridge/FeatureRepository.ts
+++ b/src/infrastructure/bridge/FeatureRepository.ts
@@ -48,16 +48,16 @@ export class FeatureRepository implements IFeatureRepository {
 		return path.value;
 	}
 
-	private folderPath(slugValue: string): string {
-		return this.checkedPath(this.getSettings().specsFolder, slugValue);
+	private folderPath(specsFolder: string, slugValue: string): string {
+		return this.checkedPath(specsFolder, slugValue);
 	}
 
-	private metaPath(slugValue: string): string {
-		return this.checkedPath(this.getSettings().specsFolder, slugValue, META_FILE);
+	private metaPath(specsFolder: string, slugValue: string): string {
+		return this.checkedPath(specsFolder, slugValue, META_FILE);
 	}
 
-	private stagePath(slugValue: string, stageName: string): string {
-		return this.checkedPath(this.getSettings().specsFolder, slugValue, `${stageName}.md`);
+	private stagePath(specsFolder: string, slugValue: string, stageName: string): string {
+		return this.checkedPath(specsFolder, slugValue, `${stageName}.md`);
 	}
 
 	async findAll(): Promise<Feature[]> {
@@ -78,7 +78,8 @@ export class FeatureRepository implements IFeatureRepository {
 	}
 
 	async findBySlug(slug: Slug): Promise<Feature | null> {
-		const path = this.metaPath(slug.toString());
+		const specsFolder = this.getSettings().specsFolder;
+		const path = this.metaPath(specsFolder, slug.toString());
 		if (!(await this.vault.fileExists(path))) return null;
 		const content = await this.vault.readFile(path);
 		const feature = deserializeWorkflowState(content);
@@ -99,10 +100,13 @@ export class FeatureRepository implements IFeatureRepository {
 	 * On first creation (file did not exist), also writes the idea.md stub.
 	 */
 	async save(feature: Feature): Promise<Result<void>> {
+		// Snapshot specsFolder once so all paths in this multi-step write resolve
+		// to the same root, even if the user changes the setting mid-flight.
+		const specsFolder = this.getSettings().specsFolder;
 		try {
-			const folder = this.folderPath(feature.slug.toString());
+			const folder = this.folderPath(specsFolder, feature.slug.toString());
 			await this.vault.createFolder(folder);
-			const path = this.metaPath(feature.slug.toString());
+			const path = this.metaPath(specsFolder, feature.slug.toString());
 			const isNew = !(await this.vault.fileExists(path));
 			if (!isNew && deserializeWorkflowState(await this.vault.readFile(path)) === null) {
 				return err(
@@ -117,7 +121,7 @@ export class FeatureRepository implements IFeatureRepository {
 			// check.  If we wrote workflow-state.md first, an idea.md failure
 			// would leave a valid metadata file and block any retry.
 			if (isNew) {
-				const ideaPath = this.stagePath(feature.slug.toString(), 'idea');
+				const ideaPath = this.stagePath(specsFolder, feature.slug.toString(), 'idea');
 				if (await this.vault.fileExists(ideaPath)) {
 					this.notifications.showInfo(`Specorator: idea.md already exists — keeping your version.`);
 				} else {
@@ -141,11 +145,12 @@ export class FeatureRepository implements IFeatureRepository {
 	 * is already present, preserving any manually edited content (REQ-AVS-005).
 	 */
 	async createStageFile(feature: Feature, stepNumber: number): Promise<Result<void>> {
+		const specsFolder = this.getSettings().specsFolder;
 		try {
 			const meta = getStepMeta(stepNumber);
 			if (!meta) return err(new Error(`Unknown step number: ${stepNumber}`));
 
-			const path = this.stagePath(feature.slug.toString(), meta.slug);
+			const path = this.stagePath(specsFolder, feature.slug.toString(), meta.slug);
 			if (await this.vault.fileExists(path)) {
 				this.notifications.showInfo(
 					`Specorator: ${meta.slug}.md already exists — keeping your version.`,
@@ -164,10 +169,11 @@ export class FeatureRepository implements IFeatureRepository {
 	}
 
 	async delete(id: string): Promise<Result<void>> {
+		const specsFolder = this.getSettings().specsFolder;
 		try {
 			const feature = await this.findById(id);
 			if (!feature) return err(new Error(`Feature "${id}" not found`));
-			const folder = this.folderPath(feature.slug.toString());
+			const folder = this.folderPath(specsFolder, feature.slug.toString());
 			const files = await this.vault.listFiles(folder);
 			await Promise.all(files.map((path) => this.vault.deleteFile(path)));
 			return ok(undefined);

--- a/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+++ b/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
@@ -252,7 +252,7 @@ function registerWorkflowTools(
       return ok({
         features: features.map((f) => ({
           slug: f.slug.toString(),
-          stage: getStepMeta(f.currentStep)?.slug ?? 'unknown',
+          stage: f.isComplete ? 'completed' : (getStepMeta(f.currentStep)?.slug ?? 'unknown'),
           title: f.title,
         })),
       })
@@ -270,7 +270,7 @@ function registerWorkflowTools(
       if (!slugResult.ok) throw new Error(`Invalid slug: ${slug}`)
       const feature = await repo.findBySlug(slugResult.value)
       if (!feature) throw new Error(`Feature not found: ${slug}`)
-      const stage = getStepMeta(feature.currentStep)?.slug ?? 'unknown'
+      const stage = feature.isComplete ? 'completed' : (getStepMeta(feature.currentStep)?.slug ?? 'unknown')
       const artifacts = await Promise.all(
         getAllStepMeta().map(async (meta) => {
           const path = joinVaultPath(joinVaultPath(specsFolder(), feature.slug.toString()), meta.fileName)

--- a/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+++ b/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
@@ -5,6 +5,8 @@ import { z } from 'zod'
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
 import type { ObsidianMcpServerPort, McpConnectionConfig, VaultPort } from '@/domain/ports'
 import type { IFeatureRepository } from '@/domain/feature/IFeatureRepository'
+import { getAllStepMeta, getStepMeta } from '@/domain/feature/FeatureStep'
+import { Slug } from '@/domain/shared/Slug'
 import { ProposalStore, type PendingProposal } from './ProposalStore'
 
 function parseFrontmatter(content: string): Record<string, unknown> {
@@ -218,13 +220,99 @@ function registerTools(mcp: McpServer, vault: VaultPort, store: ProposalStore): 
 }
 
 function registerWorkflowTools(
-  _mcp: McpServer,
-  _repo: IFeatureRepository,
-  _vault: VaultPort,
-  _store: ProposalStore,
-  _specsFolder: string,
+  mcp: McpServer,
+  repo: IFeatureRepository,
+  vault: VaultPort,
+  store: ProposalStore,
+  specsFolder: string,
 ): void {
-  // tools added in Tasks 3–7
+  mcp.registerTool(
+    'workflow_get_state',
+    {
+      description: 'Get the full workflow state for a feature by slug',
+      inputSchema: { slug: z.string().describe('Feature slug') },
+    },
+    async ({ slug }) => {
+      const feature = await repo.findBySlug(Slug.reconstitute(slug))
+      if (!feature) throw new Error(`Feature not found: ${slug}`)
+      return ok(feature.toPlainObject())
+    },
+  )
+
+  mcp.registerTool(
+    'workflow_list_features',
+    {
+      description: 'List all features with their current stage and title',
+      inputSchema: {},
+    },
+    async () => {
+      const features = await repo.findAll()
+      return ok({
+        features: features.map((f) => ({
+          slug: f.slug.toString(),
+          stage: getStepMeta(f.currentStep)?.slug ?? 'unknown',
+          title: f.title,
+        })),
+      })
+    },
+  )
+
+  mcp.registerTool(
+    'workflow_get_stage_artifacts',
+    {
+      description: 'Get all stage artifact files for a feature and their vault existence status',
+      inputSchema: { slug: z.string().describe('Feature slug') },
+    },
+    async ({ slug }) => {
+      const feature = await repo.findBySlug(Slug.reconstitute(slug))
+      if (!feature) throw new Error(`Feature not found: ${slug}`)
+      const stage = getStepMeta(feature.currentStep)?.slug ?? 'unknown'
+      const artifacts = await Promise.all(
+        getAllStepMeta().map(async (meta) => {
+          const path = `${specsFolder}/${slug}/${meta.fileName}`
+          const exists = await vault.fileExists(path)
+          return { slug: meta.slug, path, exists }
+        }),
+      )
+      return ok({ stage, artifacts })
+    },
+  )
+
+  mcp.registerTool(
+    'workflow_get_quality_gates',
+    {
+      description: 'Get all 12 workflow stage definitions (quality gates) in order',
+      inputSchema: {},
+    },
+    async () => ok({ gates: getAllStepMeta() }),
+  )
+
+  mcp.registerTool(
+    'workflow_create_artifact',
+    {
+      description: 'Queue a request to create a stage artifact — stub pending #191',
+      inputSchema: {
+        slug: z.string().describe('Feature slug'),
+        stage: z.string().describe('Stage slug (e.g. "design")'),
+      },
+    },
+    async ({ slug, stage }) => {
+      const proposalId = store.queue('workflow_create_artifact', { slug, stage }, async () => {})
+      return ok({ proposalId, status: 'pending' })
+    },
+  )
+
+  mcp.registerTool(
+    'workflow_propose_advance',
+    {
+      description: 'Queue a proposal to advance a feature to the next stage — stub pending #191',
+      inputSchema: { slug: z.string().describe('Feature slug') },
+    },
+    async ({ slug }) => {
+      const proposalId = store.queue('workflow_propose_advance', { slug }, async () => {})
+      return ok({ proposalId, status: 'pending' })
+    },
+  )
 }
 
 export class ObsidianMcpServerAdapter implements ObsidianMcpServerPort {

--- a/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+++ b/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
@@ -4,6 +4,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { z } from 'zod'
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
 import type { ObsidianMcpServerPort, McpConnectionConfig, VaultPort } from '@/domain/ports'
+import type { IFeatureRepository } from '@/domain/feature/IFeatureRepository'
 import { ProposalStore, type PendingProposal } from './ProposalStore'
 
 function parseFrontmatter(content: string): Record<string, unknown> {
@@ -216,12 +217,26 @@ function registerTools(mcp: McpServer, vault: VaultPort, store: ProposalStore): 
   )
 }
 
+function registerWorkflowTools(
+  _mcp: McpServer,
+  _repo: IFeatureRepository,
+  _vault: VaultPort,
+  _store: ProposalStore,
+  _specsFolder: string,
+): void {
+  // tools added in Tasks 3–7
+}
+
 export class ObsidianMcpServerAdapter implements ObsidianMcpServerPort {
   private readonly proposalStore = new ProposalStore()
   private httpServer: http.Server | null = null
   private assignedPort = 0
 
-  constructor(private readonly vault: VaultPort) {}
+  constructor(
+    private readonly vault: VaultPort,
+    private readonly repo: IFeatureRepository,
+    private readonly specsFolder: string,
+  ) {}
 
   // Off-port by design: called directly by the sidebar module, not via MCP.
   async acceptProposal(proposalId: string): Promise<void> {
@@ -272,6 +287,7 @@ export class ObsidianMcpServerAdapter implements ObsidianMcpServerPort {
   ): Promise<void> {
     const mcp = new McpServer({ name: 'specorator', version: '1.0.0' })
     registerTools(mcp, this.vault, this.proposalStore)
+    registerWorkflowTools(mcp, this.repo, this.vault, this.proposalStore, this.specsFolder)
     const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined })
     await mcp.connect(transport)
     try {

--- a/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+++ b/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
@@ -297,7 +297,7 @@ function registerWorkflowTools(
       },
     },
     async ({ slug, stage }) => {
-      const proposalId = store.queue('workflow_create_artifact', { slug, stage }, async () => {})
+      const proposalId = store.queue('workflow_create_artifact', { slug, stage }, () => Promise.resolve())
       return ok({ proposalId, status: 'pending' })
     },
   )
@@ -309,7 +309,7 @@ function registerWorkflowTools(
       inputSchema: { slug: z.string().describe('Feature slug') },
     },
     async ({ slug }) => {
-      const proposalId = store.queue('workflow_propose_advance', { slug }, async () => {})
+      const proposalId = store.queue('workflow_propose_advance', { slug }, () => Promise.resolve())
       return ok({ proposalId, status: 'pending' })
     },
   )

--- a/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+++ b/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
@@ -273,7 +273,7 @@ function registerWorkflowTools(
       const stage = getStepMeta(feature.currentStep)?.slug ?? 'unknown'
       const artifacts = await Promise.all(
         getAllStepMeta().map(async (meta) => {
-          const path = joinVaultPath(joinVaultPath(specsFolder(), slug), meta.fileName)
+          const path = joinVaultPath(joinVaultPath(specsFolder(), feature.slug.toString()), meta.fileName)
           const exists = await vault.fileExists(path)
           return { slug: meta.slug, path, exists }
         }),

--- a/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+++ b/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
@@ -224,7 +224,7 @@ function registerWorkflowTools(
   repo: IFeatureRepository,
   vault: VaultPort,
   store: ProposalStore,
-  specsFolder: string,
+  specsFolder: () => string,
 ): void {
   mcp.registerTool(
     'workflow_get_state',
@@ -269,7 +269,7 @@ function registerWorkflowTools(
       const stage = getStepMeta(feature.currentStep)?.slug ?? 'unknown'
       const artifacts = await Promise.all(
         getAllStepMeta().map(async (meta) => {
-          const path = `${specsFolder}/${slug}/${meta.fileName}`
+          const path = joinVaultPath(joinVaultPath(specsFolder(), slug), meta.fileName)
           const exists = await vault.fileExists(path)
           return { slug: meta.slug, path, exists }
         }),
@@ -323,7 +323,7 @@ export class ObsidianMcpServerAdapter implements ObsidianMcpServerPort {
   constructor(
     private readonly vault: VaultPort,
     private readonly repo: IFeatureRepository,
-    private readonly specsFolder: string,
+    private readonly specsFolder: () => string,
   ) {}
 
   // Off-port by design: called directly by the sidebar module, not via MCP.

--- a/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+++ b/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
@@ -252,7 +252,7 @@ function registerWorkflowTools(
       return ok({
         features: features.map((f) => ({
           slug: f.slug.toString(),
-          stage: f.isComplete ? 'completed' : (getStepMeta(f.currentStep)?.slug ?? 'unknown'),
+          stage: f.isComplete ? 'retrospective' : (getStepMeta(f.currentStep)?.slug ?? 'unknown'),
           title: f.title,
         })),
       })
@@ -270,7 +270,7 @@ function registerWorkflowTools(
       if (!slugResult.ok) throw new Error(`Invalid slug: ${slug}`)
       const feature = await repo.findBySlug(slugResult.value)
       if (!feature) throw new Error(`Feature not found: ${slug}`)
-      const stage = feature.isComplete ? 'completed' : (getStepMeta(feature.currentStep)?.slug ?? 'unknown')
+      const stage = feature.isComplete ? 'retrospective' : (getStepMeta(feature.currentStep)?.slug ?? 'unknown')
       const artifacts = await Promise.all(
         getAllStepMeta().map(async (meta) => {
           const path = joinVaultPath(joinVaultPath(specsFolder(), feature.slug.toString()), meta.fileName)

--- a/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+++ b/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
@@ -233,7 +233,9 @@ function registerWorkflowTools(
       inputSchema: { slug: z.string().describe('Feature slug') },
     },
     async ({ slug }) => {
-      const feature = await repo.findBySlug(Slug.reconstitute(slug))
+      const slugResult = Slug.create(slug)
+      if (!slugResult.ok) throw new Error(`Invalid slug: ${slug}`)
+      const feature = await repo.findBySlug(slugResult.value)
       if (!feature) throw new Error(`Feature not found: ${slug}`)
       return ok(feature.toPlainObject())
     },
@@ -264,7 +266,9 @@ function registerWorkflowTools(
       inputSchema: { slug: z.string().describe('Feature slug') },
     },
     async ({ slug }) => {
-      const feature = await repo.findBySlug(Slug.reconstitute(slug))
+      const slugResult = Slug.create(slug)
+      if (!slugResult.ok) throw new Error(`Invalid slug: ${slug}`)
+      const feature = await repo.findBySlug(slugResult.value)
       if (!feature) throw new Error(`Feature not found: ${slug}`)
       const stage = getStepMeta(feature.currentStep)?.slug ?? 'unknown'
       const artifacts = await Promise.all(

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -49,8 +49,8 @@ export default class SpecoratorPlugin extends Plugin {
       i18nMerge,
       mcpServer: new ObsidianMcpServerAdapter(
         this.bridge,
-        new FeatureRepository(this.bridge, this.bridge, this.settings),
-        this.settings.specsFolder,
+        new FeatureRepository(this.bridge, this.bridge, () => this.settings),
+        () => this.settings.specsFolder,
       ),
     })
 

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -4,6 +4,7 @@ import { SpecoratorSettingTab } from './settings'
 import { DEFAULT_SETTINGS, type PluginSettings } from '@/domain/settings/PluginSettings'
 import { ObsidianBridge } from '@/infrastructure/obsidian/ObsidianBridge'
 import { ObsidianMcpServerAdapter } from '@/infrastructure/obsidian/ObsidianMcpServerAdapter'
+import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
 import { PluginCore } from '@/core/plugin-core'
 import { ALL_MODULES, type ModuleDescriptor } from '@/modules'
 import { i18nMerge, i18nTranslate, setLocale, type SupportedLocale } from '@/ui/i18n'
@@ -46,7 +47,11 @@ export default class SpecoratorPlugin extends Plugin {
       logger: this.bridge,
       t: translationPort,
       i18nMerge,
-      mcpServer: new ObsidianMcpServerAdapter(this.bridge),
+      mcpServer: new ObsidianMcpServerAdapter(
+        this.bridge,
+        new FeatureRepository(this.bridge, this.bridge, this.settings),
+        this.settings.specsFolder,
+      ),
     })
 
     setLocale(this.settings.locale as SupportedLocale)

--- a/src/ui/composables/useFeatures.ts
+++ b/src/ui/composables/useFeatures.ts
@@ -32,7 +32,7 @@ export function useFeatures() {
   async function loadFeatures(): Promise<void> {
     await withLoading(async () => {
       const settings = await settingsPort.getSettings()
-      const repo = new FeatureRepository(vault, notifications, settings)
+      const repo = new FeatureRepository(vault, notifications, () => settings)
       const result = await new GetFeaturesUseCase(repo).execute()
       if (result.ok) {
         store.setItems(result.value.map(featureDtoFromDomain))
@@ -48,7 +48,7 @@ export function useFeatures() {
   ): Promise<FeatureDto | undefined> {
     return withLoading(async () => {
       const settings = await settingsPort.getSettings()
-      const repo = new FeatureRepository(vault, notifications, settings)
+      const repo = new FeatureRepository(vault, notifications, () => settings)
       const result = await new CreateFeatureUseCase(repo).execute({ title, area })
       if (result.ok) {
         const dto = featureDtoFromDomain(result.value)
@@ -63,7 +63,7 @@ export function useFeatures() {
   async function activateFeature(featureId: string): Promise<void> {
     await withLoading(async () => {
       const settings = await settingsPort.getSettings()
-      const repo = new FeatureRepository(vault, notifications, settings)
+      const repo = new FeatureRepository(vault, notifications, () => settings)
       const result = await new ActivateFeatureUseCase(repo).execute({ featureId })
       if (result.ok) {
         store.upsert(featureDtoFromDomain(result.value))
@@ -76,7 +76,7 @@ export function useFeatures() {
   async function archiveFeature(featureId: string): Promise<void> {
     await withLoading(async () => {
       const settings = await settingsPort.getSettings()
-      const repo = new FeatureRepository(vault, notifications, settings)
+      const repo = new FeatureRepository(vault, notifications, () => settings)
       const result = await new ArchiveFeatureUseCase(repo).execute({ featureId })
       if (result.ok) {
         store.upsert(featureDtoFromDomain(result.value))
@@ -89,7 +89,7 @@ export function useFeatures() {
   async function advanceFeatureStage(featureId: string): Promise<void> {
     await withLoading(async () => {
       const settings = await settingsPort.getSettings()
-      const repo = new FeatureRepository(vault, notifications, settings)
+      const repo = new FeatureRepository(vault, notifications, () => settings)
       const result = await new AdvanceFeatureStageUseCase(repo).execute({ featureId })
       if (result.ok) {
         store.upsert(featureDtoFromDomain(result.value))

--- a/tests/application/feature/CreateFeatureUseCase.test.ts
+++ b/tests/application/feature/CreateFeatureUseCase.test.ts
@@ -7,7 +7,7 @@ import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
 import { DEFAULT_SETTINGS, type PluginSettings } from '@/domain/settings/PluginSettings'
 
 function makeRepo(bridge: MockBridge, settings: PluginSettings = DEFAULT_SETTINGS) {
-  return new FeatureRepository(bridge, bridge, settings)
+  return new FeatureRepository(bridge, bridge, () => settings)
 }
 function makeUseCase(bridge: MockBridge) {
   return new CreateFeatureUseCase(makeRepo(bridge))

--- a/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
@@ -88,8 +88,8 @@ describe('ObsidianMcpServerAdapter — vault + frontmatter tools', () => {
 
   beforeEach(async () => {
     vault = new MockBridge(VAULT_FILES)
-    const repo = new FeatureRepository(vault, vault, DEFAULT_SETTINGS)
-    adapter = new ObsidianMcpServerAdapter(vault, repo, DEFAULT_SETTINGS.specsFolder)
+    const repo = new FeatureRepository(vault, vault, () => DEFAULT_SETTINGS)
+    adapter = new ObsidianMcpServerAdapter(vault, repo, () => DEFAULT_SETTINGS.specsFolder)
     ;({ port } = await adapter.start())
     await initMcp(port)
   })

--- a/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
@@ -99,7 +99,7 @@ describe('ObsidianMcpServerAdapter — vault + frontmatter tools', () => {
   })
 
   describe('tools/list', () => {
-    it('registers all 10 tools', async () => {
+    it('registers all 16 tools', async () => {
       const resp = (await mcpPost(port, {
         jsonrpc: '2.0',
         id: 99,
@@ -118,6 +118,12 @@ describe('ObsidianMcpServerAdapter — vault + frontmatter tools', () => {
         'vault_read_note',
         'vault_search',
         'vault_write_note',
+        'workflow_create_artifact',
+        'workflow_get_quality_gates',
+        'workflow_get_stage_artifacts',
+        'workflow_get_state',
+        'workflow_list_features',
+        'workflow_propose_advance',
       ])
     })
   })

--- a/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { ObsidianMcpServerAdapter } from '@/infrastructure/obsidian/ObsidianMcpServerAdapter'
 import { MockBridge } from '@/infrastructure/mock/MockBridge'
 import { parse as parseYaml } from 'yaml'
+import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
+import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
 
 async function mcpPost(port: number, body: unknown): Promise<unknown> {
   const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
@@ -86,7 +88,8 @@ describe('ObsidianMcpServerAdapter — vault + frontmatter tools', () => {
 
   beforeEach(async () => {
     vault = new MockBridge(VAULT_FILES)
-    adapter = new ObsidianMcpServerAdapter(vault)
+    const repo = new FeatureRepository(vault, vault, DEFAULT_SETTINGS)
+    adapter = new ObsidianMcpServerAdapter(vault, repo, DEFAULT_SETTINGS.specsFolder)
     ;({ port } = await adapter.start())
     await initMcp(port)
   })

--- a/tests/infrastructure/obsidian-mcp-server-adapter-workflow-tools.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter-workflow-tools.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { ObsidianMcpServerAdapter } from '@/infrastructure/obsidian/ObsidianMcpServerAdapter'
+import { MockBridge } from '@/infrastructure/mock/MockBridge'
+import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
+import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const SPECS_FOLDER = 'specs'
+
+const DARK_MODE_WORKFLOW_STATE = [
+  '---',
+  'id: abc123',
+  'slug: dark-mode',
+  'feature: "Dark Mode"',
+  'area: "DM"',
+  'status: active',
+  'currentStep: 3',
+  'current_stage: requirements',
+  'last_updated: 2026-01-01',
+  'last_agent: ""',
+  'artifacts:',
+  '  idea: complete',
+  '  research: complete',
+  '  requirements: in-progress',
+  '  design: pending',
+  '  spec: pending',
+  '  tasks: pending',
+  '  implementation-log: pending',
+  '  test-plan: pending',
+  '  test-report: pending',
+  '  review: pending',
+  '  release-notes: pending',
+  '  retrospective: pending',
+  'createdAt: 2026-01-01T00:00:00.000Z',
+  'updatedAt: 2026-01-01T00:00:00.000Z',
+  '---',
+  '',
+].join('\n')
+
+const LIGHT_MODE_WORKFLOW_STATE = [
+  '---',
+  'id: def456',
+  'slug: light-mode',
+  'feature: "Light Mode"',
+  'area: "LM"',
+  'status: draft',
+  'currentStep: 1',
+  'current_stage: idea',
+  'last_updated: 2026-01-02',
+  'last_agent: ""',
+  'artifacts:',
+  '  idea: complete',
+  '  research: pending',
+  '  requirements: pending',
+  '  design: pending',
+  '  spec: pending',
+  '  tasks: pending',
+  '  implementation-log: pending',
+  '  test-plan: pending',
+  '  test-report: pending',
+  '  review: pending',
+  '  release-notes: pending',
+  '  retrospective: pending',
+  'createdAt: 2026-01-02T00:00:00.000Z',
+  'updatedAt: 2026-01-02T00:00:00.000Z',
+  '---',
+  '',
+].join('\n')
+
+const VAULT_FILES = {
+  'specs/dark-mode/workflow-state.md': DARK_MODE_WORKFLOW_STATE,
+  'specs/dark-mode/idea.md': '# Idea\n',
+  'specs/dark-mode/research.md': '# Research\n',
+  // requirements.md intentionally absent — tests exist: false
+  'specs/light-mode/workflow-state.md': LIGHT_MODE_WORKFLOW_STATE,
+  'specs/light-mode/idea.md': '# Light Mode Idea\n',
+}
+
+// ── Helpers (same pattern as obsidian-mcp-server-adapter-tools.test.ts) ───────
+
+async function mcpPost(port: number, body: unknown): Promise<unknown> {
+  const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      Host: '127.0.0.1',
+    },
+    body: JSON.stringify(body),
+  })
+  const text = await res.text()
+  const dataLine = text.split('\n').find((line) => line.startsWith('data: '))
+  if (dataLine) return JSON.parse(dataLine.slice(6))
+  return JSON.parse(text)
+}
+
+async function initMcp(port: number): Promise<void> {
+  await mcpPost(port, {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'test', version: '0.0.0' },
+    },
+  })
+}
+
+interface ToolResponse {
+  result: {
+    content: Array<{ type: string; text: string }>
+    isError?: boolean
+  }
+}
+
+async function callTool(
+  port: number,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ToolResponse> {
+  return mcpPost(port, {
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/call',
+    params: { name, arguments: args },
+  }) as Promise<ToolResponse>
+}
+
+function parseToolResult(resp: ToolResponse): unknown {
+  return JSON.parse(resp.result.content[0].text)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ObsidianMcpServerAdapter — workflow tools', () => {
+  let vault: MockBridge
+  let adapter: ObsidianMcpServerAdapter
+  let port: number
+
+  beforeEach(async () => {
+    vault = new MockBridge(VAULT_FILES)
+    const repo = new FeatureRepository(vault, vault, DEFAULT_SETTINGS)
+    adapter = new ObsidianMcpServerAdapter(vault, repo, SPECS_FOLDER)
+    ;({ port } = await adapter.start())
+    await initMcp(port)
+  })
+
+  afterEach(async () => {
+    await adapter.stop()
+  })
+
+  // ── workflow_get_state ────────────────────────────────────────────────────
+
+  describe('workflow_get_state', () => {
+    it('returns full feature DTO for existing slug', async () => {
+      const resp = await callTool(port, 'workflow_get_state', { slug: 'dark-mode' })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as Record<string, unknown>
+      expect(result.id).toBe('abc123')
+      expect(result.slug).toBe('dark-mode')
+      expect(result.title).toBe('Dark Mode')
+      expect(result.status).toBe('active')
+      expect(result.currentStep).toBe(3)
+    })
+
+    it('returns isError for unknown slug', async () => {
+      const resp = await callTool(port, 'workflow_get_state', { slug: 'not-found' })
+      expect(resp.result.isError).toBe(true)
+    })
+  })
+
+  // ── workflow_list_features ────────────────────────────────────────────────
+
+  describe('workflow_list_features', () => {
+    it('returns all features with slug, stage, and title', async () => {
+      const resp = await callTool(port, 'workflow_list_features', {})
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as {
+        features: Array<{ slug: string; stage: string; title: string }>
+      }
+      expect(result.features).toHaveLength(2)
+      const darkMode = result.features.find((f) => f.slug === 'dark-mode')
+      expect(darkMode).toBeDefined()
+      expect(darkMode?.stage).toBe('requirements')
+      expect(darkMode?.title).toBe('Dark Mode')
+    })
+
+    it('returns empty array when specs folder has no features', async () => {
+      const emptyVault = new MockBridge({})
+      const emptyRepo = new FeatureRepository(emptyVault, emptyVault, DEFAULT_SETTINGS)
+      const emptyAdapter = new ObsidianMcpServerAdapter(emptyVault, emptyRepo, SPECS_FOLDER)
+      const { port: emptyPort } = await emptyAdapter.start()
+      await initMcp(emptyPort)
+      const resp = await callTool(emptyPort, 'workflow_list_features', {})
+      const result = parseToolResult(resp) as { features: unknown[] }
+      expect(result.features).toHaveLength(0)
+      await emptyAdapter.stop()
+    })
+  })
+
+  // ── workflow_get_stage_artifacts ──────────────────────────────────────────
+
+  describe('workflow_get_stage_artifacts', () => {
+    it('returns all 12 artifacts with correct exists flags and current stage', async () => {
+      const resp = await callTool(port, 'workflow_get_stage_artifacts', { slug: 'dark-mode' })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as {
+        stage: string
+        artifacts: Array<{ slug: string; path: string; exists: boolean }>
+      }
+      expect(result.stage).toBe('requirements')
+      expect(result.artifacts).toHaveLength(12)
+      const idea = result.artifacts.find((a) => a.slug === 'idea')
+      expect(idea?.exists).toBe(true)
+      expect(idea?.path).toBe('specs/dark-mode/idea.md')
+      const research = result.artifacts.find((a) => a.slug === 'research')
+      expect(research?.exists).toBe(true)
+      const requirements = result.artifacts.find((a) => a.slug === 'requirements')
+      expect(requirements?.exists).toBe(false)
+      expect(requirements?.path).toBe('specs/dark-mode/requirements.md')
+    })
+
+    it('returns isError for unknown slug', async () => {
+      const resp = await callTool(port, 'workflow_get_stage_artifacts', { slug: 'not-found' })
+      expect(resp.result.isError).toBe(true)
+    })
+  })
+
+  // ── workflow_get_quality_gates ────────────────────────────────────────────
+
+  describe('workflow_get_quality_gates', () => {
+    it('returns all 12 gates in correct order', async () => {
+      const resp = await callTool(port, 'workflow_get_quality_gates', {})
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as {
+        gates: Array<{ number: number; slug: string; fileName: string }>
+      }
+      expect(result.gates).toHaveLength(12)
+      expect(result.gates[0]).toEqual({ number: 1, slug: 'idea', fileName: 'idea.md' })
+      expect(result.gates[11]).toEqual({
+        number: 12,
+        slug: 'retrospective',
+        fileName: 'retrospective.md',
+      })
+    })
+  })
+
+  // ── workflow_create_artifact ──────────────────────────────────────────────
+
+  describe('workflow_create_artifact', () => {
+    it('returns pending proposal receipt without mutating the vault', async () => {
+      const resp = await callTool(port, 'workflow_create_artifact', {
+        slug: 'dark-mode',
+        stage: 'design',
+      })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { proposalId: string; status: string }
+      expect(result.status).toBe('pending')
+      expect(typeof result.proposalId).toBe('string')
+      expect(result.proposalId.length).toBeGreaterThan(0)
+      expect(await vault.fileExists('specs/dark-mode/design.md')).toBe(false)
+    })
+  })
+
+  // ── workflow_propose_advance ──────────────────────────────────────────────
+
+  describe('workflow_propose_advance', () => {
+    it('returns pending proposal receipt without advancing the feature', async () => {
+      const resp = await callTool(port, 'workflow_propose_advance', { slug: 'dark-mode' })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { proposalId: string; status: string }
+      expect(result.status).toBe('pending')
+      expect(typeof result.proposalId).toBe('string')
+      expect(result.proposalId.length).toBeGreaterThan(0)
+      // workflow-state.md must remain unchanged
+      const state = await vault.readFile('specs/dark-mode/workflow-state.md')
+      expect(state).toContain('currentStep: 3')
+    })
+  })
+})

--- a/tests/infrastructure/obsidian-mcp-server-adapter-workflow-tools.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter-workflow-tools.test.ts
@@ -141,8 +141,8 @@ describe('ObsidianMcpServerAdapter — workflow tools', () => {
 
   beforeEach(async () => {
     vault = new MockBridge(VAULT_FILES)
-    const repo = new FeatureRepository(vault, vault, DEFAULT_SETTINGS)
-    adapter = new ObsidianMcpServerAdapter(vault, repo, SPECS_FOLDER)
+    const repo = new FeatureRepository(vault, vault, () => DEFAULT_SETTINGS)
+    adapter = new ObsidianMcpServerAdapter(vault, repo, () => SPECS_FOLDER)
     ;({ port } = await adapter.start())
     await initMcp(port)
   })
@@ -189,8 +189,8 @@ describe('ObsidianMcpServerAdapter — workflow tools', () => {
 
     it('returns empty array when specs folder has no features', async () => {
       const emptyVault = new MockBridge({})
-      const emptyRepo = new FeatureRepository(emptyVault, emptyVault, DEFAULT_SETTINGS)
-      const emptyAdapter = new ObsidianMcpServerAdapter(emptyVault, emptyRepo, SPECS_FOLDER)
+      const emptyRepo = new FeatureRepository(emptyVault, emptyVault, () => DEFAULT_SETTINGS)
+      const emptyAdapter = new ObsidianMcpServerAdapter(emptyVault, emptyRepo, () => SPECS_FOLDER)
       const { port: emptyPort } = await emptyAdapter.start()
       await initMcp(emptyPort)
       const resp = await callTool(emptyPort, 'workflow_list_features', {})

--- a/tests/infrastructure/obsidian-mcp-server-adapter.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter.test.ts
@@ -2,10 +2,18 @@ import * as http from 'node:http'
 import { describe, it, expect } from 'vitest'
 import { ObsidianMcpServerAdapter } from '@/infrastructure/obsidian/ObsidianMcpServerAdapter'
 import { MockBridge } from '@/infrastructure/mock/MockBridge'
+import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
+import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
+
+function makeAdapter(files: Record<string, string> = {}): ObsidianMcpServerAdapter {
+  const vault = new MockBridge(files)
+  const repo = new FeatureRepository(vault, vault, DEFAULT_SETTINGS)
+  return new ObsidianMcpServerAdapter(vault, repo, DEFAULT_SETTINGS.specsFolder)
+}
 
 describe('ObsidianMcpServerAdapter', () => {
   it('start() assigns a dynamic port in valid range', async () => {
-    const adapter = new ObsidianMcpServerAdapter(new MockBridge())
+    const adapter = makeAdapter()
     const { port } = await adapter.start()
     expect(port).toBeGreaterThan(0)
     expect(port).toBeLessThanOrEqual(65535)
@@ -13,7 +21,7 @@ describe('ObsidianMcpServerAdapter', () => {
   })
 
   it('getConnectionConfig() returns 127.0.0.1 URL matching the assigned port', async () => {
-    const adapter = new ObsidianMcpServerAdapter(new MockBridge())
+    const adapter = makeAdapter()
     const { port } = await adapter.start()
     expect(adapter.getConnectionConfig()).toEqual({
       transport: 'http',
@@ -23,25 +31,25 @@ describe('ObsidianMcpServerAdapter', () => {
   })
 
   it('getConnectionConfig() throws before start()', () => {
-    const adapter = new ObsidianMcpServerAdapter(new MockBridge())
+    const adapter = makeAdapter()
     expect(() => adapter.getConnectionConfig()).toThrow(/not started/)
   })
 
   it('getConnectionConfig() throws after stop()', async () => {
-    const adapter = new ObsidianMcpServerAdapter(new MockBridge())
+    const adapter = makeAdapter()
     await adapter.start()
     await adapter.stop()
     expect(() => adapter.getConnectionConfig()).toThrow(/not started/)
   })
 
   it('stop() closes the server cleanly', async () => {
-    const adapter = new ObsidianMcpServerAdapter(new MockBridge())
+    const adapter = makeAdapter()
     await adapter.start()
     await expect(adapter.stop()).resolves.toBeUndefined()
   })
 
   it('returns 421 for requests with a non-localhost Host header (DNS rebinding guard)', async () => {
-    const adapter = new ObsidianMcpServerAdapter(new MockBridge())
+    const adapter = makeAdapter()
     const { port } = await adapter.start()
 
     const statusCode = await new Promise<number>((resolve, reject) => {
@@ -60,7 +68,7 @@ describe('ObsidianMcpServerAdapter', () => {
   })
 
   it('returns 500 and stays alive when transport.handleRequest rejects', async () => {
-    const adapter = new ObsidianMcpServerAdapter(new MockBridge())
+    const adapter = makeAdapter()
     const { port } = await adapter.start()
 
     // Send a request immediately after stop() is called on the transport
@@ -87,7 +95,7 @@ describe('ObsidianMcpServerAdapter', () => {
   })
 
   it('server responds to initialize at /mcp', async () => {
-    const adapter = new ObsidianMcpServerAdapter(new MockBridge())
+    const adapter = makeAdapter()
     const { port } = await adapter.start()
 
     const response = await fetch(`http://localhost:${port}/mcp`, {

--- a/tests/infrastructure/obsidian-mcp-server-adapter.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter.test.ts
@@ -7,8 +7,8 @@ import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
 
 function makeAdapter(files: Record<string, string> = {}): ObsidianMcpServerAdapter {
   const vault = new MockBridge(files)
-  const repo = new FeatureRepository(vault, vault, DEFAULT_SETTINGS)
-  return new ObsidianMcpServerAdapter(vault, repo, DEFAULT_SETTINGS.specsFolder)
+  const repo = new FeatureRepository(vault, vault, () => DEFAULT_SETTINGS)
+  return new ObsidianMcpServerAdapter(vault, repo, () => DEFAULT_SETTINGS.specsFolder)
 }
 
 describe('ObsidianMcpServerAdapter', () => {

--- a/tests/ui/composables/useFeatures.test.ts
+++ b/tests/ui/composables/useFeatures.test.ts
@@ -38,7 +38,7 @@ function harness(bridge: MockBridge) {
 }
 
 async function seedActiveFeature(bridge: MockBridge, title = 'Search') {
-  const repo = new FeatureRepository(bridge, bridge, DEFAULT_SETTINGS)
+  const repo = new FeatureRepository(bridge, bridge, () => DEFAULT_SETTINGS)
   const created = await new CreateFeatureUseCase(repo).execute({ title })
   if (!created.ok) throw created.error
   const activated = await new ActivateFeatureUseCase(repo).execute({ featureId: created.value.id })


### PR DESCRIPTION
## Summary

- Extends `ObsidianMcpServerAdapter` constructor with `repo: IFeatureRepository` and `specsFolder: string` params
- Adds `registerWorkflowTools()` with 4 read tools (`workflow_get_state`, `workflow_list_features`, `workflow_get_stage_artifacts`, `workflow_get_quality_gates`) and 2 pending-proposal stubs (`workflow_create_artifact`, `workflow_propose_advance`)
- 9 new integration tests covering all 6 tools; total adapter test count: 49 tests across 3 files

## Test Plan

- [x] `npx vitest run tests/infrastructure/obsidian-mcp-server-adapter*.test.ts` — 49/49 pass
- [x] `npm run typecheck` — zero errors
- [x] `npm run lint` — zero errors
- [x] `npm run verify` — full gate green

## Notes

- Write tools (`workflow_create_artifact`, `workflow_propose_advance`) are stubs pending #191 — they queue to `ProposalStore` with a no-op accept callback
- `workflow_list_features` maps `currentStep > 12` (completed features) to `stage: 'unknown'`; can be improved in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)