### PR TITLE
feat(ui): onboarding steps 1–3 — welcome, persona capture, Claude CLI check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 			},
 			"devDependencies": {
 				"@eslint/js": "^10.0.1",
+				"@pinia/testing": "^1.0.3",
 				"@storybook/addon-a11y": "^10.3.6",
 				"@storybook/addon-vitest": "^10.3.6",
 				"@storybook/vue3-vite": "^10.3.6",
@@ -1491,6 +1492,19 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/@pinia/testing": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@pinia/testing/-/testing-1.0.3.tgz",
+			"integrity": "sha512-g+qR49GNdI1Z8rZxKrQC3GN+LfnGTNf5Kk8Nz5Cz6mIGva5WRS+ffPXQfzhA0nu6TveWzPNYTjGl4nJqd3Cu9Q==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/posva"
+			},
+			"peerDependencies": {
+				"pinia": ">=3.0.4"
 			}
 		},
 		"node_modules/@pkgjs/parseargs": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 	},
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",
+		"@pinia/testing": "^1.0.3",
 		"@storybook/addon-a11y": "^10.3.6",
 		"@storybook/addon-vitest": "^10.3.6",
 		"@storybook/vue3-vite": "^10.3.6",

--- a/src/ui/components/OnboardingPersonaCard.vue
+++ b/src/ui/components/OnboardingPersonaCard.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+const props = defineProps<{ text: string }>()
+const emit = defineEmits<{ use: [text: string] }>()
+</script>
+
+<template>
+	<button
+		class="sp-onboarding__card"
+		:aria-label="`Use this example: ${props.text}`"
+		data-testid="persona-card"
+		@click="emit('use', props.text)"
+	>
+		{{ props.text }}
+	</button>
+</template>
+
+<style scoped>
+.sp-onboarding__card {
+	border-radius: 6px;
+	padding: 0.75rem 0.875rem;
+	cursor: pointer;
+	text-align: left;
+	font-size: 0.875rem;
+	color: var(--text-normal);
+	width: 100%;
+	border: 1px solid var(--background-modifier-border);
+	background: var(--background-secondary);
+	transition: background 0.15s;
+}
+
+.sp-onboarding__card:hover {
+	background: var(--background-modifier-hover);
+}
+</style>

--- a/src/ui/components/OnboardingStep1Welcome.vue
+++ b/src/ui/components/OnboardingStep1Welcome.vue
@@ -1,8 +1,21 @@
 <script setup lang="ts">
 const emit = defineEmits<{ next: [] }>()
 </script>
+
 <template>
-	<div data-testid="step1-placeholder">
-		<button data-testid="step1-cta" @click="emit('next')">Let's get started</button>
+	<div class="sp-onboarding__step" data-testid="step1">
+		<h2 class="sp-onboarding__heading">Welcome to Specorator.</h2>
+		<p class="sp-onboarding__body">
+			Specorator helps you plan features, run structured workflows, and get relevant AI suggestions
+			— all inside Obsidian. This short setup takes about two minutes and gets you to a working
+			state straightaway.
+		</p>
+		<button
+			class="sp-btn sp-btn--primary sp-btn--md"
+			data-testid="step1-cta"
+			@click="emit('next')"
+		>
+			Let's get started
+		</button>
 	</div>
 </template>

--- a/src/ui/components/OnboardingStep2Persona.vue
+++ b/src/ui/components/OnboardingStep2Persona.vue
@@ -1,10 +1,170 @@
 <script setup lang="ts">
-defineProps<{ initialValue: string }>()
+import { ref, watch } from 'vue'
+import { useSettingsPort } from '@/ui/composables/useSettingsPort'
+import { useLoggerPort } from '@/ui/composables/useLoggerPort'
+import { tryAsync } from '@/domain/shared/tryAsync'
+import OnboardingPersonaCard from './OnboardingPersonaCard.vue'
+
+const props = defineProps<{ initialValue: string }>()
 const emit = defineEmits<{ next: [payload: { skipped: boolean }] }>()
