### PR TITLE
feat(chat): PR-3 plugin integration — file-menu, startup/shutdown, port wiring, bumpSettingsVersion

### DIFF
--- a/specs/claude-cli-chat-sidebar/implementation-log.md
+++ b/specs/claude-cli-chat-sidebar/implementation-log.md
@@ -139,3 +139,149 @@ PR-1 lays the foundational infrastructure for the Claude CLI chat sidebar: the d
 | `npm audit --audit-level=high --omit=dev` | 0 vulnerabilities |
 
 **Outcome:** all gates green.
+
+---
+
+# Implementation Log — PR-3 Plugin Integration (T-CCS-031 through T-CCS-038)
+
+## Overview
+
+PR-3 wires the ClaudeCliAdapter into the Obsidian plugin lifecycle, registers
+vault file-menu and active-leaf-change event handlers that forward file references
+to the chat store, exposes `pinia`/`navigateTo`/`bumpSettingsVersion` on
+SpecoratorView, and adds the SETTINGS_VERSION_KEY reactivity bridge from settings
+tab → ChatSidebar. Setup merges PR-2 branch into this worktree first.
+
+---
+
+## Entry 8 — Merge PR-2 + resolve conflicts
+
+**Commit:** `4659327`
+**Spec reference:** pre-condition for PR-3 tasks
+
+**Files changed (conflict resolution):**
+- `src/domain/ports/ClaudeCliPort.ts` — took PR-2 full interface (query, startup, shutdown, error types)
+- `src/domain/ports/index.ts` — merged both re-export lines (ClaudeCliError class export)
+- `src/infrastructure/bridge/ports.ts` — added IS_MOBILE_KEY from PR-2
+- `src/ui/composables/useClaudeCliPort.ts` — took PR-2 strict-inject version
+- `src/domain/settings/PluginSettings.ts` — merged both: kept userPersona/onboardingComplete from HEAD plus anthropicApiKey from PR-2
+- `src/core/core-settings.ts` — merged validate/schema for all fields from both sides
+
+**Outcome:** done
+**Deviation:** none — both sides' fields preserved in the merged PluginSettings.
+
+---
+
+## Entry 9 — T-CCS-032: Bridge stubs for full ClaudeCliPort interface
+
+**Commit:** `337193c`
+**Spec reference:** SPEC-CCS-001 §5; ADR-008
+
+**Files changed:**
+- `src/infrastructure/mock/MockBridge.ts` (lines 1–18, 216–229) — added ClaudeCliQueryOptions/ClaudeCliError imports; query/startup/shutdown no-op stubs
+- `src/infrastructure/localstorage/LocalStorageBridge.ts` (lines 1–18, 170–182) — same
+- `src/infrastructure/obsidian/ObsidianBridge.ts` (lines 1–18, 233–247) — same
+
+**Outcome:** done
+**Deviation:** ObsidianBridge.query() returns ClaudeCliError{NOT_INSTALLED} because the real query path goes through ClaudeCliAdapter (provided via CLAUDE_CLI_PORT separately). ObsidianBridge keeps the old `isAvailable()` exec fallback for protocol compliance only.
+
+---
+
+## Entry 10 — T-CCS-037 (step 1): Promote SETTINGS_VERSION_KEY to ports.ts
+
+**Commit:** `474c112`
+**Spec reference:** D-CCS-003, T-CCS-037
+
+**Files changed:**
+- `src/infrastructure/bridge/ports.ts` (lines 29–33) — added `SETTINGS_VERSION_KEY: InjectionKey<Ref<number>>`
+- `src/ui/components/chat/ChatSidebar.vue` (lines 1–19) — removed local Symbol declaration; imports SETTINGS_VERSION_KEY from ports.ts
+
+**Outcome:** done
+**Deviation:** none.
+
+---
+
+## Entry 11 — T-CCS-035, T-CCS-036: SpecoratorView public API + port wiring
+
+**Commit:** `d8eba99`
+**Spec reference:** SPEC-CCS-001 §9; T-CCS-035, T-CCS-036
+
+**Files changed:**
+- `src/plugin/SpecoratorView.ts` (full rewrite, 145 lines) —
+  - Constructor now accepts `claudeCliPort: ClaudeCliPort` (3rd arg)
+  - `public pinia!: Pinia` — set in onOpen() after createPinia()
+  - `private readonly _settingsVersion = ref(0)` — reactive counter
+  - `private _router: Router | null` — stored for navigateTo()
+  - Provides: CLAUDE_CLI_PORT (adapter), IS_MOBILE_KEY (Platform.isMobile), SETTINGS_VERSION_KEY (_settingsVersion)
+  - `public navigateTo(path: string): void` — pushes to router
+  - `public bumpSettingsVersion(): void` — increments _settingsVersion
+
+**Outcome:** done
+**Deviation:** none.
+
+---
+
+## Entry 12 — T-CCS-031, T-CCS-032, T-CCS-033, T-CCS-034: main.ts plugin integration
+
+**Commit:** `93ffc9b`
+**Spec reference:** SPEC-CCS-001 §9; REQ-CCS-003, REQ-CCS-005, REQ-CCS-006, REQ-CCS-009, REQ-CCS-017
+
+**Files changed:**
+- `src/plugin/main.ts` (full rewrite, 220 lines) —
+  - Imports ClaudeCliAdapter, useChatStore
+  - `_claudeCliAdapter: ClaudeCliAdapter | null` private field
+  - `_specoratorView: SpecoratorView | null` private field
+  - onload(): creates ClaudeCliAdapter, calls startup(), registers shutdown() via this.register()
+  - registerView() factory captures view in _specoratorView
+  - registerEvent('file-menu'): adds 'Add to chat context' item → addContextFile()
+  - registerEvent('active-leaf-change'): setActiveFile() or setActiveFile(null)
+  - URI handler action='open-chat': activateView() then navigateTo('/chat')
+
+**Outcome:** done
+**Deviation:** `_specoratorView` is set by the view factory rather than passed to settings. This avoids a circular reference between main and settings.
+
+---
+
+## Entry 13 — T-CCS-037 (step 2): settings tab API key → bumpSettingsVersion
+
+**Commit:** `0d780eb`
+**Spec reference:** D-CCS-003, T-CCS-037
+
+**Files changed:**
+- `src/plugin/settings.ts` (lines 1–5, 138–165) —
+  - Imports VIEW_TYPE from SpecoratorView
+  - `_bumpAllViews()` private method: iterates getLeavesOfType(VIEW_TYPE), duck-calls bumpSettingsVersion()
+  - onChange for anthropicApiKey field now calls `_bumpAllViews()` after save
+
+**Outcome:** done
+**Deviation:** Uses duck-typing cast (unknown as Record) to call bumpSettingsVersion() without creating a direct circular import between settings.ts and SpecoratorView.ts.
+
+---
+
+## Entry 14 — T-CCS-031, T-CCS-034, T-CCS-038: plugin chat handler unit tests
+
+**Commit:** `8e111a8`
+**Spec reference:** REQ-CCS-005, REQ-CCS-006, REQ-CCS-009, TEST-CCS-001
+
+**Files changed:**
+- `tests/plugin/main.chat-handlers.test.ts` (new, 144 lines) — 9 tests for file-menu (addContextFile, dedup, isAuto=false) and active-leaf-change (setActiveFile, index 0, clear null, replace, preserve manuals)
+
+**Outcome:** done
+**Deviation:** Tests exercise callbacks as pure functions rather than mounting the full plugin lifecycle (Obsidian mocks would be required). Logic is identical to what main.ts registers.
+
+---
+
+## T-CCS-038: PR-3 gate verification
+
+**Date:** 2026-05-14
+**Results:**
+
+| Check | Result |
+|---|---|
+| `npm run typecheck` | pass |
+| `npm run lint` | pass (9 pre-existing warnings, 0 errors) |
+| `npm run test` | 805 passed (71 files) |
+| `npm run build` | pass — 538 modules |
+| `npm run build:web` | pass — 162 modules |
+
+**Outcome:** all gates green.

