### PR TITLE
chore(deploy): include .hotreload in test-vault deploy

### DIFF
--- a/scripts/deploy-to-test-vault.mjs
+++ b/scripts/deploy-to-test-vault.mjs
@@ -7,7 +7,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { pathExists } from './_utils.mjs';
 
-const PLUGIN_FILES = ['main.js', 'manifest.json', 'styles.css'];
+const PLUGIN_FILES = ['main.js', 'manifest.json', 'styles.css', '.hotreload'];
 
 /** @type {'SPECORATOR_TEST_VAULT'} */
 export const VAULT_ENV_VAR = 'SPECORATOR_TEST_VAULT';


### PR DESCRIPTION
## Summary
- Add empty `.hotreload` marker file at repo root so Obsidian Hot Reload activates the plugin in dev vaults.
- Include `.hotreload` in `PLUGIN_FILES` of `scripts/deploy-to-test-vault.mjs` so `npm run build:deploy` copies it to `$SPECORATOR_TEST_VAULT`.

## Test plan
- [ ] `SPECORATOR_TEST_VAULT=D:/TestVault npm run build:deploy` copies `.hotreload` alongside `main.js`/`manifest.json`/`styles.css`
- [ ] Obsidian Hot Reload plugin auto-reloads Specorator on next rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)