### PR TITLE
feat(mcp): #193 PR2 — canvas tools

### DIFF
--- a/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+++ b/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
@@ -3,7 +3,14 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import { z } from 'zod'
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
-import type { ObsidianMcpServerPort, McpConnectionConfig, VaultPort, MetadataCachePort } from '@/domain/ports'
+import type {
+  ObsidianMcpServerPort,
+  McpConnectionConfig,
+  VaultPort,
+  MetadataCachePort,
+  CanvasPort,
+  JsonCanvasData,
+} from '@/domain/ports'
 import type { IFeatureRepository } from '@/domain/feature/IFeatureRepository'
 import { FEATURE_STEPS, getAllStepMeta, getStepMeta } from '@/domain/feature/FeatureStep'
 import { Slug } from '@/domain/shared/Slug'
@@ -503,6 +510,161 @@ function registerLinksTools(
   )
 }
 
+const TextNodeSchema = z.object({
+  id: z.string(),
+  x: z.number(),
+  y: z.number(),
+  width: z.number(),
+  height: z.number(),
+  text: z.string(),
+  color: z.string().optional(),
+})
+
+const FileNodeSchema = z.object({
+  id: z.string(),
+  x: z.number(),
+  y: z.number(),
+  width: z.number(),
+  height: z.number(),
+  file: z.string(),
+  subpath: z.string().optional(),
+  color: z.string().optional(),
+})
+
+const EdgeSchema = z.object({
+  id: z.string(),
+  fromNode: z.string(),
+  toNode: z.string(),
+  fromSide: z.enum(['top', 'right', 'bottom', 'left']).optional(),
+  toSide: z.enum(['top', 'right', 'bottom', 'left']).optional(),
+  label: z.string().optional(),
+  color: z.string().optional(),
+})
+
+interface CanvasNode {
+  id: string
+  type: string
+  [key: string]: unknown
+}
+
+function readCanvasOrEmpty(data: JsonCanvasData): { nodes: unknown[]; edges: unknown[] } {
+  return {
+    nodes: Array.isArray(data.nodes) ? [...data.nodes] : [],
+    edges: Array.isArray(data.edges) ? [...data.edges] : [],
+  }
+}
+
+function registerCanvasTools(
+  mcp: McpServer,
+  canvas: CanvasPort,
+  store: ProposalStore,
+): void {
+  mcp.registerTool(
+    'canvas_read',
+    {
+      description: 'Read a JSON Canvas file (.canvas) — returns { nodes, edges }',
+      inputSchema: { path: z.string().describe('Vault-relative .canvas path') },
+    },
+    async ({ path }) => ok({ canvas: await canvas.readCanvas(path) }),
+  )
+
+  mcp.registerTool(
+    'canvas_create',
+    {
+      description: 'Create a new JSON Canvas file. Queued for proposal review.',
+      inputSchema: {
+        path: z.string().describe('Vault-relative .canvas path'),
+        data: z
+          .object({
+            nodes: z.array(z.unknown()).optional(),
+            edges: z.array(z.unknown()).optional(),
+          })
+          .optional(),
+      },
+    },
+    async ({ path, data }) => {
+      const initial: JsonCanvasData = data ?? { nodes: [], edges: [] }
+      const proposalId = store.queue('canvas_create', { path, data: initial }, () =>
+        canvas.writeCanvas(path, initial),
+      )
+      return ok({ proposalId, status: 'pending' })
+    },
+  )
+
+  mcp.registerTool(
+    'canvas_add_text_node',
+    {
+      description: 'Add a text node to a JSON Canvas file. Queued for proposal review.',
+      inputSchema: { path: z.string(), node: TextNodeSchema },
+    },
+    async ({ path, node }) => {
+      const proposalId = store.queue('canvas_add_text_node', { path, node }, async () => {
+        const current = readCanvasOrEmpty(await canvas.readCanvas(path))
+        current.nodes.push({ type: 'text', ...node })
+        await canvas.writeCanvas(path, current)
+      })
+      return ok({ proposalId, status: 'pending' })
+    },
+  )
+
+  mcp.registerTool(
+    'canvas_add_file_node',
+    {
+      description: 'Add a file node to a JSON Canvas file. Queued for proposal review.',
+      inputSchema: { path: z.string(), node: FileNodeSchema },
+    },
+    async ({ path, node }) => {
+      const proposalId = store.queue('canvas_add_file_node', { path, node }, async () => {
+        const current = readCanvasOrEmpty(await canvas.readCanvas(path))
+        current.nodes.push({ type: 'file', ...node })
+        await canvas.writeCanvas(path, current)
+      })
+      return ok({ proposalId, status: 'pending' })
+    },
+  )
+
+  mcp.registerTool(
+    'canvas_add_edge',
+    {
+      description: 'Add an edge to a JSON Canvas file. Queued for proposal review.',
+      inputSchema: { path: z.string(), edge: EdgeSchema },
+    },
+    async ({ path, edge }) => {
+      const proposalId = store.queue('canvas_add_edge', { path, edge }, async () => {
+        const current = readCanvasOrEmpty(await canvas.readCanvas(path))
+        current.edges.push({ ...edge })
+        await canvas.writeCanvas(path, current)
+      })
+      return ok({ proposalId, status: 'pending' })
+    },
+  )
+
+  mcp.registerTool(
+    'canvas_update_node',
+    {
+      description: 'Shallow-merge a patch into an existing canvas node by id. Queued for proposal review.',
+      inputSchema: {
+        path: z.string(),
+        id: z.string().describe('Node id to update'),
+        patch: z.record(z.string(), z.unknown()).describe('Fields to merge into the node'),
+      },
+    },
+    async ({ path, id, patch }) => {
+      const proposalId = store.queue('canvas_update_node', { path, id, patch }, async () => {
+        const current = readCanvasOrEmpty(await canvas.readCanvas(path))
+        const idx = current.nodes.findIndex(
+          (n): n is CanvasNode =>
+            n !== null && typeof n === 'object' && (n as { id?: unknown }).id === id,
+        )
+        if (idx === -1) throw new Error(`Canvas node not found: ${id}`)
+        current.nodes[idx] = { ...(current.nodes[idx] as CanvasNode), ...patch }
+        await canvas.writeCanvas(path, current)
+      })
+      return ok({ proposalId, status: 'pending' })
+    },
+  )
+}
+
 export class ObsidianMcpServerAdapter implements ObsidianMcpServerPort {
   private readonly proposalStore = new ProposalStore()
   private readonly advanceUseCase: AdvanceFeatureStageUseCase
@@ -514,6 +676,7 @@ export class ObsidianMcpServerAdapter implements ObsidianMcpServerPort {
     private readonly repo: IFeatureRepository,
     private readonly specsFolder: () => string,
     private readonly metadataCache: MetadataCachePort,
+    private readonly canvas: CanvasPort,
   ) {
     this.advanceUseCase = new AdvanceFeatureStageUseCase(repo)
   }
@@ -577,6 +740,7 @@ export class ObsidianMcpServerAdapter implements ObsidianMcpServerPort {
     )
     registerMetadataTools(mcp, this.metadataCache)
     registerLinksTools(mcp, this.vault, this.metadataCache, this.proposalStore)
+    registerCanvasTools(mcp, this.canvas, this.proposalStore)
     const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined })
     await mcp.connect(transport)
     try {

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -5,6 +5,7 @@ import { DEFAULT_SETTINGS, type PluginSettings } from '@/domain/settings/PluginS
 import { ObsidianBridge } from '@/infrastructure/obsidian/ObsidianBridge'
 import { ObsidianMcpServerAdapter } from '@/infrastructure/obsidian/ObsidianMcpServerAdapter'
 import { ObsidianMetadataCacheAdapter } from '@/infrastructure/obsidian/ObsidianMetadataCacheAdapter'
+import { ObsidianCanvasAdapter } from '@/infrastructure/obsidian/ObsidianCanvasAdapter'
 import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
 import { PluginCore } from '@/core/plugin-core'
 import { ALL_MODULES, type ModuleDescriptor } from '@/modules'
@@ -53,6 +54,7 @@ export default class SpecoratorPlugin extends Plugin {
         new FeatureRepository(this.bridge, this.bridge, () => this.settings),
         () => this.settings.specsFolder,
         new ObsidianMetadataCacheAdapter(this.app),
+        new ObsidianCanvasAdapter(this.bridge),
       ),
     })
 