--- a/specs/claude-cli-chat-sidebar/workflow-state.md
+++ b/specs/claude-cli-chat-sidebar/workflow-state.md
@@ -3,12 +3,12 @@ id: b1c2d3e4-f567-4a89-b012-c3d4e5f6a7b8
 feature: "Claude CLI chat sidebar"
 area: CCS
 slug: claude-cli-chat-sidebar
-current_stage: idea
+current_stage: implementation
 status: active
 last_updated: 2026-05-14
 last_agent: dev
 createdAt: 2026-05-05T00:00:00+02:00
-updatedAt: 2026-05-05T00:00:00+02:00
+updatedAt: 2026-05-14T00:00:00+02:00
 artifacts:
   idea: complete
   research: pending
@@ -16,7 +16,7 @@ artifacts:
   design: pending
   spec: pending
   tasks: pending
-  implementation-log: in-progress
+  implementation-log: complete
   test-plan: pending
   test-report: pending
   review: pending
@@ -34,7 +34,7 @@ artifacts:
 | 4 — Design | pending | — | |
 | 5 — Specification | pending | — | |
 | 6 — Tasks | pending | — | |
-| 7 — Implementation | in-progress | `implementation-log.md` (PR-1 done, PR-2/PR-3 pending) | |
+| 7 — Implementation | in-progress | `implementation-log.md` (PR-1, PR-2, PR-3 done) | Pending QA/Review |
 | 8 — Testing | pending | — | |
 | 9 — Review | pending | — | |
 | 10 — Release | pending | — | |
