### PR TITLE
docs: add Getting started section for marketplace readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ Specorator is not yet on the Obsidian community marketplace. While in v1 alpha y
 
 > Marketplace submission will follow once BRAT distribution has validated stability. Until then, BRAT is the only supported install path.
 
+## Getting started
+
+After installing via BRAT and enabling the plugin:
+
+1. A **Specorator** icon appears in the Obsidian ribbon. Click it to open the workflow cockpit, or run **Open Specorator** from the command palette.
+2. The cockpit lists your active features. Each feature tracks its current workflow stage — from idea through to retrospective — and surfaces the next required artifact.
+3. All generated content is plain Markdown inside your vault. You can read and edit artifacts directly whether or not the plugin is loaded.
+4. The **[browser demo](https://luis85.github.io/specorator/app/)** previews the full workflow UI without installing anything.
+
+> **v1 alpha:** The plugin shell is installed and loads. Full workflow cockpit features are in active development. Functionality may be limited until v1 is complete.
+
 ## MCP server (advanced, opt-in)
 
 Specorator can expose a local Model Context Protocol (MCP) endpoint so AI clients on the same machine can read and propose changes against your vault.


### PR DESCRIPTION
## Summary

- Adds a **Getting started** section to README between the BRAT install instructions and the MCP server section
- Covers: opening the cockpit, what the view shows, plain-Markdown note, link to browser demo, and an honest alpha-status note
- Satisfies the Phase 2 marketplace pre-submission checklist item: "README has usage instructions"

## Triage
- **Type:** chore (release infrastructure)
- **Priority:** high — blocks marketplace submission

## Phase 1 status
- ✅ BRAT install instructions — already existed in README before this PR
- ✅ Plugin ID `specorator` — confirmed unique in `obsidian-releases/community-plugins.json`
- ✅ `manifest.json` required fields — all present (`id`, `name`, `version`, `minAppVersion`, `description`, `author`, `authorUrl`, `isDesktopOnly`)
- ⏳ First release — use `/publish-release` after this PR merges
- ⏳ Smoke-test BRAT install — manual, post-release
- ⏳ Screenshot/GIF — to add after first release (requires running plugin)

Closes #274

🤖 Resolved via `/issue:tackle 274`