### PR TITLE
fix(plugin-core): serialize _syncMcpRunning to prevent stop/start race

### DIFF
--- a/src/core/plugin-core.ts
+++ b/src/core/plugin-core.ts
@@ -195,6 +195,7 @@ export class PluginCore {
   private readonly uriDispatch = new Map<string, (params: URLSearchParams) => void>()
   private _initCalled = false
   private _mcpRunning = false
+  private _syncChain: Promise<void> = Promise.resolve()
 
   constructor(
     modules: ReadonlyArray<ModuleDescriptor>,
@@ -289,10 +290,19 @@ export class PluginCore {
   }
 
   /**
-   * Reconciles the MCP server's running state with `ports.isMcpServerEnabled()`.
-   * Called after a settings change that may have toggled the enabled flag.
+   * Enqueues a reconciliation onto a serial promise chain so that concurrent
+   * calls (e.g. rapid stop→start) never observe stale `_mcpRunning` state.
+   * Each enqueued reconciliation reads `isMcpServerEnabled()` fresh when it
+   * actually runs, so the last queued call always reflects the latest intent.
    */
-  private async _syncMcpRunning(): Promise<void> {
+  private _syncMcpRunning(): Promise<void> {
+    this._syncChain = this._syncChain
+      .then(() => this._doSyncMcpRunning())
+      .catch(() => { /* start/stop errors are logged inside those methods */ })
+    return this._syncChain
+  }
+
+  private async _doSyncMcpRunning(): Promise<void> {
     if (this.ports.mcpServer === undefined) return
     const desired = this.ports.isMcpServerEnabled?.() === true
     if (desired && !this._mcpRunning) {

--- a/tests/core/plugin-core-mcp.test.ts
+++ b/tests/core/plugin-core-mcp.test.ts
@@ -161,3 +161,38 @@ describe('PluginCore MCP server settings-toggle sync', () => {
     expect(core.isMcpServerRunning()).toBe(false)
   })
 })
+
+describe('PluginCore MCP server sync serialization', () => {
+  it('serializes concurrent sync calls — later start wins over an in-flight stop', async () => {
+    let enabled = true
+    let resolveStop: () => void = () => {}
+
+    const mcpServer: ObsidianMcpServerPort = {
+      start: async () => ({ port: 3001 }),
+      stop: () => new Promise<void>(resolve => { resolveStop = resolve }),
+      getConnectionConfig: () => ({ transport: 'http', url: 'http://127.0.0.1:3001/mcp' }),
+    }
+
+    const core = new PluginCore([coreSettingsModuleAsAny], makePorts({
+      mcpServer,
+      isMcpServerEnabled: () => enabled,
+    }))
+    await core.init({})
+    expect(core.isMcpServerRunning()).toBe(true)
+
+    // Trigger stop — stop() will block until resolveStop() is called.
+    enabled = false
+    const firstSync = core.notifySettingsChanged('specorator', { ...DEFAULT_SETTINGS, mcpServerEnabled: false })
+
+    // Before stop completes, queue a start.
+    enabled = true
+    const secondSync = core.notifySettingsChanged('specorator', { ...DEFAULT_SETTINGS, mcpServerEnabled: true })
+
+    // Unblock the pending stop.
+    resolveStop()
+    await Promise.all([firstSync, secondSync])
+
+    // The serialized chain processes stop then start — server must be running.
+    expect(core.isMcpServerRunning()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `_syncChain: Promise<void>` to `PluginCore` to serialize consecutive `_syncMcpRunning` calls
- Splits `_syncMcpRunning` into a public enqueue method and a private `_doSyncMcpRunning` executor
- Each queued call re-reads `isMcpServerEnabled()` at execution time — last queued call always wins

## Root cause

Rapid stop→start (e.g. two consecutive `notifySettingsChanged` calls) queued two `_syncMcpRunning` calls in parallel. The second observed `_mcpRunning === true` before the first stop completed, skipped `startMcpServer()`, and left the server stopped after the first call settled.

## Test

Regression test: slow blocking `stop()` + immediate start queued before stop resolves → server must be running after both settle. Fails without the fix; passes with it.

## Addresses

Codex P2 finding on PR #273 review (`plugin-core.ts:301` — serialize MCP sync to avoid lost start/stop transitions).

🤖 Resolved via `/issue:tackle 273`