### PR TITLE
feat(ui): onboarding scaffold — settings fields, ClaudeCliPort, wizard shell

### DIFF
--- a/src/core/core-settings.ts
+++ b/src/core/core-settings.ts
@@ -23,20 +23,24 @@ export const coreSettingsModule = defineModule<PluginSettings>({
    * user choice.
    *
    * v2 → v3: introduces `onboardingComplete`. Default it to `true` for
-   * upgrading installs (fromVersion >= 1) so existing users are not forced
-   * through the wizard on next launch. Fresh installs (fromVersion === 0,
-   * no stored data) are left without the key so validateSettings falls
-   * through to DEFAULT_SETTINGS.onboardingComplete (false) and the wizard
-   * runs normally.
+   * upgrading installs so existing users are not forced through the wizard on
+   * next launch. "Upgrading" means fromVersion >= 1 OR fromVersion === 0 with
+   * a non-empty blob (unversioned existing installs never stored a version key
+   * and therefore arrive as v0 even though they have real settings). Fresh
+   * installs arrive as v0 with a null or empty blob and are left without the
+   * key so validateSettings falls through to DEFAULT_SETTINGS.onboardingComplete
+   * (false) and the wizard runs normally.
    */
   migrate(fromVersion: number, blob: unknown): unknown {
-    const out = (blob !== null && typeof blob === 'object' && !Array.isArray(blob)
+    const isObjectBlob = blob !== null && typeof blob === 'object' && !Array.isArray(blob)
+    const out = (isObjectBlob
       ? { ...(blob as Record<string, unknown>) }
       : {}) as Record<string, unknown>
     if (fromVersion < 2 && !('mcpServerEnabled' in out)) {
       out.mcpServerEnabled = false
     }
-    if (fromVersion >= 1 && fromVersion < 3 && !('onboardingComplete' in out)) {
+    const hadExistingData = isObjectBlob && Object.keys(blob as object).length > 0
+    if ((fromVersion >= 1 || (fromVersion === 0 && hadExistingData)) && fromVersion < 3 && !('onboardingComplete' in out)) {
       out.onboardingComplete = true
     }
     return out

--- a/src/core/core-settings.ts
+++ b/src/core/core-settings.ts
@@ -49,6 +49,11 @@ export const coreSettingsModule = defineModule<PluginSettings>({
         : DEFAULT_SETTINGS.logLevel,
       mcpServerEnabled:
         typeof r.mcpServerEnabled === 'boolean' ? r.mcpServerEnabled : DEFAULT_SETTINGS.mcpServerEnabled,
+      userPersona: typeof r.userPersona === 'string' ? r.userPersona : DEFAULT_SETTINGS.userPersona,
+      onboardingComplete:
+        typeof r.onboardingComplete === 'boolean'
+          ? r.onboardingComplete
+          : DEFAULT_SETTINGS.onboardingComplete,
     }
   },
 
@@ -131,6 +136,20 @@ export const coreSettingsModule = defineModule<PluginSettings>({
         description:
           'Allow local MCP clients to access your Specorator data via 127.0.0.1. Off by default for privacy.',
         default: DEFAULT_SETTINGS.mcpServerEnabled,
+      },
+      {
+        type: 'text',
+        key: 'userPersona',
+        label: 'User persona',
+        description: 'Your role or persona, used to personalise AI interactions.',
+        default: DEFAULT_SETTINGS.userPersona,
+      },
+      {
+        type: 'toggle',
+        key: 'onboardingComplete',
+        label: 'Onboarding complete',
+        description: 'Set automatically after the setup wizard finishes.',
+        default: DEFAULT_SETTINGS.onboardingComplete,
       },
     ],
   },

--- a/src/core/core-settings.ts
+++ b/src/core/core-settings.ts
@@ -11,7 +11,7 @@ function coerceString(value: unknown, fallback: string): string {
 export const coreSettingsModule = defineModule<PluginSettings>({
   id: 'specorator',
   settingsKey: 'specorator',
-  settingsVersion: 2,
+  settingsVersion: 3,
   settingsDefaults: { ...DEFAULT_SETTINGS },
 
   /**
@@ -21,6 +21,13 @@ export const coreSettingsModule = defineModule<PluginSettings>({
    * for upgrading installs so existing users do not silently start receiving
    * a local MCP server. Only inject when absent — never flip an existing
    * user choice.
+   *
+   * v2 → v3: introduces `onboardingComplete`. Default it to `true` for
+   * upgrading installs (fromVersion >= 1) so existing users are not forced
+   * through the wizard on next launch. Fresh installs (fromVersion === 0,
+   * no stored data) are left without the key so validateSettings falls
+   * through to DEFAULT_SETTINGS.onboardingComplete (false) and the wizard
+   * runs normally.
    */
   migrate(fromVersion: number, blob: unknown): unknown {
     const out = (blob !== null && typeof blob === 'object' && !Array.isArray(blob)
@@ -28,6 +35,9 @@ export const coreSettingsModule = defineModule<PluginSettings>({
       : {}) as Record<string, unknown>
     if (fromVersion < 2 && !('mcpServerEnabled' in out)) {
       out.mcpServerEnabled = false
+    }
+    if (fromVersion >= 1 && fromVersion < 3 && !('onboardingComplete' in out)) {
+      out.onboardingComplete = true
     }
     return out
   },

--- a/src/core/core-settings.ts
+++ b/src/core/core-settings.ts
@@ -8,6 +8,12 @@ function coerceString(value: unknown, fallback: string): string {
   return typeof value === 'string' && value.trim() ? value.trim() : fallback
 }
 
+function toMutableBlob(blob: unknown): { out: Record<string, unknown>; hadData: boolean } {
+  const isObjectBlob = blob !== null && typeof blob === 'object' && !Array.isArray(blob)
+  const out: Record<string, unknown> = isObjectBlob ? { ...(blob as Record<string, unknown>) } : {}
+  return { out, hadData: isObjectBlob && Object.keys(out).length > 0 }
+}
+
 export const coreSettingsModule = defineModule<PluginSettings>({
   id: 'specorator',
   settingsKey: 'specorator',
@@ -32,15 +38,11 @@ export const coreSettingsModule = defineModule<PluginSettings>({
    * (false) and the wizard runs normally.
    */
   migrate(fromVersion: number, blob: unknown): unknown {
-    const isObjectBlob = blob !== null && typeof blob === 'object' && !Array.isArray(blob)
-    const out = (isObjectBlob
-      ? { ...(blob as Record<string, unknown>) }
-      : {}) as Record<string, unknown>
+    const { out, hadData } = toMutableBlob(blob)
     if (fromVersion < 2 && !('mcpServerEnabled' in out)) {
       out.mcpServerEnabled = false
     }
-    const hadExistingData = isObjectBlob && Object.keys(blob as object).length > 0
-    if ((fromVersion >= 1 || (fromVersion === 0 && hadExistingData)) && fromVersion < 3 && !('onboardingComplete' in out)) {
+    if ((fromVersion >= 1 || (fromVersion === 0 && hadData)) && fromVersion < 3 && !('onboardingComplete' in out)) {
       out.onboardingComplete = true
     }
     return out

--- a/src/domain/ports/ClaudeCliPort.ts
+++ b/src/domain/ports/ClaudeCliPort.ts
@@ -1,0 +1,3 @@
+export interface ClaudeCliPort {
+	isAvailable(): Promise<boolean>
+}

--- a/src/domain/ports/index.ts
+++ b/src/domain/ports/index.ts
@@ -18,3 +18,4 @@ export type { MetadataCachePort, FileMetadataSnapshot } from './metadata-cache-p
 export type { CanvasPort, JsonCanvasData } from './canvas-port'
 export type { ObsidianMcpServerPort, McpConnectionConfig } from './obsidian-mcp-server-port'
 export type { CommunityPluginPort } from './CommunityPluginPort'
+export type { ClaudeCliPort } from './ClaudeCliPort'

--- a/src/domain/settings/PluginSettings.ts
+++ b/src/domain/settings/PluginSettings.ts
@@ -18,6 +18,8 @@ export interface PluginSettings {
 	 * command. See README "MCP server (advanced, opt-in)".
 	 */
 	readonly mcpServerEnabled: boolean
+	readonly userPersona: string
+	readonly onboardingComplete: boolean
 }
 
 export const DEFAULT_SETTINGS: PluginSettings = {
@@ -30,4 +32,6 @@ export const DEFAULT_SETTINGS: PluginSettings = {
 	teamMode: false,
 	logLevel: 'warn',
 	mcpServerEnabled: false,
+	userPersona: '',
+	onboardingComplete: false,
 }

--- a/src/infrastructure/bridge/ports.ts
+++ b/src/infrastructure/bridge/ports.ts
@@ -8,6 +8,7 @@ import type {
 	MetadataCachePort,
 	CanvasPort,
 	CommunityPluginPort,
+	ClaudeCliPort,
 } from '@/domain/ports'
 
 export const SETTINGS_PORT: InjectionKey<SettingsPort> = Symbol('SettingsPort')
@@ -18,3 +19,4 @@ export const LOGGER_PORT: InjectionKey<LoggerPort> = Symbol('LoggerPort')
 export const METADATA_CACHE_PORT: InjectionKey<MetadataCachePort> = Symbol('MetadataCachePort')
 export const CANVAS_PORT: InjectionKey<CanvasPort> = Symbol('CanvasPort')
 export const COMMUNITY_PLUGIN_PORT: InjectionKey<CommunityPluginPort> = Symbol('CommunityPluginPort')
+export const CLAUDE_CLI_PORT: InjectionKey<ClaudeCliPort> = Symbol('ClaudeCliPort')

--- a/src/infrastructure/localstorage/LocalStorageBridge.ts
+++ b/src/infrastructure/localstorage/LocalStorageBridge.ts
@@ -6,6 +6,7 @@ import type {
 	LoggerPort,
 	ActiveFileSnapshot,
 	Unsubscriber,
+	ClaudeCliPort,
 } from '@/domain/ports'
 import { type PluginSettings, DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
 
@@ -13,7 +14,7 @@ const FILE_PREFIX = 'specorator:file:'
 const SETTINGS_KEY = 'specorator:settings'
 
 export class LocalStorageBridge
-	implements SettingsPort, VaultPort, WorkspacePort, NotificationPort, LoggerPort
+	implements SettingsPort, VaultPort, WorkspacePort, NotificationPort, LoggerPort, ClaudeCliPort
 {
   async readFile(path: string): Promise<string> {
     const value = localStorage.getItem(FILE_PREFIX + path)
@@ -143,4 +144,10 @@ export class LocalStorageBridge
   }
 
   /* eslint-enable obsidianmd/rule-custom-message */
+
+  // ── ClaudeCliPort ─────────────────────────────────────────────────────────
+
+  isAvailable(): Promise<boolean> {
+    return Promise.resolve(false)
+  }
 }

--- a/src/infrastructure/mock/MockBridge.ts
+++ b/src/infrastructure/mock/MockBridge.ts
@@ -6,6 +6,7 @@ import type {
 	LoggerPort,
 	ActiveFileSnapshot,
 	Unsubscriber,
+	ClaudeCliPort,
 } from '@/domain/ports'
 import { type PluginSettings, DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
 
@@ -14,7 +15,7 @@ import { type PluginSettings, DEFAULT_SETTINGS } from '@/domain/settings/PluginS
  * Provides test helper methods for inspecting state.
  */
 export class MockBridge
-	implements SettingsPort, VaultPort, WorkspacePort, NotificationPort, LoggerPort
+	implements SettingsPort, VaultPort, WorkspacePort, NotificationPort, LoggerPort, ClaudeCliPort
 {
   private readonly files = new Map<string, string>()
   private readonly folders = new Set<string>()
@@ -194,5 +195,11 @@ export class MockBridge
   error(message: string, error?: unknown, context?: Record<string, unknown>): void {
     this.logEntries.push({ level: 'error', message, error, context })
     console.error(`[MockBridge] ${message}`, error, context)
+  }
+
+  // ── ClaudeCliPort ─────────────────────────────────────────────────────────
+
+  isAvailable(): Promise<boolean> {
+    return Promise.resolve(false)
   }
 }

--- a/src/infrastructure/mock/MockBridge.ts
+++ b/src/infrastructure/mock/MockBridge.ts
@@ -11,12 +11,17 @@ import type {
 } from '@/domain/ports'
 import { type PluginSettings, DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
 
+function folderPrefix(parent: string): string {
+  if (parent === '') return ''
+  return parent.endsWith('/') ? parent : `${parent}/`
+}
+
 /**
  * In-memory bridge used in standalone dev mode and unit tests.
  * Provides test helper methods for inspecting state.
  */
 export class MockBridge
-	implements SettingsPort, VaultPort, WorkspacePort, NotificationPort, LoggerPort, CommunityPluginPort, ClaudeCliPort
+	implements SettingsPort, VaultPort, WorkspacePort, NotificationPort, LoggerPort, ClaudeCliPort, CommunityPluginPort
 {
   private readonly files = new Map<string, string>()
   private readonly folders = new Set<string>()
@@ -71,15 +76,19 @@ export class MockBridge
   }
 
   async listFolders(parent: string): Promise<string[]> {
-    const prefix = parent.endsWith('/') ? parent : `${parent}/`
+    const prefix = folderPrefix(parent)
     const names = new Set<string>()
+    for (const folder of this.folders) {
+      if (folder.startsWith(prefix)) {
+        const rest = folder.slice(prefix.length)
+        if (rest && !rest.includes('/')) names.add(rest)
+      }
+    }
     for (const path of this.files.keys()) {
-      if (path.startsWith(prefix)) {
+      if (!prefix || path.startsWith(prefix)) {
         const rest = path.slice(prefix.length)
         const firstSegment = rest.split('/')[0]
-        if (firstSegment && rest.includes('/')) {
-          names.add(firstSegment)
-        }
+        if (firstSegment && rest.includes('/')) names.add(firstSegment)
       }
     }
     return [...names]
@@ -155,7 +164,7 @@ export class MockBridge
     this.settings = { ...settings }
   }
 
-  // ── Test helpers ──────────────────────────────────────────────────────────
+  // ── Test helpers ─────────────────────────────────────────────────────────────
 
   getNotices(): {
     severity: 'error' | 'warning' | 'success' | 'info'
@@ -177,7 +186,7 @@ export class MockBridge
     this.settings = { ...this.settings, ...partial }
   }
 
-  // ── LoggerPort ────────────────────────────────────────────────────────────
+  // ── LoggerPort ───────────────────────────────────────────────────────────────
 
   debug(message: string, context?: Record<string, unknown>): void {
     this.logEntries.push({ level: 'debug', message, context })
@@ -199,6 +208,12 @@ export class MockBridge
     console.error(`[MockBridge] ${message}`, error, context)
   }
 
+  // ── ClaudeCliPort ─────────────────────────────────────────────────────────
+
+  isAvailable(): Promise<boolean> {
+    return Promise.resolve(false)
+  }
+
   // ── CommunityPluginPort ───────────────────────────────────────────────────
 
   isPluginEnabled(id: string): boolean {
@@ -211,11 +226,5 @@ export class MockBridge
 
   seedEnabledPlugins(ids: string[]): void {
     this.enabledPluginIds = new Set(ids)
-  }
-
-  // ── ClaudeCliPort ─────────────────────────────────────────────────────────
-
-  isAvailable(): Promise<boolean> {
-    return Promise.resolve(false)
   }
 }

--- a/src/infrastructure/obsidian/ObsidianBridge.ts
+++ b/src/infrastructure/obsidian/ObsidianBridge.ts
@@ -8,6 +8,7 @@ import type {
 	LoggerPort,
 	ActiveFileSnapshot,
 	Unsubscriber,
+	ClaudeCliPort,
 } from '@/domain/ports'
 
 type FileManagerWithTrash = App['fileManager'] & {
@@ -15,7 +16,7 @@ type FileManagerWithTrash = App['fileManager'] & {
 }
 
 export class ObsidianBridge
-  implements SettingsPort, VaultPort, WorkspacePort, NotificationPort, LoggerPort
+  implements SettingsPort, VaultPort, WorkspacePort, NotificationPort, LoggerPort, ClaudeCliPort
 {
   private static readonly _LEVEL_RANK: Record<string, number> = {
     debug: 0,
@@ -191,4 +192,18 @@ export class ObsidianBridge
   }
 
   /* eslint-enable obsidianmd/rule-custom-message */
+
+  // ── ClaudeCliPort ─────────────────────────────────────────────────────────
+
+  isAvailable(): Promise<boolean> {
+    const timeoutMs = 5000
+    const deadline = new Promise<boolean>((resolve) => {
+      activeWindow.setTimeout(() => { resolve(false) }, timeoutMs)
+    })
+    const { exec } = require('node:child_process') as { exec: (cmd: string, cb: (err: Error | null) => void) => void }
+    const check = new Promise<boolean>((resolve) => {
+      exec('claude --version', (err) => { resolve(err === null) })
+    })
+    return Promise.race([check, deadline])
+  }
 }

--- a/src/infrastructure/obsidian/ObsidianBridge.ts
+++ b/src/infrastructure/obsidian/ObsidianBridge.ts
@@ -223,14 +223,10 @@ export class ObsidianBridge
   // ── ClaudeCliPort ─────────────────────────────────────────────────────────
 
   isAvailable(): Promise<boolean> {
-    const timeoutMs = 5000
-    const deadline = new Promise<boolean>((resolve) => {
-      activeWindow.setTimeout(() => { resolve(false) }, timeoutMs)
+    type ExecFn = (cmd: string, opts: { timeout: number }, cb: (err: Error | null) => void) => void
+    const { exec } = require('node:child_process') as { exec: ExecFn }
+    return new Promise<boolean>((resolve) => {
+      exec('claude --version', { timeout: 5000 }, (err) => { resolve(err === null) })
     })
-    const { exec } = require('node:child_process') as { exec: (cmd: string, cb: (err: Error | null) => void) => void }
-    const check = new Promise<boolean>((resolve) => {
-      exec('claude --version', (err) => { resolve(err === null) })
-    })
-    return Promise.race([check, deadline])
   }
 }

--- a/src/plugin/SpecoratorView.ts
+++ b/src/plugin/SpecoratorView.ts
@@ -10,6 +10,7 @@ import {
   WORKSPACE_PORT,
   NOTIFICATION_PORT,
   LOGGER_PORT,
+  CLAUDE_CLI_PORT,
 } from '@/infrastructure/bridge/ports'
 import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
 import { FeatureService } from '@/application/feature/FeatureService'
@@ -56,6 +57,7 @@ export class SpecoratorView extends ItemView {
     this.vueApp.provide(WORKSPACE_PORT, bridge)
     this.vueApp.provide(NOTIFICATION_PORT, bridge)
     this.vueApp.provide(LOGGER_PORT, bridge)
+    this.vueApp.provide(CLAUDE_CLI_PORT, bridge)
     this.vueApp.provide(
       FEATURE_SERVICE_KEY,
       new FeatureService(new FeatureRepository(bridge, bridge, bridge)),

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -92,11 +92,10 @@ export default class SpecoratorPlugin extends Plugin {
       id: 're-run-setup',
       name: 'Re-run setup',
       callback: () => {
-        void this.updateSettings({ onboardingComplete: false }).then(() =>
-          this.activateView().then(() => {
-            this._dispatchNavigate('/onboarding')
-          }),
-        )
+        void this.updateSettings({ onboardingComplete: false })
+          .then(() => this.activateView())
+          .then(() => { this._dispatchNavigate('/onboarding') })
+          .catch(() => { this.bridge?.showError('Failed to re-run setup. Please try again.') })
       },
     })
 
@@ -124,9 +123,9 @@ export default class SpecoratorPlugin extends Plugin {
     this.app.workspace.onLayoutReady(() => {
       this.detectLegacyVaultLayout()
       if (!this.settings.onboardingComplete) {
-        void this.activateView().then(() => {
-          this._dispatchNavigate('/onboarding')
-        })
+        void this.activateView()
+          .then(() => { this._dispatchNavigate('/onboarding') })
+          .catch(() => { this.bridge?.showError('Failed to open onboarding. Please reopen the panel.') })
       }
     })
   }

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -94,7 +94,7 @@ export default class SpecoratorPlugin extends Plugin {
       callback: () => {
         void this.updateSettings({ onboardingComplete: false }).then(() =>
           this.activateView().then(() => {
-            activeWindow.dispatchEvent(new CustomEvent('sp:navigate', { detail: { path: '/onboarding' } }))
+            this._dispatchNavigate('/onboarding')
           }),
         )
       },
@@ -125,7 +125,7 @@ export default class SpecoratorPlugin extends Plugin {
       this.detectLegacyVaultLayout()
       if (!this.settings.onboardingComplete) {
         void this.activateView().then(() => {
-          activeWindow.dispatchEvent(new CustomEvent('sp:navigate', { detail: { path: '/onboarding' } }))
+          this._dispatchNavigate('/onboarding')
         })
       }
     })
@@ -190,6 +190,13 @@ export default class SpecoratorPlugin extends Plugin {
         8000,
       )
     }
+  }
+
+  private _dispatchNavigate(path: string): void {
+    const win =
+      this.app.workspace.getLeavesOfType(VIEW_TYPE)[0]?.view?.containerEl?.ownerDocument?.defaultView ??
+      activeWindow
+    win.dispatchEvent(new CustomEvent('sp:navigate', { detail: { path } }))
   }
 
   private async activateView(): Promise<void> {

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -88,6 +88,14 @@ export default class SpecoratorPlugin extends Plugin {
       callback: () => void this.updateSettings({ mcpServerEnabled: false }),
     })
 
+    this.addCommand({
+      id: 're-run-setup',
+      name: 'Re-run setup',
+      callback: () => {
+        void this.updateSettings({ onboardingComplete: false }).then(() => this.activateView())
+      },
+    })
+
     this.addSettingTab(new SpecoratorSettingTab(this.app, this))
 
     this.registerObsidianProtocolHandler('specorator', (params) => {
@@ -111,6 +119,9 @@ export default class SpecoratorPlugin extends Plugin {
     // logic that reads workspace layout or vault state until layout is ready.
     this.app.workspace.onLayoutReady(() => {
       this.detectLegacyVaultLayout()
+      if (!this.settings.onboardingComplete) {
+        void this.activateView()
+      }
     })
   }
 

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -92,7 +92,11 @@ export default class SpecoratorPlugin extends Plugin {
       id: 're-run-setup',
       name: 'Re-run setup',
       callback: () => {
-        void this.updateSettings({ onboardingComplete: false }).then(() => this.activateView())
+        void this.updateSettings({ onboardingComplete: false }).then(() =>
+          this.activateView().then(() => {
+            activeWindow.dispatchEvent(new CustomEvent('sp:navigate', { detail: { path: '/onboarding' } }))
+          }),
+        )
       },
     })
 
@@ -120,7 +124,9 @@ export default class SpecoratorPlugin extends Plugin {
     this.app.workspace.onLayoutReady(() => {
       this.detectLegacyVaultLayout()
       if (!this.settings.onboardingComplete) {
-        void this.activateView()
+        void this.activateView().then(() => {
+          activeWindow.dispatchEvent(new CustomEvent('sp:navigate', { detail: { path: '/onboarding' } }))
+        })
       }
     })
   }

--- a/src/ui/AppRoot.vue
+++ b/src/ui/AppRoot.vue
@@ -4,10 +4,12 @@ import { RouterView, useRoute, useRouter } from 'vue-router'
 import AppToast from './components/common/AppToast.vue'
 import MainLayout from './layouts/MainLayout.vue'
 import { useNotificationStore } from './stores/notificationStore'
+import { useSettingsPort } from './composables/useSettingsPort'
 
 const route = useRoute()
 const router = useRouter()
 const notificationStore = useNotificationStore()
+const settingsPort = useSettingsPort()
 
 const layout = computed<Component>(() => route.meta.layout ?? MainLayout)
 
@@ -25,9 +27,13 @@ function onOpenFile(e: Event) {
   void router.push({ name: 'file', params: { filePath: path } })
 }
 
-onMounted(() => {
+onMounted(async () => {
   window.addEventListener('sp:notice', onNotice)
   window.addEventListener('sp:open-file', onOpenFile)
+  const s = await settingsPort.getSettings()
+  if (!s.onboardingComplete) {
+    void router.push('/onboarding')
+  }
 })
 
 onUnmounted(() => {

--- a/src/ui/AppRoot.vue
+++ b/src/ui/AppRoot.vue
@@ -27,9 +27,15 @@ function onOpenFile(e: Event) {
   void router.push({ name: 'file', params: { filePath: path } })
 }
 
+function onNavigate(e: Event) {
+  const { path } = (e as CustomEvent<{ path: string }>).detail
+  void router.push(path)
+}
+
 onMounted(async () => {
   window.addEventListener('sp:notice', onNotice)
   window.addEventListener('sp:open-file', onOpenFile)
+  window.addEventListener('sp:navigate', onNavigate)
   const s = await settingsPort.getSettings()
   if (!s.onboardingComplete) {
     void router.push('/onboarding')
@@ -39,6 +45,7 @@ onMounted(async () => {
 onUnmounted(() => {
   window.removeEventListener('sp:notice', onNotice)
   window.removeEventListener('sp:open-file', onOpenFile)
+  window.removeEventListener('sp:navigate', onNavigate)
 })
 </script>
 

--- a/src/ui/components/OnboardingStep1Welcome.vue
+++ b/src/ui/components/OnboardingStep1Welcome.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+const emit = defineEmits<{ next: [] }>()
+</script>
+<template>
+	<div data-testid="step1-placeholder">
+		<button data-testid="step1-cta" @click="emit('next')">Let's get started</button>
+	</div>
+</template>

--- a/src/ui/components/OnboardingStep2Persona.vue
+++ b/src/ui/components/OnboardingStep2Persona.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+defineProps<{ initialValue: string }>()
+const emit = defineEmits<{ next: [payload: { skipped: boolean }] }>()
+</script>
+<template>
+	<div data-testid="step2-placeholder">
+		<button data-testid="step2-continue" @click="emit('next', { skipped: false })">Continue</button>
+		<button data-testid="step2-skip" @click="emit('next', { skipped: true })">Skip</button>
+	</div>
+</template>

--- a/src/ui/components/OnboardingStep3ClaudeCheck.vue
+++ b/src/ui/components/OnboardingStep3ClaudeCheck.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+const emit = defineEmits<{ next: [payload: { claudeStatus: 'ready' | 'not-ready' | 'unknown' }] }>()
+</script>
+<template>
+	<div data-testid="step3-placeholder">
+		<button data-testid="step3-continue" @click="emit('next', { claudeStatus: 'unknown' })">Continue</button>
+	</div>
+</template>

--- a/src/ui/components/OnboardingStep4Workspace.vue
+++ b/src/ui/components/OnboardingStep4Workspace.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+defineProps<{ initialSpecsFolder: string }>()
+const emit = defineEmits<{ next: [payload: { templateStatus: 'installed' | 'skipped' | 'failed'; specsFolder: string }] }>()
+</script>
+<template>
+	<div data-testid="step4-placeholder">
+		<button data-testid="step4-skip-btn" @click="emit('next', { templateStatus: 'skipped', specsFolder: 'specs' })">Skip</button>
+	</div>
+</template>

--- a/src/ui/components/OnboardingStep5Done.vue
+++ b/src/ui/components/OnboardingStep5Done.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+defineProps<{
+	personaSkipped: boolean
+	claudeStatus: 'ready' | 'not-ready' | 'unknown'
+	templateStatus: 'installed' | 'skipped' | 'failed'
+}>()
+const emit = defineEmits<{ finish: [] }>()
+</script>
+<template>
+	<div data-testid="step5-placeholder">
+		<button data-testid="step5-cta" @click="emit('finish')">Start using Specorator</button>
+	</div>
+</template>

--- a/src/ui/components/OnboardingStepIndicator.vue
+++ b/src/ui/components/OnboardingStepIndicator.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+defineProps<{
+	current: number
+	total: number
+}>()
+</script>
+
+<template>
+	<p
+		class="sp-onboarding__step-indicator"
+		:aria-label="`Step ${current} of ${total}`"
+		data-testid="step-indicator"
+	>
+		Step {{ current }} of {{ total }}
+	</p>
+</template>
+
+<style scoped>
+.sp-onboarding__step-indicator {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+</style>

--- a/src/ui/components/OnboardingWizard.vue
+++ b/src/ui/components/OnboardingWizard.vue
@@ -2,6 +2,8 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useSettingsPort } from '@/ui/composables/useSettingsPort'
+import { useLoggerPort } from '@/ui/composables/useLoggerPort'
+import { tryAsync } from '@/domain/shared/tryAsync'
 import type { PluginSettings } from '@/domain/settings/PluginSettings'
 import OnboardingStepIndicator from './OnboardingStepIndicator.vue'
 import OnboardingStep1Welcome from './OnboardingStep1Welcome.vue'
@@ -17,6 +19,7 @@ interface Step3Payload { claudeStatus: ClaudeStatus }
 interface Step4Payload { templateStatus: TemplateStatus; specsFolder: string }
 
 const settingsPort = useSettingsPort()
+const logger = useLoggerPort()
 const router = useRouter()
 
 const TOTAL_STEPS = 5
@@ -51,9 +54,6 @@ onMounted(async () => {
 	const s = await settingsPort.getSettings()
 	settings.value = s
 	specsFolder.value = s.specsFolder
-	if (!s.onboardingComplete) {
-		void router.push('/onboarding')
-	}
 })
 
 function applyStep2(payload: unknown): void {
@@ -88,7 +88,14 @@ function handleNext(payload?: unknown): void {
 	}
 }
 
-function handleFinish(): void {
+async function handleFinish(): Promise<void> {
+	const result = await tryAsync(async () => {
+		const current = await settingsPort.getSettings()
+		await settingsPort.saveSettings({ ...current, onboardingComplete: true })
+	}, 'Failed to mark onboarding complete')
+	if (!result.ok) {
+		logger.error('Failed to mark onboarding complete', result.error)
+	}
 	void router.push('/')
 }
 </script>

--- a/src/ui/components/OnboardingWizard.vue
+++ b/src/ui/components/OnboardingWizard.vue
@@ -95,6 +95,7 @@ async function handleFinish(): Promise<void> {
 	}, 'Failed to mark onboarding complete')
 	if (!result.ok) {
 		logger.error('Failed to mark onboarding complete', result.error)
+		return
 	}
 	void router.push('/')
 }

--- a/src/ui/components/OnboardingWizard.vue
+++ b/src/ui/components/OnboardingWizard.vue
@@ -1,0 +1,124 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useSettingsPort } from '@/ui/composables/useSettingsPort'
+import type { PluginSettings } from '@/domain/settings/PluginSettings'
+import OnboardingStepIndicator from './OnboardingStepIndicator.vue'
+import OnboardingStep1Welcome from './OnboardingStep1Welcome.vue'
+import OnboardingStep2Persona from './OnboardingStep2Persona.vue'
+import OnboardingStep3ClaudeCheck from './OnboardingStep3ClaudeCheck.vue'
+import OnboardingStep4Workspace from './OnboardingStep4Workspace.vue'
+import OnboardingStep5Done from './OnboardingStep5Done.vue'
+
+type ClaudeStatus = 'ready' | 'not-ready' | 'unknown'
+type TemplateStatus = 'installed' | 'skipped' | 'failed'
+interface Step2Payload { skipped: boolean }
+interface Step3Payload { claudeStatus: ClaudeStatus }
+interface Step4Payload { templateStatus: TemplateStatus; specsFolder: string }
+
+const settingsPort = useSettingsPort()
+const router = useRouter()
+
+const TOTAL_STEPS = 5
+const currentStep = ref(1)
+const settings = ref<PluginSettings | null>(null)
+
+const personaSkipped = ref(false)
+const claudeStatus = ref<ClaudeStatus>('unknown')
+const templateStatus = ref<TemplateStatus>('skipped')
+const specsFolder = ref('specs')
+
+const stepComponents = [
+	OnboardingStep1Welcome,
+	OnboardingStep2Persona,
+	OnboardingStep3ClaudeCheck,
+	OnboardingStep4Workspace,
+	OnboardingStep5Done,
+]
+
+const currentStepComponent = computed(() => stepComponents[currentStep.value - 1])
+
+const stepProps = computed(() => {
+	switch (currentStep.value) {
+		case 2: return { initialValue: settings.value?.userPersona ?? '' }
+		case 4: return { initialSpecsFolder: specsFolder.value }
+		case 5: return { personaSkipped: personaSkipped.value, claudeStatus: claudeStatus.value, templateStatus: templateStatus.value }
+		default: return {}
+	}
+})
+
+onMounted(async () => {
+	const s = await settingsPort.getSettings()
+	settings.value = s
+	specsFolder.value = s.specsFolder
+	if (!s.onboardingComplete) {
+		void router.push('/onboarding')
+	}
+})
+
+function applyStep2(payload: unknown): void {
+	if (payload !== null && typeof payload === 'object' && 'skipped' in payload) {
+		personaSkipped.value = (payload as Step2Payload).skipped
+	}
+}
+
+function applyStep3(payload: unknown): void {
+	if (payload !== null && typeof payload === 'object' && 'claudeStatus' in payload) {
+		claudeStatus.value = (payload as Step3Payload).claudeStatus
+	}
+}
+
+function applyStep4(payload: unknown): void {
+	if (payload !== null && typeof payload === 'object' && 'templateStatus' in payload) {
+		const p = payload as Step4Payload
+		templateStatus.value = p.templateStatus
+		specsFolder.value = p.specsFolder
+	}
+}
+
+function handleNext(payload?: unknown): void {
+	const stepHandlers: Partial<Record<number, (p: unknown) => void>> = {
+		2: applyStep2,
+		3: applyStep3,
+		4: applyStep4,
+	}
+	stepHandlers[currentStep.value]?.(payload)
+	if (currentStep.value < TOTAL_STEPS) {
+		currentStep.value++
+	}
+}
+
+function handleFinish(): void {
+	void router.push('/')
+}
+</script>
+
+<template>
+	<div class="sp-onboarding" data-testid="onboarding-wizard">
+		<OnboardingStepIndicator :current="currentStep" :total="TOTAL_STEPS" />
+		<div class="sp-onboarding__step">
+			<component
+				:is="currentStepComponent"
+				v-bind="stepProps"
+				@next="handleNext"
+				@finish="handleFinish"
+			/>
+		</div>
+	</div>
+</template>
+
+<style scoped>
+.sp-onboarding {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.5rem 1rem;
+  height: 100%;
+}
+
+.sp-onboarding__step {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+</style>

--- a/src/ui/composables/useClaudeCliPort.ts
+++ b/src/ui/composables/useClaudeCliPort.ts
@@ -1,0 +1,7 @@
+import { inject } from 'vue'
+import type { ClaudeCliPort } from '@/domain/ports'
+import { CLAUDE_CLI_PORT } from '@/infrastructure/bridge/ports'
+
+export function useClaudeCliPort(): ClaudeCliPort | undefined {
+	return inject(CLAUDE_CLI_PORT)
+}

--- a/src/ui/main.ts
+++ b/src/ui/main.ts
@@ -17,6 +17,7 @@ import {
   WORKSPACE_PORT,
   NOTIFICATION_PORT,
   LOGGER_PORT,
+  CLAUDE_CLI_PORT,
 } from '@/infrastructure/bridge/ports'
 import { LocalStorageBridge } from '@/infrastructure/localstorage/LocalStorageBridge'
 import { MockBridge } from '@/infrastructure/mock/MockBridge'
@@ -63,6 +64,7 @@ void bridge.getSettings()
     app.provide(WORKSPACE_PORT, bridge)
     app.provide(NOTIFICATION_PORT, bridge)
     app.provide(LOGGER_PORT, bridge)
+    app.provide(CLAUDE_CLI_PORT, bridge)
     app.provide(
       FEATURE_SERVICE_KEY,
       new FeatureService(new FeatureRepository(bridge, bridge, bridge)),

--- a/src/ui/router/index.ts
+++ b/src/ui/router/index.ts
@@ -5,6 +5,7 @@ import FeaturesView from '../views/FeaturesView.vue'
 import SettingsView from '../views/SettingsView.vue'
 import FileView from '../views/FileView.vue'
 import MainLayout from '../layouts/MainLayout.vue'
+import OnboardingWizard from '../components/OnboardingWizard.vue'
 
 declare module 'vue-router' {
   interface RouteMeta {
@@ -19,5 +20,6 @@ export const router = createRouter({
     { path: '/features', name: 'features', component: FeaturesView, meta: { layout: MainLayout } },
     { path: '/settings', name: 'settings', component: SettingsView, meta: { layout: MainLayout } },
     { path: '/file/:filePath(.*)', name: 'file', component: FileView, meta: { layout: MainLayout } },
+    { path: '/onboarding', name: 'onboarding', component: OnboardingWizard },
   ],
 })

--- a/styles.css
+++ b/styles.css
@@ -380,6 +380,25 @@ to { transform: rotate(360deg);
   background: var(--background-secondary);
 }
 
+.specorator-root :where(.sp-onboarding__step-indicator[data-v-8902bb56]) {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.specorator-root :where(.sp-onboarding[data-v-0053404f]) {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.5rem 1rem;
+  height: 100%;
+}
+.specorator-root :where(.sp-onboarding__step[data-v-0053404f]) {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
 .specorator-root :where(.sp-toast-container[data-v-0721de72]) {
   position: fixed;
   bottom: 1.5rem;

--- a/tests/core/core-settings.test.ts
+++ b/tests/core/core-settings.test.ts
@@ -7,7 +7,7 @@ describe('coreSettingsModule descriptor metadata', () => {
   it('has the expected id, settingsKey, and settingsVersion', () => {
     expect(coreSettingsModule.id).toBe('specorator')
     expect(coreSettingsModule.settingsKey).toBe('specorator')
-    expect(coreSettingsModule.settingsVersion).toBe(2)
+    expect(coreSettingsModule.settingsVersion).toBe(3)
   })
 
   it('settingsDefaults equals DEFAULT_SETTINGS', () => {
@@ -57,6 +57,44 @@ describe('coreSettingsModule.migrate (v1 → v2 mcpServerEnabled)', () => {
     expect(migrate(0, null)).toEqual({ mcpServerEnabled: false })
     expect(migrate(0, 'string-junk')).toEqual({ mcpServerEnabled: false })
     expect(migrate(0, [])).toEqual({ mcpServerEnabled: false })
+  })
+})
+
+describe('coreSettingsModule.migrate (v2 → v3 onboardingComplete)', () => {
+  const migrate = (fromVersion: number, blob: unknown): unknown => {
+    const fn = coreSettingsModule.migrate
+    if (!fn) throw new Error('migrate is undefined')
+    return fn(fromVersion, blob)
+  }
+
+  it('injects onboardingComplete=true when upgrading from v1 (existing install)', () => {
+    const out = migrate(1, { specsFolder: 'specs' }) as Record<string, unknown>
+    expect(out.onboardingComplete).toBe(true)
+  })
+
+  it('injects onboardingComplete=true when upgrading from v2 (existing install)', () => {
+    const out = migrate(2, { specsFolder: 'specs' }) as Record<string, unknown>
+    expect(out.onboardingComplete).toBe(true)
+  })
+
+  it('does NOT inject onboardingComplete for a fresh install (fromVersion=0)', () => {
+    const out = migrate(0, {}) as Record<string, unknown>
+    expect('onboardingComplete' in out).toBe(false)
+  })
+
+  it('does not inject onboardingComplete when already at v3 or later', () => {
+    const out = migrate(3, {}) as Record<string, unknown>
+    expect('onboardingComplete' in out).toBe(false)
+  })
+
+  it('preserves existing onboardingComplete=false when upgrading', () => {
+    const out = migrate(2, { onboardingComplete: false }) as Record<string, unknown>
+    expect(out.onboardingComplete).toBe(false)
+  })
+
+  it('preserves existing onboardingComplete=true when upgrading', () => {
+    const out = migrate(2, { onboardingComplete: true }) as Record<string, unknown>
+    expect(out.onboardingComplete).toBe(true)
   })
 })
 

--- a/tests/core/core-settings.test.ts
+++ b/tests/core/core-settings.test.ts
@@ -77,9 +77,14 @@ describe('coreSettingsModule.migrate (v2 → v3 onboardingComplete)', () => {
     expect(out.onboardingComplete).toBe(true)
   })
 
-  it('does NOT inject onboardingComplete for a fresh install (fromVersion=0)', () => {
+  it('does NOT inject onboardingComplete for a fresh install (fromVersion=0, empty blob)', () => {
     const out = migrate(0, {}) as Record<string, unknown>
     expect('onboardingComplete' in out).toBe(false)
+  })
+
+  it('injects onboardingComplete=true for unversioned existing install (fromVersion=0, non-empty blob)', () => {
+    const out = migrate(0, { specsFolder: 'specs', locale: 'en' }) as Record<string, unknown>
+    expect(out.onboardingComplete).toBe(true)
   })
 
   it('does not inject onboardingComplete when already at v3 or later', () => {

--- a/tests/ui/AppRoot.test.ts
+++ b/tests/ui/AppRoot.test.ts
@@ -5,7 +5,7 @@ import { createMemoryHistory, createRouter } from 'vue-router'
 import AppRoot from '@/ui/AppRoot.vue'
 import DashboardLayout from '@/ui/layouts/DashboardLayout.vue'
 import { i18n } from '@/ui/i18n'
-import { LOGGER_PORT, NOTIFICATION_PORT } from '@/infrastructure/bridge/ports'
+import { LOGGER_PORT, NOTIFICATION_PORT, SETTINGS_PORT } from '@/infrastructure/bridge/ports'
 import { fakeModulePorts } from '../__fakes__/fake-ports'
 import { AppRootPageObject } from './AppRoot.po'
 
@@ -39,12 +39,15 @@ async function mountAppRoot(initialPath: string) {
 	await router.push(initialPath)
 	await router.isReady()
 	const ports = fakeModulePorts()
+	const current = await ports.settings.getSettings()
+	await ports.settings.saveSettings({ ...current, onboardingComplete: true })
 	const wrapper = mount(AppRoot, {
 		global: {
 			plugins: [i18n, router, createPinia()],
 			provide: {
 				[LOGGER_PORT as unknown as symbol]: ports.logger,
 				[NOTIFICATION_PORT as unknown as symbol]: ports.notifications,
+				[SETTINGS_PORT as unknown as symbol]: ports.settings,
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

- Adds `userPersona: string` and `onboardingComplete: boolean` to `PluginSettings` + `DEFAULT_SETTINGS`; wires both fields through the `core-settings` module validator and JSON schema
- Introduces `ClaudeCliPort` interface (`isAvailable(): Promise<boolean>`), `CLAUDE_CLI_PORT` InjectionKey, and `useClaudeCliPort` composable
- Implements `isAvailable()` across all three bridges: `ObsidianBridge` (shell `claude --version` via `Promise.race`, 5 s deadline), `MockBridge` (always `false`), `LocalStorageBridge` (always `false`)
- Wires `CLAUDE_CLI_PORT` via `app.provide()` in `SpecoratorView` and the standalone `src/ui/main.ts` entry
- Adds `/onboarding` Vue Router route and `OnboardingWizard.vue` orchestrator shell with async settings guard, shared step-DTO, and per-step payload dispatcher
- Adds `OnboardingStepIndicator.vue` and five stub step components (1–5) — stubs emit the correct events so the wizard navigation works end-to-end; real step UI lands in #195 and #196
- Extends `onLayoutReady` to auto-open the wizard on first install (`!onboardingComplete`)
- Registers `re-run-setup` command palette entry

## Test plan

- [ ] `npm run verify` passes (typecheck, lint, unit tests, build, bundle size)
- [ ] New Obsidian install: wizard auto-opens on first load
- [ ] Returning user (`onboardingComplete: true`): wizard does not auto-open
- [ ] Command palette → "Re-run setup": opens wizard
- [ ] `useClaudeCliPort()` returns `undefined` gracefully when port is not provided (browser/test context)

Closes #194

---
_Generated by [Claude Code](https://claude.ai/code/session_011G6giKLusJ5W5NoZmGwnyV)_