@@ -42,7 +42,7 @@ artifacts:
 
 ## Blocks
 
-Blocked on Phase 3 gate: #11 (plugin shell) must be closed. W13 (#163) narrow ports and MCP server must be at sufficient completion before implementation begins.
+None — PR-1, PR-2, PR-3 all complete. Pending qa/reviewer sign-off.
 
 ## Hand-off notes
 
@@ -50,6 +50,7 @@ Blocked on Phase 3 gate: #11 (plugin shell) must be closed. W13 (#163) narrow po
 |---|---|---|---|
 | 2026-05-05 | pm | — | Spec entry created to satisfy Phase 4 spec-first gate; idea authored based on #161 |
 | 2026-05-14 | dev | dev (next PR) | PR-1 Infrastructure complete (T-CCS-001–T-CCS-015, T-CCS-016 gate passed). 7 commits on worktree-agent-a61e399c3169d813a. implementation-log.md in-progress (PR-2 sidebar UI and PR-3 MCP wiring remain). |
+| 2026-05-14 | dev | qa | PR-2 Chat UI complete (T-CCS-017–T-CCS-030). PR-3 Plugin Integration complete (T-CCS-031–T-CCS-038). Draft PR open on worktree-agent-af701347fff881022. All gates green: 805 tests pass, typecheck pass, lint 0 errors, build pass. |
 
 ## Open clarifications
 

