### PR TITLE
feat(mcp): wire workflow write tools (closes #192)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -125,6 +125,7 @@ export default defineConfig(
 			'coverage/',
 			'storybook-static/',
 			'.worktrees/',
+			'.claude/',
 			'docs/',
 			// Boundary-rule proof fixtures: deliberately invalid imports/
 			// syntax that the lint test exercises via the ESLint API.

--- a/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+++ b/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
@@ -5,8 +5,9 @@ import { z } from 'zod'
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
 import type { ObsidianMcpServerPort, McpConnectionConfig, VaultPort } from '@/domain/ports'
 import type { IFeatureRepository } from '@/domain/feature/IFeatureRepository'
-import { getAllStepMeta, getStepMeta } from '@/domain/feature/FeatureStep'
+import { FEATURE_STEPS, getAllStepMeta, getStepMeta } from '@/domain/feature/FeatureStep'
 import { Slug } from '@/domain/shared/Slug'
+import { AdvanceFeatureStageUseCase } from '@/application/feature/AdvanceFeatureStageUseCase'
 import { ProposalStore, type PendingProposal } from './ProposalStore'
 
 function parseFrontmatter(content: string): Record<string, unknown> {
@@ -225,6 +226,7 @@ function registerWorkflowTools(
   vault: VaultPort,
   store: ProposalStore,
   specsFolder: () => string,
+  advanceUseCase: AdvanceFeatureStageUseCase,
 ): void {
   mcp.registerTool(
     'workflow_get_state',
@@ -294,14 +296,25 @@ function registerWorkflowTools(
   mcp.registerTool(
     'workflow_create_artifact',
     {
-      description: 'Queue a request to create a stage artifact — stub pending #191',
+      description: 'Create a stage artifact file (idempotent, overwrite-safe). Queued for proposal review.',
       inputSchema: {
         slug: z.string().describe('Feature slug'),
-        stage: z.string().describe('Stage slug (e.g. "design")'),
+        stage: z.string().describe('Stage slug (one of the 12 FEATURE_STEPS)'),
       },
     },
     async ({ slug, stage }) => {
-      const proposalId = store.queue('workflow_create_artifact', { slug, stage }, () => Promise.resolve())
+      const slugResult = Slug.create(slug)
+      if (!slugResult.ok) throw new Error(`Invalid slug: ${slug}`)
+      const stageIndex = (FEATURE_STEPS as readonly string[]).indexOf(stage)
+      if (stageIndex === -1) throw new Error(`Invalid stage: ${stage}`)
+      const feature = await repo.findBySlug(slugResult.value)
+      if (!feature) throw new Error(`Feature not found: ${slug}`)
+      const proposalId = store.queue('workflow_create_artifact', { slug, stage }, async () => {
+        const fresh = await repo.findBySlug(slugResult.value)
+        if (!fresh) throw new Error(`Feature no longer exists: ${slug}`)
+        const result = await repo.createStageFile(fresh, stageIndex + 1)
+        if (!result.ok) throw result.error
+      })
       return ok({ proposalId, status: 'pending' })
     },
   )
@@ -309,11 +322,19 @@ function registerWorkflowTools(
   mcp.registerTool(
     'workflow_propose_advance',
     {
-      description: 'Queue a proposal to advance a feature to the next stage — stub pending #191',
+      description: 'Advance a feature to the next workflow stage. Queued for proposal review.',
       inputSchema: { slug: z.string().describe('Feature slug') },
     },
     async ({ slug }) => {
-      const proposalId = store.queue('workflow_propose_advance', { slug }, () => Promise.resolve())
+      const slugResult = Slug.create(slug)
+      if (!slugResult.ok) throw new Error(`Invalid slug: ${slug}`)
+      const feature = await repo.findBySlug(slugResult.value)
+      if (!feature) throw new Error(`Feature not found: ${slug}`)
+      const featureId = feature.id
+      const proposalId = store.queue('workflow_propose_advance', { slug }, async () => {
+        const result = await advanceUseCase.execute({ featureId })
+        if (!result.ok) throw result.error
+      })
       return ok({ proposalId, status: 'pending' })
     },
   )
@@ -321,6 +342,7 @@ function registerWorkflowTools(
 
 export class ObsidianMcpServerAdapter implements ObsidianMcpServerPort {
   private readonly proposalStore = new ProposalStore()
+  private readonly advanceUseCase: AdvanceFeatureStageUseCase
   private httpServer: http.Server | null = null
   private assignedPort = 0
 
@@ -328,7 +350,9 @@ export class ObsidianMcpServerAdapter implements ObsidianMcpServerPort {
     private readonly vault: VaultPort,
     private readonly repo: IFeatureRepository,
     private readonly specsFolder: () => string,
-  ) {}
+  ) {
+    this.advanceUseCase = new AdvanceFeatureStageUseCase(repo)
+  }
 
   // Off-port by design: called directly by the sidebar module, not via MCP.
   async acceptProposal(proposalId: string): Promise<void> {
@@ -379,7 +403,14 @@ export class ObsidianMcpServerAdapter implements ObsidianMcpServerPort {
   ): Promise<void> {
     const mcp = new McpServer({ name: 'specorator', version: '1.0.0' })
     registerTools(mcp, this.vault, this.proposalStore)
-    registerWorkflowTools(mcp, this.repo, this.vault, this.proposalStore, this.specsFolder)
+    registerWorkflowTools(
+      mcp,
+      this.repo,
+      this.vault,
+      this.proposalStore,
+      this.specsFolder,
+      this.advanceUseCase,
+    )
     const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined })
     await mcp.connect(transport)
     try {

--- a/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+++ b/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
@@ -309,8 +309,11 @@ function registerWorkflowTools(
       if (stageIndex === -1) throw new Error(`Invalid stage: ${stage}`)
       const feature = await repo.findBySlug(slugResult.value)
       if (!feature) throw new Error(`Feature not found: ${slug}`)
+      // Bind to feature.id (not slug) so a delayed accept cannot retarget a
+      // replacement feature that happens to reuse the same slug after delete.
+      const featureId = feature.id
       const proposalId = store.queue('workflow_create_artifact', { slug, stage }, async () => {
-        const fresh = await repo.findBySlug(slugResult.value)
+        const fresh = await repo.findById(featureId)
         if (!fresh) throw new Error(`Feature no longer exists: ${slug}`)
         const result = await repo.createStageFile(fresh, stageIndex + 1)
         if (!result.ok) throw result.error

--- a/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
@@ -467,11 +467,12 @@ describe('ObsidianMcpServerAdapter — workflow tools', () => {
     title: string,
     activate = true,
     advanceTo = 0,
+    idOverride?: string,
   ): Promise<Feature> {
     const slugResult = Slug.create(title)
     if (!slugResult.ok) throw slugResult.error
     const featureResult = Feature.create(
-      `id-${slugResult.value.toString()}`,
+      idOverride ?? `id-${slugResult.value.toString()}`,
       slugResult.value,
       title,
     )
@@ -645,6 +646,25 @@ describe('ObsidianMcpServerAdapter — workflow tools', () => {
         stage: 'design',
       })
       expect(resp.result.isError).toBe(true)
+    })
+
+    it('binds proposal to feature.id — accept rejects after slug recycle', async () => {
+      const original = await seedFeature('Dark Mode', true, 0, 'id-original')
+      const resp = await callTool(port, 'workflow_create_artifact', {
+        slug: 'dark-mode',
+        stage: 'design',
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+
+      const deleteResult = await repo.delete(original.id)
+      expect(deleteResult.ok).toBe(true)
+      // Recreate with same slug — different id.
+      await seedFeature('Dark Mode', true, 0, 'id-replacement')
+
+      await expect(adapter.acceptProposal(proposalId)).rejects.toThrow(
+        /no longer exists/,
+      )
+      expect(await vault.fileExists('specs/dark-mode/design.md')).toBe(false)
     })
   })
 

--- a/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
@@ -4,6 +4,8 @@ import { MockBridge } from '@/infrastructure/mock/MockBridge'
 import { parse as parseYaml } from 'yaml'
 import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
 import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
+import { Feature } from '@/domain/feature/Feature'
+import { Slug } from '@/domain/shared/Slug'
 
 async function mcpPost(port: number, body: unknown): Promise<unknown> {
   const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
@@ -451,6 +453,237 @@ describe('ObsidianMcpServerAdapter — vault + frontmatter tools', () => {
         params: { path: 'notes/new.md', content: '# New' },
         status: 'pending',
       })
+    })
+  })
+})
+
+describe('ObsidianMcpServerAdapter — workflow tools', () => {
+  let adapter: ObsidianMcpServerAdapter
+  let vault: MockBridge
+  let repo: FeatureRepository
+  let port: number
+
+  async function seedFeature(
+    title: string,
+    activate = true,
+    advanceTo = 0,
+  ): Promise<Feature> {
+    const slugResult = Slug.create(title)
+    if (!slugResult.ok) throw slugResult.error
+    const featureResult = Feature.create(
+      `id-${slugResult.value.toString()}`,
+      slugResult.value,
+      title,
+    )
+    if (!featureResult.ok) throw featureResult.error
+    let feature = featureResult.value
+    if (activate) {
+      const activated = feature.activate()
+      if (!activated.ok) throw activated.error
+      feature = activated.value
+    }
+    for (let i = 0; i < advanceTo; i++) {
+      const adv = feature.advanceStep()
+      if (!adv.ok) throw adv.error
+      feature = adv.value
+    }
+    const saved = await repo.save(feature)
+    if (!saved.ok) throw saved.error
+    return feature
+  }
+
+  beforeEach(async () => {
+    vault = new MockBridge()
+    repo = new FeatureRepository(vault, vault, () => DEFAULT_SETTINGS)
+    adapter = new ObsidianMcpServerAdapter(vault, repo, () => DEFAULT_SETTINGS.specsFolder)
+    ;({ port } = await adapter.start())
+    await initMcp(port)
+  })
+
+  afterEach(async () => {
+    await adapter.stop()
+  })
+
+  describe('workflow_get_state', () => {
+    it('returns full feature DTO for an existing slug', async () => {
+      await seedFeature('Dark Mode', true, 2)
+      const resp = await callTool(port, 'workflow_get_state', { slug: 'dark-mode' })
+      expect(resp.result.isError).toBeFalsy()
+      const dto = parseToolResult(resp) as Record<string, unknown>
+      expect(dto.slug).toBe('dark-mode')
+      expect(dto.title).toBe('Dark Mode')
+      expect(dto.status).toBe('active')
+      expect(dto.currentStep).toBe(3)
+    })
+
+    it('returns isError when feature not found', async () => {
+      const resp = await callTool(port, 'workflow_get_state', { slug: 'missing' })
+      expect(resp.result.isError).toBe(true)
+    })
+
+    it('returns isError when slug is invalid', async () => {
+      const resp = await callTool(port, 'workflow_get_state', { slug: '!!!' })
+      expect(resp.result.isError).toBe(true)
+    })
+  })
+
+  describe('workflow_list_features', () => {
+    it('returns array of {slug, stage, title} for all features', async () => {
+      await seedFeature('Dark Mode', true, 2)
+      await seedFeature('Light Mode', true, 0)
+      const resp = await callTool(port, 'workflow_list_features', {})
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as {
+        features: Array<{ slug: string; stage: string; title: string }>
+      }
+      const sorted = [...result.features].sort((a, b) => a.slug.localeCompare(b.slug))
+      expect(sorted).toEqual([
+        { slug: 'dark-mode', stage: 'requirements', title: 'Dark Mode' },
+        { slug: 'light-mode', stage: 'idea', title: 'Light Mode' },
+      ])
+    })
+
+    it('returns empty array when no features exist', async () => {
+      const resp = await callTool(port, 'workflow_list_features', {})
+      expect(parseToolResult(resp)).toEqual({ features: [] })
+    })
+  })
+
+  describe('workflow_get_stage_artifacts', () => {
+    it('returns 12 artifact entries with exists flags reflecting vault state', async () => {
+      await seedFeature('Dark Mode', true, 1)
+      const resp = await callTool(port, 'workflow_get_stage_artifacts', { slug: 'dark-mode' })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as {
+        stage: string
+        artifacts: Array<{ slug: string; path: string; exists: boolean }>
+      }
+      expect(result.stage).toBe('research')
+      expect(result.artifacts).toHaveLength(12)
+      const idea = result.artifacts.find((a) => a.slug === 'idea')
+      expect(idea).toBeDefined()
+      expect(idea?.exists).toBe(true)
+      expect(idea?.path).toBe('specs/dark-mode/idea.md')
+      const design = result.artifacts.find((a) => a.slug === 'design')
+      expect(design?.exists).toBe(false)
+    })
+
+    it('returns isError when feature not found', async () => {
+      const resp = await callTool(port, 'workflow_get_stage_artifacts', { slug: 'missing' })
+      expect(resp.result.isError).toBe(true)
+    })
+  })
+
+  describe('workflow_get_quality_gates', () => {
+    it('returns all 12 stages in order', async () => {
+      const resp = await callTool(port, 'workflow_get_quality_gates', {})
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as {
+        gates: Array<{ number: number; slug: string; fileName: string }>
+      }
+      expect(result.gates).toHaveLength(12)
+      expect(result.gates[0]).toEqual({ number: 1, slug: 'idea', fileName: 'idea.md' })
+      expect(result.gates[11]).toEqual({
+        number: 12,
+        slug: 'retrospective',
+        fileName: 'retrospective.md',
+      })
+    })
+  })
+
+  describe('workflow_create_artifact', () => {
+    it('returns pending receipt without writing the stage file', async () => {
+      await seedFeature('Dark Mode', true, 0)
+      const resp = await callTool(port, 'workflow_create_artifact', {
+        slug: 'dark-mode',
+        stage: 'design',
+      })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { proposalId: string; status: string }
+      expect(result.status).toBe('pending')
+      expect(typeof result.proposalId).toBe('string')
+      expect(await vault.fileExists('specs/dark-mode/design.md')).toBe(false)
+    })
+
+    it('accept creates the stage artifact file', async () => {
+      await seedFeature('Dark Mode', true, 0)
+      const resp = await callTool(port, 'workflow_create_artifact', {
+        slug: 'dark-mode',
+        stage: 'design',
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      await adapter.acceptProposal(proposalId)
+      expect(await vault.fileExists('specs/dark-mode/design.md')).toBe(true)
+      const content = await vault.readFile('specs/dark-mode/design.md')
+      expect(content).toContain('stage: design')
+      expect(content).toContain('feature: dark-mode')
+    })
+
+    it('reject leaves the vault unchanged', async () => {
+      await seedFeature('Dark Mode', true, 0)
+      const resp = await callTool(port, 'workflow_create_artifact', {
+        slug: 'dark-mode',
+        stage: 'design',
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      adapter.rejectProposal(proposalId)
+      expect(await vault.fileExists('specs/dark-mode/design.md')).toBe(false)
+    })
+
+    it('returns isError for unknown stage slug', async () => {
+      await seedFeature('Dark Mode', true, 0)
+      const resp = await callTool(port, 'workflow_create_artifact', {
+        slug: 'dark-mode',
+        stage: 'made-up',
+      })
+      expect(resp.result.isError).toBe(true)
+    })
+
+    it('returns isError when feature not found', async () => {
+      const resp = await callTool(port, 'workflow_create_artifact', {
+        slug: 'missing',
+        stage: 'design',
+      })
+      expect(resp.result.isError).toBe(true)
+    })
+  })
+
+  describe('workflow_propose_advance', () => {
+    it('returns pending receipt without advancing the feature', async () => {
+      await seedFeature('Dark Mode', true, 0)
+      const resp = await callTool(port, 'workflow_propose_advance', { slug: 'dark-mode' })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { proposalId: string; status: string }
+      expect(result.status).toBe('pending')
+      const stateResp = await callTool(port, 'workflow_get_state', { slug: 'dark-mode' })
+      const dto = parseToolResult(stateResp) as { currentStep: number }
+      expect(dto.currentStep).toBe(1)
+    })
+
+    it('accept advances the feature to the next stage and creates the stage stub', async () => {
+      await seedFeature('Dark Mode', true, 0)
+      const resp = await callTool(port, 'workflow_propose_advance', { slug: 'dark-mode' })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      await adapter.acceptProposal(proposalId)
+      const stateResp = await callTool(port, 'workflow_get_state', { slug: 'dark-mode' })
+      const dto = parseToolResult(stateResp) as { currentStep: number }
+      expect(dto.currentStep).toBe(2)
+      expect(await vault.fileExists('specs/dark-mode/research.md')).toBe(true)
+    })
+
+    it('reject leaves the feature at its current stage', async () => {
+      await seedFeature('Dark Mode', true, 0)
+      const resp = await callTool(port, 'workflow_propose_advance', { slug: 'dark-mode' })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      adapter.rejectProposal(proposalId)
+      const stateResp = await callTool(port, 'workflow_get_state', { slug: 'dark-mode' })
+      const dto = parseToolResult(stateResp) as { currentStep: number }
+      expect(dto.currentStep).toBe(1)
+    })
+
+    it('returns isError when feature not found', async () => {
+      const resp = await callTool(port, 'workflow_propose_advance', { slug: 'missing' })
+      expect(resp.result.isError).toBe(true)
     })
   })
 })


### PR DESCRIPTION
## Summary

- Wire `workflow_create_artifact` to `FeatureRepository.createStageFile` via `ProposalStore`. Accepts any of the 12 stage slugs; relies on existing idempotent + overwrite-safe semantics. Validates slug + stage at queue time; re-fetches feature on accept.
- Wire `workflow_propose_advance` to `AdvanceFeatureStageUseCase.execute` via `ProposalStore`. Captures `featureId` at queue time so accept operates on fresh state.
- Add 17 behavior tests for the 6 workflow tools (pending/accept/reject for writes; DTO + edge cases for reads).
- Ignore `.claude/` in ESLint config — stale worktree coverage was breaking the lint gate.

## Context

PR #212 landed the workflow tool scaffold but left both write tools as `() => Promise.resolve()` no-ops, gated on the proposal queue from #191. With #191 merged (PR #209), the writes can now route through real mutations and #192 can close.

## Test plan

- [x] `npm run verify` (typecheck + lint + tests + coverage 92.05/80.32/90.45/92.98 + build + docs + manifest + scaffold + workflows + git diff --check)
- [x] All 49 MCP tool tests pass
- [x] Per-AC: 6 tools registered (`tools/list` returns 16 total), reads return DTO/array/exists/gate metadata, writes return `{proposalId, status:'pending'}` and apply on accept

🤖 Generated with [Claude Code](https://claude.com/claude-code)