+
+const settingsPort = useSettingsPort()
+const logger = useLoggerPort()
+
+const EXAMPLE_CARDS = [
+	"I'm a product manager at a mid-size SaaS company. I focus on roadmap planning and work closely with engineering and design.",
+	"I'm a founder building a B2B tool. I wear many hats — from sales to product — and need to move quickly without losing sight of the big picture.",
+	"I'm a business analyst at a financial services firm. I gather requirements, document processes, and bridge the gap between stakeholders and technical teams.",
+]
+
+const personaText = ref(props.initialValue)
+let pristine = true
+watch(() => props.initialValue, (val) => { if (pristine) personaText.value = val })
+const isSaving = ref(false)
+const saveError = ref<string | null>(null)
+
+function markEdited(): void { pristine = false }
+
+function useCard(text: string): void {
+	personaText.value = text
+	pristine = false
+}
+
+async function saveAndContinue(): Promise<void> {
+	isSaving.value = true
+	saveError.value = null
+	const result = await tryAsync(async () => {
+		const current = await settingsPort.getSettings()
+		await settingsPort.saveSettings({ ...current, userPersona: personaText.value })
+	}, 'Failed to save persona')
+	isSaving.value = false
+	if (!result.ok) {
+		logger.error('Failed to save persona', result.error)
+		saveError.value = "We couldn't save your introduction right now. Try again, or skip for now."
+		return
+	}
+	emit('next', { skipped: personaText.value.trim() === '' })
+}
+
+function skipForNow(): void {
+	if (isSaving.value) return
+	emit('next', { skipped: true })
+}
 </script>
+
 <template>
-	<div data-testid="step2-placeholder">
-		<button data-testid="step2-continue" @click="emit('next', { skipped: false })">Continue</button>
-		<button data-testid="step2-skip" @click="emit('next', { skipped: true })">Skip</button>
+	<div class="sp-onboarding__step" data-testid="step2">
+		<h2 class="sp-onboarding__heading">Tell us a little about yourself.</h2>
+		<p class="sp-onboarding__body">
+			A few sentences about your role and what you're working on helps Specorator give you more
+			relevant suggestions. There's no right or wrong answer — just describe yourself as you would
+			to a colleague.
+		</p>
+
+		<textarea
+			v-model="personaText"
+			class="sp-onboarding__textarea"
+			aria-label="About you"
+			placeholder="For example: I'm a product manager at a scale-up focusing on B2B growth. I spend most of my time on roadmap planning and stakeholder alignment."
+			data-testid="step2-textarea"
+			@input="markEdited"
+		/>
+		<p class="sp-onboarding__hint">Two to four sentences is plenty.</p>
+
+		<div class="sp-onboarding__cards">
+			<OnboardingPersonaCard
+				v-for="(card, i) in EXAMPLE_CARDS"
+				:key="i"
+				:text="card"
+				:data-testid="`step2-card-${i}`"
+				@use="useCard"
+			/>
+		</div>
+
+		<p
+			v-if="saveError !== null"
+			role="alert"
+			aria-live="assertive"
+			class="sp-onboarding__inline-error"
+			data-testid="step2-save-error"
+		>
+			{{ saveError }}
+		</p>
+
+		<div class="sp-onboarding__actions">
+			<button
+				class="sp-btn sp-btn--primary sp-btn--md"
+				:aria-label="isSaving ? 'Saving, please wait' : 'Save and continue'"
+				:disabled="isSaving"
+				data-testid="step2-continue"
+				@click="saveAndContinue"
+			>
+				{{ isSaving ? 'Saving…' : 'Save and continue' }}
+			</button>
+			<button
+				class="sp-onboarding__skip"
+				data-testid="step2-skip"
+				@click="skipForNow"
+			>
+				I'll do this later
+			</button>
+		</div>
 	</div>
 </template>
+
+<style scoped>
+.sp-onboarding__textarea {
+	min-height: 7rem;
+	resize: vertical;
+	line-height: 1.6;
+	width: 100%;
+	padding: 0.5rem 0.75rem;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 4px;
+	background: var(--background-primary);
+	color: var(--text-normal);
+	font-size: 0.9375rem;
+}
+
+.sp-onboarding__hint {
+	font-size: 0.875rem;
+	color: var(--text-muted);
+	margin: 0;
+}
+
+.sp-onboarding__cards {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	margin-top: 0.25rem;
+}
+
+.sp-onboarding__inline-error {
+	color: var(--text-error);
+	font-size: 0.875rem;
+	margin: 0;
+}
+
+.sp-onboarding__actions {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	align-items: flex-start;
+}
+
+.sp-onboarding__skip {
+	background: none;
+	border: none;
+	padding: 0;
+	cursor: pointer;
+	color: var(--text-muted);
+	font-size: 0.875rem;
+	min-width: 24px;
+	min-height: 24px;
+}
+
+.sp-onboarding__skip:disabled {
+	opacity: 0.5;
+	cursor: default;
+}
+</style>

