### PR TITLE
feat(ui): onboarding steps 4–5, nudges, settings tab additions

### DIFF
--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -191,14 +191,14 @@ export default class SpecoratorPlugin extends Plugin {
     }
   }
 
-  private _dispatchNavigate(path: string): void {
+  _dispatchNavigate(path: string): void {
     const win =
       this.app.workspace.getLeavesOfType(VIEW_TYPE)[0]?.view?.containerEl?.ownerDocument?.defaultView ??
       activeWindow
     win.dispatchEvent(new CustomEvent('sp:navigate', { detail: { path } }))
   }
 
-  private async activateView(): Promise<void> {
+  async activateView(): Promise<void> {
     const { workspace } = this.app
 
     const existing = workspace.getLeavesOfType(VIEW_TYPE)

--- a/src/plugin/settings.ts
+++ b/src/plugin/settings.ts
@@ -29,7 +29,44 @@ export class SpecoratorSettingTab extends PluginSettingTab {
       }
     }
 
+    this.renderAboutYouSection()
     this.renderMcpServerStatus()
+  }
+
+  private renderAboutYouSection(): void {
+    const { containerEl } = this
+
+    new Setting(containerEl).setName('About you').setHeading()
+
+    new Setting(containerEl)
+      .setName('Your introduction')
+      .setDesc("A few sentences about your role and what you're working on. Used to personalise AI suggestions.")
+      .addTextArea((ta) =>
+        ta
+          .setValue(this.plugin.settings.userPersona)
+          .setPlaceholder("For example: I'm a product manager at a scale-up...")
+          .onChange(async (value) => {
+            await this.plugin.updateSettings({ userPersona: value })
+          }),
+      )
+
+    if (!this.plugin.settings.userPersona) {
+      containerEl.createEl('p', {
+        text: 'Add a short introduction so Specorator can tailor its suggestions to you.',
+        cls: 'setting-item-description',
+      })
+    }
+
+    new Setting(containerEl)
+      .setName('Set up Specorator again')
+      .setDesc('Start the setup wizard again to update your workspace or introduction.')
+      .addButton((btn) =>
+        btn.setButtonText('Re-run setup').onClick(async () => {
+          await this.plugin.updateSettings({ onboardingComplete: false })
+          await this.plugin.activateView()
+          this.plugin._dispatchNavigate('/onboarding')
+        }),
+      )
   }
 
   /**

--- a/src/ui/components/HomePersonaNudge.vue
+++ b/src/ui/components/HomePersonaNudge.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useSettingsPort } from '@/ui/composables/useSettingsPort'
+import OnboardingNudge from './OnboardingNudge.vue'
+
+const router = useRouter()
+const settingsPort = useSettingsPort()
+const showNudge = ref(false)
+const dismissed = ref(false)
+
+onMounted(async () => {
+	const settings = await settingsPort.getSettings()
+	showNudge.value = settings.onboardingComplete && settings.userPersona === ''
+})
+
+function goToSettings(): void {
+	void router.push('/settings')
+}
+
+function dismiss(): void {
+	dismissed.value = true
+}
+</script>
+
+<template>
+	<OnboardingNudge
+		v-if="showNudge && !dismissed"
+		message="Tell Specorator about yourself so suggestions are more relevant to you."
+		action-label="Add your introduction"
+		:dismissible="true"
+		data-testid="home-persona-nudge"
+		@action="goToSettings"
+		@dismiss="dismiss"
+	/>
+</template>

--- a/src/ui/components/HomePersonaNudge.vue
+++ b/src/ui/components/HomePersonaNudge.vue
@@ -11,7 +11,7 @@ const dismissed = ref(false)
 
 onMounted(async () => {
 	const settings = await settingsPort.getSettings()
-	showNudge.value = settings.onboardingComplete && settings.userPersona === ''
+	showNudge.value = settings.onboardingComplete && settings.userPersona.trim() === ''
 })
 
 function goToSettings(): void {

--- a/src/ui/components/OnboardingNudge.vue
+++ b/src/ui/components/OnboardingNudge.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+defineProps<{
+	message: string
+	actionLabel?: string
+	dismissible?: boolean
+}>()
+
+const emit = defineEmits<{
+	action: []
+	dismiss: []
+}>()
+</script>
+
+<template>
+	<aside role="note" class="sp-onboarding__nudge" data-testid="onboarding-nudge">
+		<div class="sp-onboarding__nudge-body">
+			{{ message }}
+			<button
+				v-if="actionLabel"
+				class="sp-onboarding__nudge-action"
+				data-testid="nudge-action"
+				@click="emit('action')"
+			>
+				{{ actionLabel }}
+			</button>
+		</div>
+		<button
+			v-if="dismissible"
+			class="sp-onboarding__nudge-dismiss"
+			aria-label="Dismiss this suggestion"
+			data-testid="nudge-dismiss"
+			@click="emit('dismiss')"
+		>
+			×
+		</button>
+	</aside>
+</template>
+
+<style scoped>
+.sp-onboarding__nudge {
+	background: var(--background-secondary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 6px;
+	padding: 0.75rem;
+	font-size: 0.875rem;
+	color: var(--text-muted);
+	display: flex;
+	align-items: flex-start;
+	gap: 0.5rem;
+}
+
+.sp-onboarding__nudge-body {
+	flex: 1;
+	line-height: 1.5;
+}
+
+.sp-onboarding__nudge-action {
+	background: none;
+	border: none;
+	padding: 0;
+	margin-left: 0.25rem;
+	cursor: pointer;
+	color: var(--interactive-accent);
+	text-decoration: underline;
+	font-size: inherit;
+	min-width: 24px;
+	min-height: 24px;
+}
+
+.sp-onboarding__nudge-dismiss {
+	background: none;
+	border: none;
+	padding: 0;
+	cursor: pointer;
+	color: var(--text-muted);
+	font-size: 1rem;
+	line-height: 1;
+	flex-shrink: 0;
+	min-width: 24px;
+	min-height: 24px;
+}
+</style>

--- a/src/ui/components/OnboardingStep4Workspace.vue
+++ b/src/ui/components/OnboardingStep4Workspace.vue
@@ -1,9 +1,208 @@
 <script setup lang="ts">
-defineProps<{ initialSpecsFolder: string }>()
-const emit = defineEmits<{ next: [payload: { templateStatus: 'installed' | 'skipped' | 'failed'; specsFolder: string }] }>()
+import { ref, onMounted } from 'vue'
+import { useSettingsPort } from '@/ui/composables/useSettingsPort'
+import { useVaultPort } from '@/ui/composables/useVaultPort'
+import { useLoggerPort } from '@/ui/composables/useLoggerPort'
+import { tryAsync } from '@/domain/shared/tryAsync'
+
+type TemplateStatus = 'installed' | 'skipped' | 'failed'
+type WorkspaceStatus = 'checking' | 'ready' | 'not-installed' | 'error'
+
+const props = defineProps<{ initialSpecsFolder: string }>()
+const emit = defineEmits<{ next: [payload: { templateStatus: TemplateStatus; specsFolder: string }] }>()
+
+const settingsPort = useSettingsPort()
+const vaultPort = useVaultPort()
+const logger = useLoggerPort()
+
+const specsFolder = ref(props.initialSpecsFolder)
+const workspaceStatus = ref<WorkspaceStatus>('checking')
+const isInstalling = ref(false)
+const installOutcome = ref<'success' | 'failure' | null>(null)
+const folderEmpty = ref(specsFolder.value.trim() === '')
+
+onMounted(async () => {
+	const folder = specsFolder.value.trim()
+	const parentPath = folder.includes('/') ? folder.slice(0, folder.lastIndexOf('/')) : ''
+	const folderName = folder.includes('/') ? folder.slice(folder.lastIndexOf('/') + 1) : folder
+	const result = await tryAsync(() => vaultPort.listFolders(parentPath))
+	if (result.ok && result.value.includes(folderName)) {
+		workspaceStatus.value = 'ready'
+	} else if (!result.ok) {
+		logger.error('Failed to check workspace status', result.error)
+		workspaceStatus.value = 'error'
+	} else {
+		workspaceStatus.value = 'not-installed'
+	}
+})
+
+function validateFolder(): void {
+	folderEmpty.value = specsFolder.value.trim() === ''
+}
+
+async function saveFolder(): Promise<void> {
+	const current = await settingsPort.getSettings()
+	await settingsPort.saveSettings({ ...current, specsFolder: specsFolder.value.trim() })
+}
+
+async function install(): Promise<void> {
+	if (folderEmpty.value) return
+	isInstalling.value = true
+	installOutcome.value = null
+	const result = await tryAsync(async () => {
+		await saveFolder()
+		// Create the specs folder if it doesn't exist
+		await vaultPort.createFolder(specsFolder.value.trim())
+	})
+	if (result.ok) {
+		workspaceStatus.value = 'ready'
+		installOutcome.value = 'success'
+		// Auto-advance after a short pause
+		await new Promise<void>((resolve) => { window.setTimeout(resolve, 1500) })
+		emit('next', { templateStatus: 'installed', specsFolder: specsFolder.value.trim() })
+	} else {
+		logger.error('Failed to install workspace', result.error)
+		installOutcome.value = 'failure'
+	}
+	isInstalling.value = false
+}
+
+async function skip(): Promise<void> {
+	const folder = specsFolder.value.trim()
+	if (folder && folder !== props.initialSpecsFolder) {
+		await tryAsync(() => saveFolder())
+	}
+	emit('next', { templateStatus: 'skipped', specsFolder: folder || props.initialSpecsFolder })
+}
 </script>
+
 <template>
-	<div data-testid="step4-placeholder">
-		<button data-testid="step4-skip-btn" @click="emit('next', { templateStatus: 'skipped', specsFolder: 'specs' })">Skip</button>
+	<div class="sp-onboarding__step" data-testid="step4">
+		<h2 class="sp-onboarding__heading">Set up your workspace.</h2>
+		<p class="sp-onboarding__body">
+			Specorator uses a folder in your vault to store your feature files. The default works well for
+			most people — you can change it at any time from settings.
+		</p>
+
+		<div class="sp-onboarding__field-row">
+			<label for="ob-specs-folder">Where should features be stored?</label>
+			<input
+				id="ob-specs-folder"
+				v-model="specsFolder"
+				type="text"
+				class="sp-onboarding__input"
+				:readonly="isInstalling"
+				data-testid="step4-specs-folder-input"
+				@input="validateFolder"
+			/>
+			<p v-if="folderEmpty" class="sp-onboarding__field-hint" data-testid="step4-field-hint">
+				Enter a folder name for your features.
+			</p>
+		</div>
+
+		<div class="sp-onboarding__status-region" data-testid="step4-status-paragraph">
+			<template v-if="workspaceStatus === 'checking'">Checking your workspace…</template>
+			<template v-else-if="workspaceStatus === 'ready'">Your workflow templates are already set up.</template>
+			<template v-else-if="workspaceStatus === 'not-installed'">Workflow templates are not yet installed.</template>
+			<template v-else>We couldn't check your workspace status. You can install templates or continue.</template>
+		</div>
+
+		<p
+			v-if="installOutcome === 'success'"
+			role="status"
+			aria-live="polite"
+			class="sp-onboarding__outcome sp-onboarding__outcome--success"
+			data-testid="step4-outcome"
+		>
+			Your workspace is ready.
+		</p>
+		<p
+			v-if="installOutcome === 'failure'"
+			role="alert"
+			aria-live="assertive"
+			class="sp-onboarding__outcome sp-onboarding__outcome--error"
+			data-testid="step4-outcome"
+		>
+			Some templates couldn't be installed. You can try again or continue — you can always install later from settings.
+		</p>
+
+		<div v-if="workspaceStatus !== 'checking'" class="sp-onboarding__actions">
+			<button
+				class="sp-btn sp-btn--primary sp-btn--md"
+				:aria-label="isInstalling ? 'Installing, please wait' : (workspaceStatus === 'ready' ? 'Reinstall' : (installOutcome === 'failure' ? 'Try again' : 'Install'))"
+				:disabled="isInstalling || folderEmpty"
+				data-testid="step4-install-btn"
+				@click="install"
+			>
+				{{ isInstalling ? 'Installing…' : (workspaceStatus === 'ready' ? 'Reinstall' : (installOutcome === 'failure' ? 'Try again' : 'Install')) }}
+			</button>
+			<button
+				class="sp-onboarding__skip"
+				:disabled="isInstalling"
+				data-testid="step4-skip-btn"
+				@click="skip"
+			>
+				Skip for now
+			</button>
+		</div>
 	</div>
 </template>
+
+<style scoped>
+.sp-onboarding__field-row {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+}
+
+.sp-onboarding__input {
+	padding: 0.375rem 0.625rem;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 4px;
+	background: var(--background-primary);
+	color: var(--text-normal);
+	font-size: 0.9375rem;
+}
+
+.sp-onboarding__field-hint {
+	font-size: 0.8125rem;
+	color: var(--text-error);
+	margin: 0;
+}
+
+.sp-onboarding__outcome {
+	font-size: 0.875rem;
+	margin: 0;
+}
+
+.sp-onboarding__outcome--success {
+	color: var(--text-success, #4ade80);
+}
+
+.sp-onboarding__outcome--error {
+	color: var(--text-error);
+}
+
+.sp-onboarding__actions {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	align-items: flex-start;
+}
+
+.sp-onboarding__skip {
+	background: none;
+	border: none;
+	padding: 0;
+	cursor: pointer;
+	color: var(--text-muted);
+	font-size: 0.875rem;
+	min-width: 24px;
+	min-height: 24px;
+}
+
+.sp-onboarding__skip:disabled {
+	opacity: 0.5;
+	cursor: default;
+}
+</style>

--- a/src/ui/components/OnboardingStep4Workspace.vue
+++ b/src/ui/components/OnboardingStep4Workspace.vue
@@ -70,9 +70,14 @@ async function install(): Promise<void> {
 async function skip(): Promise<void> {
 	const folder = specsFolder.value.trim()
 	if (folder && folder !== props.initialSpecsFolder) {
-		await tryAsync(() => saveFolder())
+		const result = await tryAsync(() => saveFolder())
+		if (!result.ok) {
+			logger.error('Failed to save specs folder', result.error)
+			return
+		}
 	}
-	emit('next', { templateStatus: 'skipped', specsFolder: folder || props.initialSpecsFolder })
+	const templateStatus: TemplateStatus = workspaceStatus.value === 'ready' ? 'installed' : 'skipped'
+	emit('next', { templateStatus, specsFolder: folder || props.initialSpecsFolder })
 }
 </script>
 

--- a/src/ui/components/OnboardingStep5Done.vue
+++ b/src/ui/components/OnboardingStep5Done.vue
@@ -46,7 +46,7 @@ onMounted(async () => {
 
 <template>
 	<div class="sp-onboarding__step" data-testid="step5">
-		<h2 ref="headingRef" tabindex="-1" class="sp-onboarding__heading" data-testid="step5-heading">
+		<h2 class="sp-onboarding__heading" data-testid="step5-heading">
 			You're all set.
 		</h2>
 

--- a/src/ui/components/OnboardingStep5Done.vue
+++ b/src/ui/components/OnboardingStep5Done.vue
@@ -1,13 +1,164 @@
 <script setup lang="ts">
-defineProps<{
+import { ref, onMounted, computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useSettingsPort } from '@/ui/composables/useSettingsPort'
+import { useLoggerPort } from '@/ui/composables/useLoggerPort'
+import { tryAsync } from '@/domain/shared/tryAsync'
+import OnboardingNudge from './OnboardingNudge.vue'
+
+type ClaudeStatus = 'ready' | 'not-ready' | 'unknown'
+type TemplateStatus = 'installed' | 'skipped' | 'failed'
+
+const props = defineProps<{
 	personaSkipped: boolean
-	claudeStatus: 'ready' | 'not-ready' | 'unknown'
-	templateStatus: 'installed' | 'skipped' | 'failed'
+	claudeStatus: ClaudeStatus
+	templateStatus: TemplateStatus
 }>()
+
 const emit = defineEmits<{ finish: [] }>()
+
+const router = useRouter()
+const settingsPort = useSettingsPort()
+const logger = useLoggerPort()
+
+function goToSettings(): void {
+	void router.push('/settings')
+}
+
+const saveError = ref<string | null>(null)
+
+const allPositive = computed(
+	() => !props.personaSkipped && props.claudeStatus === 'ready' && props.templateStatus === 'installed',
+)
+
+onMounted(async () => {
+	const result = await tryAsync(async () => {
+		const current = await settingsPort.getSettings()
+		await settingsPort.saveSettings({ ...current, onboardingComplete: true })
+	})
+	if (!result.ok) {
+		logger.error('Failed to save onboardingComplete', result.error)
+		saveError.value =
+			"We couldn't save your setup progress. Your changes are still applied for this session — please close and reopen Specorator to try again."
+	}
+})
 </script>
+
 <template>
-	<div data-testid="step5-placeholder">
-		<button data-testid="step5-cta" @click="emit('finish')">Start using Specorator</button>
+	<div class="sp-onboarding__step" data-testid="step5">
+		<h2 ref="headingRef" tabindex="-1" class="sp-onboarding__heading" data-testid="step5-heading">
+			You're all set.
+		</h2>
+
+		<p v-if="saveError !== null" role="alert" class="sp-onboarding__save-error" data-testid="step5-save-error">
+			{{ saveError }}
+		</p>
+
+		<p class="sp-onboarding__body" data-testid="step5-body">
+			{{ allPositive
+				? 'Specorator is ready to use. Here\'s a summary of what was set up.'
+				: 'Specorator is ready to use. Here\'s a summary of what was set up — you can finish any remaining steps from settings at any time.' }}
+		</p>
+
+		<ul role="list" class="sp-onboarding__summary" data-testid="step5-summary">
+			<li role="listitem" class="sp-onboarding__summary-item" data-testid="step5-summary-persona">
+				<span class="sp-onboarding__summary-label">Introduction</span>
+				<span
+					:class="['sp-onboarding__summary-value', !personaSkipped && 'sp-onboarding__summary-value--positive']"
+				>{{ personaSkipped ? 'Not added yet.' : 'Added.' }}</span>
+			</li>
+			<li role="listitem" class="sp-onboarding__summary-item" data-testid="step5-summary-claude">
+				<span class="sp-onboarding__summary-label">AI assistant</span>
+				<span
+					:class="['sp-onboarding__summary-value', claudeStatus === 'ready' && 'sp-onboarding__summary-value--positive']"
+				>
+					<template v-if="claudeStatus === 'ready'">Ready.</template>
+					<template v-else-if="claudeStatus === 'not-ready'">Not ready.</template>
+					<template v-else>Status unknown.</template>
+				</span>
+			</li>
+			<li role="listitem" class="sp-onboarding__summary-item" data-testid="step5-summary-templates">
+				<span class="sp-onboarding__summary-label">Workflow templates</span>
+				<span
+					:class="['sp-onboarding__summary-value', templateStatus === 'installed' && 'sp-onboarding__summary-value--positive']"
+				>
+					<template v-if="templateStatus === 'installed'">Set up.</template>
+					<template v-else-if="templateStatus === 'skipped'">Not installed.</template>
+					<template v-else>Couldn't be installed.</template>
+				</span>
+			</li>
+		</ul>
+
+		<div class="sp-onboarding__nudges" data-testid="step5-nudge-persona">
+			<OnboardingNudge
+				v-if="personaSkipped"
+				message="You can tell us about yourself any time — go to Settings and look for 'About you'."
+				action-label="Add your introduction"
+				@action="goToSettings"
+			/>
+		</div>
+
+		<div data-testid="step5-nudge-claude">
+			<OnboardingNudge
+				v-if="claudeStatus === 'not-ready'"
+				message="To unlock AI-powered suggestions, install Claude from claude.ai and restart Obsidian."
+			/>
+			<OnboardingNudge
+				v-if="claudeStatus === 'unknown'"
+				message="We couldn't check whether AI help is available. If you'd like AI suggestions, visit claude.ai to get started."
+			/>
+		</div>
+
+		<button
+			class="sp-btn sp-btn--primary sp-btn--md"
+			data-testid="step5-cta"
+			@click="emit('finish')"
+		>
+			Start using Specorator
+		</button>
 	</div>
 </template>
+
+<style scoped>
+.sp-onboarding__summary {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.sp-onboarding__summary-item {
+	display: flex;
+	align-items: baseline;
+	gap: 0.5rem;
+	font-size: 0.9375rem;
+	color: var(--text-normal);
+}
+
+.sp-onboarding__summary-label {
+	font-weight: 600;
+	min-width: 7rem;
+}
+
+.sp-onboarding__summary-value {
+	color: var(--text-muted);
+}
+
+.sp-onboarding__summary-value--positive {
+	color: var(--text-success, #4ade80);
+}
+
+.sp-onboarding__nudges {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+}
+
+.sp-onboarding__save-error {
+	color: var(--text-error);
+	font-size: 0.875rem;
+	margin: 0;
+}
+</style>

--- a/src/ui/components/OnboardingWizard.vue
+++ b/src/ui/components/OnboardingWizard.vue
@@ -95,7 +95,6 @@ async function handleFinish(): Promise<void> {
 	}, 'Failed to mark onboarding complete')
 	if (!result.ok) {
 		logger.error('Failed to mark onboarding complete', result.error)
-		return
 	}
 	void router.push('/')
 }

--- a/src/ui/views/HomeView.vue
+++ b/src/ui/views/HomeView.vue
@@ -5,6 +5,7 @@ import { useRouter } from 'vue-router'
 import FeatureCard from '../components/feature/FeatureCard.vue'
 import CreateFeatureForm from '../components/feature/CreateFeatureForm.vue'
 import AppButton from '../components/common/AppButton.vue'
+import HomePersonaNudge from '../components/HomePersonaNudge.vue'
 import { useFeatures } from '../composables/useFeatures'
 import { useSettingsPort } from '../composables/useSettingsPort'
 import { useWorkspacePort } from '../composables/useWorkspacePort'
@@ -46,6 +47,7 @@ async function handleOpen(featureId: string) {
 
 <template>
   <div class="sp-home">
+    <HomePersonaNudge />
     <header class="sp-home__header">
       <div>
         <h1 class="sp-home__title" data-testid="home-title">{{ t('home.title') }}</h1>

--- a/src/ui/views/SettingsView.vue
+++ b/src/ui/views/SettingsView.vue
@@ -133,6 +133,19 @@ function update<K extends keyof PluginSettings>(key: K, value: PluginSettings[K]
           <option value="error">error</option>
         </select>
       </div>
+
+      <div class="sp-settings__field">
+        <label class="sp-settings__label" for="userPersona">About you</label>
+        <textarea
+          id="userPersona"
+          class="sp-settings__input sp-settings__textarea"
+          :value="settings.userPersona"
+          rows="4"
+          placeholder="Describe your role and what you're working on…"
+          data-testid="settings-user-persona"
+          @input="(e) => update('userPersona', (e.target as HTMLTextAreaElement).value)"
+        />
+      </div>
     </div>
 
     <div class="sp-settings__footer">
@@ -183,6 +196,13 @@ function update<K extends keyof PluginSettings>(key: K, value: PluginSettings[K]
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
+}
+
+.sp-settings__textarea {
+  resize: vertical;
+  line-height: 1.6;
+  min-height: 6rem;
+  width: 100%;
 }
 
 .sp-settings__input,

--- a/styles.css
+++ b/styles.css
@@ -386,6 +386,131 @@ to { transform: rotate(360deg);
   margin: 0;
 }
 
+.specorator-root :where(.sp-onboarding__field-row[data-v-e672d7fb]) {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+}
+.specorator-root :where(.sp-onboarding__input[data-v-e672d7fb]) {
+	padding: 0.375rem 0.625rem;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 4px;
+	background: var(--background-primary);
+	color: var(--text-normal);
+	font-size: 0.9375rem;
+}
+.specorator-root :where(.sp-onboarding__field-hint[data-v-e672d7fb]) {
+	font-size: 0.8125rem;
+	color: var(--text-error);
+	margin: 0;
+}
+.specorator-root :where(.sp-onboarding__outcome[data-v-e672d7fb]) {
+	font-size: 0.875rem;
+	margin: 0;
+}
+.specorator-root :where(.sp-onboarding__outcome--success[data-v-e672d7fb]) {
+	color: var(--text-success, #4ade80);
+}
+.specorator-root :where(.sp-onboarding__outcome--error[data-v-e672d7fb]) {
+	color: var(--text-error);
+}
+.specorator-root :where(.sp-onboarding__actions[data-v-e672d7fb]) {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	align-items: flex-start;
+}
+.specorator-root :where(.sp-onboarding__skip[data-v-e672d7fb]) {
+	background: none;
+	border: none;
+	padding: 0;
+	cursor: pointer;
+	color: var(--text-muted);
+	font-size: 0.875rem;
+	min-width: 24px;
+	min-height: 24px;
+}
+.specorator-root :where(.sp-onboarding__skip[data-v-e672d7fb]:disabled) {
+	opacity: 0.5;
+	cursor: default;
+}
+
+.specorator-root :where(.sp-onboarding__nudge[data-v-2e270bd3]) {
+	background: var(--background-secondary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 6px;
+	padding: 0.75rem;
+	font-size: 0.875rem;
+	color: var(--text-muted);
+	display: flex;
+	align-items: flex-start;
+	gap: 0.5rem;
+}
+.specorator-root :where(.sp-onboarding__nudge-body[data-v-2e270bd3]) {
+	flex: 1;
+	line-height: 1.5;
+}
+.specorator-root :where(.sp-onboarding__nudge-action[data-v-2e270bd3]) {
+	background: none;
+	border: none;
+	padding: 0;
+	margin-left: 0.25rem;
+	cursor: pointer;
+	color: var(--interactive-accent);
+	text-decoration: underline;
+	font-size: inherit;
+	min-width: 24px;
+	min-height: 24px;
+}
+.specorator-root :where(.sp-onboarding__nudge-dismiss[data-v-2e270bd3]) {
+	background: none;
+	border: none;
+	padding: 0;
+	cursor: pointer;
+	color: var(--text-muted);
+	font-size: 1rem;
+	line-height: 1;
+	flex-shrink: 0;
+	min-width: 24px;
+	min-height: 24px;
+}
+
+.specorator-root :where(.sp-onboarding__summary[data-v-0ca597ae]) {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+.specorator-root :where(.sp-onboarding__summary-item[data-v-0ca597ae]) {
+	display: flex;
+	align-items: baseline;
+	gap: 0.5rem;
+	font-size: 0.9375rem;
+	color: var(--text-normal);
+}
+.specorator-root :where(.sp-onboarding__summary-label[data-v-0ca597ae]) {
+	font-weight: 600;
+	min-width: 7rem;
+}
+.specorator-root :where(.sp-onboarding__summary-value[data-v-0ca597ae]) {
+	color: var(--text-muted);
+}
+.specorator-root :where(.sp-onboarding__summary-value--positive[data-v-0ca597ae]) {
+	color: var(--text-success, #4ade80);
+}
+.specorator-root :where(.sp-onboarding__nudges[data-v-0ca597ae]) {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+}
+.specorator-root :where(.sp-onboarding__save-error[data-v-0ca597ae]) {
+	color: var(--text-error);
+	font-size: 0.875rem;
+	margin: 0;
+}
+
 .specorator-root :where(.sp-onboarding[data-v-0053404f]) {
   display: flex;
   flex-direction: column;

--- a/tests/ui/components/OnboardingNudge.po.ts
+++ b/tests/ui/components/OnboardingNudge.po.ts
@@ -1,0 +1,9 @@
+import type { VueWrapper } from '@vue/test-utils'
+export class OnboardingNudgePO {
+	constructor(private readonly wrapper: VueWrapper) {}
+	get nudge() { return this.wrapper.find('[data-testid="onboarding-nudge"]') }
+	get action() { return this.wrapper.find('[data-testid="nudge-action"]') }
+	get dismiss() { return this.wrapper.find('[data-testid="nudge-dismiss"]') }
+	async clickAction() { await this.action.trigger('click') }
+	async clickDismiss() { await this.dismiss.trigger('click') }
+}

--- a/tests/ui/components/OnboardingNudge.test.ts
+++ b/tests/ui/components/OnboardingNudge.test.ts
@@ -1,0 +1,44 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import OnboardingNudge from '@/ui/components/OnboardingNudge.vue'
+import { OnboardingNudgePO } from './OnboardingNudge.po'
+
+describe('OnboardingNudge', () => {
+	function mountComponent(props: { message: string; actionLabel?: string; dismissible?: boolean }) {
+		const wrapper = mount(OnboardingNudge, { props })
+		return { wrapper, po: new OnboardingNudgePO(wrapper) }
+	}
+
+	it('renders the message', () => {
+		const { po } = mountComponent({ message: 'Hello nudge' })
+		expect(po.nudge.text()).toContain('Hello nudge')
+	})
+
+	it('shows action button when actionLabel is provided', () => {
+		const { po } = mountComponent({ message: 'msg', actionLabel: 'Do it' })
+		expect(po.action.exists()).toBe(true)
+		expect(po.action.text()).toBe('Do it')
+	})
+
+	it('hides action button when no actionLabel', () => {
+		const { po } = mountComponent({ message: 'msg' })
+		expect(po.action.exists()).toBe(false)
+	})
+
+	it('shows dismiss button when dismissible', () => {
+		const { po } = mountComponent({ message: 'msg', dismissible: true })
+		expect(po.dismiss.exists()).toBe(true)
+	})
+
+	it('emits action when action clicked', async () => {
+		const { wrapper, po } = mountComponent({ message: 'msg', actionLabel: 'Go' })
+		await po.clickAction()
+		expect(wrapper.emitted('action')).toHaveLength(1)
+	})
+
+	it('emits dismiss when dismiss clicked', async () => {
+		const { wrapper, po } = mountComponent({ message: 'msg', dismissible: true })
+		await po.clickDismiss()
+		expect(wrapper.emitted('dismiss')).toHaveLength(1)
+	})
+})

--- a/tests/ui/components/OnboardingStep4Workspace.po.ts
+++ b/tests/ui/components/OnboardingStep4Workspace.po.ts
@@ -1,0 +1,17 @@
+import type { VueWrapper } from '@vue/test-utils'
+
+export class OnboardingStep4WorkspacePO {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	get container() { return this.wrapper.find('[data-testid="step4"]') }
+	get folderInput() { return this.wrapper.find('[data-testid="step4-specs-folder-input"]') }
+	get fieldHint() { return this.wrapper.find('[data-testid="step4-field-hint"]') }
+	get statusParagraph() { return this.wrapper.find('[data-testid="step4-status-paragraph"]') }
+	get installBtn() { return this.wrapper.find('[data-testid="step4-install-btn"]') }
+	get skipBtn() { return this.wrapper.find('[data-testid="step4-skip-btn"]') }
+	get outcome() { return this.wrapper.find('[data-testid="step4-outcome"]') }
+
+	async clickInstall() { await this.installBtn.trigger('click') }
+	async clickSkip() { await this.skipBtn.trigger('click') }
+	async setFolder(value: string) { await this.folderInput.setValue(value) }
+}

--- a/tests/ui/components/OnboardingStep4Workspace.test.ts
+++ b/tests/ui/components/OnboardingStep4Workspace.test.ts
@@ -1,0 +1,114 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import OnboardingStep4Workspace from '@/ui/components/OnboardingStep4Workspace.vue'
+import { SETTINGS_PORT, VAULT_PORT, LOGGER_PORT } from '@/infrastructure/bridge/ports'
+import { OnboardingStep4WorkspacePO } from './OnboardingStep4Workspace.po'
+import type { SettingsPort, VaultPort } from '@/domain/ports'
+import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
+
+const mockLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+
+function makeSettingsPort(overrides: Partial<SettingsPort> = {}): SettingsPort {
+	return {
+		getSettings: vi.fn().mockResolvedValue({ ...DEFAULT_SETTINGS }),
+		saveSettings: vi.fn().mockResolvedValue(undefined),
+		...overrides,
+	}
+}
+
+function makeVaultPort(folders: string[] = [], overrides: Partial<VaultPort> = {}): VaultPort {
+	return {
+		listFolders: vi.fn().mockResolvedValue(folders),
+		createFolder: vi.fn().mockResolvedValue(undefined),
+		readFile: vi.fn(),
+		writeFile: vi.fn(),
+		deleteFile: vi.fn(),
+		listFiles: vi.fn(),
+		fileExists: vi.fn(),
+		...overrides,
+	}
+}
+
+describe('OnboardingStep4Workspace', () => {
+	beforeEach(() => { vi.useFakeTimers() })
+	afterEach(() => { vi.useRealTimers(); vi.clearAllMocks() })
+
+	function mountComponent(
+		initialSpecsFolder = 'specs',
+		vaultOverrides: Partial<VaultPort> = {},
+		settingsOverrides: Partial<SettingsPort> = {},
+		vaultFolders: string[] = [],
+	) {
+		const vault = makeVaultPort(vaultFolders, vaultOverrides)
+		const settings = makeSettingsPort(settingsOverrides)
+		const wrapper = mount(OnboardingStep4Workspace, {
+			props: { initialSpecsFolder },
+			global: {
+				provide: {
+					[VAULT_PORT as symbol]: vault,
+					[SETTINGS_PORT as symbol]: settings,
+					[LOGGER_PORT as symbol]: mockLogger,
+				},
+			},
+		})
+		return { wrapper, po: new OnboardingStep4WorkspacePO(wrapper), vault, settings }
+	}
+
+	it('shows checking status initially then not-installed when folder absent', async () => {
+		const { po } = mountComponent('specs', {}, {}, [])
+		expect(po.statusParagraph.text()).toContain('Checking')
+		await flushPromises()
+		expect(po.statusParagraph.text()).toContain('not yet installed')
+	})
+
+	it('shows ready status when folder already exists', async () => {
+		const { po } = mountComponent('specs', {}, {}, ['specs'])
+		await flushPromises()
+		expect(po.statusParagraph.text()).toContain('already set up')
+	})
+
+	it('shows error status when listFolders rejects', async () => {
+		const { po } = mountComponent('specs', {
+			listFolders: vi.fn().mockRejectedValue(new Error('disk error')),
+		})
+		await flushPromises()
+		expect(po.statusParagraph.text()).toContain("couldn't check")
+	})
+
+	it('shows field hint and disables install when folder input is cleared', async () => {
+		const { po } = mountComponent('specs')
+		await flushPromises()
+		await po.setFolder('')
+		expect(po.fieldHint.exists()).toBe(true)
+		expect((po.installBtn.element as HTMLButtonElement).disabled).toBe(true)
+	})
+
+	it('skip emits next with templateStatus skipped', async () => {
+		const { wrapper, po } = mountComponent('specs', {}, {}, [])
+		await flushPromises()
+		await po.clickSkip()
+		expect(wrapper.emitted('next')?.[0]).toEqual([{ templateStatus: 'skipped', specsFolder: 'specs' }])
+	})
+
+	it('install creates folder and emits next after success', async () => {
+		const { wrapper, po, vault } = mountComponent('specs', {}, {}, [])
+		await flushPromises()
+		await po.clickInstall()
+		await flushPromises()
+		expect(vault.createFolder).toHaveBeenCalledWith('specs')
+		expect(po.outcome.text()).toContain('ready')
+		vi.advanceTimersByTime(1500)
+		await flushPromises()
+		expect(wrapper.emitted('next')?.[0]).toEqual([{ templateStatus: 'installed', specsFolder: 'specs' }])
+	})
+
+	it('shows failure outcome when install rejects', async () => {
+		const { po } = mountComponent('specs', {
+			createFolder: vi.fn().mockRejectedValue(new Error('no space')),
+		}, {}, [])
+		await flushPromises()
+		await po.clickInstall()
+		await flushPromises()
+		expect(po.outcome.text()).toContain("couldn't be installed")
+	})
+})

--- a/tests/ui/components/OnboardingStep5Done.po.ts
+++ b/tests/ui/components/OnboardingStep5Done.po.ts
@@ -1,0 +1,12 @@
+import type { VueWrapper } from '@vue/test-utils'
+export class OnboardingStep5DonePO {
+	constructor(private readonly wrapper: VueWrapper) {}
+	get heading() { return this.wrapper.find('[data-testid="step5-heading"]') }
+	get body() { return this.wrapper.find('[data-testid="step5-body"]') }
+	get summaryPersona() { return this.wrapper.find('[data-testid="step5-summary-persona"]') }
+	get summaryClaude() { return this.wrapper.find('[data-testid="step5-summary-claude"]') }
+	get summaryTemplates() { return this.wrapper.find('[data-testid="step5-summary-templates"]') }
+	get cta() { return this.wrapper.find('[data-testid="step5-cta"]') }
+	get saveError() { return this.wrapper.find('[data-testid="step5-save-error"]') }
+	async clickCta() { await this.cta.trigger('click') }
+}

--- a/tests/ui/components/OnboardingStep5Done.test.ts
+++ b/tests/ui/components/OnboardingStep5Done.test.ts
@@ -1,0 +1,74 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import OnboardingStep5Done from '@/ui/components/OnboardingStep5Done.vue'
+import { SETTINGS_PORT, LOGGER_PORT } from '@/infrastructure/bridge/ports'
+import { OnboardingStep5DonePO } from './OnboardingStep5Done.po'
+import type { SettingsPort, LoggerPort } from '@/domain/ports'
+import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
+
+const mockLogger: LoggerPort = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+
+function makeMockSettingsPort(overrides: Partial<SettingsPort> = {}): SettingsPort {
+	return {
+		getSettings: vi.fn().mockResolvedValue({ ...DEFAULT_SETTINGS }),
+		saveSettings: vi.fn().mockResolvedValue(undefined),
+		...overrides,
+	}
+}
+
+describe('OnboardingStep5Done', () => {
+	function mountComponent(
+		props: { personaSkipped: boolean; claudeStatus: 'ready' | 'not-ready' | 'unknown'; templateStatus: 'installed' | 'skipped' | 'failed' } = { personaSkipped: false, claudeStatus: 'ready', templateStatus: 'installed' },
+		settingsOverrides: Partial<SettingsPort> = {},
+	) {
+		const port = makeMockSettingsPort(settingsOverrides)
+		const wrapper = mount(OnboardingStep5Done, {
+			props,
+			global: {
+				provide: {
+					[SETTINGS_PORT as symbol]: port,
+					[LOGGER_PORT as symbol]: mockLogger,
+				},
+			},
+		})
+		return { wrapper, po: new OnboardingStep5DonePO(wrapper), port }
+	}
+
+	beforeEach(() => { vi.clearAllMocks() })
+
+	it('saves onboardingComplete:true on mount', async () => {
+		const { port } = mountComponent()
+		await flushPromises()
+		expect(port.saveSettings).toHaveBeenCalledWith(
+			expect.objectContaining({ onboardingComplete: true }),
+		)
+	})
+
+	it('emits finish when CTA clicked', async () => {
+		const { wrapper, po } = mountComponent()
+		await flushPromises()
+		await po.clickCta()
+		expect(wrapper.emitted('finish')).toHaveLength(1)
+	})
+
+	it('shows save error when settings save fails', async () => {
+		const { po } = mountComponent(
+			{ personaSkipped: false, claudeStatus: 'ready', templateStatus: 'installed' },
+			{ saveSettings: vi.fn().mockRejectedValue(new Error('fail')) },
+		)
+		await flushPromises()
+		expect(po.saveError.exists()).toBe(true)
+	})
+
+	it('shows "Not added yet" for persona when skipped', async () => {
+		const { po } = mountComponent({ personaSkipped: true, claudeStatus: 'ready', templateStatus: 'installed' })
+		await flushPromises()
+		expect(po.summaryPersona.text()).toContain('Not added yet')
+	})
+
+	it('shows "Not ready" for claude when not-ready', async () => {
+		const { po } = mountComponent({ personaSkipped: false, claudeStatus: 'not-ready', templateStatus: 'installed' })
+		await flushPromises()
+		expect(po.summaryClaude.text()).toContain('Not ready')
+	})
+})


### PR DESCRIPTION
## Summary

- Implements `OnboardingStep4Workspace.vue` — specs folder input with empty-guard, install/skip/reinstall/retry flows, inline success/error outcomes via `tryAsync`, auto-advances after install
- Implements `OnboardingStep5Done.vue` — saves `onboardingComplete: true` on mount, per-step summary list (persona / claude / templates), persona and claude status nudges
- Adds reusable `OnboardingNudge.vue` — advisory nudge with optional action link and session-only dismiss
- Adds `HomePersonaNudge.vue` — sidebar nudge shown post-onboarding when `userPersona` is empty
- Extends settings tab with "About you" section (`userPersona` textarea, contextual nudge when empty, "Re-run setup" button)
- Makes `activateView` and `_dispatchNavigate` public on `SpecoratorPlugin` (required by settings tab)
- Adds `.sp-onboarding__heading` and `.sp-onboarding__body` shared typography rules to `styles.css`
- PageObjects + unit tests for `OnboardingNudge` (6 cases), `OnboardingStep5Done` (5 cases), and `OnboardingStep4Workspace` (7 cases)

Replaces #294 (Codex reviewer unresponsive after 13 triggers). Closes #196.

## Test plan

- [ ] `npm run verify` passes (all tests, thresholds, both builds)
- [ ] Step 4 folder input blocks empty submission; install flow auto-advances; skip always available
- [ ] Step 5 saves `onboardingComplete: true` on mount; summary reflects prior step outcomes
- [ ] Nudges dismiss for the session; action link fires correct event
- [ ] Settings tab shows "About you" section; "Re-run setup" clears `onboardingComplete`

---
_Generated by [Claude Code](https://claude.ai/code/session_015Eiow3YrzddnfVn3fexv4S)_