--- a/src/infrastructure/bridge/ports.ts
+++ b/src/infrastructure/bridge/ports.ts
@@ -1,4 +1,4 @@
-import type { InjectionKey } from 'vue'
+import type { InjectionKey, Ref } from 'vue'
 import type {
 	SettingsPort,
 	VaultPort,
@@ -21,3 +21,9 @@ export const CANVAS_PORT: InjectionKey<CanvasPort> = Symbol('CanvasPort')
 export const COMMUNITY_PLUGIN_PORT: InjectionKey<CommunityPluginPort> = Symbol('CommunityPluginPort')
 export const CLAUDE_CLI_PORT: InjectionKey<ClaudeCliPort> = Symbol('ClaudeCliPort')
 export const IS_MOBILE_KEY: InjectionKey<boolean> = Symbol('IsMobile')
+/**
+ * Reactive counter provided by SpecoratorView. ChatSidebar watches this to
+ * re-check adapter availability after the API key is saved in Settings.
+ * Satisfies D-CCS-003, T-CCS-037.
+ */
+export const SETTINGS_VERSION_KEY: InjectionKey<Ref<number>> = Symbol('settingsVersion')

--- a/src/plugin/SpecoratorView.ts
+++ b/src/plugin/SpecoratorView.ts
@@ -1,6 +1,7 @@
-import { ItemView, type WorkspaceLeaf } from 'obsidian'
-import { createApp, type App as VueApp } from 'vue'
-import { createPinia } from 'pinia'
+import { ItemView, Platform, type WorkspaceLeaf } from 'obsidian'
+import { createApp, ref, type App as VueApp } from 'vue'
+import { createPinia, type Pinia } from 'pinia'
+import type { Router } from 'vue-router'
 import { router } from '@/ui/router'
 import { i18n, setLocale, type SupportedLocale } from '@/ui/i18n'
 import AppRoot from '@/ui/AppRoot.vue'
@@ -12,10 +13,13 @@ import {
   LOGGER_PORT,
   CLAUDE_CLI_PORT,
   COMMUNITY_PLUGIN_PORT,
+  IS_MOBILE_KEY,
+  SETTINGS_VERSION_KEY,
 } from '@/infrastructure/bridge/ports'
 import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
 import { FeatureService } from '@/application/feature/FeatureService'
 import { FEATURE_SERVICE_KEY } from '@/ui/composables/useFeatureService'
+import type { ClaudeCliPort } from '@/domain/ports'
 import type SpecoratorPlugin from './main'
 
 export const VIEW_TYPE = 'specorator'
@@ -24,10 +28,27 @@ export class SpecoratorView extends ItemView {
   private vueApp: VueApp | null = null
   private _onUnhandledRejection: ((e: PromiseRejectionEvent) => void) | null = null
   private _routerErrorCleanup: (() => void) | null = null
+  private _router: Router | null = null
+
+  /**
+   * Exposed so main.ts can access the Pinia instance to call store actions
+   * (e.g. addFile, setActiveFile) from Obsidian event handlers.
+   * Set in onOpen() after createPinia().
+   * Satisfies T-CCS-035.
+   */
+  public pinia!: Pinia
+
+  /**
+   * Reactive counter. Incremented by bumpSettingsVersion() each time the
+   * Anthropic API key is saved in Settings. ChatSidebar watches this to
+   * re-check adapter availability. Satisfies D-CCS-003, T-CCS-037.
+   */
+  private readonly _settingsVersion = ref(0)
 
   constructor(
     leaf: WorkspaceLeaf,
     private readonly plugin: SpecoratorPlugin,
+    private readonly claudeCliPort: ClaudeCliPort,
   ) {
     super(leaf)
   }
@@ -49,8 +70,10 @@ export class SpecoratorView extends ItemView {
 
     setLocale(this.plugin.settings.locale as SupportedLocale)
 
+    this.pinia = createPinia()
+
     this.vueApp = createApp(AppRoot)
-    this.vueApp.use(createPinia())
+    this.vueApp.use(this.pinia)
     this.vueApp.use(router)
     this.vueApp.use(i18n)
     this.vueApp.provide(SETTINGS_PORT, bridge)
@@ -58,8 +81,10 @@ export class SpecoratorView extends ItemView {
     this.vueApp.provide(WORKSPACE_PORT, bridge)
     this.vueApp.provide(NOTIFICATION_PORT, bridge)
     this.vueApp.provide(LOGGER_PORT, bridge)
-    this.vueApp.provide(CLAUDE_CLI_PORT, bridge)
+    this.vueApp.provide(CLAUDE_CLI_PORT, this.claudeCliPort)
     this.vueApp.provide(COMMUNITY_PLUGIN_PORT, bridge)
+    this.vueApp.provide(IS_MOBILE_KEY, Platform.isMobile)
+    this.vueApp.provide(SETTINGS_VERSION_KEY, this._settingsVersion)
     this.vueApp.provide(
       FEATURE_SERVICE_KEY,
       new FeatureService(new FeatureRepository(bridge, bridge, bridge)),
@@ -85,6 +110,8 @@ export class SpecoratorView extends ItemView {
       bridge.showError('Navigation failed. Please try again.')
     })
 
+    this._router = router
+
     this.vueApp.mount(mountPoint)
     return Promise.resolve()
   }
@@ -96,9 +123,29 @@ export class SpecoratorView extends ItemView {
     }
     this._routerErrorCleanup?.()
     this._routerErrorCleanup = null
+    this._router = null
     this.plugin.bridge?.hideAllNotices()
     this.vueApp?.unmount()
     this.vueApp = null
     return Promise.resolve()
+  }
+
+  /**
+   * Navigates the embedded Vue Router to the given path.
+   * No-op if the view is not currently open.
+   * Satisfies T-CCS-035 (URI handler navigation).
+   */
+  public navigateTo(path: string): void {
+    void this._router?.push(path)
+  }
+
+  /**
+   * Increments the settings-version reactive counter, signalling ChatSidebar
+   * to re-check adapter availability. Called by the settings tab after the
+   * Anthropic API key is saved.
+   * Satisfies D-CCS-003, T-CCS-037.
+   */
+  public bumpSettingsVersion(): void {
+    this._settingsVersion.value++
   }
 }

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -68,12 +68,12 @@ export default class SpecoratorPlugin extends Plugin {
     // Persist any migrations that occurred during init.
     await this.saveData(this._storedData)
 
-    // T-CCS-032: Instantiate and pre-warm ClaudeCliAdapter.
+    // T-CCS-032: Instantiate ClaudeCliAdapter. startup() is deferred to onLayoutReady
+    // so it does not hold up the critical onload() path.
     this._claudeCliAdapter = new ClaudeCliAdapter(
       () => this.settings,
       this.bridge,
     )
-    await this._claudeCliAdapter.startup()
     this.register(() => { this._claudeCliAdapter?.shutdown() })
 
     this.registerView(VIEW_TYPE, (leaf) => {
@@ -175,6 +175,8 @@ export default class SpecoratorPlugin extends Plugin {
     // Workspace/vault index isn't guaranteed ready during onload(). Defer any
     // logic that reads workspace layout or vault state until layout is ready.
     this.app.workspace.onLayoutReady(() => {
+      // T-CCS-032: Pre-warm adapter here so startup() does not block onload().
+      void this._claudeCliAdapter?.startup()
       this.detectLegacyVaultLayout()
       if (!this.settings.onboardingComplete) {
         void this.activateView()

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -8,11 +8,13 @@ import { ObsidianBridge } from '@/infrastructure/obsidian/ObsidianBridge'
 import { ObsidianMcpServerAdapter } from '@/infrastructure/obsidian/ObsidianMcpServerAdapter'
 import { ObsidianMetadataCacheAdapter } from '@/infrastructure/obsidian/ObsidianMetadataCacheAdapter'
 import { ObsidianCanvasAdapter } from '@/infrastructure/obsidian/ObsidianCanvasAdapter'
+import { ClaudeCliAdapter } from '@/infrastructure/obsidian/ClaudeCliAdapter'
 import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
 import { PluginCore } from '@/core/plugin-core'
 import { ALL_MODULES, type ModuleDescriptor } from '@/modules'
 import { i18nMerge, i18nTranslate, setLocale, type SupportedLocale } from '@/ui/i18n'
 import type { TranslationPort } from '@/domain/ports'
+import { useChatStore } from '@/ui/stores/chatStore'
 
 export default class SpecoratorPlugin extends Plugin {
   settings: PluginSettings = { ...DEFAULT_SETTINGS }
@@ -21,6 +23,10 @@ export default class SpecoratorPlugin extends Plugin {
 
   /** Full stored data blob: specorator sub-key + per-module sub-keys + _moduleVersions. */
   private _storedData: Record<string, unknown> = {}
+  /** ClaudeCliAdapter instance — created in onload(), destroyed in onunload(). */
+  private _claudeCliAdapter: ClaudeCliAdapter | null = null
+  /** SpecoratorView instance — set when the registered view factory runs. */
+  private _specoratorView: SpecoratorView | null = null
 
   async onload(): Promise<void> {
     await this.loadSettings()
@@ -62,7 +68,19 @@ export default class SpecoratorPlugin extends Plugin {
     // Persist any migrations that occurred during init.
     await this.saveData(this._storedData)
 
-    this.registerView(VIEW_TYPE, (leaf) => new SpecoratorView(leaf, this))
+    // T-CCS-032: Instantiate and pre-warm ClaudeCliAdapter.
+    this._claudeCliAdapter = new ClaudeCliAdapter(
+      () => this.settings,
+      this.bridge,
+    )
+    await this._claudeCliAdapter.startup()
+    this.register(() => { this._claudeCliAdapter?.shutdown() })
+
+    this.registerView(VIEW_TYPE, (leaf) => {
+      const view = new SpecoratorView(leaf, this, this._claudeCliAdapter!)
+      this._specoratorView = view
+      return view
+    })
 
     this.addRibbonIcon('layout-dashboard', 'Open Specorator', () => {
       void this.activateView()
@@ -101,14 +119,50 @@ export default class SpecoratorPlugin extends Plugin {
 
     this.addSettingTab(new SpecoratorSettingTab(this.app, this))
 
+    // T-CCS-031: Right-click "Add to chat context" menu item on vault files.
+    this.registerEvent(
+      this.app.workspace.on('file-menu', (menu, file) => {
+        menu.addItem((item) => {
+          item
+            .setTitle('Add to chat context')
+            .setIcon('message-square-plus')
+            .onClick(() => {
+              void this.activateView().then(() => {
+                if (this._specoratorView?.pinia) {
+                  const store = useChatStore(this._specoratorView.pinia)
+                  store.addContextFile({ path: file.path, label: file.name, isAuto: false })
+                }
+              })
+            })
+        })
+      }),
+    )
+
+    // T-CCS-034: Track the active file and update the store's auto context slot.
+    this.registerEvent(
+      this.app.workspace.on('active-leaf-change', () => {
+        const activeFile = this.app.workspace.getActiveFile()
+        if (this._specoratorView?.pinia) {
+          const store = useChatStore(this._specoratorView.pinia)
+          if (activeFile) {
+            store.setActiveFile({ path: activeFile.path, label: activeFile.name, isAuto: true })
+          } else {
+            store.setActiveFile(null)
+          }
+        }
+      }),
+    )
+
     this.registerObsidianProtocolHandler('specorator', (params) => {
       const searchParams = new URLSearchParams(Object.entries(params))
       if (this.core?.handleUri(searchParams) === true) return
 
-      // v1 stub handlers — replaced by module uriActions when the owning module is built
+      // T-CCS-033: Navigate to /chat when action=open-chat.
       const action = params.action
       if (action === 'open-chat' || action === 'focus-chat') {
-        void this.activateView()
+        void this.activateView().then(() => {
+          this._specoratorView?.navigateTo('/chat')
+        })
         return
       }
       if (action === 'send-message' || action === 'open-workflow') {

--- a/src/plugin/settings.ts
+++ b/src/plugin/settings.ts
@@ -1,6 +1,7 @@
 import type { App } from 'obsidian'
 import { PluginSettingTab, Setting } from 'obsidian'
 import type { ModuleDescriptor, SettingsFieldDescriptor } from '@/modules/module'
+import { VIEW_TYPE } from './SpecoratorView'
 import type SpecoratorPlugin from './main'
 
 export class SpecoratorSettingTab extends PluginSettingTab {
@@ -174,11 +175,24 @@ export class SpecoratorSettingTab extends PluginSettingTab {
           .setValue(this.plugin.settings.anthropicApiKey)
           .onChange(async (value) => {
             await this.plugin.updateSettings({ anthropicApiKey: value.trim() })
-            // T-CCS-036 (PR-3): bump settings version on all open SpecoratorView leaves.
-            // The bumpSettingsVersion() call-site is wired in PR-3/T-CCS-036
-            // when SpecoratorView.bumpSettingsVersion() is added.
+            // T-CCS-037: signal ChatSidebar to re-check adapter availability.
+            this._bumpAllViews()
           })
       })
+  }
+
+  /**
+   * Calls bumpSettingsVersion() on every open SpecoratorView leaf so that
+   * ChatSidebar re-checks adapter availability after the API key changes.
+   * Satisfies T-CCS-037, D-CCS-003.
+   */
+  private _bumpAllViews(): void {
+    for (const leaf of this.app.workspace.getLeavesOfType(VIEW_TYPE)) {
+      const view = leaf.view as unknown as Record<string, unknown>
+      if (typeof view.bumpSettingsVersion === 'function') {
+        ;(view as unknown as { bumpSettingsVersion(): void }).bumpSettingsVersion()
+      }
+    }
   }
 
   private async saveField(mod: ModuleDescriptor, key: string, value: unknown): Promise<void> {

--- a/src/plugin/settings.ts
+++ b/src/plugin/settings.ts
@@ -1,7 +1,7 @@
 import type { App } from 'obsidian'
 import { PluginSettingTab, Setting } from 'obsidian'
 import type { ModuleDescriptor, SettingsFieldDescriptor } from '@/modules/module'
-import { VIEW_TYPE } from './SpecoratorView'
+import { VIEW_TYPE, SpecoratorView } from './SpecoratorView'
 import type SpecoratorPlugin from './main'
 
 export class SpecoratorSettingTab extends PluginSettingTab {
@@ -188,9 +188,8 @@ export class SpecoratorSettingTab extends PluginSettingTab {
    */
   private _bumpAllViews(): void {
     for (const leaf of this.app.workspace.getLeavesOfType(VIEW_TYPE)) {
-      const view = leaf.view as unknown as Record<string, unknown>
-      if (typeof view.bumpSettingsVersion === 'function') {
-        ;(view as unknown as { bumpSettingsVersion(): void }).bumpSettingsVersion()
+      if (leaf.view instanceof SpecoratorView) {
+        leaf.view.bumpSettingsVersion()
       }
     }
   }

--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted, nextTick, inject } from 'vue'
-import type { InjectionKey, Ref } from 'vue'
 import { tryAsync } from '@/domain/shared/tryAsync'
 import { useChatStore } from '@/ui/stores/chatStore'
 import { useClaudeCliPort } from '@/ui/composables/useClaudeCliPort'
@@ -10,12 +9,10 @@ import { useWorkspacePort } from '@/ui/composables/useWorkspacePort'
 import { useSettingsPort } from '@/ui/composables/useSettingsPort'
 import { buildPrompt } from '@/application/chat/buildPrompt'
 import type { ContextFile } from '@/application/chat/buildPrompt'
+import { SETTINGS_VERSION_KEY } from '@/infrastructure/bridge/ports'
 import ContextFileList from './ContextFileList.vue'
 import ChatInput from './ChatInput.vue'
 import ChatResponse from './ChatResponse.vue'
-
-// Settings-version injection key (provided by SpecoratorView or defaulting to ref(0))
-const SETTINGS_VERSION_KEY: InjectionKey<Ref<number>> = Symbol('settingsVersion')
 
 const store = useChatStore()
 const claudeCliPort = useClaudeCliPort()

--- a/tests/plugin/main.chat-handlers.test.ts
+++ b/tests/plugin/main.chat-handlers.test.ts
@@ -1,0 +1,144 @@
+/**
+ * T-CCS-031, T-CCS-034 — Unit tests for the file-menu and active-leaf-change
+ * handler logic wired in main.ts.
+ *
+ * Because the full Plugin lifecycle requires the Obsidian runtime, these tests
+ * exercise the handler callbacks as pure functions, decoupled from the plugin
+ * class. The Pinia store is the real `useChatStore` running in an isolated
+ * pinia instance to keep assertions honest.
+ *
+ * Satisfies REQ-CCS-009 (dedup), REQ-CCS-005/006 (active file auto-slot).
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useChatStore } from '@/ui/stores/chatStore'
+
+// ── helpers extracted from main.ts handler logic ─────────────────────────────
+
+/**
+ * Mirrors the onClick callback inside the 'file-menu' handler registered in
+ * main.ts. Takes the store directly so we can test without the full plugin.
+ */
+function handleAddToContext(
+  store: ReturnType<typeof useChatStore>,
+  file: { path: string; name: string },
+): void {
+  store.addContextFile({ path: file.path, label: file.name, isAuto: false })
+}
+
+/**
+ * Mirrors the 'active-leaf-change' handler callback in main.ts.
+ */
+function handleActiveLeafChange(
+  store: ReturnType<typeof useChatStore>,
+  activeFile: { path: string; name: string } | null,
+): void {
+  if (activeFile) {
+    store.setActiveFile({ path: activeFile.path, label: activeFile.name, isAuto: true })
+  } else {
+    store.setActiveFile(null)
+  }
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe('T-CCS-031: file-menu "Add to chat context" handler', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('adds a file to contextFiles with isAuto=false', () => {
+    const store = useChatStore()
+    handleAddToContext(store, { path: 'specs/my-feature/requirements.md', name: 'requirements.md' })
+
+    expect(store.contextFiles).toHaveLength(1)
+    expect(store.contextFiles[0]).toEqual({
+      path: 'specs/my-feature/requirements.md',
+      label: 'requirements.md',
+      isAuto: false,
+    })
+  })
+
+  it('does not duplicate when the same file is added twice (REQ-CCS-009)', () => {
+    const store = useChatStore()
+    const file = { path: 'notes/foo.md', name: 'foo.md' }
+    handleAddToContext(store, file)
+    handleAddToContext(store, file)
+
+    expect(store.contextFiles).toHaveLength(1)
+  })
+
+  it('adds multiple distinct files in order', () => {
+    const store = useChatStore()
+    handleAddToContext(store, { path: 'a.md', name: 'a.md' })
+    handleAddToContext(store, { path: 'b.md', name: 'b.md' })
+
+    expect(store.contextFiles).toHaveLength(2)
+    expect(store.contextFiles[0].path).toBe('a.md')
+    expect(store.contextFiles[1].path).toBe('b.md')
+  })
+
+  it('does not mark the file as auto-context (isAuto must be false)', () => {
+    const store = useChatStore()
+    handleAddToContext(store, { path: 'notes/bar.md', name: 'bar.md' })
+
+    expect(store.contextFiles[0].isAuto).toBe(false)
+  })
+})
+
+describe('T-CCS-034: active-leaf-change handler', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('sets the auto context slot when a file is active (REQ-CCS-005)', () => {
+    const store = useChatStore()
+    handleActiveLeafChange(store, { path: 'journal/today.md', name: 'today.md' })
+
+    const auto = store.contextFiles.find((f) => f.isAuto)
+    expect(auto).toBeDefined()
+    expect(auto?.path).toBe('journal/today.md')
+    expect(auto?.label).toBe('today.md')
+  })
+
+  it('places the auto entry at index 0 ahead of manual entries (REQ-CCS-006)', () => {
+    const store = useChatStore()
+    // Add a manual entry first
+    store.addContextFile({ path: 'manual.md', label: 'manual.md', isAuto: false })
+    handleActiveLeafChange(store, { path: 'auto.md', name: 'auto.md' })
+
+    expect(store.contextFiles[0].isAuto).toBe(true)
+    expect(store.contextFiles[0].path).toBe('auto.md')
+    expect(store.contextFiles[1].path).toBe('manual.md')
+  })
+
+  it('clears the auto slot when activeFile is null (REQ-CCS-006)', () => {
+    const store = useChatStore()
+    handleActiveLeafChange(store, { path: 'some.md', name: 'some.md' })
+    expect(store.contextFiles.some((f) => f.isAuto)).toBe(true)
+
+    handleActiveLeafChange(store, null)
+    expect(store.contextFiles.some((f) => f.isAuto)).toBe(false)
+  })
+
+  it('replaces a previous auto entry when the active file changes', () => {
+    const store = useChatStore()
+    handleActiveLeafChange(store, { path: 'first.md', name: 'first.md' })
+    handleActiveLeafChange(store, { path: 'second.md', name: 'second.md' })
+
+    const autos = store.contextFiles.filter((f) => f.isAuto)
+    expect(autos).toHaveLength(1)
+    expect(autos[0].path).toBe('second.md')
+  })
+
+  it('does not affect manual context files when active file changes', () => {
+    const store = useChatStore()
+    store.addContextFile({ path: 'manual.md', label: 'manual.md', isAuto: false })
+    handleActiveLeafChange(store, { path: 'active.md', name: 'active.md' })
+    handleActiveLeafChange(store, { path: 'active2.md', name: 'active2.md' })
+
+    const manuals = store.contextFiles.filter((f) => !f.isAuto)
+    expect(manuals).toHaveLength(1)
+    expect(manuals[0].path).toBe('manual.md')
+  })
+})


### PR DESCRIPTION
## Summary

- **T-CCS-031**: `file-menu` event — right-click "Add to chat context" on vault files
- **T-CCS-032**: `ClaudeCliAdapter` instantiated in `onload()`, `startup()` deferred to `onLayoutReady` (non-blocking — Codex round-2), `shutdown()` via `this.register()`
- **T-CCS-033**: URI `action=open-chat` → `navigateTo('/chat')`
- **T-CCS-034**: `active-leaf-change` → `store.setActiveFile()`
- **T-CCS-035**: `SpecoratorView` exposes `pinia` and `navigateTo()`
- **T-CCS-036**: `SpecoratorView` provides `CLAUDE_CLI_PORT`, `IS_MOBILE_KEY`, `SETTINGS_VERSION_KEY`
- **T-CCS-037**: `bumpSettingsVersion()` on key save
- **T-CCS-038**: 9 unit tests

### Codex fixes
- `startup()` moved from `onload()` body to `onLayoutReady` callback — removes blocking from critical init path (Codex round-2)
- `settings.ts`: `instanceof SpecoratorView` guard in `_bumpAllViews()`

## Depends on
- PR-1 #306 (merged ✅)
- PR-2 #309 (merged ✅)

Replaces #310 (closed).

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors (9 pre-existing warnings)
- [x] `npm run test` — 838 tests passing (78 files)
- [x] `npm run build` — success

https://claude.ai/code/session_015Eiow3YrzddnfVn3fexv4S

---
_Generated by [Claude Code](https://claude.ai/code/session_015Eiow3YrzddnfVn3fexv4S)_