--- a/src/ui/components/OnboardingStep3ClaudeCheck.vue
+++ b/src/ui/components/OnboardingStep3ClaudeCheck.vue
@@ -1,8 +1,113 @@
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useClaudeCliPort } from '@/ui/composables/useClaudeCliPort'
+import { useLoggerPort } from '@/ui/composables/useLoggerPort'
+import { tryAsync } from '@/domain/shared/tryAsync'
+
+type ClaudeStatus = 'checking' | 'ready' | 'not-ready' | 'unknown'
+
 const emit = defineEmits<{ next: [payload: { claudeStatus: 'ready' | 'not-ready' | 'unknown' }] }>()
+
+const claudeCliPort = useClaudeCliPort()
+const logger = useLoggerPort()
+
+const status = ref<ClaudeStatus>('checking')
+
+onMounted(async () => {
+	if (claudeCliPort === undefined) {
+		status.value = 'unknown'
+		return
+	}
+	const result = await tryAsync(
+		() => claudeCliPort.isAvailable(),
+		'ClaudeCliPort.isAvailable() threw unexpectedly',
+	)
+	if (!result.ok) {
+		logger.error('ClaudeCliPort.isAvailable() threw unexpectedly', result.error)
+		status.value = 'unknown'
+	} else {
+		status.value = result.value ? 'ready' : 'not-ready'
+	}
+	logger.debug('Claude CLI check resolved', { status: status.value })
+})
+
+function proceed(): void {
+	emit('next', { claudeStatus: status.value === 'checking' ? 'unknown' : status.value })
+}
 </script>
+
 <template>
-	<div data-testid="step3-placeholder">
-		<button data-testid="step3-continue" @click="emit('next', { claudeStatus: 'unknown' })">Continue</button>
+	<div class="sp-onboarding__step" data-testid="step3">
+		<h2 class="sp-onboarding__heading">Checking your AI assistant.</h2>
+
+		<div
+			role="status"
+			aria-live="polite"
+			class="sp-onboarding__status-region"
+			data-testid="step3-status-region"
+		>
+			<span v-if="status === 'checking'" class="sp-onboarding__spinner" aria-label="Loading" />
+
+			<p class="sp-onboarding__status-message" data-testid="step3-status-message">
+				<template v-if="status === 'checking'">Checking your AI assistant…</template>
+				<template v-else-if="status === 'ready'">Your AI assistant is ready.</template>
+				<template v-else-if="status === 'not-ready'">To get AI help, you'll need Claude installed.</template>
+				<template v-else>We couldn't check your AI assistant status right now. You can continue and check this later.</template>
+			</p>
+
+			<p v-if="status === 'not-ready'" class="sp-onboarding__status-sub" data-testid="step3-status-sub">
+				Claude is a free AI assistant made by Anthropic. Visit claude.ai to download it and follow
+				the setup instructions. Once it's installed, restart Obsidian and your AI suggestions will
+				be active.
+			</p>
+		</div>
+
+		<button
+			v-if="status !== 'checking'"
+			class="sp-btn sp-btn--primary sp-btn--md"
+			data-testid="step3-continue"
+			@click="proceed"
+		>
+			Continue
+		</button>
 	</div>
 </template>
+
+<style scoped>
+.sp-onboarding__status-region {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+	padding: 1rem;
+	background: var(--background-secondary);
+	border-radius: 8px;
+	border: 1px solid var(--background-modifier-border);
+}
+
+.sp-onboarding__status-message {
+	font-size: 0.9375rem;
+	color: var(--text-normal);
+	margin: 0;
+}
+
+.sp-onboarding__status-sub {
+	font-size: 0.875rem;
+	color: var(--text-muted);
+	margin: 0;
+	line-height: 1.5;
+}
+
+.sp-onboarding__spinner {
+	display: inline-block;
+	width: 1rem;
+	height: 1rem;
+	border: 2px solid var(--background-modifier-border);
+	border-top-color: var(--interactive-accent);
+	border-radius: 50%;
+	animation: sp-spin 0.7s linear infinite;
+}
+
+@keyframes sp-spin {
+	to { transform: rotate(360deg); }
+}
+</style>

