### PR TITLE
feat(mcp): #193 PR3 — bases tools

### DIFF
--- a/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+++ b/src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
@@ -665,6 +665,132 @@ function registerCanvasTools(
   )
 }
 
+type FilterOp = 'eq' | 'neq' | 'contains' | 'in'
+
+function matchesFilter(value: unknown, op: FilterOp, target: unknown): boolean {
+  switch (op) {
+    case 'eq':
+      return value === target
+    case 'neq':
+      return value !== target
+    case 'contains':
+      if (typeof value === 'string' && typeof target === 'string') return value.includes(target)
+      if (Array.isArray(value)) return value.includes(target)
+      return false
+    case 'in':
+      return Array.isArray(target) && target.includes(value)
+  }
+}
+
+interface BaseRecord {
+  path: string
+  frontmatter: Record<string, unknown>
+}
+
+async function loadBaseRecords(vault: VaultPort, folder: string): Promise<BaseRecord[]> {
+  const files = (await collectFiles(vault, folder)).filter((p) => p.endsWith('.md'))
+  const records = await Promise.all(
+    files.map(async (path) => {
+      try {
+        const content = await vault.readFile(path)
+        return { path, frontmatter: parseFrontmatter(content) }
+      } catch {
+        return null
+      }
+    }),
+  )
+  return records.filter((r): r is BaseRecord => r !== null)
+}
+
+const FilterSchema = z.object({
+  field: z.string(),
+  op: z.enum(['eq', 'neq', 'contains', 'in']),
+  value: z.unknown(),
+})
+
+function registerBasesTools(mcp: McpServer, vault: VaultPort, store: ProposalStore): void {
+  mcp.registerTool(
+    'bases_query',
+    {
+      description:
+        'Query a folder as a frontmatter-backed base. Optional filter = { field, op: eq|neq|contains|in, value }.',
+      inputSchema: {
+        folder: z.string().describe('Vault-relative folder to scan recursively'),
+        filter: FilterSchema.optional(),
+      },
+    },
+    async ({ folder, filter }) => {
+      const records = await loadBaseRecords(vault, folder)
+      const matched = filter
+        ? records.filter((r) =>
+            matchesFilter(r.frontmatter[filter.field], filter.op, filter.value),
+          )
+        : records
+      return ok({ records: matched })
+    },
+  )
+
+  mcp.registerTool(
+    'bases_list_fields',
+    {
+      description: 'Return the union of frontmatter keys across all records in a folder',
+      inputSchema: { folder: z.string().describe('Vault-relative folder') },
+    },
+    async ({ folder }) => {
+      const records = await loadBaseRecords(vault, folder)
+      const fields = new Set<string>()
+      for (const r of records) for (const k of Object.keys(r.frontmatter)) fields.add(k)
+      return ok({ fields: Array.from(fields).sort() })
+    },
+  )
+
+  mcp.registerTool(
+    'bases_get_record',
+    {
+      description: 'Get the frontmatter record for a single note path',
+      inputSchema: { path: z.string() },
+    },
+    async ({ path }) => {
+      const content = await vault.readFile(path)
+      return ok({ frontmatter: parseFrontmatter(content) })
+    },
+  )
+
+  mcp.registerTool(
+    'bases_find_by_field',
+    {
+      description: 'Find records in a folder where frontmatter[field] === value (eq shorthand)',
+      inputSchema: {
+        folder: z.string(),
+        field: z.string(),
+        value: z.unknown(),
+      },
+    },
+    async ({ folder, field, value }) => {
+      const records = await loadBaseRecords(vault, folder)
+      const matched = records.filter((r) => matchesFilter(r.frontmatter[field], 'eq', value))
+      return ok({ records: matched })
+    },
+  )
+
+  mcp.registerTool(
+    'bases_update_record',
+    {
+      description: 'Update frontmatter fields on a record. Queued for proposal review.',
+      inputSchema: {
+        path: z.string(),
+        fields: z.record(z.string(), z.unknown()).describe('Frontmatter keys to merge'),
+      },
+    },
+    async ({ path, fields }) => {
+      const proposalId = store.queue('bases_update_record', { path, fields }, () =>
+        applyFrontmatterUpdate(vault, path, fields),
+      )
+      return ok({ proposalId, status: 'pending' })
+    },
+  )
+}
+
 export class ObsidianMcpServerAdapter implements ObsidianMcpServerPort {
   private readonly proposalStore = new ProposalStore()
   private readonly advanceUseCase: AdvanceFeatureStageUseCase
@@ -741,6 +867,7 @@ export class ObsidianMcpServerAdapter implements ObsidianMcpServerPort {
     registerMetadataTools(mcp, this.metadataCache)
     registerLinksTools(mcp, this.vault, this.metadataCache, this.proposalStore)
     registerCanvasTools(mcp, this.canvas, this.proposalStore)
+    registerBasesTools(mcp, this.vault, this.proposalStore)
     const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined })
     await mcp.connect(transport)
     try {

--- a/tests/infrastructure/obsidian-mcp-server-adapter-bases-tools.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter-bases-tools.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { ObsidianMcpServerAdapter } from '@/infrastructure/obsidian/ObsidianMcpServerAdapter'
+import { MockBridge } from '@/infrastructure/mock/MockBridge'
+import { MockMetadataCacheAdapter } from '@/infrastructure/mock/MockMetadataCacheAdapter'
+import { MockCanvasAdapter } from '@/infrastructure/mock/MockCanvasAdapter'
+import { parse as parseYaml } from 'yaml'
+import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
+import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
+
+async function mcpPost(port: number, body: unknown): Promise<unknown> {
+  const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      Host: '127.0.0.1',
+    },
+    body: JSON.stringify(body),
+  })
+  const text = await res.text()
+  const dataLine = text.split('\n').find((line) => line.startsWith('data: '))
+  if (dataLine) return JSON.parse(dataLine.slice(6))
+  return JSON.parse(text)
+}
+
+async function initMcp(port: number): Promise<void> {
+  await mcpPost(port, {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'test', version: '0.0.0' },
+    },
+  })
+}
+
+interface ToolResponse {
+  result: { content: Array<{ type: string; text: string }>; isError?: boolean }
+}
+
+async function callTool(
+  port: number,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ToolResponse> {
+  return mcpPost(port, {
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/call',
+    params: { name, arguments: args },
+  }) as Promise<ToolResponse>
+}
+
+function parseToolResult(resp: ToolResponse): unknown {
+  return JSON.parse(resp.result.content[0].text)
+}
+
+function fm(record: Record<string, unknown>): string {
+  const lines = Object.entries(record)
+    .map(([k, v]) => `${k}: ${typeof v === 'string' ? v : JSON.stringify(v)}`)
+    .join('\n')
+  return `---\n${lines}\n---\nbody\n`
+}
+
+const VAULT_FILES = {
+  'projects/alpha.md': fm({ status: 'active', priority: 1, tags: ['a', 'b'] }),
+  'projects/beta.md': fm({ status: 'done', priority: 2, tags: ['b', 'c'] }),
+  'projects/nested/gamma.md': fm({ status: 'active', priority: 3, tags: ['c'] }),
+  'projects/no-fm.md': '# Plain note\n\nno frontmatter here',
+  'projects/board.canvas': '{}', // ignored — non-md
+  'other/delta.md': fm({ status: 'active', priority: 9 }),
+}
+
+describe('ObsidianMcpServerAdapter — bases tools', () => {
+  let adapter: ObsidianMcpServerAdapter
+  let vault: MockBridge
+  let port: number
+
+  beforeEach(async () => {
+    vault = new MockBridge(VAULT_FILES)
+    const repo = new FeatureRepository(vault, vault, () => DEFAULT_SETTINGS)
+    const metadataCache = new MockMetadataCacheAdapter()
+    const canvas = new MockCanvasAdapter()
+    adapter = new ObsidianMcpServerAdapter(
+      vault,
+      repo,
+      () => DEFAULT_SETTINGS.specsFolder,
+      metadataCache,
+      canvas,
+    )
+    ;({ port } = await adapter.start())
+    await initMcp(port)
+  })
+
+  afterEach(async () => {
+    await adapter.stop()
+  })
+
+  describe('bases_query', () => {
+    it('returns all .md records under folder (recursive), excluding non-md', async () => {
+      const resp = await callTool(port, 'bases_query', { folder: 'projects' })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { records: Array<{ path: string }> }
+      const paths = result.records.map((r) => r.path).sort()
+      expect(paths).toEqual([
+        'projects/alpha.md',
+        'projects/beta.md',
+        'projects/nested/gamma.md',
+        'projects/no-fm.md',
+      ])
+    })
+
+    it('filters by eq', async () => {
+      const resp = await callTool(port, 'bases_query', {
+        folder: 'projects',
+        filter: { field: 'status', op: 'eq', value: 'active' },
+      })
+      const result = parseToolResult(resp) as { records: Array<{ path: string }> }
+      expect(result.records.map((r) => r.path).sort()).toEqual([
+        'projects/alpha.md',
+        'projects/nested/gamma.md',
+      ])
+    })
+
+    it('filters by neq', async () => {
+      const resp = await callTool(port, 'bases_query', {
+        folder: 'projects',
+        filter: { field: 'status', op: 'neq', value: 'active' },
+      })
+      const result = parseToolResult(resp) as { records: Array<{ path: string }> }
+      const paths = result.records.map((r) => r.path).sort()
+      expect(paths).toContain('projects/beta.md')
+      expect(paths).toContain('projects/no-fm.md')
+      expect(paths).not.toContain('projects/alpha.md')
+    })
+
+    it('filters by contains on array field', async () => {
+      const resp = await callTool(port, 'bases_query', {
+        folder: 'projects',
+        filter: { field: 'tags', op: 'contains', value: 'b' },
+      })
+      const result = parseToolResult(resp) as { records: Array<{ path: string }> }
+      expect(result.records.map((r) => r.path).sort()).toEqual([
+        'projects/alpha.md',
+        'projects/beta.md',
+      ])
+    })
+
+    it('filters by in', async () => {
+      const resp = await callTool(port, 'bases_query', {
+        folder: 'projects',
+        filter: { field: 'priority', op: 'in', value: [1, 3] },
+      })
+      const result = parseToolResult(resp) as { records: Array<{ path: string }> }
+      expect(result.records.map((r) => r.path).sort()).toEqual([
+        'projects/alpha.md',
+        'projects/nested/gamma.md',
+      ])
+    })
+  })
+
+  describe('bases_list_fields', () => {
+    it('returns sorted union of frontmatter keys', async () => {
+      const resp = await callTool(port, 'bases_list_fields', { folder: 'projects' })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { fields: string[] }
+      expect(result.fields).toEqual(['priority', 'status', 'tags'])
+    })
+
+    it('returns empty array for folder with no records', async () => {
+      const resp = await callTool(port, 'bases_list_fields', { folder: 'empty' })
+      expect(parseToolResult(resp)).toEqual({ fields: [] })
+    })
+  })
+
+  describe('bases_get_record', () => {
+    it('returns the frontmatter for a path', async () => {
+      const resp = await callTool(port, 'bases_get_record', { path: 'projects/alpha.md' })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { frontmatter: Record<string, unknown> }
+      expect(result.frontmatter).toMatchObject({ status: 'active', priority: 1 })
+    })
+
+    it('returns empty frontmatter for note without frontmatter', async () => {
+      const resp = await callTool(port, 'bases_get_record', { path: 'projects/no-fm.md' })
+      expect(parseToolResult(resp)).toEqual({ frontmatter: {} })
+    })
+
+    it('returns isError when file is missing', async () => {
+      const resp = await callTool(port, 'bases_get_record', { path: 'missing.md' })
+      expect(resp.result.isError).toBe(true)
+    })
+  })
+
+  describe('bases_find_by_field', () => {
+    it('shorthand for eq filter', async () => {
+      const resp = await callTool(port, 'bases_find_by_field', {
+        folder: 'projects',
+        field: 'priority',
+        value: 2,
+      })
+      const result = parseToolResult(resp) as { records: Array<{ path: string }> }
+      expect(result.records.map((r) => r.path)).toEqual(['projects/beta.md'])
+    })
+
+    it('returns empty when nothing matches', async () => {
+      const resp = await callTool(port, 'bases_find_by_field', {
+        folder: 'projects',
+        field: 'status',
+        value: 'archived',
+      })
+      expect(parseToolResult(resp)).toEqual({ records: [] })
+    })
+  })
+
+  describe('bases_update_record', () => {
+    it('returns pending proposal without mutating the vault', async () => {
+      const resp = await callTool(port, 'bases_update_record', {
+        path: 'projects/alpha.md',
+        fields: { status: 'archived' },
+      })
+      expect(resp.result.isError).toBeFalsy()
+      const result = parseToolResult(resp) as { proposalId: string; status: string }
+      expect(result.status).toBe('pending')
+      const unchanged = await vault.readFile('projects/alpha.md')
+      expect(unchanged).toContain('status: active')
+    })
+
+    it('accept merges fields preserving body and other fm', async () => {
+      const resp = await callTool(port, 'bases_update_record', {
+        path: 'projects/alpha.md',
+        fields: { status: 'archived', owner: 'lum' },
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      await adapter.acceptProposal(proposalId)
+      const updated = await vault.readFile('projects/alpha.md')
+      const fmMatch = /^---\n([\s\S]*?)\n---/.exec(updated)
+      expect(fmMatch).not.toBeNull()
+      const parsed = parseYaml(fmMatch![1]) as Record<string, unknown>
+      expect(parsed.status).toBe('archived')
+      expect(parsed.owner).toBe('lum')
+      expect(parsed.priority).toBe(1)
+      expect(updated).toContain('body')
+    })
+
+    it('reject leaves the vault unchanged', async () => {
+      const resp = await callTool(port, 'bases_update_record', {
+        path: 'projects/alpha.md',
+        fields: { status: 'archived' },
+      })
+      const { proposalId } = parseToolResult(resp) as { proposalId: string }
+      adapter.rejectProposal(proposalId)
+      const unchanged = await vault.readFile('projects/alpha.md')
+      expect(unchanged).toContain('status: active')
+    })
+  })
+})

--- a/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
+++ b/tests/infrastructure/obsidian-mcp-server-adapter-tools.test.ts
@@ -111,7 +111,7 @@ describe('ObsidianMcpServerAdapter — vault + frontmatter tools', () => {
   })
 
   describe('tools/list', () => {
-    it('registers all 30 tools', async () => {
+    it('registers all 35 tools', async () => {
       const resp = (await mcpPost(port, {
         jsonrpc: '2.0',
         id: 99,
@@ -120,6 +120,11 @@ describe('ObsidianMcpServerAdapter — vault + frontmatter tools', () => {
       })) as { result: { tools: Array<{ name: string }> } }
       const names = resp.result.tools.map((t) => t.name).sort()
       expect(names).toEqual([
+        'bases_find_by_field',
+        'bases_get_record',
+        'bases_list_fields',
+        'bases_query',
+        'bases_update_record',
         'canvas_add_edge',
         'canvas_add_file_node',
         'canvas_add_text_node',


### PR DESCRIPTION
## Summary

Adds 5 bases MCP tools to `ObsidianMcpServerAdapter` (4 reads + 1 write). Folder-as-base, frontmatter-as-record. Recursive folder scan over `.md` files only — non-md (e.g. `.canvas`) ignored. `bases_update_record` queues via `ProposalStore` and reuses `applyFrontmatterUpdate`.

Issue #193 PR3 of 3. PR1 (metadata + links) merged via #217; PR2 (canvas) merged via #218.

Closes #193.

Spec: `docs/superpowers/specs/2026-05-10-mcp-tools-193-design.md`

## Tools added

- `bases_query` — `{ folder, filter? }` → `{ records: [{path, frontmatter}] }`. Filter ops: `eq` | `neq` | `contains` | `in`.
- `bases_list_fields` — `{ folder }` → sorted union of frontmatter keys
- `bases_get_record` — `{ path }` → `{ frontmatter }`
- `bases_find_by_field` — `{ folder, field, value }` → `eq` shorthand
- `bases_update_record` — `{ path, fields }` → `{ proposalId, status: 'pending' }`

## Acceptance (closes #193)

- [x] All 19 tools registered and reachable at `http://localhost:{port}/mcp`
- [x] `links_resolve` uses `MetadataCachePort.getFirstLinkpathDest()` — not CLI shell-out (PR1)
- [x] Canvas write tools (PR2), `links_add_to_note` (PR1), `bases_update_record` (this PR) return `{ proposalId, status: 'pending' }`
- [x] Unit tests for each tool group
- [x] `npm run verify` green

## Test plan

- [ ] CI green
- [ ] Manual smoke: enable plugin, exercise `bases_query` against a `specs/` folder; propose `bases_update_record`; accept via sidebar

## Out of scope

- `.base` JSON file parsing (Obsidian Bases plugin format) — folder scan only

🤖 Generated with [Claude Code](https://claude.com/claude-code)