### PR TITLE
test(core): cover core-settings, modules registry, hello module

### DIFF
--- a/tests/core/core-settings.test.ts
+++ b/tests/core/core-settings.test.ts
@@ -109,14 +109,15 @@ describe('coreSettingsModule.validateSettings', () => {
 })
 
 describe('coreSettingsModule.settingsSchema', () => {
-  it('exposes 8 field descriptors', () => {
-    expect(coreSettingsModule.settingsSchema?.fields).toHaveLength(8)
+  it('exposes a field descriptor for every PluginSettings key', () => {
+    const expected = Object.keys(DEFAULT_SETTINGS).length
+    expect(coreSettingsModule.settingsSchema?.fields).toHaveLength(expected)
   })
 
   it('every field key is a valid PluginSettings key', () => {
     const validKeys = Object.keys(DEFAULT_SETTINGS) as ReadonlyArray<keyof PluginSettings>
     const fieldKeys = coreSettingsModule.settingsSchema?.fields.map((f) => f.key) ?? []
-    expect(fieldKeys).toHaveLength(8)
+    expect(fieldKeys).toHaveLength(validKeys.length)
     for (const k of fieldKeys) {
       expect(validKeys).toContain(k as keyof PluginSettings)
     }

--- a/tests/core/core-settings.test.ts
+++ b/tests/core/core-settings.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest'
+import { coreSettingsModule } from '@/core/core-settings'
+import { DEFAULT_SETTINGS, type PluginSettings } from '@/domain/settings/PluginSettings'
+import { fakeModulePorts } from '../__fakes__/fake-ports'
+
+describe('coreSettingsModule descriptor metadata', () => {
+  it('has the expected id, settingsKey, and settingsVersion', () => {
+    expect(coreSettingsModule.id).toBe('specorator')
+    expect(coreSettingsModule.settingsKey).toBe('specorator')
+    expect(coreSettingsModule.settingsVersion).toBe(1)
+  })
+
+  it('settingsDefaults equals DEFAULT_SETTINGS', () => {
+    expect(coreSettingsModule.settingsDefaults).toEqual(DEFAULT_SETTINGS)
+  })
+})
+
+describe('coreSettingsModule.validateSettings', () => {
+  const validate = (raw: unknown): PluginSettings => {
+    const fn = coreSettingsModule.validateSettings
+    if (!fn) throw new Error('validateSettings is undefined')
+    return fn(raw)
+  }
+
+  it('returns DEFAULT_SETTINGS for empty object input', () => {
+    expect(validate({})).toEqual(DEFAULT_SETTINGS)
+  })
+
+  it('returns DEFAULT_SETTINGS for null input', () => {
+    expect(validate(null)).toEqual(DEFAULT_SETTINGS)
+  })
+
+  it('returns DEFAULT_SETTINGS for undefined input', () => {
+    expect(validate(undefined)).toEqual(DEFAULT_SETTINGS)
+  })
+
+  it('coerces whitespace-only specsFolder to the default', () => {
+    const out = validate({ specsFolder: '   ' })
+    expect(out.specsFolder).toBe(DEFAULT_SETTINGS.specsFolder)
+  })
+
+  it('coerces empty string specsFolder to the default', () => {
+    const out = validate({ specsFolder: '' })
+    expect(out.specsFolder).toBe(DEFAULT_SETTINGS.specsFolder)
+  })
+
+  it('coerces non-string locale to the default', () => {
+    const out = validate({ locale: 123 })
+    expect(out.locale).toBe(DEFAULT_SETTINGS.locale)
+  })
+
+  it('trims valid string fields', () => {
+    const out = validate({
+      specsFolder: '  foo  ',
+      archiveFolder: '\tbar\n',
+      decisionsFolder: '  baz',
+      constitutionFile: 'CONST.md  ',
+      locale: '  de  ',
+    })
+    expect(out.specsFolder).toBe('foo')
+    expect(out.archiveFolder).toBe('bar')
+    expect(out.decisionsFolder).toBe('baz')
+    expect(out.constitutionFile).toBe('CONST.md')
+    expect(out.locale).toBe('de')
+  })
+
+  it('falls back to default gateStrictness when invalid', () => {
+    const out = validate({ gateStrictness: 'bogus' })
+    expect(out.gateStrictness).toBe(DEFAULT_SETTINGS.gateStrictness)
+  })
+
+  it("keeps gateStrictness 'lenient' when valid", () => {
+    const out = validate({ gateStrictness: 'lenient' })
+    expect(out.gateStrictness).toBe('lenient')
+  })
+
+  it("keeps gateStrictness 'strict' when valid", () => {
+    const out = validate({ gateStrictness: 'strict' })
+    expect(out.gateStrictness).toBe('strict')
+  })
+
+  it('falls back to default logLevel when invalid', () => {
+    const out = validate({ logLevel: 'trace' })
+    expect(out.logLevel).toBe(DEFAULT_SETTINGS.logLevel)
+  })
+
+  it.each(['debug', 'info', 'warn', 'error'] as const)(
+    "keeps logLevel '%s' when valid",
+    (level) => {
+      const out = validate({ logLevel: level })
+      expect(out.logLevel).toBe(level)
+    },
+  )
+
+  it('falls back to default teamMode when non-boolean', () => {
+    const out = validate({ teamMode: 'yes' })
+    expect(out.teamMode).toBe(DEFAULT_SETTINGS.teamMode)
+  })
+
+  it('preserves teamMode=true when boolean', () => {
+    const out = validate({ teamMode: true })
+    expect(out.teamMode).toBe(true)
+  })
+
+  it('preserves teamMode=false when boolean', () => {
+    const out = validate({ teamMode: false })
+    expect(out.teamMode).toBe(false)
+  })
+})
+
+describe('coreSettingsModule.settingsSchema', () => {
+  it('exposes 8 field descriptors', () => {
+    expect(coreSettingsModule.settingsSchema?.fields).toHaveLength(8)
+  })
+
+  it('every field key is a valid PluginSettings key', () => {
+    const validKeys = Object.keys(DEFAULT_SETTINGS) as ReadonlyArray<keyof PluginSettings>
+    const fieldKeys = coreSettingsModule.settingsSchema?.fields.map((f) => f.key) ?? []
+    expect(fieldKeys).toHaveLength(8)
+    for (const k of fieldKeys) {
+      expect(validKeys).toContain(k as keyof PluginSettings)
+    }
+  })
+
+  it('every field default matches DEFAULT_SETTINGS for its key', () => {
+    const fields = coreSettingsModule.settingsSchema?.fields ?? []
+    for (const field of fields) {
+      expect(field.default).toEqual(
+        (DEFAULT_SETTINGS as unknown as Record<string, unknown>)[field.key],
+      )
+    }
+  })
+})
+
+describe('coreSettingsModule.init', () => {
+  it('returns void without throwing when invoked with valid ports and defaults', () => {
+    const ports = fakeModulePorts()
+    const defaults = coreSettingsModule.settingsDefaults
+    if (!defaults) throw new Error('settingsDefaults is undefined')
+    expect(() => coreSettingsModule.init(ports, defaults)).not.toThrow()
+  })
+})

--- a/tests/modules/hello/hello-module.test.ts
+++ b/tests/modules/hello/hello-module.test.ts
@@ -1,8 +1,55 @@
+import '@/modules/hello/hello-events' // load EventMap augmentation
 import { describe, it, expect } from 'vitest'
 import { helloModule } from '@/modules/hello/hello-module'
 import { fakeModulePorts } from '../../__fakes__/fake-ports'
 
-describe('helloModule', () => {
+describe('helloModule descriptor metadata', () => {
+  it("has id='hello', settingsKey='hello', settingsVersion=1", () => {
+    expect(helloModule.id).toBe('hello')
+    expect(helloModule.settingsKey).toBe('hello')
+    expect(helloModule.settingsVersion).toBe(1)
+  })
+
+  it('has settingsDefaults { showBadge: true }', () => {
+    expect(helloModule.settingsDefaults).toEqual({ showBadge: true })
+  })
+})
+
+describe('helloModule.validateSettings', () => {
+  const validate = (raw: unknown) => {
+    const fn = helloModule.validateSettings
+    if (!fn) throw new Error('validateSettings is undefined')
+    return fn(raw)
+  }
+
+  it('preserves explicit showBadge=false', () => {
+    expect(validate({ showBadge: false })).toEqual({ showBadge: false })
+  })
+
+  it('preserves explicit showBadge=true', () => {
+    expect(validate({ showBadge: true })).toEqual({ showBadge: true })
+  })
+
+  it('coerces non-boolean showBadge to true', () => {
+    expect(validate({ showBadge: 'yes' })).toEqual({ showBadge: true })
+    expect(validate({ showBadge: 0 })).toEqual({ showBadge: true })
+    expect(validate({ showBadge: null })).toEqual({ showBadge: true })
+  })
+
+  it('returns { showBadge: true } for null input', () => {
+    expect(validate(null)).toEqual({ showBadge: true })
+  })
+
+  it('returns { showBadge: true } for undefined input', () => {
+    expect(validate(undefined)).toEqual({ showBadge: true })
+  })
+
+  it('returns { showBadge: true } when the key is missing', () => {
+    expect(validate({})).toEqual({ showBadge: true })
+  })
+})
+
+describe('helloModule.init', () => {
   it('emits hello:initialized on init with the correct moduleId', () => {
     const ports = fakeModulePorts()
     const received: Array<{ moduleId: string }> = []
@@ -19,5 +66,34 @@ describe('helloModule', () => {
   it('has no destroy method (no bus subscriptions to clean up)', () => {
     const { destroy } = helloModule
     expect(destroy).toBeUndefined()
+  })
+})
+
+describe('helloModule shape', () => {
+  it("commands array contains 'hello:open-view'", () => {
+    const ids = helloModule.commands?.map((c) => c.id) ?? []
+    expect(ids).toContain('hello:open-view')
+  })
+
+  it("invoking the 'hello:open-view' command callback is a safe no-op", () => {
+    const cmd = helloModule.commands?.find((c) => c.id === 'hello:open-view')
+    expect(cmd).toBeDefined()
+    expect(() => { cmd!.callback() }).not.toThrow()
+  })
+
+  it("views array contains 'hello-view'", () => {
+    const ids = helloModule.views?.map((v) => v.id) ?? []
+    expect(ids).toContain('hello-view')
+  })
+
+  it("settingsSchema has a 'showBadge' toggle field", () => {
+    const field = helloModule.settingsSchema?.fields.find((f) => f.key === 'showBadge')
+    expect(field).toBeDefined()
+    expect(field?.type).toBe('toggle')
+  })
+
+  it("messages provide 'hello.title' for en and de", () => {
+    expect(helloModule.messages?.en?.['hello.title']).toBeDefined()
+    expect(helloModule.messages?.de?.['hello.title']).toBeDefined()
   })
 })

--- a/tests/modules/index.test.ts
+++ b/tests/modules/index.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { ALL_MODULES, helloModule, defineModule } from '@/modules'
+
+describe('@/modules barrel', () => {
+  it("ALL_MODULES includes the coreSettingsModule (id 'specorator')", () => {
+    const ids = ALL_MODULES.map((m) => m.id)
+    expect(ids).toContain('specorator')
+  })
+
+  it('ALL_MODULES includes the helloModule reference', () => {
+    expect(ALL_MODULES).toContain(helloModule)
+  })
+
+  it('all entries in ALL_MODULES have unique ids', () => {
+    const ids = ALL_MODULES.map((m) => m.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('every entry exposes an init function', () => {
+    for (const m of ALL_MODULES) {
+      expect(typeof m.init).toBe('function')
+    }
+  })
+
+  it('exports defineModule as a function', () => {
+    expect(typeof defineModule).toBe('function')
+  })
+
+  it('defineModule returns its descriptor unchanged', () => {
+    const desc = defineModule({ id: 'x', init: () => undefined })
+    expect(desc.id).toBe('x')
+    expect(typeof desc.init).toBe('function')
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `tests/core/core-settings.test.ts` and `tests/modules/index.test.ts`; extends `tests/modules/hello/hello-module.test.ts` with the missing init/validate cases.
- Closes the three 0–40% coverage holes in `src/core/core-settings.ts`, `src/modules/index.ts`, and `src/modules/hello/hello-module.ts` (all now 100%).

## Test plan
- [x] `npx vitest run tests/core/core-settings.test.ts tests/modules/index.test.ts tests/modules/hello/hello-module.test.ts` → 45/45 green
- [x] Targeted coverage ≥ 80/70/80/80 on all three source files
- [x] Full suite green

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)