--- a/tests/ui/components/OnboardingPersonaCard.po.ts
+++ b/tests/ui/components/OnboardingPersonaCard.po.ts
@@ -1,0 +1,9 @@
+import type { VueWrapper } from '@vue/test-utils'
+
+export class OnboardingPersonaCardPO {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	get button() { return this.wrapper.find('[data-testid="persona-card"]') }
+
+	async click() { await this.button.trigger('click') }
+}

--- a/tests/ui/components/OnboardingPersonaCard.test.ts
+++ b/tests/ui/components/OnboardingPersonaCard.test.ts
@@ -1,0 +1,29 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import OnboardingPersonaCard from '@/ui/components/OnboardingPersonaCard.vue'
+import { OnboardingPersonaCardPO } from './OnboardingPersonaCard.po'
+
+const EXAMPLE = "I'm a test persona."
+
+describe('OnboardingPersonaCard', () => {
+	function mountComponent(text = EXAMPLE) {
+		const wrapper = mount(OnboardingPersonaCard, { props: { text } })
+		return { wrapper, po: new OnboardingPersonaCardPO(wrapper) }
+	}
+
+	it('renders card text', () => {
+		const { po } = mountComponent()
+		expect(po.button.text()).toBe(EXAMPLE)
+	})
+
+	it('has aria-label with the example text', () => {
+		const { po } = mountComponent()
+		expect(po.button.attributes('aria-label')).toBe(`Use this example: ${EXAMPLE}`)
+	})
+
+	it('emits use with text when clicked', async () => {
+		const { wrapper, po } = mountComponent()
+		await po.click()
+		expect(wrapper.emitted('use')?.[0]).toEqual([EXAMPLE])
+	})
+})

--- a/tests/ui/components/OnboardingStep1Welcome.po.ts
+++ b/tests/ui/components/OnboardingStep1Welcome.po.ts
@@ -1,0 +1,11 @@
+import type { VueWrapper } from '@vue/test-utils'
+
+export class OnboardingStep1WelcomePO {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	get container() { return this.wrapper.find('[data-testid="step1"]') }
+	get heading() { return this.wrapper.find('h2') }
+	get cta() { return this.wrapper.find('[data-testid="step1-cta"]') }
+
+	async clickCta() { await this.cta.trigger('click') }
+}

--- a/tests/ui/components/OnboardingStep1Welcome.test.ts
+++ b/tests/ui/components/OnboardingStep1Welcome.test.ts
@@ -1,0 +1,22 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import OnboardingStep1Welcome from '@/ui/components/OnboardingStep1Welcome.vue'
+import { OnboardingStep1WelcomePO } from './OnboardingStep1Welcome.po'
+
+describe('OnboardingStep1Welcome', () => {
+	function mountComponent() {
+		const wrapper = mount(OnboardingStep1Welcome)
+		return { wrapper, po: new OnboardingStep1WelcomePO(wrapper) }
+	}
+
+	it('renders the welcome heading', () => {
+		const { po } = mountComponent()
+		expect(po.heading.text()).toBe('Welcome to Specorator.')
+	})
+
+	it('emits next when CTA is clicked', async () => {
+		const { wrapper, po } = mountComponent()
+		await po.clickCta()
+		expect(wrapper.emitted('next')).toHaveLength(1)
+	})
+})

--- a/tests/ui/components/OnboardingStep2Persona.po.ts
+++ b/tests/ui/components/OnboardingStep2Persona.po.ts
@@ -1,0 +1,18 @@
+import type { VueWrapper } from '@vue/test-utils'
+
+export class OnboardingStep2PersonaPO {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	get container() { return this.wrapper.find('[data-testid="step2"]') }
+	get textarea() { return this.wrapper.find('[data-testid="step2-textarea"]') }
+	get continueBtn() { return this.wrapper.find('[data-testid="step2-continue"]') }
+	get skipBtn() { return this.wrapper.find('[data-testid="step2-skip"]') }
+	get saveError() { return this.wrapper.find('[data-testid="step2-save-error"]') }
+	cards() { return this.wrapper.findAll('[data-testid^="step2-card"]') }
+
+	async typePersona(text: string) {
+		await this.textarea.setValue(text)
+	}
+	async clickContinue() { await this.continueBtn.trigger('click') }
+	async clickSkip() { await this.skipBtn.trigger('click') }
+}

