### PR TITLE
feat(ui): onboarding steps 1–3 — welcome, persona capture, Claude CLI check [superseded by #293]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 			},
 			"devDependencies": {
 				"@eslint/js": "^10.0.1",
+				"@pinia/testing": "^1.0.3",
 				"@storybook/addon-a11y": "^10.3.6",
 				"@storybook/addon-vitest": "^10.3.6",
 				"@storybook/vue3-vite": "^10.3.6",
@@ -1491,6 +1492,19 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/@pinia/testing": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@pinia/testing/-/testing-1.0.3.tgz",
+			"integrity": "sha512-g+qR49GNdI1Z8rZxKrQC3GN+LfnGTNf5Kk8Nz5Cz6mIGva5WRS+ffPXQfzhA0nu6TveWzPNYTjGl4nJqd3Cu9Q==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/posva"
+			},
+			"peerDependencies": {
+				"pinia": ">=3.0.4"
 			}
 		},
 		"node_modules/@pkgjs/parseargs": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 	},
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",
+		"@pinia/testing": "^1.0.3",
 		"@storybook/addon-a11y": "^10.3.6",
 		"@storybook/addon-vitest": "^10.3.6",
 		"@storybook/vue3-vite": "^10.3.6",

--- a/src/core/core-settings.ts
+++ b/src/core/core-settings.ts
@@ -23,20 +23,24 @@ export const coreSettingsModule = defineModule<PluginSettings>({
    * user choice.
    *
    * v2 → v3: introduces `onboardingComplete`. Default it to `true` for
-   * upgrading installs (fromVersion >= 1) so existing users are not forced
-   * through the wizard on next launch. Fresh installs (fromVersion === 0,
-   * no stored data) are left without the key so validateSettings falls
-   * through to DEFAULT_SETTINGS.onboardingComplete (false) and the wizard
-   * runs normally.
+   * upgrading installs so existing users are not forced through the wizard on
+   * next launch. "Upgrading" means fromVersion >= 1 OR fromVersion === 0 with
+   * a non-empty blob (unversioned existing installs never stored a version key
+   * and therefore arrive as v0 even though they have real settings). Fresh
+   * installs arrive as v0 with a null or empty blob and are left without the
+   * key so validateSettings falls through to DEFAULT_SETTINGS.onboardingComplete
+   * (false) and the wizard runs normally.
    */
   migrate(fromVersion: number, blob: unknown): unknown {
-    const out = (blob !== null && typeof blob === 'object' && !Array.isArray(blob)
+    const isObjectBlob = blob !== null && typeof blob === 'object' && !Array.isArray(blob)
+    const out = (isObjectBlob
       ? { ...(blob as Record<string, unknown>) }
       : {}) as Record<string, unknown>
     if (fromVersion < 2 && !('mcpServerEnabled' in out)) {
       out.mcpServerEnabled = false
     }
-    if (fromVersion >= 1 && fromVersion < 3 && !('onboardingComplete' in out)) {
+    const hadExistingData = isObjectBlob && Object.keys(blob as object).length > 0
+    if ((fromVersion >= 1 || (fromVersion === 0 && hadExistingData)) && fromVersion < 3 && !('onboardingComplete' in out)) {
       out.onboardingComplete = true
     }
     return out

--- a/src/core/core-settings.ts
+++ b/src/core/core-settings.ts
@@ -49,6 +49,11 @@ export const coreSettingsModule = defineModule<PluginSettings>({
         : DEFAULT_SETTINGS.logLevel,
       mcpServerEnabled:
         typeof r.mcpServerEnabled === 'boolean' ? r.mcpServerEnabled : DEFAULT_SETTINGS.mcpServerEnabled,
+      userPersona: typeof r.userPersona === 'string' ? r.userPersona : DEFAULT_SETTINGS.userPersona,
+      onboardingComplete:
+        typeof r.onboardingComplete === 'boolean'
+          ? r.onboardingComplete
+          : DEFAULT_SETTINGS.onboardingComplete,
     }
   },
 
@@ -131,6 +136,20 @@ export const coreSettingsModule = defineModule<PluginSettings>({
         description:
           'Allow local MCP clients to access your Specorator data via 127.0.0.1. Off by default for privacy.',
         default: DEFAULT_SETTINGS.mcpServerEnabled,
+      },
+      {
+        type: 'text',
+        key: 'userPersona',
+        label: 'User persona',
+        description: 'Your role or persona, used to personalise AI interactions.',
+        default: DEFAULT_SETTINGS.userPersona,
+      },
+      {
+        type: 'toggle',
+        key: 'onboardingComplete',
+        label: 'Onboarding complete',
+        description: 'Set automatically after the setup wizard finishes.',
+        default: DEFAULT_SETTINGS.onboardingComplete,
       },
     ],
   },

--- a/src/core/core-settings.ts
+++ b/src/core/core-settings.ts
@@ -11,7 +11,7 @@ function coerceString(value: unknown, fallback: string): string {
 export const coreSettingsModule = defineModule<PluginSettings>({
   id: 'specorator',
   settingsKey: 'specorator',
-  settingsVersion: 2,
+  settingsVersion: 3,
   settingsDefaults: { ...DEFAULT_SETTINGS },
 
   /**
@@ -21,6 +21,13 @@ export const coreSettingsModule = defineModule<PluginSettings>({
    * for upgrading installs so existing users do not silently start receiving
    * a local MCP server. Only inject when absent — never flip an existing
    * user choice.
+   *
+   * v2 → v3: introduces `onboardingComplete`. Default it to `true` for
+   * upgrading installs (fromVersion >= 1) so existing users are not forced
+   * through the wizard on next launch. Fresh installs (fromVersion === 0,
+   * no stored data) are left without the key so validateSettings falls
+   * through to DEFAULT_SETTINGS.onboardingComplete (false) and the wizard
+   * runs normally.
    */
   migrate(fromVersion: number, blob: unknown): unknown {
     const out = (blob !== null && typeof blob === 'object' && !Array.isArray(blob)
@@ -28,6 +35,9 @@ export const coreSettingsModule = defineModule<PluginSettings>({
       : {}) as Record<string, unknown>
     if (fromVersion < 2 && !('mcpServerEnabled' in out)) {
       out.mcpServerEnabled = false
+    }
+    if (fromVersion >= 1 && fromVersion < 3 && !('onboardingComplete' in out)) {
+      out.onboardingComplete = true
     }
     return out
   },

--- a/src/core/core-settings.ts
+++ b/src/core/core-settings.ts
@@ -8,6 +8,12 @@ function coerceString(value: unknown, fallback: string): string {
   return typeof value === 'string' && value.trim() ? value.trim() : fallback
 }
 
+function toMutableBlob(blob: unknown): { out: Record<string, unknown>; hadData: boolean } {
+  const isObjectBlob = blob !== null && typeof blob === 'object' && !Array.isArray(blob)
+  const out: Record<string, unknown> = isObjectBlob ? { ...(blob as Record<string, unknown>) } : {}
+  return { out, hadData: isObjectBlob && Object.keys(out).length > 0 }
+}
+
 export const coreSettingsModule = defineModule<PluginSettings>({
   id: 'specorator',
   settingsKey: 'specorator',
@@ -32,15 +38,11 @@ export const coreSettingsModule = defineModule<PluginSettings>({
    * (false) and the wizard runs normally.
    */
   migrate(fromVersion: number, blob: unknown): unknown {
-    const isObjectBlob = blob !== null && typeof blob === 'object' && !Array.isArray(blob)
-    const out = (isObjectBlob
-      ? { ...(blob as Record<string, unknown>) }
-      : {}) as Record<string, unknown>
+    const { out, hadData } = toMutableBlob(blob)
     if (fromVersion < 2 && !('mcpServerEnabled' in out)) {
       out.mcpServerEnabled = false
     }
-    const hadExistingData = isObjectBlob && Object.keys(blob as object).length > 0
-    if ((fromVersion >= 1 || (fromVersion === 0 && hadExistingData)) && fromVersion < 3 && !('onboardingComplete' in out)) {
+    if ((fromVersion >= 1 || (fromVersion === 0 && hadData)) && fromVersion < 3 && !('onboardingComplete' in out)) {
       out.onboardingComplete = true
     }
     return out

--- a/src/domain/ports/ClaudeCliPort.ts
+++ b/src/domain/ports/ClaudeCliPort.ts
@@ -1,0 +1,3 @@
+export interface ClaudeCliPort {
+	isAvailable(): Promise<boolean>
+}

--- a/src/domain/ports/index.ts
+++ b/src/domain/ports/index.ts
@@ -18,3 +18,4 @@ export type { MetadataCachePort, FileMetadataSnapshot } from './metadata-cache-p
 export type { CanvasPort, JsonCanvasData } from './canvas-port'
 export type { ObsidianMcpServerPort, McpConnectionConfig } from './obsidian-mcp-server-port'
 export type { CommunityPluginPort } from './CommunityPluginPort'
+export type { ClaudeCliPort } from './ClaudeCliPort'

--- a/src/domain/settings/PluginSettings.ts
+++ b/src/domain/settings/PluginSettings.ts
@@ -18,6 +18,8 @@ export interface PluginSettings {
 	 * command. See README "MCP server (advanced, opt-in)".
 	 */
 	readonly mcpServerEnabled: boolean
+	readonly userPersona: string
+	readonly onboardingComplete: boolean
 }
 
 export const DEFAULT_SETTINGS: PluginSettings = {
@@ -30,4 +32,6 @@ export const DEFAULT_SETTINGS: PluginSettings = {
 	teamMode: false,
 	logLevel: 'warn',
 	mcpServerEnabled: false,
+	userPersona: '',
+	onboardingComplete: false,
 }

--- a/src/infrastructure/bridge/ports.ts
+++ b/src/infrastructure/bridge/ports.ts
@@ -8,6 +8,7 @@ import type {
 	MetadataCachePort,
 	CanvasPort,
 	CommunityPluginPort,
+	ClaudeCliPort,
 } from '@/domain/ports'
 
 export const SETTINGS_PORT: InjectionKey<SettingsPort> = Symbol('SettingsPort')
@@ -18,3 +19,4 @@ export const LOGGER_PORT: InjectionKey<LoggerPort> = Symbol('LoggerPort')
 export const METADATA_CACHE_PORT: InjectionKey<MetadataCachePort> = Symbol('MetadataCachePort')
 export const CANVAS_PORT: InjectionKey<CanvasPort> = Symbol('CanvasPort')
 export const COMMUNITY_PLUGIN_PORT: InjectionKey<CommunityPluginPort> = Symbol('CommunityPluginPort')
+export const CLAUDE_CLI_PORT: InjectionKey<ClaudeCliPort> = Symbol('ClaudeCliPort')

--- a/src/infrastructure/localstorage/LocalStorageBridge.ts
+++ b/src/infrastructure/localstorage/LocalStorageBridge.ts
@@ -6,6 +6,7 @@ import type {
 	LoggerPort,
 	ActiveFileSnapshot,
 	Unsubscriber,
+	ClaudeCliPort,
 } from '@/domain/ports'
 import { type PluginSettings, DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
 
@@ -13,7 +14,7 @@ const FILE_PREFIX = 'specorator:file:'
 const SETTINGS_KEY = 'specorator:settings'
 
 export class LocalStorageBridge
-	implements SettingsPort, VaultPort, WorkspacePort, NotificationPort, LoggerPort
+	implements SettingsPort, VaultPort, WorkspacePort, NotificationPort, LoggerPort, ClaudeCliPort
 {
   async readFile(path: string): Promise<string> {
     const value = localStorage.getItem(FILE_PREFIX + path)
@@ -143,4 +144,10 @@ export class LocalStorageBridge
   }
 
   /* eslint-enable obsidianmd/rule-custom-message */
+
+  // ── ClaudeCliPort ─────────────────────────────────────────────────────────
+
+  isAvailable(): Promise<boolean> {
+    return Promise.resolve(false)
+  }
 }

--- a/src/infrastructure/mock/MockBridge.ts
+++ b/src/infrastructure/mock/MockBridge.ts
@@ -71,15 +71,19 @@ export class MockBridge
   }
 
   async listFolders(parent: string): Promise<string[]> {
-    const prefix = parent.endsWith('/') ? parent : `${parent}/`
+    const prefix = parent === '' ? '' : (parent.endsWith('/') ? parent : `${parent}/`)
     const names = new Set<string>()
+    for (const folder of this.folders) {
+      if (folder.startsWith(prefix)) {
+        const rest = folder.slice(prefix.length)
+        if (rest && !rest.includes('/')) names.add(rest)
+      }
+    }
     for (const path of this.files.keys()) {
-      if (path.startsWith(prefix)) {
+      if (!prefix || path.startsWith(prefix)) {
         const rest = path.slice(prefix.length)
         const firstSegment = rest.split('/')[0]
-        if (firstSegment && rest.includes('/')) {
-          names.add(firstSegment)
-        }
+        if (firstSegment && rest.includes('/')) names.add(firstSegment)
       }
     }
     return [...names]

--- a/src/infrastructure/mock/MockBridge.ts
+++ b/src/infrastructure/mock/MockBridge.ts
@@ -6,6 +6,7 @@ import type {
 	LoggerPort,
 	ActiveFileSnapshot,
 	Unsubscriber,
+	ClaudeCliPort,
 } from '@/domain/ports'
 import { type PluginSettings, DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
 
@@ -14,7 +15,7 @@ import { type PluginSettings, DEFAULT_SETTINGS } from '@/domain/settings/PluginS
  * Provides test helper methods for inspecting state.
  */
 export class MockBridge
-	implements SettingsPort, VaultPort, WorkspacePort, NotificationPort, LoggerPort
+	implements SettingsPort, VaultPort, WorkspacePort, NotificationPort, LoggerPort, ClaudeCliPort
 {
   private readonly files = new Map<string, string>()
   private readonly folders = new Set<string>()
@@ -194,5 +195,11 @@ export class MockBridge
   error(message: string, error?: unknown, context?: Record<string, unknown>): void {
     this.logEntries.push({ level: 'error', message, error, context })
     console.error(`[MockBridge] ${message}`, error, context)
+  }
+
+  // ── ClaudeCliPort ─────────────────────────────────────────────────────────
+
+  isAvailable(): Promise<boolean> {
+    return Promise.resolve(false)
   }
 }

--- a/src/infrastructure/mock/MockBridge.ts
+++ b/src/infrastructure/mock/MockBridge.ts
@@ -11,6 +11,11 @@ import type {
 } from '@/domain/ports'
 import { type PluginSettings, DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
 
+function folderPrefix(parent: string): string {
+  if (parent === '') return ''
+  return parent.endsWith('/') ? parent : `${parent}/`
+}
+
 /**
  * In-memory bridge used in standalone dev mode and unit tests.
  * Provides test helper methods for inspecting state.
@@ -71,7 +76,7 @@ export class MockBridge
   }
 
   async listFolders(parent: string): Promise<string[]> {
-    const prefix = parent === '' ? '' : (parent.endsWith('/') ? parent : `${parent}/`)
+    const prefix = folderPrefix(parent)
     const names = new Set<string>()
     for (const folder of this.folders) {
       if (folder.startsWith(prefix)) {

--- a/src/infrastructure/obsidian/ObsidianBridge.ts
+++ b/src/infrastructure/obsidian/ObsidianBridge.ts
@@ -8,6 +8,7 @@ import type {
 	LoggerPort,
 	ActiveFileSnapshot,
 	Unsubscriber,
+	ClaudeCliPort,
 } from '@/domain/ports'
 
 type FileManagerWithTrash = App['fileManager'] & {
@@ -15,7 +16,7 @@ type FileManagerWithTrash = App['fileManager'] & {
 }
 
 export class ObsidianBridge
-  implements SettingsPort, VaultPort, WorkspacePort, NotificationPort, LoggerPort
+  implements SettingsPort, VaultPort, WorkspacePort, NotificationPort, LoggerPort, ClaudeCliPort
 {
   private static readonly _LEVEL_RANK: Record<string, number> = {
     debug: 0,
@@ -191,4 +192,18 @@ export class ObsidianBridge
   }
 
   /* eslint-enable obsidianmd/rule-custom-message */
+
+  // ── ClaudeCliPort ─────────────────────────────────────────────────────────
+
+  isAvailable(): Promise<boolean> {
+    const timeoutMs = 5000
+    const deadline = new Promise<boolean>((resolve) => {
+      activeWindow.setTimeout(() => { resolve(false) }, timeoutMs)
+    })
+    const { exec } = require('node:child_process') as { exec: (cmd: string, cb: (err: Error | null) => void) => void }
+    const check = new Promise<boolean>((resolve) => {
+      exec('claude --version', (err) => { resolve(err === null) })
+    })
+    return Promise.race([check, deadline])
+  }
 }

--- a/src/plugin/SpecoratorView.ts
+++ b/src/plugin/SpecoratorView.ts
@@ -10,6 +10,7 @@ import {
   WORKSPACE_PORT,
   NOTIFICATION_PORT,
   LOGGER_PORT,
+  CLAUDE_CLI_PORT,
 } from '@/infrastructure/bridge/ports'
 import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
 import { FeatureService } from '@/application/feature/FeatureService'
@@ -56,6 +57,7 @@ export class SpecoratorView extends ItemView {
     this.vueApp.provide(WORKSPACE_PORT, bridge)
     this.vueApp.provide(NOTIFICATION_PORT, bridge)
     this.vueApp.provide(LOGGER_PORT, bridge)
+    this.vueApp.provide(CLAUDE_CLI_PORT, bridge)
     this.vueApp.provide(
       FEATURE_SERVICE_KEY,
       new FeatureService(new FeatureRepository(bridge, bridge, bridge)),

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -92,11 +92,10 @@ export default class SpecoratorPlugin extends Plugin {
       id: 're-run-setup',
       name: 'Re-run setup',
       callback: () => {
-        void this.updateSettings({ onboardingComplete: false }).then(() =>
-          this.activateView().then(() => {
-            this._dispatchNavigate('/onboarding')
-          }),
-        )
+        void this.updateSettings({ onboardingComplete: false })
+          .then(() => this.activateView())
+          .then(() => { this._dispatchNavigate('/onboarding') })
+          .catch(() => { this.bridge?.showError('Failed to re-run setup. Please try again.') })
       },
     })
 
@@ -124,9 +123,9 @@ export default class SpecoratorPlugin extends Plugin {
     this.app.workspace.onLayoutReady(() => {
       this.detectLegacyVaultLayout()
       if (!this.settings.onboardingComplete) {
-        void this.activateView().then(() => {
-          this._dispatchNavigate('/onboarding')
-        })
+        void this.activateView()
+          .then(() => { this._dispatchNavigate('/onboarding') })
+          .catch(() => { this.bridge?.showError('Failed to open onboarding. Please reopen the panel.') })
       }
     })
   }

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -94,7 +94,7 @@ export default class SpecoratorPlugin extends Plugin {
       callback: () => {
         void this.updateSettings({ onboardingComplete: false }).then(() =>
           this.activateView().then(() => {
-            activeWindow.dispatchEvent(new CustomEvent('sp:navigate', { detail: { path: '/onboarding' } }))
+            this._dispatchNavigate('/onboarding')
           }),
         )
       },
@@ -125,7 +125,7 @@ export default class SpecoratorPlugin extends Plugin {
       this.detectLegacyVaultLayout()
       if (!this.settings.onboardingComplete) {
         void this.activateView().then(() => {
-          activeWindow.dispatchEvent(new CustomEvent('sp:navigate', { detail: { path: '/onboarding' } }))
+          this._dispatchNavigate('/onboarding')
         })
       }
     })
@@ -190,6 +190,13 @@ export default class SpecoratorPlugin extends Plugin {
         8000,
       )
     }
+  }
+
+  private _dispatchNavigate(path: string): void {
+    const win =
+      this.app.workspace.getLeavesOfType(VIEW_TYPE)[0]?.view?.containerEl?.ownerDocument?.defaultView ??
+      activeWindow
+    win.dispatchEvent(new CustomEvent('sp:navigate', { detail: { path } }))
   }
 
   private async activateView(): Promise<void> {

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -88,6 +88,14 @@ export default class SpecoratorPlugin extends Plugin {
       callback: () => void this.updateSettings({ mcpServerEnabled: false }),
     })
 
+    this.addCommand({
+      id: 're-run-setup',
+      name: 'Re-run setup',
+      callback: () => {
+        void this.updateSettings({ onboardingComplete: false }).then(() => this.activateView())
+      },
+    })
+
     this.addSettingTab(new SpecoratorSettingTab(this.app, this))
 
     this.registerObsidianProtocolHandler('specorator', (params) => {
@@ -111,6 +119,9 @@ export default class SpecoratorPlugin extends Plugin {
     // logic that reads workspace layout or vault state until layout is ready.
     this.app.workspace.onLayoutReady(() => {
       this.detectLegacyVaultLayout()
+      if (!this.settings.onboardingComplete) {
+        void this.activateView()
+      }
     })
   }
 

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -92,7 +92,11 @@ export default class SpecoratorPlugin extends Plugin {
       id: 're-run-setup',
       name: 'Re-run setup',
       callback: () => {
-        void this.updateSettings({ onboardingComplete: false }).then(() => this.activateView())
+        void this.updateSettings({ onboardingComplete: false }).then(() =>
+          this.activateView().then(() => {
+            activeWindow.dispatchEvent(new CustomEvent('sp:navigate', { detail: { path: '/onboarding' } }))
+          }),
+        )
       },
     })
 
@@ -120,7 +124,9 @@ export default class SpecoratorPlugin extends Plugin {
     this.app.workspace.onLayoutReady(() => {
       this.detectLegacyVaultLayout()
       if (!this.settings.onboardingComplete) {
-        void this.activateView()
+        void this.activateView().then(() => {
+          activeWindow.dispatchEvent(new CustomEvent('sp:navigate', { detail: { path: '/onboarding' } }))
+        })
       }
     })
   }

--- a/src/ui/AppRoot.vue
+++ b/src/ui/AppRoot.vue
@@ -32,24 +32,20 @@ function onNavigate(e: Event) {
   void router.push(path)
 }
 
-const stopGuard = router.beforeEach(async (to) => {
-  if (to.path === '/onboarding') return true
-  const s = await settingsPort.getSettings()
-  if (!s.onboardingComplete) return '/onboarding'
-  return true
-})
-
-onMounted(() => {
+onMounted(async () => {
   window.addEventListener('sp:notice', onNotice)
   window.addEventListener('sp:open-file', onOpenFile)
   window.addEventListener('sp:navigate', onNavigate)
+  const s = await settingsPort.getSettings()
+  if (!s.onboardingComplete) {
+    void router.push('/onboarding')
+  }
 })
 
 onUnmounted(() => {
   window.removeEventListener('sp:notice', onNotice)
   window.removeEventListener('sp:open-file', onOpenFile)
   window.removeEventListener('sp:navigate', onNavigate)
-  stopGuard()
 })
 </script>
 

--- a/src/ui/AppRoot.vue
+++ b/src/ui/AppRoot.vue
@@ -4,10 +4,12 @@ import { RouterView, useRoute, useRouter } from 'vue-router'
 import AppToast from './components/common/AppToast.vue'
 import MainLayout from './layouts/MainLayout.vue'
 import { useNotificationStore } from './stores/notificationStore'
+import { useSettingsPort } from './composables/useSettingsPort'
 
 const route = useRoute()
 const router = useRouter()
 const notificationStore = useNotificationStore()
+const settingsPort = useSettingsPort()
 
 const layout = computed<Component>(() => route.meta.layout ?? MainLayout)
 
@@ -25,9 +27,13 @@ function onOpenFile(e: Event) {
   void router.push({ name: 'file', params: { filePath: path } })
 }
 
-onMounted(() => {
+onMounted(async () => {
   window.addEventListener('sp:notice', onNotice)
   window.addEventListener('sp:open-file', onOpenFile)
+  const s = await settingsPort.getSettings()
+  if (!s.onboardingComplete) {
+    void router.push('/onboarding')
+  }
 })
 
 onUnmounted(() => {

--- a/src/ui/AppRoot.vue
+++ b/src/ui/AppRoot.vue
@@ -32,20 +32,24 @@ function onNavigate(e: Event) {
   void router.push(path)
 }
 
-onMounted(async () => {
+const stopGuard = router.beforeEach(async (to) => {
+  if (to.path === '/onboarding') return true
+  const s = await settingsPort.getSettings()
+  if (!s.onboardingComplete) return '/onboarding'
+  return true
+})
+
+onMounted(() => {
   window.addEventListener('sp:notice', onNotice)
   window.addEventListener('sp:open-file', onOpenFile)
   window.addEventListener('sp:navigate', onNavigate)
-  const s = await settingsPort.getSettings()
-  if (!s.onboardingComplete) {
-    void router.push('/onboarding')
-  }
 })
 
 onUnmounted(() => {
   window.removeEventListener('sp:notice', onNotice)
   window.removeEventListener('sp:open-file', onOpenFile)
   window.removeEventListener('sp:navigate', onNavigate)
+  stopGuard()
 })
 </script>
 

--- a/src/ui/AppRoot.vue
+++ b/src/ui/AppRoot.vue
@@ -27,9 +27,15 @@ function onOpenFile(e: Event) {
   void router.push({ name: 'file', params: { filePath: path } })
 }
 
+function onNavigate(e: Event) {
+  const { path } = (e as CustomEvent<{ path: string }>).detail
+  void router.push(path)
+}
+
 onMounted(async () => {
   window.addEventListener('sp:notice', onNotice)
   window.addEventListener('sp:open-file', onOpenFile)
+  window.addEventListener('sp:navigate', onNavigate)
   const s = await settingsPort.getSettings()
   if (!s.onboardingComplete) {
     void router.push('/onboarding')
@@ -39,6 +45,7 @@ onMounted(async () => {
 onUnmounted(() => {
   window.removeEventListener('sp:notice', onNotice)
   window.removeEventListener('sp:open-file', onOpenFile)
+  window.removeEventListener('sp:navigate', onNavigate)
 })
 </script>
 

--- a/src/ui/components/OnboardingPersonaCard.vue
+++ b/src/ui/components/OnboardingPersonaCard.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+const props = defineProps<{ text: string }>()
+const emit = defineEmits<{ use: [text: string] }>()
+</script>
+
+<template>
+	<button
+		class="sp-onboarding__card"
+		:aria-label="`Use this example: ${props.text}`"
+		data-testid="persona-card"
+		@click="emit('use', props.text)"
+	>
+		{{ props.text }}
+	</button>
+</template>
+
+<style scoped>
+.sp-onboarding__card {
+	border-radius: 6px;
+	padding: 0.75rem 0.875rem;
+	cursor: pointer;
+	text-align: left;
+	font-size: 0.875rem;
+	color: var(--text-normal);
+	width: 100%;
+	border: 1px solid var(--background-modifier-border);
+	background: var(--background-secondary);
+	transition: background 0.15s;
+}
+
+.sp-onboarding__card:hover {
+	background: var(--background-modifier-hover);
+}
+</style>

--- a/src/ui/components/OnboardingStep1Welcome.vue
+++ b/src/ui/components/OnboardingStep1Welcome.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+const emit = defineEmits<{ next: [] }>()
+</script>
+<template>
+	<div data-testid="step1-placeholder">
+		<button data-testid="step1-cta" @click="emit('next')">Let's get started</button>
+	</div>
+</template>

--- a/src/ui/components/OnboardingStep1Welcome.vue
+++ b/src/ui/components/OnboardingStep1Welcome.vue
@@ -1,8 +1,21 @@
 <script setup lang="ts">
 const emit = defineEmits<{ next: [] }>()
 </script>
+
 <template>
-	<div data-testid="step1-placeholder">
-		<button data-testid="step1-cta" @click="emit('next')">Let's get started</button>
+	<div class="sp-onboarding__step" data-testid="step1">
+		<h2 class="sp-onboarding__heading">Welcome to Specorator.</h2>
+		<p class="sp-onboarding__body">
+			Specorator helps you plan features, run structured workflows, and get relevant AI suggestions
+			— all inside Obsidian. This short setup takes about two minutes and gets you to a working
+			state straightaway.
+		</p>
+		<button
+			class="sp-btn sp-btn--primary sp-btn--md"
+			data-testid="step1-cta"
+			@click="emit('next')"
+		>
+			Let's get started
+		</button>
 	</div>
 </template>

--- a/src/ui/components/OnboardingStep2Persona.vue
+++ b/src/ui/components/OnboardingStep2Persona.vue
@@ -1,10 +1,164 @@
 <script setup lang="ts">
-defineProps<{ initialValue: string }>()
+import { ref } from 'vue'
+import { useSettingsPort } from '@/ui/composables/useSettingsPort'
+import { useLoggerPort } from '@/ui/composables/useLoggerPort'
+import { tryAsync } from '@/domain/shared/tryAsync'
+import OnboardingPersonaCard from './OnboardingPersonaCard.vue'
+
+const props = defineProps<{ initialValue: string }>()
 const emit = defineEmits<{ next: [payload: { skipped: boolean }] }>()
+
+const settingsPort = useSettingsPort()
+const logger = useLoggerPort()
+
+const EXAMPLE_CARDS = [
+	"I'm a product manager at a mid-size SaaS company. I focus on roadmap planning and work closely with engineering and design.",
+	"I'm a founder building a B2B tool. I wear many hats — from sales to product — and need to move quickly without losing sight of the big picture.",
+	"I'm a business analyst at a financial services firm. I gather requirements, document processes, and bridge the gap between stakeholders and technical teams.",
+]
+
+const personaText = ref(props.initialValue)
+const isSaving = ref(false)
+const saveError = ref<string | null>(null)
+
+function useCard(text: string): void {
+	personaText.value = text
+}
+
+async function saveAndContinue(): Promise<void> {
+	isSaving.value = true
+	saveError.value = null
+	const result = await tryAsync(async () => {
+		const current = await settingsPort.getSettings()
+		await settingsPort.saveSettings({ ...current, userPersona: personaText.value })
+	}, 'Failed to save persona')
+	isSaving.value = false
+	if (!result.ok) {
+		logger.error('Failed to save persona', result.error)
+		saveError.value = "We couldn't save your introduction right now. Try again, or skip for now."
+		return
+	}
+	emit('next', { skipped: false })
+}
+
+function skipForNow(): void {
+	emit('next', { skipped: true })
+}
 </script>
+
 <template>
-	<div data-testid="step2-placeholder">
-		<button data-testid="step2-continue" @click="emit('next', { skipped: false })">Continue</button>
-		<button data-testid="step2-skip" @click="emit('next', { skipped: true })">Skip</button>
+	<div class="sp-onboarding__step" data-testid="step2">
+		<h2 class="sp-onboarding__heading">Tell us a little about yourself.</h2>
+		<p class="sp-onboarding__body">
+			A few sentences about your role and what you're working on helps Specorator give you more
+			relevant suggestions. There's no right or wrong answer — just describe yourself as you would
+			to a colleague.
+		</p>
+
+		<textarea
+			v-model="personaText"
+			class="sp-onboarding__textarea"
+			aria-label="About you"
+			placeholder="For example: I'm a product manager at a scale-up focusing on B2B growth. I spend most of my time on roadmap planning and stakeholder alignment."
+			data-testid="step2-textarea"
+		/>
+		<p class="sp-onboarding__hint">Two to four sentences is plenty.</p>
+
+		<div class="sp-onboarding__cards">
+			<OnboardingPersonaCard
+				v-for="(card, i) in EXAMPLE_CARDS"
+				:key="i"
+				:text="card"
+				:data-testid="`step2-card-${i}`"
+				@use="useCard"
+			/>
+		</div>
+
+		<p
+			v-if="saveError !== null"
+			role="alert"
+			aria-live="assertive"
+			class="sp-onboarding__inline-error"
+			data-testid="step2-save-error"
+		>
+			{{ saveError }}
+		</p>
+
+		<div class="sp-onboarding__actions">
+			<button
+				class="sp-btn sp-btn--primary sp-btn--md"
+				:aria-label="isSaving ? 'Saving, please wait' : 'Save and continue'"
+				:disabled="isSaving"
+				data-testid="step2-continue"
+				@click="saveAndContinue"
+			>
+				{{ isSaving ? 'Saving…' : 'Save and continue' }}
+			</button>
+			<button
+				class="sp-onboarding__skip"
+				:disabled="isSaving"
+				data-testid="step2-skip"
+				@click="skipForNow"
+			>
+				I'll do this later
+			</button>
+		</div>
 	</div>
 </template>
+
+<style scoped>
+.sp-onboarding__textarea {
+	min-height: 7rem;
+	resize: vertical;
+	line-height: 1.6;
+	width: 100%;
+	padding: 0.5rem 0.75rem;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 4px;
+	background: var(--background-primary);
+	color: var(--text-normal);
+	font-size: 0.9375rem;
+}
+
+.sp-onboarding__hint {
+	font-size: 0.875rem;
+	color: var(--text-muted);
+	margin: 0;
+}
+
+.sp-onboarding__cards {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	margin-top: 0.25rem;
+}
+
+.sp-onboarding__inline-error {
+	color: var(--text-error);
+	font-size: 0.875rem;
+	margin: 0;
+}
+
+.sp-onboarding__actions {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	align-items: flex-start;
+}
+
+.sp-onboarding__skip {
+	background: none;
+	border: none;
+	padding: 0;
+	cursor: pointer;
+	color: var(--text-muted);
+	font-size: 0.875rem;
+	min-width: 24px;
+	min-height: 24px;
+}
+
+.sp-onboarding__skip:disabled {
+	opacity: 0.5;
+	cursor: default;
+}
+</style>

--- a/src/ui/components/OnboardingStep2Persona.vue
+++ b/src/ui/components/OnboardingStep2Persona.vue
@@ -65,9 +65,9 @@ function skipForNow(): void {
 			v-model="personaText"
 			class="sp-onboarding__textarea"
 			aria-label="About you"
-			@input="markEdited"
 			placeholder="For example: I'm a product manager at a scale-up focusing on B2B growth. I spend most of my time on roadmap planning and stakeholder alignment."
 			data-testid="step2-textarea"
+			@input="markEdited"
 		/>
 		<p class="sp-onboarding__hint">Two to four sentences is plenty.</p>
 

--- a/src/ui/components/OnboardingStep2Persona.vue
+++ b/src/ui/components/OnboardingStep2Persona.vue
@@ -18,12 +18,16 @@ const EXAMPLE_CARDS = [
 ]
 
 const personaText = ref(props.initialValue)
-watch(() => props.initialValue, (val) => { personaText.value = val })
+let pristine = true
+watch(() => props.initialValue, (val) => { if (pristine) personaText.value = val })
 const isSaving = ref(false)
 const saveError = ref<string | null>(null)
 
+function markEdited(): void { pristine = false }
+
 function useCard(text: string): void {
 	personaText.value = text
+	pristine = false
 }
 
 async function saveAndContinue(): Promise<void> {
@@ -39,7 +43,7 @@ async function saveAndContinue(): Promise<void> {
 		saveError.value = "We couldn't save your introduction right now. Try again, or skip for now."
 		return
 	}
-	emit('next', { skipped: false })
+	emit('next', { skipped: personaText.value.trim() === '' })
 }
 
 function skipForNow(): void {
@@ -60,6 +64,7 @@ function skipForNow(): void {
 			v-model="personaText"
 			class="sp-onboarding__textarea"
 			aria-label="About you"
+			@input="markEdited"
 			placeholder="For example: I'm a product manager at a scale-up focusing on B2B growth. I spend most of my time on roadmap planning and stakeholder alignment."
 			data-testid="step2-textarea"
 		/>

--- a/src/ui/components/OnboardingStep2Persona.vue
+++ b/src/ui/components/OnboardingStep2Persona.vue
@@ -47,6 +47,7 @@ async function saveAndContinue(): Promise<void> {
 }
 
 function skipForNow(): void {
+	if (isSaving.value) return
 	emit('next', { skipped: true })
 }
 </script>

--- a/src/ui/components/OnboardingStep2Persona.vue
+++ b/src/ui/components/OnboardingStep2Persona.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+defineProps<{ initialValue: string }>()
+const emit = defineEmits<{ next: [payload: { skipped: boolean }] }>()
+</script>
+<template>
+	<div data-testid="step2-placeholder">
+		<button data-testid="step2-continue" @click="emit('next', { skipped: false })">Continue</button>
+		<button data-testid="step2-skip" @click="emit('next', { skipped: true })">Skip</button>
+	</div>
+</template>

--- a/src/ui/components/OnboardingStep2Persona.vue
+++ b/src/ui/components/OnboardingStep2Persona.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { useSettingsPort } from '@/ui/composables/useSettingsPort'
 import { useLoggerPort } from '@/ui/composables/useLoggerPort'
 import { tryAsync } from '@/domain/shared/tryAsync'
@@ -18,6 +18,7 @@ const EXAMPLE_CARDS = [
 ]
 
 const personaText = ref(props.initialValue)
+watch(() => props.initialValue, (val) => { personaText.value = val })
 const isSaving = ref(false)
 const saveError = ref<string | null>(null)
 
@@ -96,7 +97,6 @@ function skipForNow(): void {
 			</button>
 			<button
 				class="sp-onboarding__skip"
-				:disabled="isSaving"
 				data-testid="step2-skip"
 				@click="skipForNow"
 			>

--- a/src/ui/components/OnboardingStep3ClaudeCheck.vue
+++ b/src/ui/components/OnboardingStep3ClaudeCheck.vue
@@ -1,8 +1,113 @@
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useClaudeCliPort } from '@/ui/composables/useClaudeCliPort'
+import { useLoggerPort } from '@/ui/composables/useLoggerPort'
+import { tryAsync } from '@/domain/shared/tryAsync'
+
+type ClaudeStatus = 'checking' | 'ready' | 'not-ready' | 'unknown'
+
 const emit = defineEmits<{ next: [payload: { claudeStatus: 'ready' | 'not-ready' | 'unknown' }] }>()
+
+const claudeCliPort = useClaudeCliPort()
+const logger = useLoggerPort()
+
+const status = ref<ClaudeStatus>('checking')
+
+onMounted(async () => {
+	if (claudeCliPort === undefined) {
+		status.value = 'unknown'
+		return
+	}
+	const result = await tryAsync(
+		() => claudeCliPort.isAvailable(),
+		'ClaudeCliPort.isAvailable() threw unexpectedly',
+	)
+	if (!result.ok) {
+		logger.error('ClaudeCliPort.isAvailable() threw unexpectedly', result.error)
+		status.value = 'unknown'
+	} else {
+		status.value = result.value ? 'ready' : 'not-ready'
+	}
+	logger.debug('Claude CLI check resolved', { status: status.value })
+})
+
+function proceed(): void {
+	emit('next', { claudeStatus: status.value === 'checking' ? 'unknown' : status.value })
+}
 </script>
+
 <template>
-	<div data-testid="step3-placeholder">
-		<button data-testid="step3-continue" @click="emit('next', { claudeStatus: 'unknown' })">Continue</button>
+	<div class="sp-onboarding__step" data-testid="step3">
+		<h2 class="sp-onboarding__heading">Checking your AI assistant.</h2>
+
+		<div
+			role="status"
+			aria-live="polite"
+			class="sp-onboarding__status-region"
+			data-testid="step3-status-region"
+		>
+			<span v-if="status === 'checking'" class="sp-onboarding__spinner" aria-label="Loading" />
+
+			<p class="sp-onboarding__status-message" data-testid="step3-status-message">
+				<template v-if="status === 'checking'">Checking your AI assistant…</template>
+				<template v-else-if="status === 'ready'">Your AI assistant is ready.</template>
+				<template v-else-if="status === 'not-ready'">To get AI help, you'll need Claude installed.</template>
+				<template v-else>We couldn't check your AI assistant status right now. You can continue and check this later.</template>
+			</p>
+
+			<p v-if="status === 'not-ready'" class="sp-onboarding__status-sub" data-testid="step3-status-sub">
+				Claude is a free AI assistant made by Anthropic. Visit claude.ai to download it and follow
+				the setup instructions. Once it's installed, restart Obsidian and your AI suggestions will
+				be active.
+			</p>
+		</div>
+
+		<button
+			v-if="status !== 'checking'"
+			class="sp-btn sp-btn--primary sp-btn--md"
+			data-testid="step3-continue"
+			@click="proceed"
+		>
+			Continue
+		</button>
 	</div>
 </template>
+
+<style scoped>
+.sp-onboarding__status-region {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+	padding: 1rem;
+	background: var(--background-secondary);
+	border-radius: 8px;
+	border: 1px solid var(--background-modifier-border);
+}
+
+.sp-onboarding__status-message {
+	font-size: 0.9375rem;
+	color: var(--text-normal);
+	margin: 0;
+}
+
+.sp-onboarding__status-sub {
+	font-size: 0.875rem;
+	color: var(--text-muted);
+	margin: 0;
+	line-height: 1.5;
+}
+
+.sp-onboarding__spinner {
+	display: inline-block;
+	width: 1rem;
+	height: 1rem;
+	border: 2px solid var(--background-modifier-border);
+	border-top-color: var(--interactive-accent);
+	border-radius: 50%;
+	animation: sp-spin 0.7s linear infinite;
+}
+
+@keyframes sp-spin {
+	to { transform: rotate(360deg); }
+}
+</style>

--- a/src/ui/components/OnboardingStep3ClaudeCheck.vue
+++ b/src/ui/components/OnboardingStep3ClaudeCheck.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+const emit = defineEmits<{ next: [payload: { claudeStatus: 'ready' | 'not-ready' | 'unknown' }] }>()
+</script>
+<template>
+	<div data-testid="step3-placeholder">
+		<button data-testid="step3-continue" @click="emit('next', { claudeStatus: 'unknown' })">Continue</button>
+	</div>
+</template>

--- a/src/ui/components/OnboardingStep4Workspace.vue
+++ b/src/ui/components/OnboardingStep4Workspace.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+defineProps<{ initialSpecsFolder: string }>()
+const emit = defineEmits<{ next: [payload: { templateStatus: 'installed' | 'skipped' | 'failed'; specsFolder: string }] }>()
+</script>
+<template>
+	<div data-testid="step4-placeholder">
+		<button data-testid="step4-skip-btn" @click="emit('next', { templateStatus: 'skipped', specsFolder: 'specs' })">Skip</button>
+	</div>
+</template>

--- a/src/ui/components/OnboardingStep5Done.vue
+++ b/src/ui/components/OnboardingStep5Done.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+defineProps<{
+	personaSkipped: boolean
+	claudeStatus: 'ready' | 'not-ready' | 'unknown'
+	templateStatus: 'installed' | 'skipped' | 'failed'
+}>()
+const emit = defineEmits<{ finish: [] }>()
+</script>
+<template>
+	<div data-testid="step5-placeholder">
+		<button data-testid="step5-cta" @click="emit('finish')">Start using Specorator</button>
+	</div>
+</template>

--- a/src/ui/components/OnboardingStepIndicator.vue
+++ b/src/ui/components/OnboardingStepIndicator.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+defineProps<{
+	current: number
+	total: number
+}>()
+</script>
+
+<template>
+	<p
+		class="sp-onboarding__step-indicator"
+		:aria-label="`Step ${current} of ${total}`"
+		data-testid="step-indicator"
+	>
+		Step {{ current }} of {{ total }}
+	</p>
+</template>
+
+<style scoped>
+.sp-onboarding__step-indicator {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+</style>

--- a/src/ui/components/OnboardingWizard.vue
+++ b/src/ui/components/OnboardingWizard.vue
@@ -2,6 +2,8 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useSettingsPort } from '@/ui/composables/useSettingsPort'
+import { useLoggerPort } from '@/ui/composables/useLoggerPort'
+import { tryAsync } from '@/domain/shared/tryAsync'
 import type { PluginSettings } from '@/domain/settings/PluginSettings'
 import OnboardingStepIndicator from './OnboardingStepIndicator.vue'
 import OnboardingStep1Welcome from './OnboardingStep1Welcome.vue'
@@ -17,6 +19,7 @@ interface Step3Payload { claudeStatus: ClaudeStatus }
 interface Step4Payload { templateStatus: TemplateStatus; specsFolder: string }
 
 const settingsPort = useSettingsPort()
+const logger = useLoggerPort()
 const router = useRouter()
 
 const TOTAL_STEPS = 5
@@ -51,9 +54,6 @@ onMounted(async () => {
 	const s = await settingsPort.getSettings()
 	settings.value = s
 	specsFolder.value = s.specsFolder
-	if (!s.onboardingComplete) {
-		void router.push('/onboarding')
-	}
 })
 
 function applyStep2(payload: unknown): void {
@@ -88,7 +88,14 @@ function handleNext(payload?: unknown): void {
 	}
 }
 
-function handleFinish(): void {
+async function handleFinish(): Promise<void> {
+	const result = await tryAsync(async () => {
+		const current = await settingsPort.getSettings()
+		await settingsPort.saveSettings({ ...current, onboardingComplete: true })
+	}, 'Failed to mark onboarding complete')
+	if (!result.ok) {
+		logger.error('Failed to mark onboarding complete', result.error)
+	}
 	void router.push('/')
 }
 </script>

--- a/src/ui/components/OnboardingWizard.vue
+++ b/src/ui/components/OnboardingWizard.vue
@@ -95,6 +95,7 @@ async function handleFinish(): Promise<void> {
 	}, 'Failed to mark onboarding complete')
 	if (!result.ok) {
 		logger.error('Failed to mark onboarding complete', result.error)
+		return
 	}
 	void router.push('/')
 }

--- a/src/ui/components/OnboardingWizard.vue
+++ b/src/ui/components/OnboardingWizard.vue
@@ -1,0 +1,124 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useSettingsPort } from '@/ui/composables/useSettingsPort'
+import type { PluginSettings } from '@/domain/settings/PluginSettings'
+import OnboardingStepIndicator from './OnboardingStepIndicator.vue'
+import OnboardingStep1Welcome from './OnboardingStep1Welcome.vue'
+import OnboardingStep2Persona from './OnboardingStep2Persona.vue'
+import OnboardingStep3ClaudeCheck from './OnboardingStep3ClaudeCheck.vue'
+import OnboardingStep4Workspace from './OnboardingStep4Workspace.vue'
+import OnboardingStep5Done from './OnboardingStep5Done.vue'
+
+type ClaudeStatus = 'ready' | 'not-ready' | 'unknown'
+type TemplateStatus = 'installed' | 'skipped' | 'failed'
+interface Step2Payload { skipped: boolean }
+interface Step3Payload { claudeStatus: ClaudeStatus }
+interface Step4Payload { templateStatus: TemplateStatus; specsFolder: string }
+
+const settingsPort = useSettingsPort()
+const router = useRouter()
+
+const TOTAL_STEPS = 5
+const currentStep = ref(1)
+const settings = ref<PluginSettings | null>(null)
+
+const personaSkipped = ref(false)
+const claudeStatus = ref<ClaudeStatus>('unknown')
+const templateStatus = ref<TemplateStatus>('skipped')
+const specsFolder = ref('specs')
+
+const stepComponents = [
+	OnboardingStep1Welcome,
+	OnboardingStep2Persona,
+	OnboardingStep3ClaudeCheck,
+	OnboardingStep4Workspace,
+	OnboardingStep5Done,
+]
+
+const currentStepComponent = computed(() => stepComponents[currentStep.value - 1])
+
+const stepProps = computed(() => {
+	switch (currentStep.value) {
+		case 2: return { initialValue: settings.value?.userPersona ?? '' }
+		case 4: return { initialSpecsFolder: specsFolder.value }
+		case 5: return { personaSkipped: personaSkipped.value, claudeStatus: claudeStatus.value, templateStatus: templateStatus.value }
+		default: return {}
+	}
+})
+
+onMounted(async () => {
+	const s = await settingsPort.getSettings()
+	settings.value = s
+	specsFolder.value = s.specsFolder
+	if (!s.onboardingComplete) {
+		void router.push('/onboarding')
+	}
+})
+
+function applyStep2(payload: unknown): void {
+	if (payload !== null && typeof payload === 'object' && 'skipped' in payload) {
+		personaSkipped.value = (payload as Step2Payload).skipped
+	}
+}
+
+function applyStep3(payload: unknown): void {
+	if (payload !== null && typeof payload === 'object' && 'claudeStatus' in payload) {
+		claudeStatus.value = (payload as Step3Payload).claudeStatus
+	}
+}
+
+function applyStep4(payload: unknown): void {
+	if (payload !== null && typeof payload === 'object' && 'templateStatus' in payload) {
+		const p = payload as Step4Payload
+		templateStatus.value = p.templateStatus
+		specsFolder.value = p.specsFolder
+	}
+}
+
+function handleNext(payload?: unknown): void {
+	const stepHandlers: Partial<Record<number, (p: unknown) => void>> = {
+		2: applyStep2,
+		3: applyStep3,
+		4: applyStep4,
+	}
+	stepHandlers[currentStep.value]?.(payload)
+	if (currentStep.value < TOTAL_STEPS) {
+		currentStep.value++
+	}
+}
+
+function handleFinish(): void {
+	void router.push('/')
+}
+</script>
+
+<template>
+	<div class="sp-onboarding" data-testid="onboarding-wizard">
+		<OnboardingStepIndicator :current="currentStep" :total="TOTAL_STEPS" />
+		<div class="sp-onboarding__step">
+			<component
+				:is="currentStepComponent"
+				v-bind="stepProps"
+				@next="handleNext"
+				@finish="handleFinish"
+			/>
+		</div>
+	</div>
+</template>
+
+<style scoped>
+.sp-onboarding {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.5rem 1rem;
+  height: 100%;
+}
+
+.sp-onboarding__step {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+</style>

--- a/src/ui/composables/useClaudeCliPort.ts
+++ b/src/ui/composables/useClaudeCliPort.ts
@@ -1,0 +1,7 @@
+import { inject } from 'vue'
+import type { ClaudeCliPort } from '@/domain/ports'
+import { CLAUDE_CLI_PORT } from '@/infrastructure/bridge/ports'
+
+export function useClaudeCliPort(): ClaudeCliPort | undefined {
+	return inject(CLAUDE_CLI_PORT)
+}

--- a/src/ui/main.ts
+++ b/src/ui/main.ts
@@ -17,6 +17,7 @@ import {
   WORKSPACE_PORT,
   NOTIFICATION_PORT,
   LOGGER_PORT,
+  CLAUDE_CLI_PORT,
 } from '@/infrastructure/bridge/ports'
 import { LocalStorageBridge } from '@/infrastructure/localstorage/LocalStorageBridge'
 import { MockBridge } from '@/infrastructure/mock/MockBridge'
@@ -63,6 +64,7 @@ void bridge.getSettings()
     app.provide(WORKSPACE_PORT, bridge)
     app.provide(NOTIFICATION_PORT, bridge)
     app.provide(LOGGER_PORT, bridge)
+    app.provide(CLAUDE_CLI_PORT, bridge)
     app.provide(
       FEATURE_SERVICE_KEY,
       new FeatureService(new FeatureRepository(bridge, bridge, bridge)),

--- a/src/ui/router/index.ts
+++ b/src/ui/router/index.ts
@@ -5,6 +5,7 @@ import FeaturesView from '../views/FeaturesView.vue'
 import SettingsView from '../views/SettingsView.vue'
 import FileView from '../views/FileView.vue'
 import MainLayout from '../layouts/MainLayout.vue'
+import OnboardingWizard from '../components/OnboardingWizard.vue'
 
 declare module 'vue-router' {
   interface RouteMeta {
@@ -19,5 +20,6 @@ export const router = createRouter({
     { path: '/features', name: 'features', component: FeaturesView, meta: { layout: MainLayout } },
     { path: '/settings', name: 'settings', component: SettingsView, meta: { layout: MainLayout } },
     { path: '/file/:filePath(.*)', name: 'file', component: FileView, meta: { layout: MainLayout } },
+    { path: '/onboarding', name: 'onboarding', component: OnboardingWizard },
   ],
 })

--- a/styles.css
+++ b/styles.css
@@ -386,6 +386,105 @@ to { transform: rotate(360deg);
   margin: 0;
 }
 
+.specorator-root :where(.sp-onboarding__card[data-v-e8e2f4e1]) {
+	border-radius: 6px;
+	padding: 0.75rem 0.875rem;
+	cursor: pointer;
+	text-align: left;
+	font-size: 0.875rem;
+	color: var(--text-normal);
+	width: 100%;
+	border: 1px solid var(--background-modifier-border);
+	background: var(--background-secondary);
+	transition: background 0.15s;
+}
+.specorator-root :where(.sp-onboarding__card[data-v-e8e2f4e1]:hover) {
+	background: var(--background-modifier-hover);
+}
+
+.specorator-root :where(.sp-onboarding__textarea[data-v-b5554fae]) {
+	min-height: 7rem;
+	resize: vertical;
+	line-height: 1.6;
+	width: 100%;
+	padding: 0.5rem 0.75rem;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 4px;
+	background: var(--background-primary);
+	color: var(--text-normal);
+	font-size: 0.9375rem;
+}
+.specorator-root :where(.sp-onboarding__hint[data-v-b5554fae]) {
+	font-size: 0.875rem;
+	color: var(--text-muted);
+	margin: 0;
+}
+.specorator-root :where(.sp-onboarding__cards[data-v-b5554fae]) {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	margin-top: 0.25rem;
+}
+.specorator-root :where(.sp-onboarding__inline-error[data-v-b5554fae]) {
+	color: var(--text-error);
+	font-size: 0.875rem;
+	margin: 0;
+}
+.specorator-root :where(.sp-onboarding__actions[data-v-b5554fae]) {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	align-items: flex-start;
+}
+.specorator-root :where(.sp-onboarding__skip[data-v-b5554fae]) {
+	background: none;
+	border: none;
+	padding: 0;
+	cursor: pointer;
+	color: var(--text-muted);
+	font-size: 0.875rem;
+	min-width: 24px;
+	min-height: 24px;
+}
+.specorator-root :where(.sp-onboarding__skip[data-v-b5554fae]:disabled) {
+	opacity: 0.5;
+	cursor: default;
+}
+
+.specorator-root :where(.sp-onboarding__status-region[data-v-665e4aa5]) {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+	padding: 1rem;
+	background: var(--background-secondary);
+	border-radius: 8px;
+	border: 1px solid var(--background-modifier-border);
+}
+.specorator-root :where(.sp-onboarding__status-message[data-v-665e4aa5]) {
+	font-size: 0.9375rem;
+	color: var(--text-normal);
+	margin: 0;
+}
+.specorator-root :where(.sp-onboarding__status-sub[data-v-665e4aa5]) {
+	font-size: 0.875rem;
+	color: var(--text-muted);
+	margin: 0;
+	line-height: 1.5;
+}
+.specorator-root :where(.sp-onboarding__spinner[data-v-665e4aa5]) {
+	display: inline-block;
+	width: 1rem;
+	height: 1rem;
+	border: 2px solid var(--background-modifier-border);
+	border-top-color: var(--interactive-accent);
+	border-radius: 50%;
+	animation: sp-spin-665e4aa5 0.7s linear infinite;
+}
+@keyframes sp-spin-665e4aa5 {
+to { transform: rotate(360deg);
+}
+}
+
 .specorator-root :where(.sp-onboarding[data-v-0053404f]) {
   display: flex;
   flex-direction: column;

--- a/styles.css
+++ b/styles.css
@@ -380,6 +380,25 @@ to { transform: rotate(360deg);
   background: var(--background-secondary);
 }
 
+.specorator-root :where(.sp-onboarding__step-indicator[data-v-8902bb56]) {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.specorator-root :where(.sp-onboarding[data-v-0053404f]) {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.5rem 1rem;
+  height: 100%;
+}
+.specorator-root :where(.sp-onboarding__step[data-v-0053404f]) {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
 .specorator-root :where(.sp-toast-container[data-v-0721de72]) {
   position: fixed;
   bottom: 1.5rem;

--- a/tests/core/core-settings.test.ts
+++ b/tests/core/core-settings.test.ts
@@ -7,7 +7,7 @@ describe('coreSettingsModule descriptor metadata', () => {
   it('has the expected id, settingsKey, and settingsVersion', () => {
     expect(coreSettingsModule.id).toBe('specorator')
     expect(coreSettingsModule.settingsKey).toBe('specorator')
-    expect(coreSettingsModule.settingsVersion).toBe(2)
+    expect(coreSettingsModule.settingsVersion).toBe(3)
   })
 
   it('settingsDefaults equals DEFAULT_SETTINGS', () => {
@@ -57,6 +57,44 @@ describe('coreSettingsModule.migrate (v1 → v2 mcpServerEnabled)', () => {
     expect(migrate(0, null)).toEqual({ mcpServerEnabled: false })
     expect(migrate(0, 'string-junk')).toEqual({ mcpServerEnabled: false })
     expect(migrate(0, [])).toEqual({ mcpServerEnabled: false })
+  })
+})
+
+describe('coreSettingsModule.migrate (v2 → v3 onboardingComplete)', () => {
+  const migrate = (fromVersion: number, blob: unknown): unknown => {
+    const fn = coreSettingsModule.migrate
+    if (!fn) throw new Error('migrate is undefined')
+    return fn(fromVersion, blob)
+  }
+
+  it('injects onboardingComplete=true when upgrading from v1 (existing install)', () => {
+    const out = migrate(1, { specsFolder: 'specs' }) as Record<string, unknown>
+    expect(out.onboardingComplete).toBe(true)
+  })
+
+  it('injects onboardingComplete=true when upgrading from v2 (existing install)', () => {
+    const out = migrate(2, { specsFolder: 'specs' }) as Record<string, unknown>
+    expect(out.onboardingComplete).toBe(true)
+  })
+
+  it('does NOT inject onboardingComplete for a fresh install (fromVersion=0)', () => {
+    const out = migrate(0, {}) as Record<string, unknown>
+    expect('onboardingComplete' in out).toBe(false)
+  })
+
+  it('does not inject onboardingComplete when already at v3 or later', () => {
+    const out = migrate(3, {}) as Record<string, unknown>
+    expect('onboardingComplete' in out).toBe(false)
+  })
+
+  it('preserves existing onboardingComplete=false when upgrading', () => {
+    const out = migrate(2, { onboardingComplete: false }) as Record<string, unknown>
+    expect(out.onboardingComplete).toBe(false)
+  })
+
+  it('preserves existing onboardingComplete=true when upgrading', () => {
+    const out = migrate(2, { onboardingComplete: true }) as Record<string, unknown>
+    expect(out.onboardingComplete).toBe(true)
   })
 })
 

--- a/tests/core/core-settings.test.ts
+++ b/tests/core/core-settings.test.ts
@@ -77,9 +77,14 @@ describe('coreSettingsModule.migrate (v2 → v3 onboardingComplete)', () => {
     expect(out.onboardingComplete).toBe(true)
   })
 
-  it('does NOT inject onboardingComplete for a fresh install (fromVersion=0)', () => {
+  it('does NOT inject onboardingComplete for a fresh install (fromVersion=0, empty blob)', () => {
     const out = migrate(0, {}) as Record<string, unknown>
     expect('onboardingComplete' in out).toBe(false)
+  })
+
+  it('injects onboardingComplete=true for unversioned existing install (fromVersion=0, non-empty blob)', () => {
+    const out = migrate(0, { specsFolder: 'specs', locale: 'en' }) as Record<string, unknown>
+    expect(out.onboardingComplete).toBe(true)
   })
 
   it('does not inject onboardingComplete when already at v3 or later', () => {

--- a/tests/ui/AppRoot.test.ts
+++ b/tests/ui/AppRoot.test.ts
@@ -5,7 +5,7 @@ import { createMemoryHistory, createRouter } from 'vue-router'
 import AppRoot from '@/ui/AppRoot.vue'
 import DashboardLayout from '@/ui/layouts/DashboardLayout.vue'
 import { i18n } from '@/ui/i18n'
-import { LOGGER_PORT, NOTIFICATION_PORT } from '@/infrastructure/bridge/ports'
+import { LOGGER_PORT, NOTIFICATION_PORT, SETTINGS_PORT } from '@/infrastructure/bridge/ports'
 import { fakeModulePorts } from '../__fakes__/fake-ports'
 import { AppRootPageObject } from './AppRoot.po'
 
@@ -39,12 +39,15 @@ async function mountAppRoot(initialPath: string) {
 	await router.push(initialPath)
 	await router.isReady()
 	const ports = fakeModulePorts()
+	const current = await ports.settings.getSettings()
+	await ports.settings.saveSettings({ ...current, onboardingComplete: true })
 	const wrapper = mount(AppRoot, {
 		global: {
 			plugins: [i18n, router, createPinia()],
 			provide: {
 				[LOGGER_PORT as unknown as symbol]: ports.logger,
 				[NOTIFICATION_PORT as unknown as symbol]: ports.notifications,
+				[SETTINGS_PORT as unknown as symbol]: ports.settings,
 			},
 		},
 	})

--- a/tests/ui/components/OnboardingPersonaCard.po.ts
+++ b/tests/ui/components/OnboardingPersonaCard.po.ts
@@ -1,0 +1,9 @@
+import type { VueWrapper } from '@vue/test-utils'
+
+export class OnboardingPersonaCardPO {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	get button() { return this.wrapper.find('[data-testid="persona-card"]') }
+
+	async click() { await this.button.trigger('click') }
+}

--- a/tests/ui/components/OnboardingPersonaCard.test.ts
+++ b/tests/ui/components/OnboardingPersonaCard.test.ts
@@ -1,0 +1,29 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import OnboardingPersonaCard from '@/ui/components/OnboardingPersonaCard.vue'
+import { OnboardingPersonaCardPO } from './OnboardingPersonaCard.po'
+
+const EXAMPLE = "I'm a test persona."
+
+describe('OnboardingPersonaCard', () => {
+	function mountComponent(text = EXAMPLE) {
+		const wrapper = mount(OnboardingPersonaCard, { props: { text } })
+		return { wrapper, po: new OnboardingPersonaCardPO(wrapper) }
+	}
+
+	it('renders card text', () => {
+		const { po } = mountComponent()
+		expect(po.button.text()).toBe(EXAMPLE)
+	})
+
+	it('has aria-label with the example text', () => {
+		const { po } = mountComponent()
+		expect(po.button.attributes('aria-label')).toBe(`Use this example: ${EXAMPLE}`)
+	})
+
+	it('emits use with text when clicked', async () => {
+		const { wrapper, po } = mountComponent()
+		await po.click()
+		expect(wrapper.emitted('use')?.[0]).toEqual([EXAMPLE])
+	})
+})

--- a/tests/ui/components/OnboardingStep1Welcome.po.ts
+++ b/tests/ui/components/OnboardingStep1Welcome.po.ts
@@ -1,0 +1,11 @@
+import type { VueWrapper } from '@vue/test-utils'
+
+export class OnboardingStep1WelcomePO {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	get container() { return this.wrapper.find('[data-testid="step1"]') }
+	get heading() { return this.wrapper.find('h2') }
+	get cta() { return this.wrapper.find('[data-testid="step1-cta"]') }
+
+	async clickCta() { await this.cta.trigger('click') }
+}

--- a/tests/ui/components/OnboardingStep1Welcome.test.ts
+++ b/tests/ui/components/OnboardingStep1Welcome.test.ts
@@ -1,0 +1,22 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import OnboardingStep1Welcome from '@/ui/components/OnboardingStep1Welcome.vue'
+import { OnboardingStep1WelcomePO } from './OnboardingStep1Welcome.po'
+
+describe('OnboardingStep1Welcome', () => {
+	function mountComponent() {
+		const wrapper = mount(OnboardingStep1Welcome)
+		return { wrapper, po: new OnboardingStep1WelcomePO(wrapper) }
+	}
+
+	it('renders the welcome heading', () => {
+		const { po } = mountComponent()
+		expect(po.heading.text()).toBe('Welcome to Specorator.')
+	})
+
+	it('emits next when CTA is clicked', async () => {
+		const { wrapper, po } = mountComponent()
+		await po.clickCta()
+		expect(wrapper.emitted('next')).toHaveLength(1)
+	})
+})

--- a/tests/ui/components/OnboardingStep2Persona.po.ts
+++ b/tests/ui/components/OnboardingStep2Persona.po.ts
@@ -1,0 +1,18 @@
+import type { VueWrapper } from '@vue/test-utils'
+
+export class OnboardingStep2PersonaPO {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	get container() { return this.wrapper.find('[data-testid="step2"]') }
+	get textarea() { return this.wrapper.find('[data-testid="step2-textarea"]') }
+	get continueBtn() { return this.wrapper.find('[data-testid="step2-continue"]') }
+	get skipBtn() { return this.wrapper.find('[data-testid="step2-skip"]') }
+	get saveError() { return this.wrapper.find('[data-testid="step2-save-error"]') }
+	cards() { return this.wrapper.findAll('[data-testid^="step2-card"]') }
+
+	async typePersona(text: string) {
+		await this.textarea.setValue(text)
+	}
+	async clickContinue() { await this.continueBtn.trigger('click') }
+	async clickSkip() { await this.skipBtn.trigger('click') }
+}

--- a/tests/ui/components/OnboardingStep2Persona.test.ts
+++ b/tests/ui/components/OnboardingStep2Persona.test.ts
@@ -1,0 +1,70 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createTestingPinia } from '@pinia/testing'
+import OnboardingStep2Persona from '@/ui/components/OnboardingStep2Persona.vue'
+import { SETTINGS_PORT, LOGGER_PORT } from '@/infrastructure/bridge/ports'
+import { OnboardingStep2PersonaPO } from './OnboardingStep2Persona.po'
+import type { SettingsPort } from '@/domain/ports'
+import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
+
+function makeMockSettingsPort(overrides: Partial<SettingsPort> = {}): SettingsPort {
+	return {
+		getSettings: vi.fn().mockResolvedValue({ ...DEFAULT_SETTINGS }),
+		saveSettings: vi.fn().mockResolvedValue(undefined),
+		...overrides,
+	}
+}
+
+const mockLogger = {
+	debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+}
+
+describe('OnboardingStep2Persona', () => {
+	function mountComponent(initialValue = '', settingsPort?: Partial<SettingsPort>) {
+		const port = makeMockSettingsPort(settingsPort)
+		const wrapper = mount(OnboardingStep2Persona, {
+			props: { initialValue },
+			global: {
+				plugins: [createTestingPinia()],
+				provide: {
+					[SETTINGS_PORT as symbol]: port,
+					[LOGGER_PORT as symbol]: mockLogger,
+				},
+			},
+		})
+		return { wrapper, po: new OnboardingStep2PersonaPO(wrapper), port }
+	}
+
+	beforeEach(() => { vi.clearAllMocks() })
+
+	it('renders textarea with initialValue', () => {
+		const { po } = mountComponent('hello')
+		expect((po.textarea.element as HTMLTextAreaElement).value).toBe('hello')
+	})
+
+	it('skip emits next with skipped:true and does not save', async () => {
+		const { wrapper, po, port } = mountComponent()
+		await po.clickSkip()
+		expect(wrapper.emitted('next')?.[0]).toEqual([{ skipped: true }])
+		expect(port.saveSettings).not.toHaveBeenCalled()
+	})
+
+	it('continue saves persona and emits next with skipped:false', async () => {
+		const { wrapper, po, port } = mountComponent()
+		await po.typePersona('I am a PM.')
+		await po.clickContinue()
+		await wrapper.vm.$nextTick()
+		expect(port.saveSettings).toHaveBeenCalled()
+		expect(wrapper.emitted('next')?.[0]).toEqual([{ skipped: false }])
+	})
+
+	it('shows error message when save fails', async () => {
+		const { wrapper, po } = mountComponent('', {
+			saveSettings: vi.fn().mockRejectedValue(new Error('disk full')),
+		})
+		await po.clickContinue()
+		await wrapper.vm.$nextTick()
+		expect(po.saveError.exists()).toBe(true)
+		expect(wrapper.emitted('next')).toBeUndefined()
+	})
+})

--- a/tests/ui/components/OnboardingStep3ClaudeCheck.po.ts
+++ b/tests/ui/components/OnboardingStep3ClaudeCheck.po.ts
@@ -1,0 +1,12 @@
+import type { VueWrapper } from '@vue/test-utils'
+
+export class OnboardingStep3ClaudeCheckPO {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	get container() { return this.wrapper.find('[data-testid="step3"]') }
+	get statusRegion() { return this.wrapper.find('[data-testid="step3-status-region"]') }
+	get statusMessage() { return this.wrapper.find('[data-testid="step3-status-message"]') }
+	get continueBtn() { return this.wrapper.find('[data-testid="step3-continue"]') }
+
+	async clickContinue() { await this.continueBtn.trigger('click') }
+}

--- a/tests/ui/components/OnboardingStep3ClaudeCheck.test.ts
+++ b/tests/ui/components/OnboardingStep3ClaudeCheck.test.ts
@@ -1,0 +1,70 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+import { createTestingPinia } from '@pinia/testing'
+import OnboardingStep3ClaudeCheck from '@/ui/components/OnboardingStep3ClaudeCheck.vue'
+import { CLAUDE_CLI_PORT, LOGGER_PORT } from '@/infrastructure/bridge/ports'
+import { OnboardingStep3ClaudeCheckPO } from './OnboardingStep3ClaudeCheck.po'
+import type { ClaudeCliPort } from '@/domain/ports'
+
+const mockLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+
+function makePort(available: boolean | 'throw'): ClaudeCliPort {
+	return {
+		isAvailable: available === 'throw'
+			? vi.fn().mockRejectedValue(new Error('boom'))
+			: vi.fn().mockResolvedValue(available),
+	}
+}
+
+describe('OnboardingStep3ClaudeCheck', () => {
+	function mountComponent(port?: ClaudeCliPort) {
+		const provide: Record<symbol, unknown> = {
+			[LOGGER_PORT as symbol]: mockLogger,
+		}
+		if (port !== undefined) {
+			provide[CLAUDE_CLI_PORT as symbol] = port
+		}
+		const wrapper = mount(OnboardingStep3ClaudeCheck, {
+			global: { plugins: [createTestingPinia()], provide },
+		})
+		return { wrapper, po: new OnboardingStep3ClaudeCheckPO(wrapper) }
+	}
+
+	it('shows checking state initially', () => {
+		const { po } = mountComponent(makePort(true))
+		expect(po.statusMessage.text()).toContain('Checking')
+		expect(po.continueBtn.exists()).toBe(false)
+	})
+
+	it('shows ready state when CLI is available', async () => {
+		const { po } = mountComponent(makePort(true))
+		await flushPromises()
+		expect(po.statusMessage.text()).toContain('ready')
+		expect(po.continueBtn.exists()).toBe(true)
+	})
+
+	it('shows not-ready state when CLI is unavailable', async () => {
+		const { po } = mountComponent(makePort(false))
+		await flushPromises()
+		expect(po.statusMessage.text()).toContain('Claude installed')
+	})
+
+	it('shows unknown state when port is not provided', async () => {
+		const { po } = mountComponent(undefined)
+		await flushPromises()
+		expect(po.statusMessage.text()).toContain("couldn't check")
+	})
+
+	it('shows unknown state when port throws', async () => {
+		const { po } = mountComponent(makePort('throw'))
+		await flushPromises()
+		expect(po.statusMessage.text()).toContain("couldn't check")
+	})
+
+	it('emits next with claudeStatus when continue clicked', async () => {
+		const { wrapper, po } = mountComponent(makePort(true))
+		await flushPromises()
+		await po.clickContinue()
+		expect(wrapper.emitted('next')?.[0]).toEqual([{ claudeStatus: 'ready' }])
+	})
+})


### PR DESCRIPTION
## Summary

- Implements real `OnboardingStep1Welcome.vue` (heading + CTA), `OnboardingPersonaCard.vue` (focusable example card), `OnboardingStep2Persona.vue` (textarea + save/skip + error handling using `tryAsync`), and `OnboardingStep3ClaudeCheck.vue` (calls `ClaudeCliPort.isAvailable()`, handles ready/not-ready/unknown/checking states)
- Adds missing `OnboardingStep3ClaudeCheck.test.ts` (6 cases) and co-located PageObjects for all 4 components; all components tested via `data-testid` selectors only
- Adds `@pinia/testing` dev dependency required by the new Vue component tests

Closes #195

## Test plan

- [ ] `npm run verify` passes (630 tests, 0 errors, all coverage thresholds met, both builds succeed)
- [ ] Step 1 CTA emits `next`; step 2 textarea saves persona or skips gracefully; step 3 reflects `isAvailable()` result
- [ ] Error banner shown on step 2 save failure; skip button always available
- [ ] Step 3 shows "checking…" then transitions to ready/not-ready/unknown based on CLI probe result

https://claude.ai/code/session_011G6giKLusJ5W5NoZmGwnyV

---
_Generated by [Claude Code](https://claude.ai/code/session_011G6giKLusJ5W5NoZmGwnyV)_