### PR TITLE
spec(terminal-sidepanel): idea for embedded Claude CLI terminal (TSP-001)

### DIFF
--- a/specs/terminal-sidepanel/idea.md
+++ b/specs/terminal-sidepanel/idea.md
@@ -1,0 +1,67 @@
+---
+id: IDEA-TSP-001
+title: "Terminal sidepanel — embedded Claude CLI interactive session"
+stage: idea
+feature: terminal-sidepanel
+status: accepted
+owner: pm
+created: 2026-05-10
+updated: 2026-05-10
+references:
+  - specs/claude-cli-chat-sidebar/idea.md
+---
+
+## Problem statement
+
+The full Claude CLI chat sidebar (IDEA-CCS-001) requires a custom streaming chat UI, five-layer context assembly, write-operation review cards, and SDK subprocess management — a significant implementation surface. Users need a working AI interaction point in the plugin now, not after all of that is built. The simplest credible first version is: spawn a `claude` CLI interactive session as a child process and display it in the Obsidian sidepanel through an embedded terminal emulator. The user gets the full Claude CLI experience — slash commands, multi-turn conversation, tool use — without the plugin needing to mediate any of it.
+
+## Primary users
+
+- **Developers and technical PMs** who are comfortable with a CLI and want to start using Claude inside Obsidian immediately.
+- **Any user** who has Claude CLI installed and wants AI assistance scoped to their vault without switching applications.
+
+## Success criteria
+
+- Opening the terminal sidepanel launches a `claude` interactive session inside Obsidian with no extra configuration.
+- The terminal renders ANSI colors, cursor movement, and interactive input correctly (full PTY semantics, not line-buffered pipe).
+- The user can type, submit, and receive multi-turn responses exactly as they would in a system terminal running `claude`.
+- When Claude CLI is not installed or not on `PATH`, the panel shows a plain-language install prompt rather than a blank or broken terminal.
+- The session persists while the sidepanel is open; closing and reopening the panel starts a fresh session (no zombie processes left behind).
+- The terminal respects the Obsidian theme (background, text color) and is legible in both light and dark mode.
+- Works in the Obsidian desktop app (Electron); gracefully disabled in the standalone browser UI with an explanatory message.
+
+## Constraints
+
+- Obsidian runs on Electron. The terminal emulator library (`xterm.js`) and PTY library (`node-pty`) must be compatible with Obsidian's bundled Electron and Node.js versions. `node-pty` is a native addon and must be pre-built for the correct Electron ABI (via `electron-rebuild` or bundled prebuilds).
+- `TerminalPort` must be a narrow domain port (ADR-008 pattern) — a stable seam so the implementation can evolve without changing call sites in the UI.
+- All process lifecycle operations (spawn, write, resize, kill) go through `TerminalPort`; no direct `child_process` or `node-pty` calls from Vue components.
+- The terminal sidepanel must not be registered or rendered in MockBridge or LocalStorageBridge environments (standalone browser UI, tests) — those contexts have no process-spawning capability.
+- No modification to the Claude CLI session itself: no system-prompt injection, no automatic file reads, no intercepted output. The terminal is a transparent passthrough.
+- Must degrade gracefully: if `claude` is not found on `PATH`, show a clear message with install instructions; all other plugin features remain available.
+
+## Research questions
+
+- What is the correct approach to bundle `node-pty` (a native Node.js addon) inside an Obsidian plugin without breaking the Electron sandbox? Does `electron-rebuild` work reliably, or are prebuilt binaries for each Electron version the better path?
+- Does Obsidian's CSP and plugin sandbox allow loading `node-pty`'s `.node` binary at runtime?
+- How should terminal resize events be communicated from the `xterm.js` component to the `node-pty` process? (FitAddon + ResizeObserver is the standard approach — confirm it works inside Obsidian's leaf view.)
+- Is there a risk of zombie `claude` processes if Obsidian closes unexpectedly, and how should cleanup be handled in the plugin's `onunload` hook?
+- Should the initial working directory for the spawned `claude` session be set to the vault root, so Claude CLI's file tool calls land in the vault by default?
+
+## Preliminary scope
+
+**In scope:**
+- `TerminalPort` narrow port interface (`spawn`, `write`, `resize`, `kill`, `onData`, `onExit`) in `src/domain/ports/`
+- `ObsidianTerminalAdapter` implementing `TerminalPort` via `node-pty` in `src/infrastructure/obsidian/`
+- `TerminalSidepanelView` — Obsidian `ItemView` subclass registered in `src/plugin/`
+- Vue component `TerminalPane.vue` wrapping `xterm.js` and its `FitAddon`
+- Graceful not-installed state: detect `claude` on `PATH` at panel open; show install guidance if missing
+- Process cleanup in plugin `onunload` and on panel close
+- `NullTerminalAdapter` stub for non-Obsidian environments (returns capability flag `supported: false`)
+
+**Out of scope:**
+- Context injection (vault files, workflow state) into the Claude CLI session — that is IDEA-CCS-001 territory
+- Custom commands or slash-command interception
+- Conversation history persistence
+- MockBridge or LocalStorageBridge terminal implementations
+- Any UI chrome beyond the raw terminal (no toolbar, no title bar, no controls in v1)
+- Windows support (PTY semantics on Windows differ; v1 targets macOS/Linux only)

--- a/specs/terminal-sidepanel/workflow-state.md
+++ b/specs/terminal-sidepanel/workflow-state.md
@@ -1,0 +1,56 @@
+---
+id: a1b2c3d4-e567-4f89-a012-b3c4d5e6f7a8
+feature: "Terminal sidepanel"
+area: TSP
+slug: terminal-sidepanel
+current_stage: idea
+status: active
+last_updated: 2026-05-10
+last_agent: pm
+createdAt: 2026-05-10T00:00:00+02:00
+updatedAt: 2026-05-10T00:00:00+02:00
+artifacts:
+  idea: complete
+  research: pending
+  requirements: pending
+  design: pending
+  spec: pending
+  tasks: pending
+  implementation-log: pending
+  test-plan: pending
+  test-report: pending
+  review: pending
+  release-notes: pending
+  retrospective: pending
+---
+
+## Stage progress
+
+| Stage | Status | Artifact | Notes |
+|---|---|---|---|
+| 1 — Idea | complete | `idea.md` | |
+| 2 — Research | pending | — | |
+| 3 — Requirements | pending | — | |
+| 4 — Design | pending | — | |
+| 5 — Specification | pending | — | |
+| 6 — Tasks | pending | — | |
+| 7 — Implementation | pending | — | |
+| 8 — Testing | pending | — | |
+| 9 — Review | pending | — | |
+| 10 — Release | pending | — | |
+| 11 — Retrospective | pending | — | |
+
+## Blocks
+
+None at this stage.
+
+## Hand-off notes
+
+| Date | From | To | Note |
+|---|---|---|---|
+| 2026-05-10 | pm | — | Spec entry created; idea authored as the pragmatic v1 path toward IDEA-CCS-001 |
+
+## Open clarifications
+
+- node-pty Electron ABI compatibility needs a research spike before requirements can be finalised.
+- Windows PTY semantics deferred to a follow-on scope discussion.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `specs/terminal-sidepanel/idea.md` (IDEA-TSP-001) and `workflow-state.md` for the terminal emulator sidepanel feature
- Scopes the pragmatic v1 LLM interaction path: spawn `claude` CLI as an interactive child process via `node-pty` and display it in the Obsidian sidepanel through `xterm.js`
- Treats this as a stepping stone toward the full SDK-based chat sidebar (IDEA-CCS-001) — no context assembly, no custom chat UI, just a transparent PTY passthrough

## Key decisions captured in the idea

- `TerminalPort` as a narrow ADR-008 port (`spawn`, `write`, `resize`, `kill`, `onData`, `onExit`)
- `node-pty` for PTY semantics (not line-buffered pipes); `xterm.js` + `FitAddon` for rendering
- `NullTerminalAdapter` stub for non-Obsidian environments (browser UI, tests)
- Graceful not-installed state: detect `claude` on `PATH` at panel open, show install guidance if missing
- Windows PTY support deferred; v1 targets macOS/Linux only

## Open research questions (flagged in the spec)

- `node-pty` Electron ABI compatibility — needs a spike before requirements can be finalised
- Obsidian CSP / sandbox constraints for loading `.node` binaries at runtime
- Zombie process risk on unexpected Obsidian quit

## Test plan

- [ ] Spec files are present at `specs/terminal-sidepanel/idea.md` and `specs/terminal-sidepanel/workflow-state.md`
- [ ] Frontmatter validates against ADR-005 schema (id, stage, status, owner, feature fields present)
- [ ] `workflow-state.md` `current_stage` is `idea` and `idea` artifact is `complete`
- [ ] No source code changed; CI lint/typecheck/test should be unaffected

https://claude.ai/code/session_01SXJrXBhZmTpCbJ7AXePcyi
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXJrXBhZmTpCbJ7AXePcyi)_