--- a/tests/infrastructure/obsidian-mcp-server-adapter-canvas-tools.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter-canvas-tools.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { ObsidianMcpServerAdapter } from '@/infrastructure/obsidian/ObsidianMcpServerAdapter'
+import { MockBridge } from '@/infrastructure/mock/MockBridge'
+import { MockMetadataCacheAdapter } from '@/infrastructure/mock/MockMetadataCacheAdapter'
+import { MockCanvasAdapter } from '@/infrastructure/mock/MockCanvasAdapter'
+import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
+import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
+
+async function mcpPost(port: number, body: unknown): Promise<unknown> {
+  const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      Host: '127.0.0.1',
+    },
+    body: JSON.stringify(body),
+  })
+  const text = await res.text()
+  const dataLine = text.split('\n').find((line) => line.startsWith('data: '))
+  if (dataLine) return JSON.parse(dataLine.slice(6))
+  return JSON.parse(text)
+}
+
+async function initMcp(port: number): Promise<void> {
+  await mcpPost(port, {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'test', version: '0.0.0' },
+    },
+  })
+}
+
+interface ToolResponse {
+  result: { content: Array<{ type: string; text: string }>; isError?: boolean }
+}
+
+async function callTool(
+  port: number,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ToolResponse> {
+  return mcpPost(port, {
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/call',
+    params: { name, arguments: args },
+  }) as Promise<ToolResponse>
+}
+
+function parseToolResult(resp: ToolResponse): unknown {
+  return JSON.parse(resp.result.content[0].text)
+}
+
+describe('ObsidianMcpServerAdapter — canvas tools', () => {
+  let adapter: ObsidianMcpServerAdapter
+  let canvas: MockCanvasAdapter
+  let port: number
+
+  beforeEach(async () => {
+    const vault = new MockBridge({})
+    const repo = new FeatureRepository(vault, vault, () => DEFAULT_SETTINGS)
+    const metadataCache = new MockMetadataCacheAdapter()
+    canvas = new MockCanvasAdapter()
+    adapter = new ObsidianMcpServerAdapter(
+      vault,
+      repo,
+      () => DEFAULT_SETTINGS.specsFolder,
+      metadataCache,
+      canvas,
+    )
+    ;({ port } = await adapter.start())
+    await initMcp(port)
+  })
+
+  afterEach(async () => {
+    await adapter.stop()
+  })
+
+  describe('canvas_read', () => {
+    it('returns the seeded canvas', async () => {
+      canvas.seedCanvas('boards/a.canvas', {
+        nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'hi' }],
+        edges: [],
+      })
+      const resp = await callTool(port, 'canvas_read', { path: 'boards/a.canvas' })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { canvas: { nodes: unknown[]; edges: unknown[] } }
+      expect(result.canvas.nodes).toHaveLength(1)
+    })
+
+    it('returns isError when canvas is missing', async () => {
+      const resp = await callTool(port, 'canvas_read', { path: 'missing.canvas' })
+      expect(resp.result.isError).toBe(true)
+    })
+  })
+
+  describe('canvas_create', () => {
+    it('returns a pending proposal without writing the file', async () => {
+      const resp = await callTool(port, 'canvas_create', { path: 'boards/new.canvas' })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { proposalId: string; status: string }
+      expect(result.status).toBe('pending')
+      expect(canvas.getWritten('boards/new.canvas')).toBeUndefined()
+    })
+
+    it('accept writes empty canvas by default', async () => {
+      const resp = await callTool(port, 'canvas_create', { path: 'boards/new.canvas' })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      await adapter.acceptProposal(proposalId)
+      expect(canvas.getWritten('boards/new.canvas')).toEqual({ nodes: [], edges: [] })
+    })
+
+    it('accept writes provided initial data', async () => {
+      const seed = {
+        nodes: [{ id: 'a', type: 'text', x: 0, y: 0, width: 1, height: 1, text: 't' }],
+        edges: [],
+      }
+      const resp = await callTool(port, 'canvas_create', {
+        path: 'boards/new.canvas',
+        data: seed,
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      await adapter.acceptProposal(proposalId)
+      expect(canvas.getWritten('boards/new.canvas')).toEqual(seed)
+    })
+  })
+
+  describe('canvas_add_text_node', () => {
+    beforeEach(() => {
+      canvas.seedCanvas('boards/a.canvas', { nodes: [], edges: [] })
+    })
+
+    it('returns a pending proposal without mutating the canvas', async () => {
+      const resp = await callTool(port, 'canvas_add_text_node', {
+        path: 'boards/a.canvas',
+        node: { id: 'n1', x: 0, y: 0, width: 100, height: 50, text: 'hello' },
+      })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { proposalId: string; status: string }
+      expect(result.status).toBe('pending')
+      expect(canvas.getWritten('boards/a.canvas')).toBeUndefined()
+    })
+
+    it('accept appends a typed text node', async () => {
+      const resp = await callTool(port, 'canvas_add_text_node', {
+        path: 'boards/a.canvas',
+        node: { id: 'n1', x: 1, y: 2, width: 100, height: 50, text: 'hello' },
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      await adapter.acceptProposal(proposalId)
+      const written = canvas.getWritten('boards/a.canvas')
+      expect(written?.nodes).toEqual([
+        { type: 'text', id: 'n1', x: 1, y: 2, width: 100, height: 50, text: 'hello' },
+      ])
+    })
+
+    it('rejects malformed node payload', async () => {
+      const resp = await callTool(port, 'canvas_add_text_node', {
+        path: 'boards/a.canvas',
+        node: { id: 'n1', text: 'missing coords' },
+      })
+      expect(resp.result.isError).toBe(true)
+    })
+  })
+
+  describe('canvas_add_file_node', () => {
+    beforeEach(() => {
+      canvas.seedCanvas('boards/a.canvas', { nodes: [], edges: [] })
+    })
+
+    it('accept appends a typed file node with optional subpath', async () => {
+      const resp = await callTool(port, 'canvas_add_file_node', {
+        path: 'boards/a.canvas',
+        node: {
+          id: 'f1',
+          x: 0,
+          y: 0,
+          width: 200,
+          height: 100,
+          file: 'notes/foo.md',
+          subpath: '#Section',
+        },
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      await adapter.acceptProposal(proposalId)
+      const written = canvas.getWritten('boards/a.canvas')
+      expect(written?.nodes).toEqual([
+        {
+          type: 'file',
+          id: 'f1',
+          x: 0,
+          y: 0,
+          width: 200,
+          height: 100,
+          file: 'notes/foo.md',
+          subpath: '#Section',
+        },
+      ])
+    })
+
+    it('rejects payload missing required `file` field', async () => {
+      const resp = await callTool(port, 'canvas_add_file_node', {
+        path: 'boards/a.canvas',
+        node: { id: 'f1', x: 0, y: 0, width: 1, height: 1 },
+      })
+      expect(resp.result.isError).toBe(true)
+    })
+  })
+
+  describe('canvas_add_edge', () => {
+    beforeEach(() => {
+      canvas.seedCanvas('boards/a.canvas', { nodes: [], edges: [] })
+    })
+
+    it('accept appends the edge', async () => {
+      const resp = await callTool(port, 'canvas_add_edge', {
+        path: 'boards/a.canvas',
+        edge: {
+          id: 'e1',
+          fromNode: 'n1',
+          toNode: 'n2',
+          fromSide: 'right',
+          toSide: 'left',
+          label: 'depends',
+        },
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      await adapter.acceptProposal(proposalId)
+      const written = canvas.getWritten('boards/a.canvas')
+      expect(written?.edges).toEqual([
+        {
+          id: 'e1',
+          fromNode: 'n1',
+          toNode: 'n2',
+          fromSide: 'right',
+          toSide: 'left',
+          label: 'depends',
+        },
+      ])
+    })
+
+    it('rejects edge with invalid side value', async () => {
+      const resp = await callTool(port, 'canvas_add_edge', {
+        path: 'boards/a.canvas',
+        edge: { id: 'e1', fromNode: 'a', toNode: 'b', fromSide: 'diagonal' },
+      })
+      expect(resp.result.isError).toBe(true)
+    })
+  })
+
+  describe('canvas_update_node', () => {
+    beforeEach(() => {
+      canvas.seedCanvas('boards/a.canvas', {
+        nodes: [
+          { id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'old' },
+        ],
+        edges: [],
+      })
+    })
+
+    it('accept shallow-merges the patch into the matching node', async () => {
+      const resp = await callTool(port, 'canvas_update_node', {
+        path: 'boards/a.canvas',
+        id: 'n1',
+        patch: { text: 'new', color: '4' },
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      await adapter.acceptProposal(proposalId)
+      const written = canvas.getWritten('boards/a.canvas')
+      expect(written?.nodes?.[0]).toEqual({
+        id: 'n1',
+        type: 'text',
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 50,
+        text: 'new',
+        color: '4',
+      })
+    })
+
+    it('accept rejects when target id is not present', async () => {
+      const resp = await callTool(port, 'canvas_update_node', {
+        path: 'boards/a.canvas',
+        id: 'missing',
+        patch: { text: 'x' },
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      await expect(adapter.acceptProposal(proposalId)).rejects.toThrow(/not found/)
+    })
+  })
+})

--- a/tests/infrastructure/obsidian-mcp-server-adapter-links-tools.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter-links-tools.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { ObsidianMcpServerAdapter } from '@/infrastructure/obsidian/ObsidianMcpServerAdapter'
 import { MockBridge } from '@/infrastructure/mock/MockBridge'
 import { MockMetadataCacheAdapter } from '@/infrastructure/mock/MockMetadataCacheAdapter'
+import { MockCanvasAdapter } from '@/infrastructure/mock/MockCanvasAdapter'
 import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
 import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
 
@@ -67,11 +68,13 @@ describe('ObsidianMcpServerAdapter — links tools', () => {
     })
     const repo = new FeatureRepository(vault, vault, () => DEFAULT_SETTINGS)
     metadataCache = new MockMetadataCacheAdapter()
+    const canvas = new MockCanvasAdapter()
     adapter = new ObsidianMcpServerAdapter(
       vault,
       repo,
       () => DEFAULT_SETTINGS.specsFolder,
       metadataCache,
+      canvas,
     )
     ;({ port } = await adapter.start())
     await initMcp(port)

--- a/tests/infrastructure/obsidian-mcp-server-adapter-metadata-tools.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter-metadata-tools.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { ObsidianMcpServerAdapter } from '@/infrastructure/obsidian/ObsidianMcpServerAdapter'
 import { MockBridge } from '@/infrastructure/mock/MockBridge'
 import { MockMetadataCacheAdapter } from '@/infrastructure/mock/MockMetadataCacheAdapter'
+import { MockCanvasAdapter } from '@/infrastructure/mock/MockCanvasAdapter'
 import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
 import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
 
@@ -64,11 +65,13 @@ describe('ObsidianMcpServerAdapter — metadata tools', () => {
     const vault = new MockBridge({})
     const repo = new FeatureRepository(vault, vault, () => DEFAULT_SETTINGS)
     metadataCache = new MockMetadataCacheAdapter()
+    const canvas = new MockCanvasAdapter()
     adapter = new ObsidianMcpServerAdapter(
       vault,
       repo,
       () => DEFAULT_SETTINGS.specsFolder,
       metadataCache,
+      canvas,
     )
     ;({ port } = await adapter.start())
     await initMcp(port)

--- a/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { ObsidianMcpServerAdapter } from '@/infrastructure/obsidian/ObsidianMcpServerAdapter'
 import { MockBridge } from '@/infrastructure/mock/MockBridge'
 import { MockMetadataCacheAdapter } from '@/infrastructure/mock/MockMetadataCacheAdapter'
+import { MockCanvasAdapter } from '@/infrastructure/mock/MockCanvasAdapter'
 import { parse as parseYaml } from 'yaml'
 import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
 import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
@@ -93,7 +94,14 @@ describe('ObsidianMcpServerAdapter — vault + frontmatter tools', () => {
     vault = new MockBridge(VAULT_FILES)
     const repo = new FeatureRepository(vault, vault, () => DEFAULT_SETTINGS)
     const metadataCache = new MockMetadataCacheAdapter()
-    adapter = new ObsidianMcpServerAdapter(vault, repo, () => DEFAULT_SETTINGS.specsFolder, metadataCache)
+    const canvas = new MockCanvasAdapter()
+    adapter = new ObsidianMcpServerAdapter(
+      vault,
+      repo,
+      () => DEFAULT_SETTINGS.specsFolder,
+      metadataCache,
+      canvas,
+    )
     ;({ port } = await adapter.start())
     await initMcp(port)
   })
@@ -103,7 +111,7 @@ describe('ObsidianMcpServerAdapter — vault + frontmatter tools', () => {
   })
 
   describe('tools/list', () => {
-    it('registers all 24 tools', async () => {
+    it('registers all 30 tools', async () => {
       const resp = (await mcpPost(port, {
         jsonrpc: '2.0',
         id: 99,
@@ -112,6 +120,12 @@ describe('ObsidianMcpServerAdapter — vault + frontmatter tools', () => {
       })) as { result: { tools: Array<{ name: string }> } }
       const names = resp.result.tools.map((t) => t.name).sort()
       expect(names).toEqual([
+        'canvas_add_edge',
+        'canvas_add_file_node',
+        'canvas_add_text_node',
+        'canvas_create',
+        'canvas_read',
+        'canvas_update_node',
         'frontmatter_get',
         'frontmatter_get_field',
         'frontmatter_set_field',
@@ -507,7 +521,14 @@ describe('ObsidianMcpServerAdapter — workflow tools', () => {
     vault = new MockBridge()
     repo = new FeatureRepository(vault, vault, () => DEFAULT_SETTINGS)
     const metadataCache = new MockMetadataCacheAdapter()
-    adapter = new ObsidianMcpServerAdapter(vault, repo, () => DEFAULT_SETTINGS.specsFolder, metadataCache)
+    const canvas = new MockCanvasAdapter()
+    adapter = new ObsidianMcpServerAdapter(
+      vault,
+      repo,
+      () => DEFAULT_SETTINGS.specsFolder,
+      metadataCache,
+      canvas,
+    )
     ;({ port } = await adapter.start())
     await initMcp(port)
   })

--- a/tests/infrastructure/obsidian-mcp-server-adapter-workflow-tools.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter-workflow-tools.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { ObsidianMcpServerAdapter } from '@/infrastructure/obsidian/ObsidianMcpServerAdapter'
 import { MockBridge } from '@/infrastructure/mock/MockBridge'
 import { MockMetadataCacheAdapter } from '@/infrastructure/mock/MockMetadataCacheAdapter'
+import { MockCanvasAdapter } from '@/infrastructure/mock/MockCanvasAdapter'
 import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
 import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
 
@@ -144,7 +145,14 @@ describe('ObsidianMcpServerAdapter — workflow tools', () => {
     vault = new MockBridge(VAULT_FILES)
     const repo = new FeatureRepository(vault, vault, () => DEFAULT_SETTINGS)
     const metadataCache = new MockMetadataCacheAdapter()
-    adapter = new ObsidianMcpServerAdapter(vault, repo, () => SPECS_FOLDER, metadataCache)
+    const canvas = new MockCanvasAdapter()
+    adapter = new ObsidianMcpServerAdapter(
+      vault,
+      repo,
+      () => SPECS_FOLDER,
+      metadataCache,
+      canvas,
+    )
     ;({ port } = await adapter.start())
     await initMcp(port)
   })
@@ -193,7 +201,14 @@ describe('ObsidianMcpServerAdapter — workflow tools', () => {
       const emptyVault = new MockBridge({})
       const emptyRepo = new FeatureRepository(emptyVault, emptyVault, () => DEFAULT_SETTINGS)
       const emptyMetadataCache = new MockMetadataCacheAdapter()
-      const emptyAdapter = new ObsidianMcpServerAdapter(emptyVault, emptyRepo, () => SPECS_FOLDER, emptyMetadataCache)
+      const emptyCanvas = new MockCanvasAdapter()
+      const emptyAdapter = new ObsidianMcpServerAdapter(
+        emptyVault,
+        emptyRepo,
+        () => SPECS_FOLDER,
+        emptyMetadataCache,
+        emptyCanvas,
+      )
       const { port: emptyPort } = await emptyAdapter.start()
       await initMcp(emptyPort)
       const resp = await callTool(emptyPort, 'workflow_list_features', {})

--- a/tests/infrastructure/obsidian-mcp-server-adapter.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest'
 import { ObsidianMcpServerAdapter } from '@/infrastructure/obsidian/ObsidianMcpServerAdapter'
 import { MockBridge } from '@/infrastructure/mock/MockBridge'
 import { MockMetadataCacheAdapter } from '@/infrastructure/mock/MockMetadataCacheAdapter'
+import { MockCanvasAdapter } from '@/infrastructure/mock/MockCanvasAdapter'
 import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
 import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
 
@@ -10,7 +11,14 @@ function makeAdapter(files: Record<string, string> = {}): ObsidianMcpServerAdapt
   const vault = new MockBridge(files)
   const repo = new FeatureRepository(vault, vault, () => DEFAULT_SETTINGS)
   const metadataCache = new MockMetadataCacheAdapter()
-  return new ObsidianMcpServerAdapter(vault, repo, () => DEFAULT_SETTINGS.specsFolder, metadataCache)
+  const canvas = new MockCanvasAdapter()
+  return new ObsidianMcpServerAdapter(
+    vault,
+    repo,
+    () => DEFAULT_SETTINGS.specsFolder,
+    metadataCache,
+    canvas,
+  )
 }
 
 describe('ObsidianMcpServerAdapter', () => {


### PR DESCRIPTION
## Summary

Adds 6 canvas MCP tools to `ObsidianMcpServerAdapter` (1 read + 5 writes). Write tools queue via `ProposalStore` and return `{ proposalId, status: 'pending' }`. Inputs validated against JSON Canvas spec via zod; malformed payloads return `isError` without queueing.

`ObsidianMcpServerAdapter` constructor now takes a `CanvasPort`; plugin entry wires `ObsidianCanvasAdapter`.

Issue #193 PR2 of 3. PR1 (metadata + links) merged via #217. PR3 will add the bases group.

Spec: `docs/superpowers/specs/2026-05-10-mcp-tools-193-design.md`

## Tools added

- `canvas_read`
- `canvas_create`
- `canvas_add_text_node`
- `canvas_add_file_node`
- `canvas_add_edge`
- `canvas_update_node`

## Acceptance (this PR)

- [x] Canvas write tools return `{ proposalId, status: 'pending' }`
- [x] Read tool delegates to `CanvasPort.readCanvas`
- [x] Zod schemas reject malformed node/edge payloads
- [x] Unit tests cover read happy/missing, write proposal flow, accept/reject, malformed payload rejection
- [x] `npm run verify` green

## Test plan

- [ ] CI green on `develop` target
- [ ] Manual smoke: enable plugin, exercise `canvas_read` against an existing `.canvas` file, propose `canvas_add_text_node`, accept via sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)