--- a/tests/ui/components/OnboardingStep2Persona.test.ts
+++ b/tests/ui/components/OnboardingStep2Persona.test.ts
@@ -1,0 +1,70 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createTestingPinia } from '@pinia/testing'
+import OnboardingStep2Persona from '@/ui/components/OnboardingStep2Persona.vue'
+import { SETTINGS_PORT, LOGGER_PORT } from '@/infrastructure/bridge/ports'
+import { OnboardingStep2PersonaPO } from './OnboardingStep2Persona.po'
+import type { SettingsPort } from '@/domain/ports'
+import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
+
+function makeMockSettingsPort(overrides: Partial<SettingsPort> = {}): SettingsPort {
+	return {
+		getSettings: vi.fn().mockResolvedValue({ ...DEFAULT_SETTINGS }),
+		saveSettings: vi.fn().mockResolvedValue(undefined),
+		...overrides,
+	}
+}
+
+const mockLogger = {
+	debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+}
+
+describe('OnboardingStep2Persona', () => {
+	function mountComponent(initialValue = '', settingsPort?: Partial<SettingsPort>) {
+		const port = makeMockSettingsPort(settingsPort)
+		const wrapper = mount(OnboardingStep2Persona, {
+			props: { initialValue },
+			global: {
+				plugins: [createTestingPinia()],
+				provide: {
+					[SETTINGS_PORT as symbol]: port,
+					[LOGGER_PORT as symbol]: mockLogger,
+				},
+			},
+		})
+		return { wrapper, po: new OnboardingStep2PersonaPO(wrapper), port }
+	}
+
+	beforeEach(() => { vi.clearAllMocks() })
+
+	it('renders textarea with initialValue', () => {
+		const { po } = mountComponent('hello')
+		expect((po.textarea.element as HTMLTextAreaElement).value).toBe('hello')
+	})
+
+	it('skip emits next with skipped:true and does not save', async () => {
+		const { wrapper, po, port } = mountComponent()
+		await po.clickSkip()
+		expect(wrapper.emitted('next')?.[0]).toEqual([{ skipped: true }])
+		expect(port.saveSettings).not.toHaveBeenCalled()
+	})
+
+	it('continue saves persona and emits next with skipped:false', async () => {
+		const { wrapper, po, port } = mountComponent()
+		await po.typePersona('I am a PM.')
+		await po.clickContinue()
+		await wrapper.vm.$nextTick()
+		expect(port.saveSettings).toHaveBeenCalled()
+		expect(wrapper.emitted('next')?.[0]).toEqual([{ skipped: false }])
+	})
+
+	it('shows error message when save fails', async () => {
+		const { wrapper, po } = mountComponent('', {
+			saveSettings: vi.fn().mockRejectedValue(new Error('disk full')),
+		})
+		await po.clickContinue()
+		await wrapper.vm.$nextTick()
+		expect(po.saveError.exists()).toBe(true)
+		expect(wrapper.emitted('next')).toBeUndefined()
+	})
+})

--- a/tests/ui/components/OnboardingStep3ClaudeCheck.po.ts
+++ b/tests/ui/components/OnboardingStep3ClaudeCheck.po.ts
@@ -1,0 +1,12 @@
+import type { VueWrapper } from '@vue/test-utils'
+
+export class OnboardingStep3ClaudeCheckPO {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	get container() { return this.wrapper.find('[data-testid="step3"]') }
+	get statusRegion() { return this.wrapper.find('[data-testid="step3-status-region"]') }
+	get statusMessage() { return this.wrapper.find('[data-testid="step3-status-message"]') }
+	get continueBtn() { return this.wrapper.find('[data-testid="step3-continue"]') }
+
+	async clickContinue() { await this.continueBtn.trigger('click') }
+}

