### PR TITLE
docs(architecture): #222 ADR-010..013 + module-authoring sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ The 12 stage slugs (from `src/domain/feature/FeatureStep.ts`): `idea`, `research
 ### Testing conventions (ADR-009)
 
 - Tests live under `tests/`, mirroring `src/` path-for-path. The test for `src/x/y.ts` is `tests/x/y.test.ts`. The `.test.ts` extension is canonical; `.spec.ts` is no longer used. `__tests__/` folders inside `src/` are forbidden.
-- The shared fake-ports factory `tests/__fakes__/fake-ports.ts` exposes `fakeModulePorts()` returning the four ADR-008 ports plus the underlying `MockBridge` reference. Mutations through one port are visible through the others. Use it for any test that needs more than one port.
+- The shared fake-ports factory `tests/__fakes__/fake-ports.ts` exposes `fakeModulePorts()` returning the five ADR-008 ports plus a fresh `EventBus`, a `TranslationPort` stub, and the underlying `MockBridge` reference (and `metadataCache` / `canvas` mocks for W13 ports). Mutations through one port are visible through the others. Use it for any test that needs more than one port.
 - Vue component tests that mount a component MUST have a co-located class-based PageObject (e.g. `Home.po.ts` next to `Home.test.ts`). Elements are queried exclusively by `data-testid`. CSS-class and id selectors (`.foo`, `#bar`) are forbidden in `tests/**`; ESLint enforces this.
 - `npm run test:coverage` enforces hard thresholds 80/70/80/80 (statements/branches/functions/lines). The threshold gate runs as part of `npm run verify`, so CI inherits it automatically.
 

