### PR TITLE
feat(plugin-shell): adopt normalizePath() at the bridge boundary

### DIFF
--- a/src/infrastructure/obsidian/ObsidianBridge.ts
+++ b/src/infrastructure/obsidian/ObsidianBridge.ts
@@ -1,4 +1,4 @@
-import { Notice, TFile, TFolder, type App } from 'obsidian'
+import { Notice, TFile, TFolder, normalizePath, type App } from 'obsidian'
 import type { PluginSettings } from '@/domain/settings/PluginSettings'
 import type {
 	SettingsPort,
@@ -33,22 +33,25 @@ export class ObsidianBridge
   ) {}
 
   async readFile(path: string): Promise<string> {
-    const file = this.app.vault.getAbstractFileByPath(path)
-    if (!(file instanceof TFile)) throw new Error(`File not found: ${path}`)
+    const normalized = normalizePath(path)
+    const file = this.app.vault.getAbstractFileByPath(normalized)
+    if (!(file instanceof TFile)) throw new Error(`File not found: ${normalized}`)
     return this.app.vault.read(file)
   }
 
   async writeFile(path: string, content: string): Promise<void> {
-    const existing = this.app.vault.getAbstractFileByPath(path)
+    const normalized = normalizePath(path)
+    const existing = this.app.vault.getAbstractFileByPath(normalized)
     if (existing instanceof TFile) {
       await this.app.vault.modify(existing, content)
     } else {
-      await this.app.vault.create(path, content)
+      await this.app.vault.create(normalized, content)
     }
   }
 
   async deleteFile(path: string): Promise<void> {
-    const file = this.app.vault.getAbstractFileByPath(path)
+    const normalized = normalizePath(path)
+    const file = this.app.vault.getAbstractFileByPath(normalized)
     if (file instanceof TFile) {
       const fileManager = this.app.fileManager as FileManagerWithTrash
       if (typeof fileManager.trashFile === 'function') {
@@ -62,29 +65,34 @@ export class ObsidianBridge
   }
 
   async listFiles(folder: string): Promise<string[]> {
-    const dir = this.app.vault.getAbstractFileByPath(folder)
+    const normalized = normalizePath(folder)
+    const dir = this.app.vault.getAbstractFileByPath(normalized)
     if (!(dir instanceof TFolder)) return []
     return dir.children.filter((f): f is TFile => f instanceof TFile).map((f) => f.path)
   }
 
   async listFolders(parent: string): Promise<string[]> {
-    const dir = this.app.vault.getAbstractFileByPath(parent)
+    const normalized = normalizePath(parent)
+    const dir = this.app.vault.getAbstractFileByPath(normalized)
     if (!(dir instanceof TFolder)) return []
     return dir.children.filter((f): f is TFolder => f instanceof TFolder).map((f) => f.name)
   }
 
   async fileExists(path: string): Promise<boolean> {
-    return this.app.vault.getAbstractFileByPath(path) instanceof TFile
+    const normalized = normalizePath(path)
+    return this.app.vault.getAbstractFileByPath(normalized) instanceof TFile
   }
 
   async createFolder(path: string): Promise<void> {
-    if (!(this.app.vault.getAbstractFileByPath(path) instanceof TFolder)) {
-      await this.app.vault.createFolder(path)
+    const normalized = normalizePath(path)
+    if (!(this.app.vault.getAbstractFileByPath(normalized) instanceof TFolder)) {
+      await this.app.vault.createFolder(normalized)
     }
   }
 
   async openFile(path: string): Promise<void> {
-    const file = this.app.vault.getAbstractFileByPath(path)
+    const normalized = normalizePath(path)
+    const file = this.app.vault.getAbstractFileByPath(normalized)
     if (file instanceof TFile) {
       await this.app.workspace.getLeaf().openFile(file)
     }

--- a/tests/__fakes__/obsidian.stub.ts
+++ b/tests/__fakes__/obsidian.stub.ts
@@ -1,0 +1,43 @@
+/**
+ * Vitest stub for the `obsidian` package, which ships only `.d.ts` files in
+ * node_modules and has no runtime outside the Obsidian app itself. This stub
+ * is wired in via `vitest.config.ts` alias so that tests can exercise the
+ * real `ObsidianBridge` (or any other source file that imports from
+ * `'obsidian'`) without crashing Vite's import-analysis pass.
+ *
+ * The stub implements just enough surface for `ObsidianBridge`:
+ *   - `normalizePath` — matches Obsidian's documented behaviour (backslashes
+ *     to forward slashes, collapse runs of slashes, strip leading + trailing
+ *     slashes).
+ *   - `Notice`, `TFile`, `TFolder` — empty classes so `instanceof` checks
+ *     work and tests can construct sentinel instances.
+ *
+ * Individual tests that need richer behaviour can override entries with
+ * `vi.mock('obsidian', () => ({ ... }))`.
+ */
+
+export function normalizePath(path: string): string {
+  let p = path.replace(/\\/g, '/').replace(/\/+/g, '/')
+  if (p.startsWith('/')) p = p.slice(1)
+  if (p.length > 1 && p.endsWith('/')) p = p.slice(0, -1)
+  return p
+}
+
+export class Notice {
+  noticeEl = { addEventListener: () => {} }
+  constructor(_msg: string, _ms?: number) {}
+  hide(): void {}
+}
+
+export class TFile {
+  path = ''
+  basename = ''
+  extension = ''
+}
+
+export class TFolder {
+  children: unknown[] = []
+  name = ''
+}
+
+export type App = unknown

--- a/tests/__fakes__/obsidian.stub.ts
+++ b/tests/__fakes__/obsidian.stub.ts
@@ -6,9 +6,10 @@
  * `'obsidian'`) without crashing Vite's import-analysis pass.
  *
  * The stub implements just enough surface for `ObsidianBridge`:
- *   - `normalizePath` — matches Obsidian's documented behaviour (backslashes
- *     to forward slashes, collapse runs of slashes, strip leading + trailing
- *     slashes).
+ *   - `normalizePath` — matches Obsidian's behaviour for the cases this stub
+ *     exercises (backslashes to forward slashes, collapse runs of slashes,
+ *     strip leading + trailing slashes). Does NOT implement Obsidian's NBSP
+ *     replacement, Unicode NFC normalisation, or the empty-path → '/' case.
  *   - `Notice`, `TFile`, `TFolder` — empty classes so `instanceof` checks
  *     work and tests can construct sentinel instances.
  *

--- a/tests/infrastructure/obsidian/ObsidianBridge.normalizePath.test.ts
+++ b/tests/infrastructure/obsidian/ObsidianBridge.normalizePath.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { TFile, TFolder } from 'obsidian'
+import { ObsidianBridge } from '@/infrastructure/obsidian/ObsidianBridge'
+import type { PluginSettings } from '@/domain/settings/PluginSettings'
+
+// `obsidian` is aliased to `tests/__fakes__/obsidian.stub.ts` via
+// `vitest.config.ts`. The stub provides a real `normalizePath` (matching
+// Obsidian's documented behaviour) plus minimal class stubs for `TFile` /
+// `TFolder` / `Notice`. That lets us instantiate the real `ObsidianBridge`
+// against a fake `App` and assert that `vault.getAbstractFileByPath` /
+// `vault.create` / `vault.createFolder` receive normalized paths.
+
+type AbstractFile = object | null
+
+interface FakeVault {
+  getAbstractFileByPath: ReturnType<typeof vi.fn>
+  read: ReturnType<typeof vi.fn>
+  modify: ReturnType<typeof vi.fn>
+  create: ReturnType<typeof vi.fn>
+  createFolder: ReturnType<typeof vi.fn>
+  delete: ReturnType<typeof vi.fn>
+}
+
+interface FakeApp {
+  vault: FakeVault
+  fileManager: { trashFile: ReturnType<typeof vi.fn> }
+  workspace: {
+    getLeaf: () => { openFile: ReturnType<typeof vi.fn> }
+    getActiveFile: () => null
+    on: () => unknown
+    offref: () => void
+  }
+}
+
+function makeBridge(
+  opts: { fileLookup?: (path: string) => AbstractFile } = {},
+): { bridge: ObsidianBridge; app: FakeApp; openFile: ReturnType<typeof vi.fn> } {
+  const openFile = vi.fn().mockResolvedValue(undefined)
+  const lookup = opts.fileLookup ?? (() => null)
+  const app: FakeApp = {
+    vault: {
+      getAbstractFileByPath: vi.fn(lookup),
+      read: vi.fn().mockResolvedValue('file-contents'),
+      modify: vi.fn().mockResolvedValue(undefined),
+      create: vi.fn().mockResolvedValue(undefined),
+      createFolder: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+    },
+    fileManager: { trashFile: vi.fn().mockResolvedValue(undefined) },
+    workspace: {
+      getLeaf: () => ({ openFile }),
+      getActiveFile: () => null,
+      on: () => ({}),
+      offref: () => {},
+    },
+  }
+  const settings: PluginSettings = {
+    specsFolder: 'specs',
+    logLevel: 'warn',
+  } as PluginSettings
+  const bridge = new ObsidianBridge(
+    app as unknown as ConstructorParameters<typeof ObsidianBridge>[0],
+    () => settings,
+    async () => {},
+  )
+  return { bridge, app, openFile }
+}
+
+describe('ObsidianBridge.normalizePath integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('backslash inputs to forward slashes', () => {
+    it('readFile normalizes backslashes before vault lookup', async () => {
+      const file = new TFile()
+      const { bridge, app } = makeBridge({ fileLookup: () => file })
+      await bridge.readFile('foo\\bar.md')
+      expect(app.vault.getAbstractFileByPath).toHaveBeenCalledWith('foo/bar.md')
+    })
+  })
+
+  describe('leading slash stripped', () => {
+    it('writeFile normalizes leading slash before vault.create', async () => {
+      const { bridge, app } = makeBridge({ fileLookup: () => null })
+      await bridge.writeFile('/foo/bar.md', 'hello')
+      expect(app.vault.getAbstractFileByPath).toHaveBeenCalledWith('foo/bar.md')
+      expect(app.vault.create).toHaveBeenCalledWith('foo/bar.md', 'hello')
+    })
+
+    it('fileExists normalizes leading slash', async () => {
+      const file = new TFile()
+      const { bridge, app } = makeBridge({ fileLookup: () => file })
+      const result = await bridge.fileExists('/foo/bar.md')
+      expect(result).toBe(true)
+      expect(app.vault.getAbstractFileByPath).toHaveBeenCalledWith('foo/bar.md')
+    })
+  })
+
+  describe('trailing slash stripped', () => {
+    it('listFiles normalizes trailing slash on folder', async () => {
+      const folder = new TFolder()
+      folder.children = []
+      const { bridge, app } = makeBridge({ fileLookup: () => folder })
+      await bridge.listFiles('foo/bar/')
+      expect(app.vault.getAbstractFileByPath).toHaveBeenCalledWith('foo/bar')
+    })
+
+    it('listFolders normalizes trailing slash on parent', async () => {
+      const folder = new TFolder()
+      folder.children = []
+      const { bridge, app } = makeBridge({ fileLookup: () => folder })
+      await bridge.listFolders('foo/bar/')
+      expect(app.vault.getAbstractFileByPath).toHaveBeenCalledWith('foo/bar')
+    })
+
+    it('createFolder normalizes trailing slash before createFolder call', async () => {
+      const { bridge, app } = makeBridge({ fileLookup: () => null })
+      await bridge.createFolder('foo/bar/')
+      expect(app.vault.getAbstractFileByPath).toHaveBeenCalledWith('foo/bar')
+      expect(app.vault.createFolder).toHaveBeenCalledWith('foo/bar')
+    })
+  })
+
+  describe('duplicate slashes collapsed', () => {
+    it('deleteFile normalizes duplicate slashes', async () => {
+      const file = new TFile()
+      const { bridge, app } = makeBridge({ fileLookup: () => file })
+      await bridge.deleteFile('foo//bar.md')
+      expect(app.vault.getAbstractFileByPath).toHaveBeenCalledWith('foo/bar.md')
+      expect(app.fileManager.trashFile).toHaveBeenCalledWith(file)
+    })
+
+    it('openFile normalizes duplicate slashes', async () => {
+      const file = new TFile()
+      const { bridge, app, openFile } = makeBridge({ fileLookup: () => file })
+      await bridge.openFile('foo//bar.md')
+      expect(app.vault.getAbstractFileByPath).toHaveBeenCalledWith('foo/bar.md')
+      expect(openFile).toHaveBeenCalledWith(file)
+    })
+  })
+
+  describe('readFile error message reports normalized path', () => {
+    it('throws with normalized path, not the raw input', async () => {
+      const { bridge } = makeBridge({ fileLookup: () => null })
+      await expect(bridge.readFile('\\foo//bar.md/')).rejects.toThrow(
+        'File not found: foo/bar.md',
+      )
+    })
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,14 @@ import { fileURLToPath } from 'node:url'
 import { resolve } from 'path'
 
 const projectRoot = fileURLToPath(new URL('.', import.meta.url))
-const alias = { '@': resolve(projectRoot, 'src') }
+const alias = {
+  '@': resolve(projectRoot, 'src'),
+  // `obsidian` ships only `.d.ts` files in node_modules — no runtime. Map the
+  // import to a lightweight stub so tests that exercise the real
+  // `ObsidianBridge` (or anything that imports from `'obsidian'`) can run.
+  // Individual tests may override with `vi.mock('obsidian', ...)`.
+  obsidian: resolve(projectRoot, 'tests/__fakes__/obsidian.stub.ts'),
+}
 
 export default defineConfig({
   resolve: { alias },


### PR DESCRIPTION
## Summary
- All eight `ObsidianBridge` path-taking methods (`readFile`, `writeFile`, `deleteFile`, `listFiles`, `listFolders`, `fileExists`, `createFolder`, `openFile`) now run their path argument through Obsidian's `normalizePath()` before any vault call.
- Domain and application layers remain Obsidian-free — normalization happens once at the bridge boundary (ADR-008).
- Adds a runtime stub for the `'obsidian'` package so the real `ObsidianBridge` can be instantiated under vitest, plus a regression test for backslash / leading-slash / trailing-slash / duplicate-slash inputs across every method.

## Test plan
- [x] `npx vitest run tests/infrastructure/obsidian/ObsidianBridge.normalizePath.test.ts` → 9/9 green
- [x] Full suite green
- [x] `npm run lint` clean for touched files
- [x] No `from 'obsidian'` imports under `src/domain/` or `src/application/`

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)