--- a/tests/ui/components/OnboardingStep3ClaudeCheck.test.ts
+++ b/tests/ui/components/OnboardingStep3ClaudeCheck.test.ts
@@ -1,0 +1,70 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+import { createTestingPinia } from '@pinia/testing'
+import OnboardingStep3ClaudeCheck from '@/ui/components/OnboardingStep3ClaudeCheck.vue'
+import { CLAUDE_CLI_PORT, LOGGER_PORT } from '@/infrastructure/bridge/ports'
+import { OnboardingStep3ClaudeCheckPO } from './OnboardingStep3ClaudeCheck.po'
+import type { ClaudeCliPort } from '@/domain/ports'
+
+const mockLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+
+function makePort(available: boolean | 'throw'): ClaudeCliPort {
+	return {
+		isAvailable: available === 'throw'
+			? vi.fn().mockRejectedValue(new Error('boom'))
+			: vi.fn().mockResolvedValue(available),
+	}
+}
+
+describe('OnboardingStep3ClaudeCheck', () => {
+	function mountComponent(port?: ClaudeCliPort) {
+		const provide: Record<symbol, unknown> = {
+			[LOGGER_PORT as symbol]: mockLogger,
+		}
+		if (port !== undefined) {
+			provide[CLAUDE_CLI_PORT as symbol] = port
+		}
+		const wrapper = mount(OnboardingStep3ClaudeCheck, {
+			global: { plugins: [createTestingPinia()], provide },
+		})
+		return { wrapper, po: new OnboardingStep3ClaudeCheckPO(wrapper) }
+	}
+
+	it('shows checking state initially', () => {
+		const { po } = mountComponent(makePort(true))
+		expect(po.statusMessage.text()).toContain('Checking')
+		expect(po.continueBtn.exists()).toBe(false)
+	})
+
+	it('shows ready state when CLI is available', async () => {
+		const { po } = mountComponent(makePort(true))
+		await flushPromises()
+		expect(po.statusMessage.text()).toContain('ready')
+		expect(po.continueBtn.exists()).toBe(true)
+	})
+
+	it('shows not-ready state when CLI is unavailable', async () => {
+		const { po } = mountComponent(makePort(false))
+		await flushPromises()
+		expect(po.statusMessage.text()).toContain('Claude installed')
+	})
+
+	it('shows unknown state when port is not provided', async () => {
+		const { po } = mountComponent(undefined)
+		await flushPromises()
+		expect(po.statusMessage.text()).toContain("couldn't check")
+	})
+
+	it('shows unknown state when port throws', async () => {
+		const { po } = mountComponent(makePort('throw'))
+		await flushPromises()
+		expect(po.statusMessage.text()).toContain("couldn't check")
+	})
+
+	it('emits next with claudeStatus when continue clicked', async () => {
+		const { wrapper, po } = mountComponent(makePort(true))
+		await flushPromises()
+		await po.clickContinue()
+		expect(wrapper.emitted('next')?.[0]).toEqual([{ claudeStatus: 'ready' }])
+	})
+})


### PR DESCRIPTION
## Summary

- Implements real `OnboardingStep1Welcome.vue` (heading + CTA), `OnboardingPersonaCard.vue` (focusable example card), `OnboardingStep2Persona.vue` (textarea + save/skip + error handling using `tryAsync`), and `OnboardingStep3ClaudeCheck.vue` (calls `ClaudeCliPort.isAvailable()`, handles ready/not-ready/unknown/checking states)
- Adds missing `OnboardingStep3ClaudeCheck.test.ts` (6 cases) and co-located PageObjects for all 4 components; all components tested via `data-testid` selectors only
- Adds `@pinia/testing` dev dependency required by the new Vue component tests

Replaces #289 (closed — had an unresolvable merge conflict after #287 squash-merged stub implementations into develop).

Closes #195

## Test plan

- [ ] `npm run verify` passes (all tests, thresholds, both builds)
- [ ] Step 1 CTA emits `next`; step 2 textarea saves persona or skips gracefully; step 3 reflects `isAvailable()` result
- [ ] Error banner shown on step 2 save failure; skip button always available
- [ ] Step 3 shows "checking…" then transitions to ready/not-ready/unknown based on CLI probe result

---
_Generated by [Claude Code](https://claude.ai/code/session_015Eiow3YrzddnfVn3fexv4S)_