--- a/docs/adr/ADR-008-narrow-ports-supersede-ibridge.md
+++ b/docs/adr/ADR-008-narrow-ports-supersede-ibridge.md
@@ -43,7 +43,8 @@ Dependency injection registers the same instance under distinct Vue `InjectionKe
 
 ## Notes for downstream work
 
-- W2 (#100): module manifest declares port dependencies by symbol (`SETTINGS_PORT`, `VAULT_PORT`, ...). Module loader injects the requested ports into the module's bootstrap function.
-- W3 (#101): EventBus is its own port (`EventBusPort`) introduced in W3, not here.
-- W7 (#105): settings schema work touches `SettingsPort` shape; that PR may add migration methods to the port.
-- W8 (#106): vue-i18n integration introduces `TranslationPort` if the module needs it.
+- W2 (#100): the module descriptor receives every port through a single `ModulePorts` object (`{ settings, vault, workspace, notifications, logger, bus, t }`); modules do not declare per-port dependency symbols. See [ADR-010](ADR-010-module-system-and-defineModule.md).
+- W3 (#101): EventBus is a runtime-agnostic in-process primitive (`src/domain/shared/event-bus.ts`), not a port. Modules receive it on `ModulePorts.bus`. See [ADR-011](ADR-011-typed-eventbus-envelope.md). The earlier prediction that W3 would introduce an `EventBusPort` did not survive design.
+- W7 (#105): per-module settings versioning (`settingsKey` + `settingsVersion` + `migrate` + `validateSettings`) lives on the module descriptor; `SettingsPort` shape was not extended. See [ADR-010](ADR-010-module-system-and-defineModule.md).
+- W8 (#106): `TranslationPort` shipped as `ports.t`. Module-owned `messages.{locale}` blocks are merged into vue-i18n at module init.
+- W13 (#163): `ObsidianMcpServerPort` (`src/domain/ports/obsidian-mcp-server-port.ts`) is the sixth narrow port. Lifecycle ownership lives on `PluginCore`. See [ADR-013](ADR-013-obsidian-mcp-server.md).

--- a/docs/adr/ADR-010-module-system-and-defineModule.md
+++ b/docs/adr/ADR-010-module-system-and-defineModule.md
@@ -1,0 +1,62 @@
+---
+id: ADR-010
+title: Module system with the defineModule contract
+status: accepted
+date: 2026-05-10
+references:
+  - src/modules/module.ts
+  - src/modules/index.ts
+  - src/core/plugin-core.ts
+  - docs/module-authoring.md
+---
+
+# ADR-010 — Module system with the `defineModule` contract
+
+## Decision
+
+Feature areas live as bounded-context **modules** under `src/modules/<module-id>/`. Each module is a single descriptor produced by `defineModule()` (`src/modules/module.ts`) and registered in the central array `ALL_MODULES` exported from `src/modules/index.ts`. Modules declare what they need from the rest of the plugin and what they contribute to it through one shape:
+
+| Field | Purpose |
+|---|---|
+| `id` | Unique kebab-case identifier; used as the prefix for command IDs (`hello:open-view`) and event channels (`hello:initialized`). |
+| `dependsOn` | Optional sibling-module IDs. `PluginCore` topo-sorts modules so dependencies init first; if a dependency is degraded, dependants are skipped and emitted as `core:module-degraded`. |
+| `commands` | Obsidian commands registered through the descriptor — never via `app.commands.addCommand` directly. |
+| `uriActions` | URL action handlers routed by `PluginCore.handleUri()` (see ADR-012). |
+| `views` | View intents (id + label). W4/W11 wire them to the router. |
+| `settingsSchema` | Declarative field list (`toggle`, `text`, `number`, `dropdown`) rendered by the central settings tab. |
+| `settingsKey` / `settingsVersion` / `settingsDefaults` / `migrate` / `validateSettings` | Per-module settings slice with versioned migration; `_moduleVersions` tracks stored versions. |
+| `messages` | Flat dotted-key locale messages merged into vue-i18n. |
+| `init` / `onSettingsChange` / `destroy` | Lifecycle hooks; receive a `ModulePorts` object containing the five narrow ports (ADR-008), the typed `EventBus` (ADR-011), and `TranslationPort`. |
+
+Modules receive **all dependencies through `ModulePorts`**. They never import other modules directly; cross-module communication goes through `EventBus`. ESLint enforces this by banning `@/modules/<other>/*` imports inside any `src/modules/<id>/` directory.
+
+Vue components owned by a module live in the same directory and use `<script setup>` plus `<style scoped>`. Sibling-module SFC imports are forbidden by the same ESLint rule.
+
+## Rationale
+
+- **Bounded contexts have one declared seam.** Before W2, feature wiring was scattered across `main.ts`, the settings tab, command registration, and ad-hoc Vue mounts. The descriptor centralises all of it on one object that can be statically analysed, scaffolded (`npm run scaffold:module`), and tested with `fakeModulePorts()` (ADR-009).
+- **Declarative wins over imperative for cross-cutting registration.** Commands, settings fields, locale messages, and URI actions are data — `PluginCore` reads the descriptor array once and registers everything in lockstep. Per-module imperative `onload()` hooks would push the same registration logic into every module.
+- **The descriptor is the test boundary.** A unit test calls `helloModule.init(fakeModulePorts(), settings)` and asserts on bus emissions; no Obsidian runtime is required. This keeps W10's coverage thresholds reachable without component mounts.
+- **Modules can degrade independently.** `PluginCore.initModule` catches init errors, calls `destroy()` defensively, records the failure on `degradedModules`, emits `core:module-degraded`, and skips dependants. One broken module does not stop the plugin from loading.
+- **Settings versioning lives with the module that owns the data.** A migration that knows about a `hello.showBadge` key belongs in the `hello` module file, not in a global migration registry that grows with every feature.
+
+## Consequences
+
+- New feature areas start with `npm run scaffold:module -- <name>` (W12) which produces module file, events file, view, and test mirroring `tests/modules/<name>/`.
+- Cross-module collaboration is **always** through `EventBus`. Any direct `import { otherModule }` inside `src/modules/<id>/` is an ESLint error (ADR-011 has more on the bus contract).
+- `ALL_MODULES` is the single registration list. Adding a module is one import and one array-push edit; nothing else in `main.ts` changes.
+- `PluginCore` validates the registry at init time: duplicate `id`, duplicate `settingsKey`, reserved `_`-prefixed `settingsKey`, unknown `dependsOn`, self-dependency, and dependency cycles all throw before any module runs.
+- Per-module settings live in their own top-level keys in the stored data blob (`{ specorator: …, hello: …, _moduleVersions: { hello: 1 } }`). The legacy flat `PluginSettings` shape stays under the reserved `specorator` key (handled by `coreSettingsModule`).
+- Modules must release every bus subscription acquired in `init()` from `destroy()`. `PluginCore` measures listener delta per module and logs a `listener leak detected` warning on teardown when fewer listeners are released than were registered (ADR-012). Component-lifecycle teardown (`onUnmounted`) is **not** a substitute — modules outlive components.
+
+## Alternatives considered
+
+- **Per-module classes with an `onload()` method.** Rejected: pushes registration plumbing into every module and makes static analysis of the registry harder. The descriptor is a value, not a class — easier to scaffold, snapshot, and diff in tests.
+- **Global event hub without a descriptor.** Rejected: leaves command, settings, and locale registration scattered with no single seam to enforce ESLint rules against.
+- **Auto-discovery of modules by directory scan at build time.** Rejected: explicit registration in `ALL_MODULES` keeps the dependency graph readable and makes ordering bugs visible in the diff.
+
+## Notes for downstream work
+
+- W11 (#109) wires `ModuleViewIntent` IDs into the router; modules emit a `view-open` event and the router resolves it.
+- W13 (#163) extends `CorePorts` with `mcpServer?: ObsidianMcpServerPort`. Modules cannot register MCP tools directly — see ADR-013 for the extension seam.
+- v2 agent runtime introduces `dependsOn` checks against agent capabilities; the validator already supports cross-module dependency edges.

--- a/docs/adr/ADR-011-typed-eventbus-envelope.md
+++ b/docs/adr/ADR-011-typed-eventbus-envelope.md
@@ -1,0 +1,68 @@
+---
+id: ADR-011
+title: Typed EventBus with envelope and trace correlation
+status: accepted
+date: 2026-05-10
+references:
+  - src/domain/shared/event-bus.ts
+  - src/core/core-events.ts
+  - src/modules/hello/hello-events.ts
+---
+
+# ADR-011 — Typed `EventBus` with envelope and trace correlation
+
+## Decision
+
+Cross-module communication uses a single in-process `EventBus<EventMap>` constructed by `createEventBus()` (`src/domain/shared/event-bus.ts`). `PluginCore` instantiates one bus and exposes it on every module's `ports.bus`. The bus has four shape commitments:
+
+1. **Typed channels via declaration merging.** Modules add channels by augmenting `EventMap` from a side-effect import:
+   ```ts
+   // hello-events.ts
+   declare module '@/domain/shared/event-bus' {
+     interface EventMap {
+       'hello:initialized': { moduleId: string }
+     }
+   }
+   ```
+   Channel keys follow `<module-id>:<event-name>`. Core emits its own `core:*` channels (`core:module-degraded`, `core:init-complete`, `core:destroy-complete`) declared in `src/core/core-events.ts`.
+
+2. **Envelopes carry trace metadata, not just payload.** Every listener receives an `EventEnvelope<Payload>`:
+   ```ts
+   { channel, payload, eventId, traceId, parentId?, emittedAt }
+   ```
+   `traceId` propagates: if `emit({ parentId })` is supplied with a known `parentId`, the new envelope inherits the parent's `traceId`; otherwise the envelope starts a new trace where `traceId === eventId`. The bus retains the last `traceLimit` (default 200) trace entries to resolve `parentId` lookups.
+
+3. **Snapshotted dispatch with priority.** When `emit()` fires, listeners are sorted by descending `priority` (default 0) and snapshotted before invocation. Listeners added or removed during dispatch take effect on the next emit, never the current one. Listener errors are caught per-listener, logged via the `onListenerError` hook (`PluginCore` wires this to `LoggerPort.error`), and never propagated to siblings.
+
+4. **Async dispatch is bounded.** `emitAsync()` runs listeners with bounded concurrency (`asyncConcurrency`, default 4) — fire-and-forget rejections from `emit()` go through the same error hook.
+
+Direct module-to-module imports are forbidden. ESLint rejects any `import … from '@/modules/<other>/…'` inside `src/modules/<id>/`.
+
+## Rationale
+
+- **Type-safe channels prevent silent renames.** A typo in a channel name is a compile error, not a runtime no-op. The merged `EventMap` is the canonical channel registry — adding a channel is a one-line `declare module` augmentation.
+- **Envelopes give us correlation for free.** A v1 chat-sidebar action that triggers a write proposal that triggers an MCP-server event needs to be correlated end-to-end for diagnostics. Carrying `traceId`/`parentId` on every event makes this trivial without a separate tracing primitive. v2 agent flows reuse the same envelope shape.
+- **Snapshotted dispatch matches Obsidian's expectations.** Plugin lifecycle hooks routinely add or remove subscribers in response to other events. Snapshotting prevents "listener registered during emit" classes of bugs and removes the need to copy listener arrays at every call site.
+- **Per-listener error isolation prevents cascading failures.** A bad subscriber in one module must not block other modules from receiving the same event. The `onListenerError` hook is the single place where errors are observed and logged through `LoggerPort` — never `NotificationPort` (logger errors are not user-facing diagnostics).
+- **Bus is its own port, not part of `IBridge` or any narrow port.** ADR-008 deliberately scoped the narrow ports to Obsidian/runtime concerns; the bus is a runtime-agnostic in-process primitive that lives in `src/domain/shared/`. Modules receive it via `ModulePorts.bus` so they do not import the implementation.
+
+## Consequences
+
+- Modules **must not** call sibling modules directly. The bus is the only shared substrate. ESLint enforces this; the listener-leak tripwire (ADR-012) catches the symmetric mistake of forgetting to release subscriptions.
+- Every module that subscribes also stores the unsubscribe handle and releases it from `destroy()`. The `module-authoring.md` guide treats this as a hard rule. Component-lifecycle release (`onUnmounted`) is insufficient because modules outlive components.
+- Channel names are versioned by module. A breaking-change rename is a new channel name plus a transition listener that bridges old → new for one release.
+- Envelopes are **never** serialised. `core:module-degraded` carries an `Error` instance directly; consumers must read `error.message` only and never round-trip the envelope through JSON. v2 may introduce a serialisation port for cross-process trace export.
+- `emit()` is fire-and-forget. Listeners that need to influence the caller use `emitAsync()` with a payload that includes a result-collecting object (e.g., `votes: string[]`), or a request/response convention layered on top.
+- Do not emit bus events from `destroy()`. The leak tripwire (ADR-012) measures per-module listener delta; emissions during destroy can corrupt that delta.
+
+## Alternatives considered
+
+- **DOM `EventTarget` / `CustomEvent`.** Rejected: payloads are untyped, listeners run in DOM order rather than priority order, and there is no native trace metadata. Wrapping `EventTarget` to fix these problems is more code than the current implementation, with a worse type story.
+- **An external pub/sub library (mitt, nanoevents).** Rejected: adds a runtime dependency for a primitive that is small enough to maintain in-tree. None of the candidates ship envelopes with trace correlation; each would need a wrapper anyway.
+- **Per-module event buses with a parent broadcaster.** Rejected: `dependsOn` resolution at runtime is harder when listeners are scattered across multiple buses, and the snapshot semantics get harder to reason about.
+
+## Notes for downstream work
+
+- v2 agentonomous integration adds `agent:*` channels and reuses the envelope's `traceId` to correlate with MCP tool calls.
+- A future `BusInspector` view (debug-only) reads `traceEntries` to render a per-trace event timeline; the bus already retains the last 200 entries with no extra plumbing needed.
+- Settings live-reload uses `PluginCore.notifySettingsChanged` rather than a bus event, by design — the call site needs the migrated/validated settings object back, which a fire-and-forget event cannot return.

--- a/docs/adr/ADR-012-plugin-core-lifecycle.md
+++ b/docs/adr/ADR-012-plugin-core-lifecycle.md
@@ -1,0 +1,55 @@
+---
+id: ADR-012
+title: PluginCore owns the module lifecycle, URI dispatch, and MCP server start/stop
+status: accepted
+date: 2026-05-10
+references:
+  - src/core/plugin-core.ts
+  - src/plugin/main.ts
+  - src/core/core-events.ts
+---
+
+# ADR-012 — `PluginCore` owns the module lifecycle, URI dispatch, and MCP server start/stop
+
+## Decision
+
+`PluginCore` (`src/core/plugin-core.ts`) is the single object responsible for orchestrating registered modules across the plugin's lifetime. The Obsidian `Plugin` subclass (`src/plugin/main.ts`) constructs one `PluginCore` in `onload()`, hands it `ALL_MODULES` plus a `CorePorts` bag, and delegates four distinct responsibilities to it:
+
+1. **Module init in dependency order.** `init(rawSettings)` runs once. It validates the registry (duplicate IDs, duplicate `settingsKey`, reserved `_`-prefixed keys, unknown / cyclic / self-dependencies, duplicate URI actions), topo-sorts `dependsOn` edges with Kahn's BFS, runs per-module migration via `migrateSettings`, and then calls `mod.init(modulePorts, settings)` for each module in topological order. Modules whose dependencies degraded are skipped; their failure is recorded on `degradedModules` and emitted as `core:module-degraded`. After all modules complete (or degrade), `PluginCore` starts the MCP server (if provided) and emits `core:init-complete` with the degraded count.
+
+2. **URI dispatch in one place.** During `init`, `PluginCore` indexes every module's `uriActions[].action` into a single map. The Obsidian `Plugin` calls `core.handleUri(searchParams)` from its single `registerObsidianProtocolHandler('specorator', …)` callback. Modules **never** register their own protocol handlers. Duplicate `action` values across modules throw at `init` time before any handler runs.
+
+3. **MCP server lifecycle.** When `CorePorts.mcpServer` is provided (`ObsidianMcpServerAdapter` in production, undefined in unit tests), `PluginCore.init` calls `mcpServer.start()` after module init succeeds, and `destroy()` calls `mcpServer.stop()` after module teardown. Failures from start/stop are logged but do not block the rest of the lifecycle. See ADR-013 for the server itself.
+
+4. **Listener-leak tripwire.** Before each `mod.init`, `PluginCore` snapshots `bus.listenerCount()` and stores the per-module delta in `leakMap`. On `destroy()`, modules are torn down in reverse topological order; for each module, the bus listener count is sampled before and after `destroy()`. If `released < subscribed`, `PluginCore` logs a `listener leak detected` warning and increments a leak counter that is published with `core:destroy-complete`.
+
+`PluginCore.notifySettingsChanged(settingsKey, rawValue)` is the single live-reload entry point: it runs `validateSettings` first, caches the validated value in `moduleSettingsMap`, and then invokes the module's `onSettingsChange` hook. The Obsidian `Plugin` calls this from `updateSettings` and `updateModuleSettings` and persists the validated (possibly coerced) value back to disk.
+
+## Rationale
+
+- **Single owner removes "who registers what" ambiguity.** Pre-W4, command registration, settings tab population, URI handler dispatch, and i18n message loading lived in `main.ts` and grew with every new feature area. Pulling all of it into `PluginCore` makes `main.ts` a thin Obsidian-shape adapter and lets the registry validators run before any side effect.
+- **Topological init makes `dependsOn` honest.** A module that needs another module's bus channels alive at `init` time can declare it; `PluginCore` guarantees the order. Without topo-sort, declaration-order coupling becomes implicit.
+- **Listener-leak detection at the bus boundary catches the most common module bug.** Modules subscribe in `init` and are expected to release in `destroy`. Measuring listener delta at the only place that owns both lifecycle ends (the bus) means leaks surface at the right spot, in the right log line, instead of as memory growth in long-running Obsidian sessions.
+- **One protocol handler simplifies extension.** Obsidian fires the protocol handler synchronously per URL; routing inside `handleUri` lets modules contribute actions without each fighting for the protocol slot, and lets v1 stub handlers (`open-chat`, `focus-chat`) live in `main.ts` while real handlers slot in once their owning module ships.
+- **MCP start/stop is keyed to module readiness.** Starting the MCP server before modules finish initialising would expose tool calls to a half-initialised plugin; starting it after (and stopping it before module teardown) keeps invariants ordered.
+
+## Consequences
+
+- Modules cannot call `app.commands.addCommand`, `app.workspace.registerObsidianProtocolHandler`, or `app.metadataCache.on` directly — those go through the descriptor (commands), `uriActions` (URI), or `MetadataCachePort` (metadata). ESLint enforces no `obsidian` imports outside `src/infrastructure/obsidian/` and `src/plugin/`.
+- `init()` is idempotent-by-throw: a second call throws. The Obsidian `Plugin` calls it exactly once.
+- `onunload()` is synchronous (Obsidian contract). `core.destroy()` is fired and not awaited; module `destroy` implementations must be fast and side-effect-light.
+- Module destroy errors are caught and logged (`module destroy failed`); they do not stop subsequent modules from being torn down.
+- Settings live-reload always validates first. If `validateSettings` rejects the new value, `onSettingsChange` is **not** called and the persisted blob remains the previous value.
+- `core:module-degraded` is emitted whenever (a) a module's init throws, (b) i18n message merge throws, or (c) any of its `dependsOn` is already degraded. UI may surface degraded modules in a settings panel; v1 only logs them.
+
+## Alternatives considered
+
+- **Each module owns its lifecycle (`onload`/`onunload` per module).** Rejected: spreads `app.*` registration across modules, breaks the ESLint boundary, and makes `dependsOn` impossible to enforce.
+- **Lifecycle hooks via the bus (`emit('core:init')` and listen).** Rejected: hides ordering, makes init failures hard to attribute to a specific module, and gives no return value to the lifecycle owner.
+- **Multiple `PluginCore` instances per concern (commands core, settings core, …).** Rejected: every concern needs the same module list. One `PluginCore` per `Plugin` keeps state colocated.
+
+## Notes for downstream work
+
+- v2 agentonomous integration introduces `mod.dependsOnAgent?: AgentCapabilityId[]` and `PluginCore` short-circuits modules whose required agent capabilities are missing — same degraded-module mechanism.
+- Settings live-reload triggers a downstream `vue-i18n` re-merge when locale settings change; `applyModuleMessages` is already idempotent.
+- A future "module restart" admin command would call `mod.destroy?()` then `mod.init(...)` for one module; the registry validator and `leakMap` already work per-module.

--- a/docs/adr/ADR-013-obsidian-mcp-server.md
+++ b/docs/adr/ADR-013-obsidian-mcp-server.md
@@ -1,0 +1,67 @@
+---
+id: ADR-013
+title: Native Obsidian MCP server with proposal-queued writes
+status: accepted
+date: 2026-05-10
+references:
+  - src/domain/ports/obsidian-mcp-server-port.ts
+  - src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts
+  - src/infrastructure/obsidian/ProposalStore.ts
+  - src/core/plugin-core.ts
+---
+
+# ADR-013 — Native Obsidian MCP server with proposal-queued writes
+
+## Decision
+
+The plugin runs a Model Context Protocol (MCP) server in-process inside Obsidian, exposing the vault as a typed agent tool surface. The contract lives in `ObsidianMcpServerPort` (`src/domain/ports/obsidian-mcp-server-port.ts`):
+
+```ts
+interface ObsidianMcpServerPort {
+  start(): Promise<{ port: number }>
+  stop(): Promise<void>
+  getConnectionConfig(): McpConnectionConfig
+}
+```
+
+Three commitments shape the implementation in `ObsidianMcpServerAdapter`:
+
+1. **Loopback HTTP transport with a dynamic port.** A Node `http.Server` binds to `127.0.0.1:0` so the OS chooses a free port; the adapter rejects requests whose `Host` header is not `127.0.0.1` or `localhost` (HTTP 421). Each request is handled by a fresh `McpServer` from `@modelcontextprotocol/sdk` connected to a `StreamableHTTPServerTransport` with no session ID. `getConnectionConfig()` returns `{ transport: 'http', url: 'http://127.0.0.1:<port>/mcp' }` for the Claude CLI subprocess to consume.
+
+2. **Tool registration is grouped, not scattered.** Six register-functions split tools into vault, workflow, metadata, links, canvas, and bases groups. Read tools wrap port methods directly; **write tools never mutate** — they call `proposalStore.queue(toolName, params, mutate)` and return `{ proposalId, status: 'pending' }`. The mutator closure is invoked only when the user accepts the proposal.
+
+3. **`ProposalStore` is the write boundary.** A single in-memory map of pending proposals indexed by UUID. `queue` returns the ID synchronously; `accept(id)` flips status to `accepted` and runs the captured mutator (rolls back to `pending` on failure); `reject(id)` flips status to `rejected` and runs nothing. `getAll()` returns deep-cloned snapshots so UI code cannot mutate stored params. The chat-sidebar module reads pending proposals from the adapter via off-port methods (`acceptProposal`, `rejectProposal`, `getProposals`) — these methods exist on the concrete adapter, not on `ObsidianMcpServerPort`, by design.
+
+`PluginCore` owns server start/stop (ADR-012). Modules **cannot** register MCP tools themselves; the tool surface is a fixed contract owned by the adapter, and module-level extensions go through events or off-port adapter methods.
+
+## Rationale
+
+- **Native (in-process) over external sidecar.** An MCP server that lives inside the plugin shares vault access through `VaultPort` and respects every narrow-port invariant — overwrite protection, vault-path normalisation, settings — without having to re-authenticate or re-implement the rules. An external sidecar would need its own auth boundary and copy of the same logic.
+- **Loopback-only listener with a `Host`-header gate.** Binding to `127.0.0.1` is the OS-level seal. Checking the `Host` header rejects DNS-rebinding-style attempts where a remote attacker tricks a browser into sending a request to a local socket — the request body would be HTTP/1.1 valid but `Host` would not be `localhost`. Combined with dynamic port assignment (no scannable default), the attack surface is the local machine only.
+- **Dynamic port, not a fixed one.** A fixed port would conflict with other MCP implementations on the same machine and create a guessable target. The port is published only through `getConnectionConfig()`, which the chat-sidebar reads when starting the Claude CLI subprocess.
+- **Proposal queue, not direct vault writes.** v1 explicitly defers live agent runtime behind a review boundary (ADR-007). Agents propose, humans accept. Implementing this as a queue in front of every write tool keeps the contract uniform across vault, workflow, links, canvas, and bases tools — there is no "this tool is safe so we skip the queue" exception.
+- **Per-request `McpServer` instance.** Each HTTP request constructs a new `McpServer` and `StreamableHTTPServerTransport`; this matches the transport's stateless-session model (`sessionIdGenerator: undefined`) and avoids leaking listener state across calls. The 35-tool registration cost per request is negligible compared to the round-trip.
+- **Off-port accept/reject is intentional.** The chat-sidebar UI needs to read pending proposals and act on them; exposing those methods on `ObsidianMcpServerPort` would put UI-shaped methods on a port that an MCP client never calls. They live on the concrete adapter and are passed to the sidebar module via construction, not via the port interface.
+
+## Consequences
+
+- The plugin opens a localhost listener while loaded. The bind is loopback-only and the `Host` header gate is mandatory. The chosen port is not advertised anywhere outside the running plugin — the chat-sidebar reads it through `getConnectionConfig()`.
+- **Every** write tool returns a proposal receipt, not a success/error. Callers must wait for human accept/reject. There is no "trusted tool" bypass.
+- A pending proposal that the user closes Obsidian on is lost. Proposals are in-memory; they do not persist across reloads. v2 may persist them; v1 does not.
+- Tool surface is closed to module-side registration. A module that needs a new agent-callable tool files an issue against the adapter; the registration goes in the appropriate `register*Tools` function. This keeps the audit story honest: every tool is visible in one place.
+- The MCP server starts after all modules init and stops before they tear down. Tool calls that race the very start or end of the plugin lifecycle see "server not started" errors from `getConnectionConfig()`.
+- Tools that depend on Obsidian-only APIs (`MetadataCachePort`, `CanvasPort`) work because those ports are real adapters in production and mocked in tests; the MCP server itself does not import `obsidian` directly.
+
+## Alternatives considered
+
+- **stdio transport (subprocess pipes).** Rejected: Obsidian is the parent process; spawning a child to host the MCP server reverses the natural dependency direction, complicates lifecycle (who restarts whom), and breaks vault access without a serialisation layer between processes.
+- **WebSocket transport.** Rejected: HTTP+SSE via `StreamableHTTPServerTransport` is the documented transport for `@modelcontextprotocol/sdk` and matches the Claude CLI's expectations without bespoke framing.
+- **Direct vault writes from MCP write tools.** Rejected per ADR-007 — agent acceptance must be a human governance event in v1. The proposal queue is the implementation of that decision.
+- **Static well-known port (e.g., 7777).** Rejected: collisions with other MCP servers and a stable scan target. Dynamic port + loopback-only is strictly better.
+- **Letting modules register tools.** Rejected: agent capability surface is a security-relevant contract. Centralising it in the adapter keeps the audit story tractable; the trade-off is module authors file an issue against the adapter when they need a new tool.
+
+## Notes for downstream work
+
+- The chat-sidebar module (#197/#198/#199) reads `getConnectionConfig()` on startup to point the Claude CLI subprocess at the running server, and registers a UI panel that lists pending proposals via `getProposals()`.
+- v2 agentonomous orchestrator may persist proposals (durable queue), add a `proposal_status_changed` event, and expose proposal acceptance as an HTTP endpoint protected by a per-session token. The current in-memory store is the v1 floor.
+- A future `tool_capabilities` MCP method will let clients introspect the registered tool surface; today the registration is visible only by reading `register*Tools` source.

--- a/docs/module-authoring.md
+++ b/docs/module-authoring.md
@@ -1,6 +1,12 @@
 # Module Authoring Guide
 
-This guide explains how to add a bounded-context module to the plugin. A module is a self-contained feature area that declares its commands, views, settings fields, and locale messages in one descriptor, and receives all dependencies through a `ModulePorts` object.
+This guide explains how to add a bounded-context module to the plugin. A module is a self-contained feature area that declares its commands, views, settings fields, locale messages, URI actions, and event channels in one descriptor, and receives all dependencies through a `ModulePorts` object.
+
+The system contracts are captured in:
+- [ADR-010 — Module system with the `defineModule` contract](adr/ADR-010-module-system-and-defineModule.md)
+- [ADR-011 — Typed `EventBus` with envelope and trace correlation](adr/ADR-011-typed-eventbus-envelope.md)
+- [ADR-012 — `PluginCore` lifecycle, URI dispatch, and MCP server start/stop](adr/ADR-012-plugin-core-lifecycle.md)
+- [ADR-013 — Native Obsidian MCP server with proposal-queued writes](adr/ADR-013-obsidian-mcp-server.md)
 
 ## Quick start — `npm run scaffold:module`
 
@@ -116,6 +122,139 @@ export const helloModule = defineModule({
 })
 ```
 
+## Declaring URI actions
+
+A module can register handlers for `obsidian://specorator?action=…` URLs by adding `uriActions` to its descriptor. `PluginCore` indexes every module's actions into a single dispatch map at init time and routes incoming URLs through `core.handleUri()` (registered once in `src/plugin/main.ts` via `registerObsidianProtocolHandler('specorator', …)`). Modules **never** register their own protocol handlers.
+
+```typescript
+export const featuresModule = defineModule({
+  id: 'features',
+
+  uriActions: [
+    {
+      action: 'open-feature',
+      handler: (params: URLSearchParams) => {
+        const slug = params.get('slug')
+        if (slug === null) return
+        // route, open file, emit a bus event — anything synchronous-ish
+      },
+    },
+  ],
+  // …
+})
+```
+
+Handlers receive a `URLSearchParams` instance built from the raw URL. `PluginCore`:
+- validates that no two modules declare the same `action` value (throws at init);
+- catches handler errors and logs them via `LoggerPort.error` — a buggy URI handler does not crash the plugin;
+- returns `false` to the protocol-handler callback when the action is unknown, letting `main.ts` show a fallback warning.
+
+Test a URI handler with `https-style`-deep linking:
+
+```
+obsidian://specorator?action=open-feature&slug=auth-flow
+```
+
+Background and rationale: [ADR-012](adr/ADR-012-plugin-core-lifecycle.md).
+
+## Extending the MCP tool surface
+
+The plugin runs a native Obsidian MCP server (see [ADR-013](adr/ADR-013-obsidian-mcp-server.md)) that exposes the vault as a typed agent tool surface. The server lives in `src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts`; tools are registered in grouped functions (`registerTools` for vault, `registerWorkflowTools`, `registerMetadataTools`, `registerLinksTools`, `registerCanvasTools`, `registerBasesTools`).
+
+**Modules cannot register MCP tools themselves.** The agent capability surface is a security-relevant contract (every write goes through the proposal queue — there is no trusted-tool bypass), so registration is centralised. To add a tool:
+
+1. Open an issue against the adapter describing the tool, its inputs, and whether it reads or writes.
+2. Add a `mcp.registerTool(name, { description, inputSchema }, handler)` call in the appropriate `register*Tools` group.
+3. **Read tool:** call the relevant port (`vault`, `metadataCache`, `canvas`) and return `ok(data)`.
+4. **Write tool:** never mutate directly. Capture the mutation in a closure and queue it through `ProposalStore`:
+
+```typescript
+mcp.registerTool(
+  'template_install',
+  {
+    description: 'Install a feature scaffold from template — queued for proposal review',
+    inputSchema: { templateId: z.string(), slug: z.string() },
+  },
+  async ({ templateId, slug }) => {
+    const proposalId = store.queue(
+      'template_install',
+      { templateId, slug },
+      () => installTemplate(templateId, slug),  // runs only on accept
+    )
+    return ok({ proposalId, status: 'pending' })
+  },
+)
+```
+
+The chat-sidebar module reads pending proposals from the adapter (off-port: `getProposals()`, `acceptProposal(id)`, `rejectProposal(id)`) and renders accept/reject UI.
+
+Tool-naming convention: `<group>_<verb>[_<noun>]` (e.g., `vault_read_note`, `bases_update_record`). Inputs are `zod` schemas so the SDK auto-generates JSON-schema for the MCP introspection endpoint.
+
+## Working with the `EventBus`
+
+Modules talk to each other only through `ports.bus`. The bus is constructed once by `PluginCore` and exposes `on`/`onAny`/`emit`/`emitAsync`/`listenerCount`. Every listener receives an `EventEnvelope`:
+
+```ts
+{ channel, payload, eventId, traceId, parentId?, emittedAt }
+```
+
+### Subscribing
+
+```typescript
+let unsub: (() => void) | null = null
+
+const featuresModule = defineModule({
+  id: 'features',
+  init(ports) {
+    unsub = ports.bus.on('hello:initialized', (envelope) => {
+      ports.logger.debug('features saw hello init', {
+        moduleId: envelope.payload.moduleId,
+        traceId: envelope.traceId,
+      })
+    })
+  },
+  destroy() {
+    unsub?.()
+    unsub = null
+  },
+})
+```
+
+Listeners run in descending `priority` order (default 0). The listener list is snapshotted at the start of each `emit`, so subscribing or unsubscribing during dispatch only affects the next emit. Per-listener errors are caught and logged via `LoggerPort.error` — a bad subscriber never blocks siblings.
+
+### Publishing
+
+Add the channel to `EventMap` via declaration merging in `<module-id>-events.ts` (see [Event channels](#event-channels)). Then:
+
+```typescript
+ports.bus.emit('features:opened', { slug: 'auth-flow' })
+```
+
+To correlate a downstream emit with the envelope you are reacting to, pass the parent's `eventId`:
+
+```typescript
+ports.bus.on('features:opened', (envelope) => {
+  ports.bus.emit(
+    'analytics:feature-viewed',
+    { slug: envelope.payload.slug },
+    { parentId: envelope.eventId },
+  )
+})
+```
+
+The downstream envelope inherits the parent's `traceId`, so a single trace stitches the chain together for diagnostics.
+
+`emitAsync()` runs listeners with bounded concurrency (default 4) and resolves once they all settle — use it when listeners do real I/O. `emit()` is fire-and-forget; promise rejections from sync emits are routed through the same error hook.
+
+### Hard rules
+
+- Always store the unsubscribe handle from `bus.on()` and release it from `destroy()`. `PluginCore` measures listener delta per module and logs `listener leak detected` when fewer listeners are released than were registered.
+- **Do not** delegate unsubscription to Vue component hooks (`onUnmounted`). Modules outlive components.
+- **Do not** emit bus events from `destroy()`. The leak tripwire samples listener count before and after `destroy()`; emissions during teardown can corrupt the per-module delta.
+- **Do not** import sibling modules. ESLint blocks `@/modules/<other>/…` imports inside `src/modules/<id>/`. Cross-module collaboration is bus-only.
+
+Background and rationale: [ADR-011](adr/ADR-011-typed-eventbus-envelope.md).
+
 ## `ModulePorts`
 
 `init(ports, settings)` receives:
@@ -127,31 +266,10 @@ export const helloModule = defineModule({
 | `ports.workspace` | `WorkspacePort` | `openFile()` |
 | `ports.notifications` | `NotificationPort` | `showError()` / `showWarning()` / `showSuccess()` / `showInfo()` |
 | `ports.logger` | `LoggerPort` | Structured logging (debug/info/warn/error). |
-| `ports.bus` | `EventBus` | cross-module events |
+| `ports.bus` | `EventBus` | Cross-module events; see [Working with the `EventBus`](#working-with-the-eventbus). |
+| `ports.t` | `TranslationPort` | i18n lookup (`t(key, params?)`). Messages from all modules are merged into vue-i18n at init. |
 
-### Bus subscription ownership
-
-All bus subscriptions acquired in `init()` must be stored in module-local scope and released in `destroy()`:
-
-```ts
-// ✅ correct
-let unsub: (() => void) | null = null
-
-const myModule = defineModule({
-  id: 'my-module',
-  init(ports) {
-    unsub = ports.bus.on('some:event', handler)
-  },
-  destroy() {
-    unsub?.()
-    unsub = null
-  },
-})
-```
-
-Do **not** delegate unsubscription to Vue component lifecycle hooks (`onUnmounted`). A module may outlive or be destroyed independently of any component, and leaked listeners will trigger the W4 listener-leak tripwire.
-
-Modules must not hold references to sibling module instances. All inter-module communication goes through the shared `EventBus`. Do not emit bus events from `destroy()` — this can corrupt the per-module listener delta measurement in the tripwire.
+The bus, port surface, and lifecycle ownership rules are covered in their own sections — this table is the index, not the rulebook. Subscription ownership and the listener-leak tripwire live under [Working with the `EventBus` → Hard rules](#hard-rules).
 
 ## Vue SFC isolation
 
@@ -162,7 +280,7 @@ Modules must not hold references to sibling module instances. All inter-module c
 
 ## Event channels
 
-Channels follow `<module-id>:<event-name>`:
+Channels follow `<module-id>:<event-name>` and are added to the shared `EventMap` via TypeScript declaration merging in `<module-id>-events.ts`:
 
 ```typescript
 // hello-events.ts
@@ -174,7 +292,9 @@ declare module '@/domain/shared/event-bus' {
 }
 ```
 
-Import this as a side-effect in your module file: `import './hello-events'`.
+Import this as a side-effect in your module file: `import './hello-events'`. The empty `import type {}` keeps TypeScript module-mode active so the `declare module` block applies.
+
+For subscribe / publish patterns, listener priority, trace correlation, and the listener-leak rules, see [Working with the `EventBus`](#working-with-the-eventbus).
 
 ## When to use Vue emits vs. EventBus
 
@@ -194,10 +314,11 @@ Import this as a side-effect in your module file: `import './hello-events'`.
 
 ## Registering a new module
 
-Add your module to `src/modules/index.ts`. The full file after adding `myModule` looks like:
+Add your module to `src/modules/index.ts`. After adding `myModule` the file looks like:
 
 ```typescript
 import type { ModuleDescriptor } from './module'
+import { coreSettingsModule } from '@/core/core-settings'
 import { helloModule } from './hello/hello-module'
 import { myModule } from './my-module/my-module-module'
 
@@ -212,10 +333,137 @@ export type {
 } from './module'
 export { helloModule, myModule }
 
-export const ALL_MODULES: ReadonlyArray<ModuleDescriptor> = [helloModule, myModule]
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Module registry holds descriptors with heterogeneous settings types.
+export const ALL_MODULES: ReadonlyArray<ModuleDescriptor<any>> = [coreSettingsModule, helloModule, myModule]
 ```
 
-Modules init in declaration order; teardown runs in reverse order.
+Modules init in **topological order** based on `dependsOn` edges (Kahn's BFS over the registry); modules without dependencies init in declaration order. Teardown runs in reverse topological order. Registry validation rejects duplicate IDs, duplicate `settingsKey` values, reserved `_`-prefixed keys, unknown / cyclic / self `dependsOn`, and duplicate `uriActions[].action` values — all at `PluginCore.init()`, before any module runs. See [ADR-012](adr/ADR-012-plugin-core-lifecycle.md).
+
+## Worked example — `helloModule` end-to-end
+
+`helloModule` (`src/modules/hello/hello-module.ts`) is the canonical demo wired through every contract surface. It is the smallest module that exercises the full descriptor.
+
+### 1. Events file
+
+```typescript
+// src/modules/hello/hello-events.ts
+import type {} from '@/domain/shared/event-bus'
+
+declare module '@/domain/shared/event-bus' {
+  interface EventMap {
+    'hello:initialized': { moduleId: string }
+  }
+}
+```
+
+### 2. Module file
+
+```typescript
+// src/modules/hello/hello-module.ts
+import './hello-events'
+import { defineModule } from '@/modules/module'
+
+interface HelloSettings {
+  showBadge: boolean
+}
+
+export const helloModule = defineModule<HelloSettings>({
+  id: 'hello',
+  settingsKey: 'hello',
+  settingsVersion: 1,
+  settingsDefaults: { showBadge: true },
+
+  validateSettings(raw: unknown): HelloSettings {
+    const r = (raw ?? {}) as Record<string, unknown>
+    return { showBadge: typeof r.showBadge === 'boolean' ? r.showBadge : true }
+  },
+
+  commands: [{ id: 'hello:open-view', name: 'Hello: Open view', callback: () => undefined }],
+  views:    [{ id: 'hello-view', label: 'Hello' }],
+  settingsSchema: {
+    fields: [{ type: 'toggle', key: 'showBadge', label: 'Show badge', default: true }],
+  },
+  messages: {
+    en: { 'hello.title': 'Hello from Specorator' },
+    de: { 'hello.title': 'Hallo von Specorator' },
+  },
+  init(ports) {
+    ports.bus.emit('hello:initialized', { moduleId: 'hello' })
+  },
+})
+```
+
+### 3. Registry entry
+
+`src/modules/index.ts`:
+
+```typescript
+import { helloModule } from './hello/hello-module'
+// …
+export const ALL_MODULES = [coreSettingsModule, helloModule, /* … */]
+```
+
+### 4. What every contract surface gives you
+
+| Surface | Effect once `PluginCore.init()` runs |
+|---|---|
+| `id: 'hello'` | Reserves the `hello:*` channel and command-id namespace; registry validator rejects duplicates. |
+| `settingsKey + settingsVersion + validateSettings + settingsDefaults` | The `hello` slice in stored data is migrated/validated on load; `_moduleVersions.hello` is stamped to `1`. Live edits in the settings tab call `notifySettingsChanged('hello', …)` which re-runs `validateSettings` before persisting. |
+| `commands` | Obsidian command palette gets `Hello: Open view` (id `hello:open-view`). |
+| `views` | View intent registered for the router. |
+| `settingsSchema.fields` | The central settings tab renders a toggle bound to `showBadge`. |
+| `messages.{en,de}` | `applyModuleMessages` merges them into vue-i18n; `ports.t('hello.title')` resolves per locale. |
+| `init(ports)` | Runs in topological order; emits `hello:initialized`; listener-leak tripwire snapshots the bus listener count before/after. |
+
+### 5. Worked example with the rest of the surfaces
+
+A larger module that adds a URI action and reacts to `hello:initialized` over the bus:
+
+```typescript
+import './features-events'
+import { defineModule } from '@/modules/module'
+
+let unsub: (() => void) | null = null
+
+export const featuresModule = defineModule({
+  id: 'features',
+  dependsOn: ['hello'],
+
+  commands: [
+    { id: 'features:open', name: 'Features: Open panel', callback: () => undefined },
+  ],
+
+  uriActions: [
+    {
+      action: 'open-feature',
+      handler: (params) => {
+        const slug = params.get('slug')
+        if (slug !== null) {
+          // route to the feature view
+        }
+      },
+    },
+  ],
+
+  init(ports) {
+    unsub = ports.bus.on('hello:initialized', (envelope) => {
+      ports.logger.debug('features observed hello init', {
+        traceId: envelope.traceId,
+        moduleId: envelope.payload.moduleId,
+      })
+    })
+  },
+
+  destroy() {
+    unsub?.()
+    unsub = null
+  },
+})
+```
+
+`obsidian://specorator?action=open-feature&slug=auth-flow` is now routed through `core.handleUri()` to this handler. The module also subscribes to `hello:initialized` on init and releases the subscription on destroy — the listener-leak tripwire stays quiet.
+
+(When the chat-sidebar module #197 lands, it will replace this composite example with the first production module that exercises every surface, including MCP off-port hooks for accept/reject of pending proposals.)
 
 ## Testing
 

--- a/tests/__fakes__/fake-ports.ts
+++ b/tests/__fakes__/fake-ports.ts
@@ -14,8 +14,10 @@ import { createEventBus } from '@/domain/shared/event-bus'
 import type { EventBus } from '@/domain/shared/event-bus'
 
 /**
- * Standard test seam: all four narrow ports backed by a single MockBridge
- * instance, plus a fresh EventBus and a vi.fn() spy LoggerPort.
+ * Standard test seam: all five narrow ports (settings/vault/workspace/notifications
+ * + logger) backed by a single MockBridge instance, plus a fresh EventBus and a
+ * vi.fn() spy LoggerPort, a TranslationPort stub, and W13 mocks (metadataCache,
+ * canvas).
  *
  * `bridge` is exposed so tests can inspect recorded notices and opened-file paths.
  * `bus` is exposed so tests can subscribe to events before calling module init.


### PR DESCRIPTION
Closes out [#222](https://github.com/Luis85/specorator/issues/222) — the deferred docs/ADR sweep from epic #85 (acceptance items 10 + 11). Item 9 (production demo module) lands with #197.

## Summary

Adds four new ADRs covering the W2–W4 + W13 surfaces that previously had no canonical decision record, and patches `docs/module-authoring.md` so module authors learn URI actions, MCP tool extensions, and the typed `EventBus` from one place. Stale prediction lines in ADR-008 are realigned with what actually shipped.

## What changed

### New ADRs

| ADR | Subject |
|---|---|
| ADR-010 | Module system + `defineModule` contract — bounded contexts, registry validation, ESLint enforcement, scoped Vue SFCs |
| ADR-011 | Typed `EventBus` + envelope + trace correlation — declaration merging, snapshotted dispatch, priority, per-listener error isolation |
| ADR-012 | `PluginCore` lifecycle ownership — topo-sort init, single URI handler, MCP server start/stop, listener-leak tripwire |
| ADR-013 | Native Obsidian MCP server — loopback HTTP + dynamic port + `Host` gate, grouped tool registration, `ProposalStore` write queue |

### `docs/module-authoring.md`

- ToC links to ADR-010..013 at the top of the doc
- **New section** — Declaring URI actions (descriptor field, dispatch, validation)
- **New section** — Extending the MCP tool surface (read tools direct, write tools through `ProposalStore`)
- **New section** — Working with the `EventBus` (subscribe / publish / trace correlation / hard rules)
- **Expanded** — Worked example: `helloModule` end-to-end + composite `featuresModule` showing every contract surface
- `ModulePorts` table now lists `TranslationPort`
- "Registering" corrected from declaration-order to topological order; calls out registry-validation invariants

### ADR-008 realignment

- Replaced stale "W3 introduces `EventBusPort`" prediction with a pointer to ADR-011 (EventBus is a runtime primitive, not a port)
- Updated W2/W7/W8 notes to match what shipped
- Added W13 `ObsidianMcpServerPort` entry pointing to ADR-013

### Tiny consistency fixes

- `CLAUDE.md` and `tests/__fakes__/fake-ports.ts` corrected from "four ADR-008 ports" to five (ADR-008 itself already lists five; fake-ports ships a logger spy and W13 mocks)

## Acceptance (from #222)

- [x] `docs/module-authoring.md` includes URI actions, MCP tool extensions, EventBus sections
- [x] ADR-010, ADR-011, ADR-012, ADR-013 land under `docs/adr/`
- [x] Demo-module walkthrough references `helloModule` (real, end-to-end). Production demo (`#197` chat-sidebar) will replace the composite `featuresModule` example when it lands.
- [x] `npm run docs:api` regenerates without warnings
- [x] `npm run typecheck` clean
- [x] `npm run lint` — 0 errors (8 pre-existing warnings)

## Verification notes

- **Tests:** 489/489 pass via `npm run test`.
- **Coverage gate (`npm run verify`):** Vitest browser-mode dynamically imports `@vitest/coverage-v8/browser` and 6 storybook stories from a `D:/Projects/specorator-plugin/...` URL that does not exist inside this worktree's `node_modules` — environmental, not caused by this PR. The same failure pattern is reproducible by running `npm run verify` in any worktree on Windows; will track separately.
- **Spec-first gate:** docs-only change, no Phase 4 feature implementation, no new specs/ folders.

## Test plan

- [ ] Reviewer skims ADR-010 / 011 / 012 / 013 for technical accuracy against `src/modules/module.ts`, `src/domain/shared/event-bus.ts`, `src/core/plugin-core.ts`, `src/infrastructure/obsidian/ObsidianMcpServerAdapter.ts`
- [ ] Reviewer checks the `helloModule` worked example in `docs/module-authoring.md` against `src/modules/hello/hello-module.ts`
- [ ] Reviewer confirms the URI / MCP / EventBus sections answer "how do I do X in a module" for a new contributor

🤖 Generated with [Claude Code](https://claude.com/claude-code)