### PR TITLE
docs(spec): add config-driven prototype builder idea (CDP)

### DIFF
--- a/docs/superpowers/specs/2026-05-10-config-driven-prototype-builder-design.md
+++ b/docs/superpowers/specs/2026-05-10-config-driven-prototype-builder-design.md
@@ -1,0 +1,249 @@
+# Config-driven prototype builder — Design
+
+**Date:** 2026-05-10
+**Author:** brainstorming session (pm)
+**Status:** Draft — design accepted in brainstorming, awaiting written-spec review
+**Related:** [`specs/config-driven-prototype-builder/idea.md`](../../../specs/config-driven-prototype-builder/idea.md)
+
+## 1. Summary
+
+Add a Lowdefy-inspired, config-driven app prototype runtime to the Specorator plugin. The user authors `specs/{slug}/prototype.md` (frontmatter + markdown). The plugin renders that file as a runnable multi-page Vue 3 app inside an Obsidian view tab. AI assistance is delegated to the existing Claude CLI Chat Sidebar.
+
+The runtime is a thin Vue-3 port of the Lowdefy interpretation model: pages and blocks as a typed tree, operator-object expressions (no `eval`), three local data adapters (`vault-file`, `feature-data`, `inline`), curated built-in block library only.
+
+## 2. Architecture
+
+DDD layered (ADR-001) with strict inward-only imports.
+
+```
+domain/prototype/
+  PrototypeConfig.ts            # Zod-validated value object
+  Block.ts, Page.ts             # immutable nodes
+  Operator.ts                   # pure operator engine
+  Expression.ts                 # operator-object resolver
+  ports/PrototypeDataPort.ts    # narrow port for data sources
+
+application/prototype/
+  LoadPrototypeUseCase.ts
+  ValidatePrototypeUseCase.ts
+  ResolveExpressionUseCase.ts
+
+infrastructure/prototype/
+  PrototypeRepository.ts        # gray-matter + Zod, via VaultPort
+  adapters/
+    VaultFileDataAdapter.ts     # JSON/CSV/MD reader
+    FeatureDataAdapter.ts       # binds to Feature aggregate
+    InlineDataAdapter.ts        # config-embedded fixtures
+
+ui/prototype/
+  PrototypeView.vue             # Obsidian view tab
+  blocks/                       # ~20 built-in Vue components
+  PrototypeRuntime.ts           # composable, owns reactive state tree
+  stores/prototypeRuntime.ts    # Pinia store per prototype
+  composables/usePrototypeData.ts
+
+plugin/
+  registerPrototypeView()
+```
+
+`PrototypeDataPort` joins the existing five narrow ports (Settings, Vault, Workspace, Notification, Logger). Single method dispatched by adapter id internally — keeps ADR-008 narrow-port count flat.
+
+## 3. Schema (`prototype.md`)
+
+```yaml
+---
+specorator: 0.1
+prototype:
+  id: feature-card-demo
+  title: Feature Card Demo
+  pages:
+    - id: home
+      path: /
+      title: Home
+      blocks:
+        - id: featureList
+          type: List
+          properties:
+            data: { _data: featuresFromVault }
+            empty: "No features yet"
+          blocks:
+            - id: card
+              type: Card
+              properties:
+                title: { _item: title }
+                subtitle: { _item: stage }
+              events:
+                onClick:
+                  - id: goDetail
+                    type: Navigate
+                    params:
+                      path: { _format: ["/feature/{}", { _item: id }] }
+    - id: detail
+      path: /feature/:id
+      blocks: [ ... ]
+  data:
+    - id: featuresFromVault
+      adapter: feature-data
+      params: { status: active }
+    - id: notes
+      adapter: vault-file
+      params: { path: data/notes.json }
+    - id: countries
+      adapter: inline
+      params: { rows: [{ code: DE }, { code: US }] }
+---
+
+# Feature Card Demo
+
+Markdown body free for design notes, prose, decisions.
+AI uses body as context; runtime ignores it.
+```
+
+- Top-level `specorator:` key isolates from existing markdown frontmatter (`title`, `tags`).
+- `prototype:` namespace leaves room for sibling configs (e.g. `dataset:`).
+- Schema versioned (`specorator: 0.1`) for forward-compatible migrations.
+- Body markdown is free prose. The runtime ignores it; AI uses it as authoring context.
+
+## 4. Operator set (v1, ~15)
+
+| Operator | Arg | Purpose |
+|---|---|---|
+| `_state` | string path | runtime state read |
+| `_data` | string id | resolved data binding |
+| `_item` | string path | current `List` iteration item |
+| `_event` | string path | event payload |
+| `_url_query` | string key | hash-route query param |
+| `_url_params` | string key | route path param |
+| `_if` | `{test, then, else}` | branch |
+| `_eq` / `_not_eq` | `[a, b]` | compare |
+| `_and` / `_or` / `_not` | array / value | boolean combinators |
+| `_get` | `{from, key}` | object property |
+| `_format` | `[template, ...args]` | string interpolation `"{}"` |
+| `_length` | array | count |
+| `_filter` | `{from, where}` | filter array by truthy expr |
+| `_ref` | string path | include another markdown's prototype frontmatter |
+
+Resolver evaluates **most-nested first**, returns `null` and logs to `LoggerPort` on failure (Lowdefy parity). Pure function, no IO. Tested with golden-file fixtures.
+
+**Excluded v1:** `_js`, `_request`, `_secret`, date math, regex.
+
+## 5. Built-in block library (v1, ~20)
+
+**Containers (4):** `Page`, `Box`, `Card`, `List`
+**Display (5):** `Heading`, `Text`, `Badge`, `Markdown`, `Empty`
+**Inputs (8):** `TextInput`, `TextArea`, `NumberInput`, `Checkbox`, `Toggle`, `Select`, `RadioGroup`, `DatePicker`
+**Action (3):** `Button`, `Link`, `IconButton`
+
+Inputs implicitly bind to `state[blockId]` (Lowdefy convention). All inputs support `required` and `validate: [{pass, message, status}]`.
+
+Events: `onClick`, `onChange`, `onMount`, `onSubmit`.
+Action types: `Navigate`, `SetState`, `ResetState`, `RefreshData`, `Notify`.
+Action lists support `try` / `catch` semantics.
+
+Styling uses Obsidian CSS variables; no external UI library — keeps bundle small and theme-native.
+
+## 6. Data flow
+
+```
+prototype.md (vault)
+   │  VaultPort.readFile
+   ▼
+gray-matter split → frontmatter + body
+   │
+   ▼
+Zod validate (PrototypeConfigSchema)
+   │  Result<PrototypeConfig, ValidationError>
+   ▼
+LoadPrototypeUseCase
+   │
+   ▼
+PrototypeRuntime (Pinia store)
+  ├─ state:  Map<blockId, value>      # implicit input binding
+  ├─ data:   Map<dataId, resolved>    # adapter results, reactive
+  ├─ route:  {path, params, query}
+  └─ events: action queue
+   │
+   ▼
+Renderer (PrototypeView.vue)
+  walks page tree → Block component → resolves operators per render
+   │
+   ▼
+User input → SetState action → state mutation → reactive re-render
+                                              + dependent _data refresh
+```
+
+`PrototypeDataPort` contract:
+
+```ts
+interface PrototypeDataPort {
+  resolve(adapter: string, params: unknown): Promise<Result<unknown[], DataError>>
+}
+```
+
+Single port, dispatched by adapter id. Adds one port to ADR-008's family (six total). Reactivity rides Vue's reactive system — operator resolution sits inside computed wrappers, so re-eval auto-triggers on dependency change.
+
+## 7. Error handling
+
+| Failure | Layer | Response |
+|---|---|---|
+| Frontmatter YAML parse | repo | `Result.err(ParseError)` → red banner; body markdown still shown |
+| Zod validation | repo | `Result.err(ValidationError)` w/ Zod path → inline error per offending block |
+| Operator resolves null/throws | engine | log via LoggerPort; render block w/ placeholder |
+| Data adapter fails | adapter | `Result.err(DataError)` → block in error state; `RefreshData` retry available |
+| Unknown block `type` | renderer | `<UnknownBlock>` placeholder; ErrorBoundary catches Vue errors |
+| Action dispatch fail | runtime | `try` / `catch` action lists; FeedbackService surfaces user-facing notice |
+
+Domain mutations stay `Result<T, E>` (ADR-004). No throws across layer boundaries.
+
+## 8. Testing
+
+- **Domain:** golden-file operator tests (`tests/domain/prototype/Operator.test.ts`) covering every operator + nesting cases.
+- **Repository:** Zod schema fuzz + valid/malformed `prototype.md` fixtures under `tests/infrastructure/prototype/__fixtures__/`.
+- **Adapters:** `fakeModulePorts` + table-driven inputs.
+- **UI:** PageObject per block (`Card.po.ts`, `List.po.ts`, …) under `tests/ui/prototype/blocks/`. Mounted via `@vue/test-utils` with MockBridge.
+- **Integration:** end-to-end "load → render → click → state mutates → block re-renders" via `PrototypeView.po.ts`.
+- Coverage thresholds 80/70/80/80 (existing gate).
+
+## 9. Workflow integration
+
+- **Artifact:** `specs/{slug}/prototype.md` — sibling to `idea.md` / `spec.md` / etc. Not a new stage. No `FEATURE_STEPS` change.
+- **Repository:** `FeatureRepository.readPrototype(slug)` / `writePrototype(slug, config)`. Overwrite-protected per AVS-005.
+- **View entry:** command palette `Specorator: Open Prototype` + button on workflow nav. Opens new Obsidian tab with `PrototypeView`.
+- **CCS reuse:** prototype.md edits flow through Claude CLI Chat Sidebar's existing write-proposal review card. Zero new AI infrastructure.
+- **Settings:** `PluginSettings.enablePrototypes: boolean` (default `false`). Feature-flagged for safe rollout.
+
+## 10. Out of scope (deferred)
+
+- Custom user-authored blocks (composition templates or `.vue` loading)
+- HTTP / fetch adapter; auth and secrets
+- Standalone export to runnable Vite repo
+- Visual / drag-and-drop block editor
+- Multi-user / real-time collaboration
+- `_js` operator (QuickJS-emscripten sandbox)
+- Date math, regex, server-only operators
+
+## 11. Open questions for next stage (research)
+
+1. Tab vs pane integration with the existing workflow view.
+2. Hot-reload contract on external `prototype.md` edits (`MetadataCachePort.onFileChange` vs explicit reload).
+3. Whether the AI proposal review card needs prototype-specific block-diff rendering, or the existing markdown diff suffices for v1.
+4. Caching strategy: re-resolve data on every view mount, or cache per session.
+
+## 12. References
+
+- [Lowdefy GitHub](https://github.com/lowdefy/lowdefy)
+- [Lowdefy blocks schema](https://github.com/lowdefy/lowdefy/blob/main/packages/docs/concepts/blocks.yaml)
+- [Lowdefy operators](https://github.com/lowdefy/lowdefy/blob/main/packages/docs/concepts/operators.yaml)
+- [Lowdefy events / actions](https://github.com/lowdefy/lowdefy/blob/main/packages/docs/concepts/events-and-actions.yaml)
+- [Astro Content Collections](https://docs.astro.build/en/guides/content-collections/) — frontmatter + Zod pattern
+- [JSON-e operators](https://json-e.js.org/operators.html) — operator-object dialect prior art
+- [FormKit Schema](https://formkit.com/guides/create-a-custom-input) — Vue-3 schema-driven form prior art
+- [Formily Vue](https://github.com/alibaba/formily) — multi-framework schema engine
+- [JSONForms Vue](https://jsonforms.io/api/vue/) — `tester + renderer` registry pattern
+
+## 13. Spec self-review
+
+- **Placeholders:** none. All sections populated.
+- **Internal consistency:** schema example uses `_format` and `_data`, both listed in operator table; block types in example (`List`, `Card`) appear in the block library. Consistent.
+- **Scope:** focused on a single feature with clear v1/deferred split. Single-plan implementable.
+- **Ambiguity:** open questions explicitly enumerated for the research stage rather than left implicit.

--- a/specs/config-driven-prototype-builder/idea.md
+++ b/specs/config-driven-prototype-builder/idea.md
@@ -1,0 +1,93 @@
+---
+id: IDEA-CDP-001
+title: "Config-driven prototype builder"
+stage: idea
+feature: config-driven-prototype-builder
+status: draft
+owner: pm
+created: 2026-05-10
+updated: 2026-05-10
+references:
+  - external: "https://github.com/lowdefy/lowdefy"
+  - external: "https://lowdefy.com/docs"
+  - adr: "ADR-001"
+  - adr: "ADR-004"
+  - adr: "ADR-008"
+  - spec: "claude-cli-chat-sidebar"
+---
+
+## Problem statement
+
+Specorator users need to move from a written specification to a tangible, demonstrable prototype without leaving the vault and without writing application code. Today, the workflow ends at written artifacts (idea, requirements, design, spec, tasks). There is no way to validate flow, layout, and data shapes interactively. Stakeholders cannot click through a proposal, and feedback loops stretch across days because every design tweak requires a developer.
+
+A config-driven prototype builder closes this gap. The user authors a single human-readable file (markdown + YAML frontmatter) that describes pages, blocks, data, and actions. The plugin renders that file as a live multi-page app inside an Obsidian view tab. AI assists authoring through the existing Claude CLI Chat Sidebar — same write-proposal review flow that already governs other vault edits.
+
+The conceptual model is borrowed from [Lowdefy](https://github.com/lowdefy/lowdefy): YAML config interpreted at runtime, operator-object expressions instead of `eval`, blocks as a typed component registry. The implementation is a Vue-3-native thin runtime — Lowdefy is React-based and not directly reusable — sized for in-Obsidian rendering, not standalone deployment.
+
+## Primary users
+
+- **Non-technical founders, PMs, designers** who want to mock multi-page flows with real data shapes without engineering involvement.
+- **Solo developers** validating UX choices before writing production code; prototype.md becomes living spec.
+- **Stakeholders / reviewers** who click through a real interface as part of feature acceptance, replacing static screenshots.
+
+## Success criteria
+
+- A user can author `specs/{slug}/prototype.md` (frontmatter config + free-text body) and open it in a new Obsidian view tab as a runnable multi-page app.
+- The rendered prototype supports navigation between pages, input blocks bound to local state, container blocks (Card, List, Box), and display blocks — all from declarative config.
+- Three data adapters work end-to-end: `vault-file` (JSON / CSV / MD-frontmatter), `feature-data` (Specorator features), `inline` (config-embedded fixtures). No HTTP in v1.
+- An expression engine resolves operator-object references (`_state`, `_data`, `_item`, `_if`, `_format`, …) without using `eval`/`Function()` — passes Obsidian plugin review.
+- Schema validation via Zod produces precise error locations; failures show inline in the prototype view, sibling blocks still render.
+- The Claude CLI Chat Sidebar can read and propose edits to `prototype.md` through its existing write-proposal review card. Zero new AI infrastructure.
+- The prototype is a sibling artifact under `specs/{slug}/` — no new workflow stage, no change to FEATURE_STEPS, no change to the spec-first gate.
+- Behind a `enablePrototypes` PluginSettings flag (default `false`) for safe rollout.
+
+## Constraints
+
+- Stack stays Vue 3 + TypeScript. Lowdefy is not a dependency.
+- No `eval` or `Function()` constructor anywhere in the runtime — Obsidian plugin review excludes plugins that ship arbitrary code execution.
+- All Obsidian I/O goes through the existing narrow ports (ADR-008). One new narrow port joins the family: `PrototypeDataPort` (single-method, dispatched by adapter id).
+- Domain mutations and use cases continue to return `Result<T, E>` (ADR-004); no exceptions across layer boundaries.
+- DDD layered import direction (ADR-001) is preserved — `domain/prototype` depends on nothing; renderer in `ui/prototype` consumes use cases plus port keys.
+- Custom user blocks are explicitly out of scope for v1 — a curated built-in library only. Composition / SFC loading deferred.
+- Coverage thresholds 80/70/80/80 enforced on all new source files via `npm run verify`.
+
+## Research questions
+
+- What is the minimum operator surface that covers ~80% of realistic prototype configs? The proposed v1 set is ~15 operators (`_state`, `_data`, `_item`, `_event`, `_url_query`, `_url_params`, `_if`, `_eq`, `_not_eq`, `_and`, `_or`, `_not`, `_get`, `_format`, `_length`, `_filter`, `_ref`). Should `_request` (HTTP) and `_js` (sandboxed JS) be deferred to v2 or be reserved as schema slots from day one?
+- Should the runtime cache resolved data per session (and across opens), or always re-resolve on view mount? Caching simplifies snappy reopens but complicates `RefreshData` semantics.
+- How should the prototype tab respond when the underlying `prototype.md` is edited externally? Hot reload via `MetadataCachePort.onFileChange`, or explicit "reload" button only?
+- What is the right boundary between the prototype view and the existing Specorator workflow view — separate tabs (current proposal) or a tab pane inside the workflow view? Separate tabs feel cleaner; pane is closer to a single feature workspace.
+- How should validation errors be surfaced to the AI in the chat sidebar so the next proposed edit fixes them? Pass the Zod error path + message into the next system-prompt context layer? Treat validation as a tool-call result?
+
+## Preliminary scope
+
+**In scope (v1):**
+
+- New artifact `specs/{slug}/prototype.md` (frontmatter + body markdown).
+- Zod-validated config schema versioned `specorator: 0.1`, namespace `prototype:`.
+- Domain operator engine (~15 operators, pure functions, no IO).
+- `PrototypeDataPort` narrow port + three adapters (`vault-file`, `feature-data`, `inline`).
+- Built-in block library (~20 components): containers (Page, Box, Card, List), display (Heading, Text, Badge, Markdown, Empty), inputs (TextInput, TextArea, NumberInput, Checkbox, Toggle, Select, RadioGroup, DatePicker), action (Button, Link, IconButton).
+- Action types: `Navigate`, `SetState`, `ResetState`, `RefreshData`, `Notify`. Action lists with `try` / `catch` semantics (Lowdefy parity).
+- Vue 3 renderer (`PrototypeView.vue`) registered as Obsidian view; Pinia store for runtime state per prototype.
+- `FeatureRepository` extension: `readPrototype(slug)`, `writePrototype(slug, config)` with overwrite-protection per AVS-005.
+- Command palette entry `Specorator: Open Prototype` + button on workflow nav.
+- CCS reuse: prototype.md edits flow through existing write-proposal review card.
+- `PluginSettings.enablePrototypes` feature flag (default `false`).
+- Storybook stories per built-in block; PageObject tests for renderer; golden-file tests for operator engine.
+
+**Out of scope (deferred):**
+
+- Custom user-authored blocks (composition templates or .vue file loading).
+- HTTP / fetch data adapter; auth and secrets handling.
+- Standalone export (Lowdefy's `lowdefy build` equivalent / runnable Vite repo generation).
+- Visual / drag-and-drop block editor.
+- Multi-user or real-time collaboration on prototype.md.
+- `_js` operator (QuickJS-emscripten sandbox).
+- Date math, regex, server-only operators, request engine, secret store.
+
+## Open questions to resolve before requirements
+
+1. Tab vs pane integration with the existing workflow view (research question #4).
+2. Hot-reload contract on external edits (research question #3).
+3. Whether the AI proposal review card needs prototype-specific rendering (block diff) or the existing markdown diff is acceptable for v1.

--- a/specs/config-driven-prototype-builder/workflow-state.md
+++ b/specs/config-driven-prototype-builder/workflow-state.md
@@ -1,0 +1,61 @@
+---
+id: b79e2d65-6464-45fd-9dc2-fc475f1001f8
+feature: "Config-driven prototype builder"
+area: CDP
+slug: config-driven-prototype-builder
+current_stage: idea
+status: active
+last_updated: 2026-05-10
+last_agent: pm
+createdAt: 2026-05-10T00:00:00+02:00
+updatedAt: 2026-05-10T00:00:00+02:00
+artifacts:
+  idea: complete
+  research: pending
+  requirements: pending
+  design: pending
+  spec: pending
+  tasks: pending
+  implementation-log: pending
+  test-plan: pending
+  test-report: pending
+  review: pending
+  release-notes: pending
+  retrospective: pending
+---
+
+## Stage progress
+
+| Stage | Status | Artifact | Notes |
+|---|---|---|---|
+| 1 — Idea | complete | `idea.md` | Drafted from Lowdefy concept; brainstorming-skill design doc at `docs/superpowers/specs/2026-05-10-config-driven-prototype-builder-design.md` |
+| 2 — Research | pending | — | Resolve open questions in idea (operator surface, hot reload, tab vs pane) |
+| 3 — Requirements | pending | — | |
+| 4 — Design | pending | — | |
+| 5 — Specification | pending | — | |
+| 6 — Tasks | pending | — | |
+| 7 — Implementation | pending | — | |
+| 8 — Testing | pending | — | |
+| 9 — Review | pending | — | |
+| 10 — Release | pending | — | |
+| 11 — Retrospective | pending | — | |
+
+## Blocks
+
+None at idea stage. Implementation is gated on:
+
+- `enablePrototypes` feature flag added to `PluginSettings`.
+- `PrototypeDataPort` design accepted (joins existing five narrow ports).
+- Design-stage decision on caching, hot-reload, and tab-vs-pane integration.
+
+## Hand-off notes
+
+| Date | From | To | Note |
+|---|---|---|---|
+| 2026-05-10 | pm | — | Spec entry created. Brainstorming-skill design doc co-located under `docs/superpowers/specs/`. GitHub backlog issue created on the same day (link in the issue body to this folder). |
+
+## Open clarifications
+
+- Tab vs pane integration with existing workflow view.
+- External-edit hot-reload contract (`MetadataCachePort.onFileChange` vs explicit reload button).
+- Whether AI proposal review card needs prototype-specific block diff rendering for v1.


### PR DESCRIPTION
## Summary

Idea-stage spec entry for a Lowdefy-inspired, config-driven prototype runtime rendered inside an Obsidian view tab. No code; docs only.

- `specs/config-driven-prototype-builder/idea.md` — IDEA-CDP-001
- `specs/config-driven-prototype-builder/workflow-state.md` — `current_stage: idea`
- `docs/superpowers/specs/2026-05-10-config-driven-prototype-builder-design.md` — brainstorming-skill design doc

Backlog issue: #215 — **stays open after this merge.** Issue tracks the multi-stage feature lifecycle (idea → research → requirements → design → spec → tasks → implementation). This PR closes only the idea stage; later stages will reference the same issue.

> No GitHub closing keywords (`close`, `fix`, `resolve` …) are used against #215 in this PR.

## Why merge before research

Subsequent research / requirements / design branches cut cleanly from a base that already has the spec folder, avoiding rebases as the workflow advances.

## Scope

Docs only. No source under `src/` touched. No package changes. No CI surface change.

## Test plan

- [ ] CI green on `develop` (lint + typecheck still pass — neither reads `specs/` content)
- [ ] `specs/config-driven-prototype-builder/workflow-state.md` parses against ADR-005 schema
- [ ] `idea.md` frontmatter renders in Obsidian / GitHub markdown
- [ ] After merge: confirm issue #215 is **still open**

🤖 Generated with [Claude Code](https://claude.com/claude-code)