### PR TITLE
docs(chat): add spec artifacts for claude-cli-chat-sidebar (research → tasks)

### DIFF
--- a/docs/adr/0027-claude-cli-context-as-single-user-turn.md
+++ b/docs/adr/0027-claude-cli-context-as-single-user-turn.md
@@ -1,0 +1,117 @@
+---
+id: ADR-0027
+title: Assemble context as a single user turn in the Claude SDK call
+status: accepted
+date: 2026-05-14
+deciders:
+  - architect
+consulted:
+  - pm
+informed:
+  - dev
+supersedes: []
+superseded-by: []
+tags: [chat, sdk, prompt-assembly]
+---
+
+# ADR-0027 — Assemble context as a single user turn in the Claude SDK call
+
+## Status
+
+Accepted
+
+## Context
+
+The `@anthropic-ai/claude-agent-sdk` `query()` generator accepts a `prompt` string and
+`options.maxTurns`. The chat sidebar must include the content of one or more vault files
+alongside the user's typed message. Two assembly strategies were considered:
+
+1. **System-prompt injection:** place file content in a separate system-prompt field.
+2. **Single user-turn preamble:** prepend file sections directly to the `prompt` string
+   as a structured preamble, then append the user's message.
+
+The feature is v1, single-turn only (`maxTurns = 1`). There is no conversation history.
+All context must fit in one prompt. The PRD explicitly prohibits exposing "system prompt"
+terminology to users (NFR-CCS-012).
+
+## Decision
+
+We assemble context and user text into a single `prompt` string using the format:
+
+```
+The following files are provided for context:
+
+---
+File: <vault-relative-path>
+---
+<file content>
+
+---
+
+<user text>
+```
+
+The assembled string is passed as the sole `prompt` argument to `sdkQuery()`. No separate
+system-prompt channel is used. `maxTurns` is clamped to 1 in the adapter.
+
+This is implemented in `src/application/chat/buildPrompt.ts` as a pure function with no
+I/O or side effects.
+
+## Considered options
+
+### Option A — Single user-turn preamble (chosen)
+
+- Pros: works with any SDK that accepts a single prompt string; easy to test as a pure
+  function; no SDK-specific system-prompt API surface; `buildPrompt` is independently
+  testable; no terminology leakage.
+- Cons: the preamble occupies part of the user-turn budget rather than a separate context
+  channel; the model may treat file content and user message with equal authority.
+
+### Option B — System-prompt injection
+
+- Pros: model may give stronger attention to system-context; cleaner semantic separation.
+- Cons: requires SDK-specific API that breaks the narrow-port contract (ClaudeCliPort
+  interface would need a system-prompt parameter, leaking SDK semantics); conflicts with
+  NFR-CCS-012 (no system-prompt terminology in user-visible surface); complicates the
+  v2 multi-provider swap.
+
+## Consequences
+
+### Positive
+
+- `buildPrompt()` is a pure function testable without any SDK dependency.
+- The `ClaudeCliPort.query()` signature stays minimal (`prompt: string, options?`).
+- Swapping the underlying SDK in v2 does not require changes to `buildPrompt`.
+
+### Negative
+
+- File content and user message share the same token budget; the 50 000-token cap
+  applies to the combined string (addressed by the LIFO-removal and auto-file-trim
+  algorithm in `buildPrompt`).
+- The model has no semantic boundary between "context" and "instruction"; this is
+  acceptable for v1 single-turn use.
+
+### Neutral
+
+- `maxTurns > 1` is clamped by the adapter with a warn-level log; v2 can revisit the
+  turn structure without touching the port interface.
+
+## Compliance
+
+- `src/application/chat/buildPrompt.ts` must have no imports from `obsidian` or
+  `@anthropic-ai/claude-agent-sdk` (enforced by ESLint `no-restricted-imports`).
+- `buildPrompt` unit tests must verify the exact preamble format (REQ-CCS-025).
+- The adapter's `_runSdkQuery` passes only `{ prompt, options: { maxTurns: 1 } }` to
+  `sdkQuery`; no system-prompt argument is present.
+
+## References
+
+- PRD-CCS-001 REQ-CCS-025, REQ-CCS-026, REQ-CCS-027, NFR-CCS-008, NFR-CCS-012
+- `src/application/chat/buildPrompt.ts`
+- `src/infrastructure/obsidian/ClaudeCliAdapter.ts` (`_runSdkQuery`)
+- ADR-008 (narrow port interfaces)
+
+---
+
+> **ADR bodies are immutable.** To change a decision, supersede it with a new ADR; only
+> the predecessor's `status` and `superseded-by` pointer fields may be updated.

--- a/docs/adr/0028-api-key-field-outside-module-settings-loop.md
+++ b/docs/adr/0028-api-key-field-outside-module-settings-loop.md
@@ -1,0 +1,119 @@
+---
+id: ADR-0028
+title: Store the Anthropic API key in the top-level plugin settings blob, not in a module settings sub-key
+status: accepted
+date: 2026-05-14
+deciders:
+  - architect
+consulted:
+  - pm
+informed:
+  - dev
+supersedes: []
+superseded-by: []
+tags: [chat, settings, security, api-key]
+---
+
+# ADR-0028 — Store the Anthropic API key in the top-level plugin settings blob, not in a module settings sub-key
+
+## Status
+
+Accepted
+
+## Context
+
+Specorator stores plugin configuration in a nested data blob written by Obsidian's
+`this.saveData()`. The blob structure is:
+
+```
+{
+  specorator: { ...PluginSettings },    // top-level plugin settings
+  <moduleKey>: { ...ModuleSettings },   // per-module sub-keys (iterated by PluginCore)
+  _moduleVersions: { ... }
+}
+```
+
+The `ClaudeCliAdapter` is instantiated in `main.ts` before `PluginCore` loads its
+modules. It receives a `getSettings: () => PluginSettings` getter and reads
+`settings.anthropicApiKey` at call time.
+
+Two placement options were evaluated for `anthropicApiKey`:
+
+1. **Inside a module settings sub-key** (e.g., `_storedData['chat'].anthropicApiKey`).
+2. **Inside the top-level `specorator` blob** (i.e., `PluginSettings.anthropicApiKey`).
+
+## Decision
+
+`anthropicApiKey` is a field of `PluginSettings` stored in the `specorator` sub-key of
+the plugin data blob. It is not placed under any module's settings sub-key.
+
+The settings tab field writes the trimmed value via `plugin.updateSettings({ anthropicApiKey })`,
+which persists to `_storedData.specorator`. The adapter reads the key through the
+`getSettings()` closure that returns `plugin.settings` (the merged, validated value).
+
+## Considered options
+
+### Option A — Top-level PluginSettings (chosen)
+
+- Pros: accessible to `ClaudeCliAdapter` before modules load; consistent with how
+  `specsFolder`, `logLevel`, and other plugin-wide fields are stored; the settings tab
+  naturally groups all top-level fields together; no coupling between module lifecycle
+  and the adapter.
+- Cons: `PluginSettings` grows by one field (`anthropicApiKey`); the security notice
+  about Obsidian Sync applies to any key in the blob (Obsidian Sync syncs the entire
+  plugin data blob).
+
+### Option B — Module settings sub-key
+
+- Pros: logically groups chat-related settings.
+- Cons: requires `ClaudeCliAdapter` to depend on the module registry being fully loaded,
+  creating a startup-ordering risk; `PluginCore.notifySettingsChanged` would need to be
+  called to persist the key, adding indirection; settings-version bumping (`bumpSettingsVersion`)
+  would need to observe module settings changes, not just top-level plugin settings.
+
+## Consequences
+
+### Positive
+
+- `ClaudeCliAdapter` can be instantiated and its `getSettings()` getter called at any
+  point in the plugin lifecycle without ordering dependencies on `PluginCore`.
+- The settings tab uses the same `plugin.updateSettings(partial)` path used for all
+  other top-level fields, requiring no special-case code.
+- `bumpSettingsVersion()` in `SpecoratorView` is called from the settings tab's
+  `onChange` handler for the API key field only, keeping the reactivity surface narrow.
+
+### Negative
+
+- `PluginSettings` now carries a security-sensitive field. The interface comment and
+  settings-tab description must both note the Obsidian Sync disclosure (REQ-CCS-028).
+- The field ships with a default of `''` in `DEFAULT_SETTINGS`, so any consumer that
+  reads `settings.anthropicApiKey` without checking for empty string will silently
+  receive the empty value (acceptable — adapters already guard for empty key).
+
+### Neutral
+
+- A future per-device key store (RISK-CCS-006 mitigation) would supersede this ADR and
+  move the key out of the synced blob entirely.
+
+## Compliance
+
+- `PluginSettings.ts` must include the `anthropicApiKey` field with a comment referencing
+  REQ-CCS-001, REQ-CCS-002, NFR-CCS-005, NFR-CCS-006.
+- The settings tab input must use `type = 'password'` and `autocomplete = 'off'`
+  (NFR-CCS-006).
+- `LoggerPort` calls in `ClaudeCliAdapter` must never include the key value
+  (NFR-CCS-005).
+- The settings tab description must mention Obsidian Sync (REQ-CCS-028).
+
+## References
+
+- PRD-CCS-001 REQ-CCS-001, REQ-CCS-002, REQ-CCS-028, NFR-CCS-005, NFR-CCS-006
+- `src/domain/settings/PluginSettings.ts`
+- `src/infrastructure/obsidian/ClaudeCliAdapter.ts`
+- `src/plugin/main.ts` (adapter instantiation and settings getter)
+- `src/plugin/SpecoratorView.ts` (`bumpSettingsVersion`)
+
+---
+
+> **ADR bodies are immutable.** To change a decision, supersede it with a new ADR; only
+> the predecessor's `status` and `superseded-by` pointer fields may be updated.

--- a/specs/claude-cli-chat-sidebar/design.md
+++ b/specs/claude-cli-chat-sidebar/design.md
@@ -1,0 +1,882 @@
+---
+id: DES-CCS-001
+title: "Claude CLI chat sidebar — design"
+feature: claude-cli-chat-sidebar
+stage: design
+status: in-progress
+owner: ux-designer
+inputs:
+  - PRD-CCS-001
+  - RESEARCH-CCS-001
+created: 2026-05-14
+updated: 2026-05-14
+---
+
+# Design — Claude CLI chat sidebar
+
+---
+
+## Part A — UX
+
+### A1. User flows
+
+#### Flow 1 — Open the chat panel
+
+1. User is inside Obsidian with the Specorator panel closed or on a different route.
+2. User clicks the Specorator ribbon icon **or** runs the "Open panel" command.
+3. Specorator view opens in the right sidebar. The active route navigates to `/chat`.
+4. `ChatSidebar` mounts. Availability check runs asynchronously (`ClaudeCliPort.isAvailable()`).
+5. While the check is pending the panel renders nothing (blank — no flash of degraded copy).
+6. Check resolves:
+   - If platform is mobile — go to **Flow 5 (Mobile degraded)**.
+   - If unavailable and API key is empty — go to **Flow 4a (No-key degraded)**.
+   - If unavailable and API key is set — go to **Flow 4b (SDK-unavailable degraded)**.
+   - If available — panel renders the ready state (title, context strip, input, response area). Focus moves to the text input.
+
+Alternately the user may navigate directly to `/#/chat` via the URI `obsidian://specorator?action=open-chat`, which activates the same view.
+
+The Chat nav tab in the top navigation bar is always present; clicking it from any other route performs a router push to `/chat`.
+
+---
+
+#### Flow 2 — Send a prompt
+
+Pre-condition: panel is in the ready state; at least one context file may or may not be present.
+
+1. User reads the context strip. Zero or more chips are shown. If no file is open, the empty-context hint is displayed inside the strip.
+2. User clicks the text input (or it already has focus from mount).
+3. User types a question. The send button label reads "Ask".
+4. User submits via the "Ask" button or via Ctrl+Enter / Cmd+Enter.
+5. **Empty guard:** if text is whitespace-only the submission is silently ignored; status stays idle.
+6. Send begins:
+   - Store status transitions to `loading`.
+   - Send button becomes disabled and its label changes to "Asking…" with a spinner.
+   - Context chip remove buttons are hidden (chips themselves stay visible as read-only context).
+   - Text input becomes read-only.
+7. File contents for all context entries are read from the vault in parallel. A failed read yields empty content without surfacing an error to the user.
+8. `buildPrompt` assembles the payload. If the result is over budget, LIFO manual-file removal and then auto-file trimming reduce it; `truncated` is noted.
+9. `ClaudeCliPort.query()` is awaited with a 30-second timeout.
+10. On success:
+    - If `truncated` is true — trim notice is shown above the response text. See copy in A3.
+    - Response text is rendered in the response area.
+    - Status returns to `idle`.
+    - User text is cleared.
+    - Focus returns to the text input.
+11. On error — see **Flow 3 (Error states)**.
+
+---
+
+#### Flow 3 — Error states during a query
+
+Pre-condition: a query is in flight (status is `loading`) and the adapter returns a failure.
+
+**Timeout (errorCode `TIMEOUT`):**
+
+1. Status transitions to `error`, `errorType` becomes `timeout`.
+2. Response area renders the timeout message in place of any previous response.
+3. Text input retains the user's original message so they can retry without retyping.
+4. Send button is re-enabled. Focus returns to the text input.
+
+**Generic query failure (any other errorCode):**
+
+1. Status transitions to `error`, `errorType` becomes `query_failed`.
+2. Response area renders the generic error message.
+3. Text input retains the user's original message.
+4. Send button is re-enabled. Focus returns to the text input.
+
+In both error cases the context strip is unchanged. The user can edit the message, add or wait and resend.
+
+---
+
+#### Flow 4a — No-key degraded state
+
+Pre-condition: `ClaudeCliPort.isAvailable()` resolved to `false` and `anthropicApiKey` is empty.
+
+1. Panel renders a framed notice block (no input, no context strip, no title).
+2. Heading reads: "Chat is not set up yet."
+3. Body reads: "To use this feature, add your Anthropic key in Settings. Your key is stored privately on this device and is never shared."
+4. A button-styled link labelled "Open settings" routes to `/settings`.
+5. Programmatic focus is placed on the heading on mount.
+6. User clicks "Open settings", completes key entry, and saves.
+7. Settings save fires `bumpSettingsVersion()`. The `settingsVersion` watcher in `ChatSidebar` fires, re-calls `isAvailable()`, and if it now returns `true` the ready state replaces the degraded block without a page reload.
+
+---
+
+#### Flow 4b — SDK-unavailable degraded state
+
+Pre-condition: `ClaudeCliPort.isAvailable()` resolved to `false` and `anthropicApiKey` is non-empty.
+
+1. Panel renders a framed notice block (no input).
+2. Heading reads: "AI assistant is not available right now."
+3. Body reads: "The AI assistant could not start. This may be a temporary issue. If the problem continues, try restarting Obsidian."
+4. No action link is shown.
+5. Programmatic focus is placed on the heading on mount.
+6. Settings version watcher is still active; if the user later enters or changes their API key, availability is re-checked live.
+
+---
+
+#### Flow 5 — Mobile degraded state
+
+Pre-condition: `usePlatform().isMobile` is `true`.
+
+1. This check runs before the availability check and takes precedence.
+2. Panel renders a framed notice block.
+3. Heading reads: "Chat is available on desktop only."
+4. Body reads: "Open Obsidian on your Mac, Windows, or Linux computer to use the AI assistant."
+5. No input, no context strip, no action link.
+6. Programmatic focus is placed on the heading on mount.
+
+---
+
+#### Flow 6 — Add a file to context via right-click
+
+Pre-condition: user is anywhere in Obsidian with the file explorer or an editor tab visible.
+
+1. User right-clicks a vault file.
+2. Obsidian file menu shows "Add to chat context" as an item.
+3. User clicks the item.
+4. `chatStore.addContextFile({ path, label, isAuto: false })` is called. Duplicate guard: if the path already exists in the store, the call is a no-op.
+5. The Specorator view is activated and navigated to `/chat`.
+6. The new chip appears in the context strip with a remove button.
+7. Focus is not forcibly moved (the user was in the file explorer; returning focus would be disruptive).
+
+---
+
+#### Flow 7 — Remove a manual context file
+
+Pre-condition: one or more manual (non-auto) chips are visible; status is not `loading`.
+
+1. User identifies the chip to remove by its filename label.
+2. User clicks the "×" remove button on the chip, or focuses the button and presses Enter or Space.
+3. `store.removeContextFile(path)` is called.
+4. The chip disappears from the strip immediately.
+5. Focus is not explicitly managed after removal (browser default — focus may move to body; this is acceptable given there is no sensible adjacent target).
+
+Auto chips (the currently open file) have no remove button. They cannot be removed manually.
+
+---
+
+### A2. Information architecture
+
+#### Route placement
+
+`/chat` is a top-level named route registered in `src/ui/router/index.ts`. It sits alongside `/`, `/features`, `/settings`, and `/file/:filePath`.
+
+```
+/                   Home
+/features           Feature list
+/settings           Settings
+/chat               Chat sidebar   ← this feature
+/file/:filePath     File viewer
+```
+
+`/chat` is wrapped by `MainLayout`, which provides the four-item top navigation bar. The "Chat" tab is the fourth item, rendered after Settings.
+
+Tab order in the nav bar (left to right):
+1. Home
+2. Features
+3. Settings
+4. Chat
+
+The Chat tab carries `data-testid="nav-link-chat"`.
+
+#### Deep-link convention
+
+- Internal navigation: `router.push({ name: 'chat' })` or `router.push('/chat')`
+- External URI: `obsidian://specorator?action=open-chat`
+
+The URI handler activates the Specorator view and dispatches an internal router navigation to `/chat`. No additional query parameters are defined for v1.
+
+#### Panel hosting
+
+The Specorator view (`SpecoratorView`) opens in Obsidian's right sidebar leaf. The entire plugin UI, including the Chat route, is hosted inside this single leaf via the embedded Vue application. There is no second, dedicated sidebar leaf for chat.
+
+---
+
+### A3. Empty, loading, and error state copy
+
+All copy is derived from `src/ui/i18n/locales/en.ts` (`chat.*` keys) and the literal strings in the component templates. None of the strings below introduce terminology from the non-goals list (no "token", "context window", "system prompt", "Claude CLI", "SDK", "subprocess").
+
+#### Context strip — empty (no file open)
+
+> "No file is currently open. Open a file in your vault and it will be included here automatically."
+
+Shown inside the context strip section when `store.contextFiles` is empty. This is an inline informational string, not a blocking state. The send input is still accessible.
+
+#### Response area — idle (no query yet)
+
+> "(Response will appear here.)"
+
+Shown as a muted italic placeholder in the response area when `store.response` is null and status is idle.
+
+#### Response area — loading (query in flight)
+
+> "Thinking…"
+
+Shown in the response area wrapped in `role="status"` with `aria-live="polite"`. The send button label simultaneously reads "Asking…".
+
+#### Response area — trimmed-success (query succeeded, context was reduced)
+
+Trim notice (shown above response text):
+> "Some context was trimmed to keep the message within size limits."
+
+The response text follows immediately below the notice. No blocking action is required from the user.
+
+#### Response area — timeout error
+
+> "That took too long. Please try again."
+
+Rendered inside `role="alert"` with `aria-live="assertive"`. The user's input text is preserved.
+
+#### Response area — generic error
+
+> "Something went wrong. Please try again."
+
+Rendered inside `role="alert"` with `aria-live="assertive"`. The user's input text is preserved.
+
+#### Degraded — no API key
+
+- **Heading:** "Chat is not set up yet."
+- **Body:** "To use this feature, add your Anthropic key in Settings. Your key is stored privately on this device and is never shared."
+- **Action link label:** "Open settings"
+
+#### Degraded — SDK unavailable
+
+- **Heading:** "AI assistant is not available right now."
+- **Body:** "The AI assistant could not start. This may be a temporary issue. If the problem continues, try restarting Obsidian."
+- No action link.
+
+#### Degraded — mobile
+
+- **Heading:** "Chat is available on desktop only."
+- **Body:** "Open Obsidian on your Mac, Windows, or Linux computer to use the AI assistant."
+- No action link.
+
+---
+
+### A4. Accessibility
+
+#### Keyboard navigation order — ready state
+
+When the chat panel is in the ready state the natural tab order from top to bottom is:
+
+1. Navigation bar links (Home, Features, Settings, Chat) — these are `RouterLink` elements, keyboard-focusable by default.
+2. Context strip — the strip itself carries `aria-label="Context for this message."` on the `<section>` wrapper. Auto chips are `<span>` elements (not interactive, not in tab order). Manual chip remove buttons are `<button>` elements and appear in tab order; each is labelled `aria-label="Remove <filename> from context"`. When status is `loading`, remove buttons are not rendered, so they vacate the tab order.
+3. Text input (`<textarea>`) — `aria-label="Message"`, `aria-multiline="true"`. Receives programmatic focus on mount when the panel is in the ready state.
+4. Send button — `aria-label="Send message"`. Disabled during loading (native HTML `disabled` attribute).
+
+#### Keyboard shortcut
+
+Ctrl+Enter (Windows/Linux) or Cmd+Enter (macOS) in the textarea fires the send action, equivalent to clicking the send button. This is the only non-standard keyboard shortcut; it is consistent with other multi-line input patterns users encounter in chat tools.
+
+#### Focus management
+
+| Event | Focus destination |
+|---|---|
+| Chat panel mounts — ready state | Text textarea (`ChatInput.textareaEl`) |
+| Chat panel mounts — any degraded state | Degraded heading (`[data-testid="chat-degraded-heading"]`, `tabindex="-1"`) |
+| Send succeeds | Text textarea |
+| Send fails (timeout or error) | Text textarea |
+| Manual chip removed | Browser default (no explicit management) |
+
+The degraded heading has `tabindex="-1"` so it can receive programmatic focus without entering the normal tab sequence. Screen readers will announce the heading copy when focus arrives.
+
+#### ARIA on the response area
+
+| Component state | Element role | Live region |
+|---|---|---|
+| Loading | `role="status"` | `aria-live="polite"` |
+| Timeout error | `role="alert"` | `aria-live="assertive"` |
+| Generic error | `role="alert"` | `aria-live="assertive"` |
+| Success | Plain `<div>` | (none — content is stable) |
+| Trimmed-success trim notice | `role="status"` | `aria-live="polite"` |
+
+#### ARIA on context chips
+
+- Auto chip: The visual "(auto)" suffix is `aria-hidden="true"`. A visually hidden `<span class="sr-only">` reads "(included automatically)" so screen reader users receive the full meaning.
+- The decorative indicator square on the auto chip is `aria-hidden="true"`.
+- Manual chip remove button: `aria-label="Remove <filename> from context"` where `<filename>` is the chip's label value. The "×" glyph inside the button is `aria-hidden="true"`.
+
+#### Context strip region
+
+The `<section>` wrapping the context list carries `aria-label="Context for this message."`. The inner `<ul>` carries `aria-label="Context files"` with `role="list"`.
+
+#### Send button disabled state
+
+The send button uses the native HTML `disabled` attribute when `store.status === 'loading'`. This removes it from the tab order and announces as disabled to screen readers without needing `aria-disabled`.
+
+#### Settings link in degraded state
+
+The "Open settings" link is a `RouterLink` (renders as `<a>`) — keyboard-focusable and accessible by default.
+
+#### Colour-independent communication
+
+All state distinctions (active context, error, loading) are communicated through copy and structural change, not through colour alone. The trim notice uses a background change alongside its text; error states use explicit alert copy.
+
+---
+
+### A5. Requirements coverage (Part A)
+
+| REQ ID | Description | Where addressed in Part A |
+|---|---|---|
+| REQ-CCS-005 | Active file auto-context | Flow 1 step 6 (ready state), Flow 2 step 1 |
+| REQ-CCS-006 | Active file cleared when no file open | A3 — context strip empty copy |
+| REQ-CCS-007 | Chat panel via ribbon and command | Flow 1 steps 1–3 |
+| REQ-CCS-008 | URI handler open-chat | Flow 1 (alternate path); A2 deep-link convention |
+| REQ-CCS-009 | Right-click "Add to chat context" | Flow 6 |
+| REQ-CCS-010 | No-duplicate context files | Flow 6 step 4 (duplicate guard noted) |
+| REQ-CCS-011 | Remove manual context file | Flow 7 |
+| REQ-CCS-012 | Context truncation notice | A3 — trimmed-success copy; Flow 2 step 10 |
+| REQ-CCS-013 | Send message and display response | Flow 2 steps 3–10 |
+| REQ-CCS-014 | Loading state during query | Flow 2 step 6; A4 send button disabled state |
+| REQ-CCS-015 | Empty message guard | Flow 2 step 5 |
+| REQ-CCS-016 | Error state on query failure | Flow 3; A3 error copy |
+| REQ-CCS-017 | userText retained on error | Flow 3 steps 3, 7 |
+| REQ-CCS-018 | API key missing degraded state | Flow 4a; A3 degraded no-key copy |
+| REQ-CCS-019 | SDK unavailable degraded state | Flow 4b; A3 degraded SDK-unavailable copy |
+| REQ-CCS-020 | Mobile degraded state | Flow 5; A3 degraded mobile copy |
+| REQ-CCS-024 | Settings change re-checks availability | Flow 4a step 6–7 |
+| NFR-CCS-009 | Degraded headings receive programmatic focus | A4 focus management table |
+| NFR-CCS-010 | Context chip remove buttons carry accessible labels | A4 ARIA on context chips |
+| NFR-CCS-012 | No AI terminology in UI copy | A3 all copy verified against prohibited word list |
+
+Requirements REQ-CCS-001 through REQ-CCS-004, REQ-CCS-021 through REQ-CCS-023, and REQ-CCS-025 through REQ-CCS-028 are infrastructure, port-interface, and settings-field requirements that have no UX surface; they are addressed in Part C (architect) or in the settings tab implementation.
+
+---
+
+---
+
+## Part B — UI (visual design)
+
+### B1. Component inventory
+
+| File | Role |
+|---|---|
+| `src/ui/views/ChatSidebarView.vue` | Route component for `/chat`; thin shell that mounts `ChatSidebar` |
+| `src/ui/components/chat/ChatSidebar.vue` | Orchestrator: availability check, active-file watcher, send handler, state branching between degraded and ready views |
+| `src/ui/components/chat/ContextFileList.vue` | `<section>` container rendering the context-file chip list and the empty-state hint |
+| `src/ui/components/chat/ContextFileChip.vue` | Single chip: auto variant (no remove) and manual variant (with remove button) |
+| `src/ui/components/chat/ChatInput.vue` | `<textarea>` with `<button>` send control; exposes `textareaEl` ref for programmatic focus |
+| `src/ui/components/chat/ChatResponse.vue` | Response area: renders one of six mutually exclusive states (`idle`, `loading`, `success`, `trimmed-success`, `timeout`, `error`) |
+
+### B2. Design tokens (Obsidian CSS variables used)
+
+| CSS variable | Where used |
+|---|---|
+| `--text-normal` | Panel title, chip labels, response text, degraded heading |
+| `--text-muted` | Context-label caption, context-empty hint, loading text, idle placeholder, chip suffix, remove button icon |
+| `--text-error` | Error message text (`ChatResponse` `.sp-chat__error`) |
+| `--text-warning` (with `--text-muted` fallback) | Trim-notice text (`ChatResponse` `.sp-chat__trim-notice`) |
+| `--background-primary` | Textarea background |
+| `--background-secondary` | Degraded state block background; manual chip background |
+| `--background-modifier-border` | Degraded block border; chip border; divider `<hr>`; textarea border; trim-notice background |
+| `--background-modifier-hover` | Chip remove button hover/focus background |
+| `--interactive-accent` | Textarea focus border colour; auto chip indicator square colour |
+| `--font-text` | Textarea and response text font family |
+
+No Specorator-custom CSS variables are introduced by this feature. All colours reference Obsidian theme tokens so the chat panel inherits any installed Obsidian theme automatically.
+
+### B3. Microcopy source
+
+All user-visible strings are sourced from `src/ui/i18n/locales/en.ts` under the `chat.*` namespace. No hardcoded English strings are introduced outside of the template literals in Vue component templates (which mirror the i18n values exactly for the degraded-state headings and body paragraphs, given that those are rendered as literal text nodes rather than via `$t()`).
+
+Key i18n keys:
+
+| Key | Value |
+|---|---|
+| `chat.title` | `Ask Claude.` |
+| `chat.contextLabel` | `Context for this message.` |
+| `chat.contextEmpty` | `No file is currently open. Open a file in your vault and it will be included here automatically.` |
+| `chat.autoSuffix` | `(auto)` |
+| `chat.autoSrOnly` | `(included automatically)` |
+| `chat.dismissAriaLabel` | `Remove {label} from context` |
+| `chat.inputPlaceholder` | `Ask anything about your work…` |
+| `chat.inputAriaLabel` | `Message` |
+| `chat.sendIdle` | `Ask` |
+| `chat.sendLoading` | `Asking…` |
+| `chat.sendAriaLabel` | `Send message` |
+| `chat.responsePlaceholder` | `(Response will appear here.)` |
+| `chat.responseLoading` | `Thinking…` |
+| `chat.responseTrimmed` | `Some context was trimmed to keep the message within size limits.` |
+| `chat.responseTimeout` | `That took too long. Please try again.` |
+| `chat.responseError` | `Something went wrong. Please try again.` |
+| `chat.degradedNoKeyHeading` | `Chat is not set up yet.` |
+| `chat.degradedNoKeyBody` | `To use this feature, add your Anthropic key in Settings. Your key is stored privately on this device and is never shared.` |
+| `chat.degradedNoKeyAction` | `Open settings` |
+| `chat.degradedUnavailableHeading` | `AI assistant is not available right now.` |
+| `chat.degradedUnavailableBody` | `The AI assistant could not start. This may be a temporary issue. If the problem continues, try restarting Obsidian.` |
+| `chat.degradedMobileHeading` | `Chat is available on desktop only.` |
+| `chat.degradedMobileBody` | `Open Obsidian on your Mac, Windows, or Linux computer to use the AI assistant.` |
+| `chat.addToContext` | `Add to chat context` |
+
+### B4. Requirements coverage (Part B)
+
+| REQ ID | Where addressed in Part B |
+|---|---|
+| REQ-CCS-012 | B1 `ChatResponse` — `trimmed-success` state renders trim notice |
+| REQ-CCS-013 | B1 `ChatSidebar` send handler; `ChatResponse` success state |
+| REQ-CCS-014 | B1 `ChatInput` disabled prop; `ContextFileList` disabled prop hides remove buttons |
+| REQ-CCS-016 | B1 `ChatResponse` timeout/error states; B3 error copy |
+| REQ-CCS-018 | B1 `ChatSidebar` degraded no-key branch; B3 degraded-no-key copy |
+| REQ-CCS-019 | B1 `ChatSidebar` degraded unavailable branch; B3 degraded-unavailable copy |
+| REQ-CCS-020 | B1 `ChatSidebar` mobile degraded branch; B3 degraded-mobile copy |
+| NFR-CCS-010 | B1 `ContextFileChip` — `aria-label` on remove button from B3 `dismissAriaLabel` |
+| NFR-CCS-012 | B3 — verified: no prohibited term appears in any `chat.*` value |
+
+---
+
+## Part C — Architecture
+
+### C1. System overview
+
+```mermaid
+graph TD
+    subgraph Plugin ["Plugin layer (src/plugin/)"]
+        Main["main.ts\nSpecoratorPlugin"]
+        View["SpecoratorView.ts"]
+        Settings["settings.ts\nSpecoratorSettingTab"]
+    end
+
+    subgraph UI ["UI layer (src/ui/)"]
+        Router["router/index.ts\n/chat → ChatSidebarView"]
+        ChatSidebar["components/chat/ChatSidebar.vue"]
+        ChatInput["components/chat/ChatInput.vue"]
+        ChatResponse["components/chat/ChatResponse.vue"]
+        ContextFileList["components/chat/ContextFileList.vue"]
+        ContextFileChip["components/chat/ContextFileChip.vue"]
+        ChatStore["stores/chatStore.ts\nuseChatStore (Pinia)"]
+    end
+
+    subgraph Application ["Application layer (src/application/)"]
+        BuildPrompt["chat/buildPrompt.ts\nbuildPrompt()"]
+    end
+
+    subgraph Domain ["Domain layer (src/domain/)"]
+        ClaudeCliPort["ports/ClaudeCliPort.ts\nClaudeCliPort interface\nClaudeCliError\nClaudeCliQueryOptions\nClaudeCliErrorCode"]
+        PluginSettings["settings/PluginSettings.ts\nanthropicApiKey field"]
+    end
+
+    subgraph Infrastructure ["Infrastructure layer (src/infrastructure/)"]
+        Adapter["obsidian/ClaudeCliAdapter.ts\nproduction impl"]
+        MockPort["mock/MockClaudeCliPort.ts\ndev/test stub"]
+        Ports["bridge/ports.ts\nCLAUDE_CLI_PORT\nIS_MOBILE_KEY\nSETTINGS_VERSION_KEY"]
+    end
+
+    subgraph External ["External"]
+        SDK["@anthropic-ai/claude-agent-sdk\nquery() generator"]
+        ObsidianAPI["Obsidian API\nWorkspace events\nFile menu\nURI handler"]
+    end
+
+    Main --> Adapter
+    Main --> View
+    Main --> Settings
+    Main -->|"file-menu event"| ChatStore
+    Main -->|"active-leaf-change event"| ChatStore
+    Main -->|"URI specorator?action=open-chat"| View
+    Settings -->|"bumpSettingsVersion()"| View
+    View -->|"provide CLAUDE_CLI_PORT"| ChatSidebar
+    View -->|"provide IS_MOBILE_KEY"| ChatSidebar
+    View -->|"provide SETTINGS_VERSION_KEY"| ChatSidebar
+    Router --> ChatSidebar
+    ChatSidebar --> ChatStore
+    ChatSidebar --> BuildPrompt
+    ChatSidebar --> ClaudeCliPort
+    ChatSidebar --> ChatInput
+    ChatSidebar --> ChatResponse
+    ChatSidebar --> ContextFileList
+    ContextFileList --> ContextFileChip
+    Adapter -.->|"implements"| ClaudeCliPort
+    MockPort -.->|"implements"| ClaudeCliPort
+    Adapter --> SDK
+    Main -->|"onLayoutReady startup()"| Adapter
+    Ports -->|"CLAUDE_CLI_PORT InjectionKey"| View
+```
+
+### C2. Component responsibilities
+
+| Component | Single responsibility |
+|---|---|
+| `ClaudeCliPort` (interface) | Declare the four-method narrow port contract; define `ClaudeCliError`, `ClaudeCliErrorCode`, `ClaudeCliQueryOptions` |
+| `ClaudeCliAdapter` | Resolve the SDK binary, manage `_available`/`_sdkReady` flags, call `sdkQuery`, enforce the timeout race, map errors to `ClaudeCliErrorCode`, never log the API key |
+| `MockClaudeCliPort` | Provide a configurable test/dev stub: `available`, `cannedResponse`, `queryError`, `delayMs`, `queryLog` |
+| `buildPrompt()` | Assemble the final prompt string from user text and context file contents; enforce the LIFO manual-removal + auto-file-trim + hard-truncate algorithm; return `{ prompt, truncated }` |
+| `useChatStore` | Hold the chat panel's DTO state: `contextFiles`, `userText`, `response`, `status`, `errorType`, `truncated`; expose typed actions |
+| `ChatSidebar.vue` | Orchestrate the availability check, active-file subscription, send flow, error mapping, and state branching between degraded and ready views |
+| `ChatInput.vue` | Render the textarea and send button; expose `textareaEl` for programmatic focus; emit `send` on button click or Ctrl+Enter |
+| `ChatResponse.vue` | Render one of six response states as a pure display component given `state` and optional `text` props |
+| `ContextFileList.vue` | Render the chip list section, the empty-state hint, and the `disabled` forwarding to chips |
+| `ContextFileChip.vue` | Render auto or manual chip variant; emit `remove` for manual chips |
+| `SpecoratorView` | Host the Vue application; provide all injection keys; expose `navigateTo` and `bumpSettingsVersion`; hold the `_settingsVersion` reactive counter |
+| `main.ts` (`SpecoratorPlugin`) | Wire Obsidian lifecycle: instantiate adapter, register view, ribbon, commands, file-menu handler, active-leaf handler, URI handler, and `onLayoutReady` startup |
+
+### C3. Data model changes
+
+#### New field on `PluginSettings`
+
+```typescript
+// src/domain/settings/PluginSettings.ts
+interface PluginSettings {
+  // ... existing fields ...
+  readonly anthropicApiKey: string  // default: ''
+}
+```
+
+Stored in the `specorator` sub-key of the plugin data blob via `this.saveData()`. Never written to any vault file. Subject to Obsidian Sync if the user has Sync enabled (disclosed in settings UI per REQ-CCS-028).
+
+#### New Pinia store — `chatStore`
+
+State shape (all fields are `ref<T>`):
+
+| Field | Type | Initial value | Semantics |
+|---|---|---|---|
+| `contextFiles` | `ContextFileEntry[]` | `[]` | Ordered list; auto entry at index 0 when present |
+| `userText` | `string` | `''` | Bound to textarea; cleared on success, retained on error |
+| `response` | `string \| null` | `null` | Last successful response text |
+| `status` | `ChatStatus` | `'idle'` | `'idle' \| 'loading' \| 'error'` |
+| `errorType` | `ChatErrorType \| null` | `null` | `'timeout' \| 'query_failed' \| null` |
+| `truncated` | `boolean` | `false` | True when `buildPrompt` removed content to stay within the cap |
+
+`ContextFileEntry` shape:
+
+```typescript
+interface ContextFileEntry {
+  readonly path: string    // vault-relative, used as unique key
+  readonly label: string   // filename for chip display
+  readonly isAuto: boolean // true = active editor file; false = manually added
+}
+```
+
+`ContextFileEntry` is a plain DTO. No domain class instances cross the store boundary (per ADR-003). File content is never stored in the store; it is loaded on-demand from `VaultPort.readFile()` at send time.
+
+#### No vault schema changes
+
+No new vault files are created or read as part of the chat feature itself. Context files are read transiently from the vault at send time and discarded after prompt assembly. Conversation history is not persisted (NG1).
+
+### C4. Data flows
+
+#### Flow A — Send a message (happy path)
+
+```
+User submits text in ChatInput
+  → ChatSidebar.handleSend()
+    [guard: userText.trim() is non-empty]
+    [guard: store.status !== 'loading']
+    [guard: available === true]
+  → store.beginRequest()           // status='loading', clears response/errorType/truncated
+  → VaultPort.readFile(path) × N  // parallel reads for all context files; errors yield ''
+  → buildPrompt(userText, loadedFiles)
+      → assemblePrompt() → string
+      → LIFO manual file removal if over charBudget
+      → auto file trim if still over charBudget
+      → hard-truncate if still over charBudget
+      → returns { prompt, truncated }
+  → ClaudeCliPort.query(prompt, { timeoutMs: 30_000 })
+      → ClaudeCliAdapter._runSdkQuery(prompt, controller)
+          → sdkQuery({ prompt, options: { maxTurns: 1, abortController } })
+          → iterates generator for message.type === 'result'
+          → returns resultText
+      → on success: ok(resultText)
+  → store.setResponse(resultText, truncated)   // status='idle'
+  → store.setUserText('')
+  → focusTextarea()
+```
+
+#### Flow B — Query timeout
+
+```
+ClaudeCliPort.query()
+  → setTimeout fires at timeoutMs → controller.abort() → rejects with ClaudeCliError{TIMEOUT}
+  → Promise.race resolves with the rejection
+  → _mapError(e) → returns ClaudeCliError{TIMEOUT}
+  → err(ClaudeCliError{TIMEOUT}) returned to ChatSidebar
+  → store.setError('timeout')   // status='error', errorType='timeout', userText retained
+  → focusTextarea()
+```
+
+#### Flow C — Settings change re-checks availability
+
+```
+User saves API key in SpecoratorSettingTab
+  → plugin.updateSettings({ anthropicApiKey })
+  → specoratorView.bumpSettingsVersion()        // _settingsVersion.value++
+  → SETTINGS_VERSION_KEY reactive ref increments
+  → ChatSidebar watch(settingsVersion) fires
+  → claudeCliPort.isAvailable()
+      → ClaudeCliAdapter.isAvailable()
+          → returns _available && settings.anthropicApiKey.trim() !== ''
+  → available.value updated
+  → template re-renders (degraded vs. ready)
+```
+
+#### Flow D — Right-click file menu
+
+```
+User right-clicks a vault file
+  → Obsidian fires 'file-menu' workspace event
+  → main.ts handler adds "Add to chat context" menu item
+  → User clicks the item
+  → plugin.activateView()
+  → useChatStore(specoratorView.pinia).addContextFile({ path, label, isAuto: false })
+      → duplicate guard: no-op if path already in contextFiles
+      → appends ContextFileEntry to contextFiles
+```
+
+#### Flow E — Active file tracking
+
+```
+Obsidian fires 'active-leaf-change' workspace event
+  → main.ts handler reads app.workspace.getActiveFile()
+  → useChatStore(specoratorView.pinia).setActiveFile(file | null)
+      → removes existing isAuto entry
+      → if non-null: inserts { path, label, isAuto: true } at index 0
+```
+
+### C5. API / interaction contracts
+
+#### `ClaudeCliPort` interface (exact TypeScript)
+
+```typescript
+// src/domain/ports/ClaudeCliPort.ts
+
+export type ClaudeCliErrorCode =
+  | 'NOT_INSTALLED'
+  | 'API_KEY_MISSING'
+  | 'TIMEOUT'
+  | 'QUERY_FAILED'
+
+export class ClaudeCliError extends Error {
+  public readonly name = 'ClaudeCliError'
+  constructor(
+    public readonly errorCode: ClaudeCliErrorCode,
+    message: string,
+    public readonly cause?: unknown,
+  ) { super(message) }
+}
+
+export interface ClaudeCliQueryOptions {
+  readonly timeoutMs?: number   // default 30 000; clamped to [1 000, 300 000]
+  readonly maxTurns?: number    // clamped to 1 in v1
+}
+
+export interface ClaudeCliPort {
+  query(prompt: string, options?: ClaudeCliQueryOptions): Promise<Result<string, ClaudeCliError>>
+  isAvailable(): Promise<boolean>
+  startup(): Promise<void>
+  shutdown(): void
+}
+```
+
+The file imports only `Result` from `@/domain/shared/Result`. No import from `obsidian` or `@anthropic-ai/claude-agent-sdk` is present (REQ-CCS-021, NFR-CCS-011).
+
+#### `buildPrompt()` function signature and algorithm
+
+```typescript
+// src/application/chat/buildPrompt.ts
+
+export function buildPrompt(
+  userText: string,
+  contextFiles: ReadonlyArray<ContextFile>,
+  options?: { readonly tokenCap?: number },  // default 50 000
+): BuildPromptResult
+// BuildPromptResult = { prompt: string, truncated: boolean }
+```
+
+Algorithm (seven steps):
+
+1. Compute `charBudget = (tokenCap ?? 50_000) × 4`.
+2. Assemble full prompt via `assemblePrompt(userText, contextFiles)`.
+   - Format when `files.length > 0`: `"The following files are provided for context:\n\n" + fileSections + "---\n\n" + userText`
+   - Format when `files.length === 0`: `userText`
+3. If `fullPrompt.length <= charBudget` → return `{ prompt: fullPrompt, truncated: false }`.
+4. Separate `autoFiles` and `manualFiles` (mutable copy for LIFO removal).
+5. While `assembled.length > charBudget && manualFiles.length > 0`: pop last manual file, reassemble.
+6. If now within budget → return `{ prompt: assembled, truncated: true }`.
+7. If auto file exists and still over budget: trim `autoFile.content` from the end, preserving at minimum `MIN_ACTIVE_FILE_CHARS = 500` characters; reassemble.
+8. If still over budget (e.g., `userText` alone exceeds budget): hard-truncate `assembled` to `charBudget`.
+9. Return `{ prompt: assembled, truncated: true }`.
+
+#### Injection keys
+
+```typescript
+// src/infrastructure/bridge/ports.ts
+
+export const CLAUDE_CLI_PORT: InjectionKey<ClaudeCliPort> = Symbol('ClaudeCliPort')
+export const IS_MOBILE_KEY: InjectionKey<boolean> = Symbol('IsMobile')
+export const SETTINGS_VERSION_KEY: InjectionKey<Ref<number>> = Symbol('settingsVersion')
+```
+
+`SETTINGS_VERSION_KEY` holds a `Ref<number>` that `SpecoratorView` owns and increments via `bumpSettingsVersion()`. `ChatSidebar` watches it with `watch(settingsVersion, ...)` to re-check adapter availability after a settings save.
+
+### C6. `ClaudeCliAdapter` — class outline
+
+`src/infrastructure/obsidian/ClaudeCliAdapter.ts`
+
+```
+class ClaudeCliAdapter implements ClaudeCliPort
+  private _available: boolean          // true only after startup() succeeds
+  private _sdkReady: boolean           // guards idempotent startup
+  private _getSettings: () => PluginSettings
+  private _logger: LoggerPort
+  private _resolveCliPath: () => string  // injectable for testability
+
+  startup(): Promise<void>
+    1. Idempotency: return early if _sdkReady
+    2. Read key; if empty, set _available=false and return
+    3. Set process.env.ANTHROPIC_API_KEY = key
+    4. Resolve binary path via _resolveCliPath(); catch → _available=false, return
+    5. Validate binary path is absolute; if not → _available=false, return
+    6. Set _sdkReady=true, _available=true
+
+  query(prompt, options?): Promise<Result<string, ClaudeCliError>>
+    - Guard: return err if !_available (with _unavailableCode())
+    - Re-read key at call time; if empty → err API_KEY_MISSING
+    - Clamp timeout to [1 000, 300 000] ms
+    - Clamp maxTurns to 1 (log warn if > 1)
+    - Race: _runSdkQuery(prompt, AbortController) vs. timeout promise
+    - Catch any error → _mapError()
+    - Finally: clearTimeout, controller.abort()
+
+  isAvailable(): Promise<boolean>
+    → _available && _getSettings().anthropicApiKey.trim() !== ''
+
+  shutdown(): void
+    → _sdkReady=false, _available=false (synchronous, never throws)
+
+  private _runSdkQuery(prompt, controller): Promise<string>
+    → sdkQuery({ prompt, options: { maxTurns: 1, abortController: controller } })
+    → iterates async generator; collects message.type === 'result'
+    → throws if no result message received
+
+  private _mapError(e, timeoutMs): ClaudeCliError
+    → ClaudeCliError{TIMEOUT} passthrough
+    → API key / auth patterns → API_KEY_MISSING (key value never logged)
+    → Error instance → QUERY_FAILED
+    → unknown → QUERY_FAILED
+
+  private _unavailableCode(): 'API_KEY_MISSING' | 'NOT_INSTALLED'
+    → API_KEY_MISSING if key is empty, NOT_INSTALLED otherwise
+
+  private _clampTimeout(raw?): number
+    → Math.min(Math.max(raw ?? 30_000, 1_000), 300_000)
+```
+
+### C7. `MockClaudeCliPort` — configuration fields
+
+`src/infrastructure/mock/MockClaudeCliPort.ts`
+
+| Field | Type | Default | Purpose |
+|---|---|---|---|
+| `available` | `boolean` | `false` | Controls `isAvailable()` return value and `query()` no-op branch |
+| `cannedResponse` | `string` | `'Mock response from MockClaudeCliPort.'` | Text returned on success |
+| `queryError` | `ClaudeCliError \| null` | `null` | If non-null, `query()` returns this error |
+| `delayMs` | `number` | `0` | Artificial delay before `query()` resolves (simulates latency) |
+| `queryLog` | `string[]` (readonly) | `[]` | Append-only log of every prompt passed to `query()` |
+
+`startup()` and `shutdown()` are no-ops. `isAvailable()` returns `available`. When `available === false`, `query()` returns `err(ClaudeCliError{ NOT_INSTALLED })` without logging.
+
+### C8. Plugin wiring (main.ts)
+
+#### Lifecycle events
+
+| Obsidian hook | Action |
+|---|---|
+| `onload()` | Instantiate `ClaudeCliAdapter`; register `shutdown()` via `this.register()`; register the `SpecoratorView` view factory; add ribbon icon; add commands; register `file-menu` and `active-leaf-change` events; register `specorator` URI handler; add settings tab |
+| `onLayoutReady()` (inside `onload`) | Call `ClaudeCliAdapter.startup()` (fire-and-forget); detect legacy vault layout |
+| `onunload()` | Detach view leaves; `core.destroy()`; adapter `shutdown()` fires via the registered cleanup function |
+
+#### File-menu handler
+
+Registered with `this.app.workspace.on('file-menu', ...)`. On item click:
+1. `activateView()` — opens or reveals the Specorator leaf.
+2. `useChatStore(specoratorView.pinia).addContextFile({ path: file.path, label: file.name, isAuto: false })` — guarded by the store's duplicate check.
+
+Applies to all vault files regardless of type (no TFile extension filter — `TFolder` instances do not receive file-menu events in practice).
+
+#### Active-leaf-change handler
+
+Registered with `this.app.workspace.on('active-leaf-change', ...)`. On fire:
+- Reads `app.workspace.getActiveFile()`.
+- Calls `store.setActiveFile(file | null)` on the view's Pinia instance.
+- Guards against `_specoratorView?.pinia` being undefined (view not yet opened).
+
+#### URI handler
+
+Registered with `this.registerObsidianProtocolHandler('specorator', ...)`.
+
+| `action` value | Behaviour |
+|---|---|
+| `open-chat` or `focus-chat` | `activateView()` then `specoratorView.navigateTo('/chat')` |
+| `send-message` or `open-workflow` | `bridge.showInfo("URI action … is not yet implemented.")` |
+| anything else | `bridge.showWarning("Unknown Specorator URI action: …")` |
+| any value handled by `PluginCore.handleUri()` | Delegated to core; handler returns early |
+
+#### Settings-version bump
+
+`SpecoratorSettingTab` calls `specoratorView.bumpSettingsVersion()` from the `onChange` handler of the Anthropic API key input field. This increments `_settingsVersion.value`, which `ChatSidebar` watches via `SETTINGS_VERSION_KEY`.
+
+### C9. Key decisions
+
+| Decision | Rationale | ADR |
+|---|---|---|
+| Context assembled as a single user-turn preamble | Keeps the `ClaudeCliPort.query()` signature SDK-agnostic; `buildPrompt` testable without any SDK dependency | ADR-0027 |
+| `anthropicApiKey` stored in top-level `PluginSettings` | Adapter must be instantiatable before `PluginCore` loads modules; consistent with other plugin-wide fields | ADR-0028 |
+| `ClaudeCliPort` as a narrow domain-layer port | Consistent with ADR-008; allows `MockClaudeCliPort` for dev/test without subprocess; enables future SDK swap | ADR-008 |
+| `maxTurns` clamped to 1 in v1 | Defers multi-turn complexity (NG2); adapter logs a warn if caller passes `> 1`, so the contract is visible | — |
+| No streaming in v1 | Response buffered and displayed as a complete string (NG3); simplifies error handling and `ChatResponse` state model | — |
+| No conversation history persistence | Memory-only in v1 (NG1); avoids vault write complexity for the initial release | — |
+| `SETTINGS_VERSION_KEY` reactive counter pattern | Avoids a direct coupling from the settings tab to `ChatSidebar`; the view mediates the signal via `bumpSettingsVersion()` | — |
+| `process.env.ANTHROPIC_API_KEY` written at startup and re-written at query time | SDK reads the key from the environment at call time; re-reading at query time means settings changes take effect without an adapter restart | — |
+
+### C10. Rejected alternatives
+
+| Alternative | Why rejected |
+|---|---|
+| Expose a `systemPrompt` parameter on `ClaudeCliPort.query()` | Would leak SDK semantics through the narrow port; violates NFR-CCS-012 (no "system prompt" in user surface) |
+| Store conversation history in a vault file | NG1; adds vault-write complexity and opens vault-pollution concerns for v1 |
+| Streaming (`queryStream()`) | NG3; requires `ChatResponse` to handle partial-update state machine; deferred to v2 |
+| Separate Vue leaf for chat | NG — only one leaf is used (ADR-003 convention); routing within the single leaf is simpler |
+| Store `anthropicApiKey` in a module sub-key | Requires `PluginCore` to be fully loaded before adapter initialisation; creates startup-ordering fragility (see ADR-0028) |
+| `ClaudeCliPort` in the application layer | Would break the inward-only import direction (domain ← application); the port must live in the domain layer per ADR-001 and ADR-008 |
+| `useBridge()` aggregate injection for `ClaudeCliPort` | `useBridge` / `IBridge` are deleted symbols; per-port injection is enforced by ESLint (ADR-008) |
+
+### C11. Requirements coverage (Part C)
+
+| REQ ID | Where addressed in Part C |
+|---|---|
+| REQ-CCS-001 | C9 (`anthropicApiKey` in `PluginSettings`); ADR-0028 |
+| REQ-CCS-002 | C6 `startup()` — key trimmed via `.trim()` before writing to env |
+| REQ-CCS-003 | C6 `startup()` deferred to `onLayoutReady`; C8 lifecycle table |
+| REQ-CCS-004 | C6 `shutdown()` — synchronous, registered via `this.register()`; C8 lifecycle table |
+| REQ-CCS-005 | C8 active-leaf-change handler; C4 Flow E |
+| REQ-CCS-006 | C8 active-leaf-change handler (null case); C3 `setActiveFile(null)` |
+| REQ-CCS-007 | C8 ribbon icon and command registration |
+| REQ-CCS-008 | C8 URI handler (`open-chat` / `focus-chat`); C4 (implicitly) |
+| REQ-CCS-009 | C8 file-menu handler; C4 Flow D |
+| REQ-CCS-010 | C3 `addContextFile` duplicate guard |
+| REQ-CCS-011 | C3 `removeContextFile` action |
+| REQ-CCS-012 | C5 `buildPrompt` `truncated` return value; C4 Flow A |
+| REQ-CCS-013 | C4 Flow A; C5 `ClaudeCliPort.query()` contract |
+| REQ-CCS-014 | C3 `beginRequest()` sets `status='loading'` |
+| REQ-CCS-015 | C4 Flow A guard: `userText.trim()` is non-empty |
+| REQ-CCS-016 | C4 Flow B; C6 `_mapError()`; C3 `setError()` |
+| REQ-CCS-017 | C3 store: `userText` not cleared by `setError()` |
+| REQ-CCS-018 | C5 `isAvailable()` returns false when key empty; C4 Flow C |
+| REQ-CCS-019 | C6 `_unavailableCode()` returns `NOT_INSTALLED` when key non-empty |
+| REQ-CCS-020 | C5 `IS_MOBILE_KEY`; C1 `Platform.isMobile` provided in `SpecoratorView.onOpen()` |
+| REQ-CCS-021 | C5 `ClaudeCliPort` interface — exactly four methods; no forbidden imports |
+| REQ-CCS-022 | C6 `isAvailable()` — never throws; returns `_available && key !== ''` |
+| REQ-CCS-023 | C7 `MockClaudeCliPort.available` defaults to `false` |
+| REQ-CCS-024 | C4 Flow C; C9 `SETTINGS_VERSION_KEY` counter pattern |
+| REQ-CCS-025 | C5 `buildPrompt` algorithm step 2 — exact preamble format; ADR-0027 |
+| REQ-CCS-026 | C5 `buildPrompt` algorithm step 5 — LIFO manual file removal |
+| REQ-CCS-027 | C5 `buildPrompt` algorithm step 7 — auto file trim with `MIN_ACTIVE_FILE_CHARS = 500` floor |
+| REQ-CCS-028 | ADR-0028 Consequences — settings description must mention Obsidian Sync |
+| NFR-CCS-001 | C5 `buildPrompt()` — pure function, no I/O |
+| NFR-CCS-002 | C8 — `startup()` deferred to `onLayoutReady`; `onload()` completes before startup |
+| NFR-CCS-003 | C6 `_clampTimeout()` — clamps to [1 000, 300 000] |
+| NFR-CCS-004 | C7 — `MockClaudeCliPort` all five config fields listed |
+| NFR-CCS-005 | C6 `_mapError()` — auth errors logged without key value; `startup()` logs only presence/absence |
+| NFR-CCS-006 | ADR-0028 Compliance — `type='password'`, `autocomplete='off'` |
+| NFR-CCS-007 | C6 `shutdown()` — synchronous, never throws |
+| NFR-CCS-008 | C5 `buildPrompt` algorithm step 8 — hard-truncate fallback |
+| NFR-CCS-011 | C5 `ClaudeCliPort` — no imports from `obsidian` or SDK |

--- a/specs/claude-cli-chat-sidebar/requirements.md
+++ b/specs/claude-cli-chat-sidebar/requirements.md
@@ -1,0 +1,502 @@
+---
+id: PRD-CCS-001
+title: "Claude CLI chat sidebar"
+stage: requirements
+feature: claude-cli-chat-sidebar
+status: accepted
+owner: pm
+inputs:
+  - IDEA-CCS-001
+  - RESEARCH-CCS-001
+created: 2026-05-14
+updated: 2026-05-14
+---
+
+# PRD — Claude CLI chat sidebar
+
+## Summary
+
+Specorator embeds a chat sidebar inside the Obsidian panel that lets users ask questions about their vault files and receive AI-generated responses without leaving the application. The sidebar is backed by the Anthropic Claude SDK via a narrow `ClaudeCliPort` port; it assembles file context automatically from the active editor file and from files the user explicitly adds, trims that context to a 50 000-token ceiling, and forwards the assembled prompt to the adapter. When the adapter is not usable — because the API key is absent, the SDK cannot start, or the user is on a mobile device — the sidebar renders a plain-language explanation and keeps all other plugin capabilities intact. The feature closes the gap that forces users to leave Obsidian and switch to a separate AI tool whenever they need help with their workflow.
+
+## Goals
+
+- G1: Provide a persistent, always-accessible chat surface inside the Obsidian panel.
+- G2: Include the file the user is actively editing in every message without any manual step.
+- G3: Let users pin additional vault files as context with a single right-click action.
+- G4: Enforce a 50 000-token context ceiling that degrades gracefully rather than failing.
+- G5: Surface all error and degraded states in plain language with no AI or SDK terminology.
+- G6: Keep the `ClaudeCliPort` interface as a stable narrow port so the underlying SDK can be swapped in a future version without touching application or UI call sites.
+
+## Non-goals
+
+- NG1: Conversation history persistence to the vault or plugin settings. (Memory-only in v1; deferred.)
+- NG2: Multi-turn agent responses. (maxTurns is fixed at 1 in v1.)
+- NG3: Streaming token-by-token rendering. (Response is buffered, then displayed as a complete string.)
+- NG4: Write-operation proposal / review cards. (Deferred to v2 design.)
+- NG5: Stage-aware suggested conversation starters. (Deferred to v2 design.)
+- NG6: Provider selection UI or model configuration surface.
+- NG7: Multi-agent orchestration or direct integration with the Specorator agent orchestrator.
+- NG8: Persona or workflow-stage context injection (Layer 1–4). (Only file content and user text are assembled in v1.)
+
+## Personas / stakeholders
+
+| Persona | Need | Why it matters |
+|---|---|---|
+| Non-technical founder / PM | Ask open-ended questions about a spec or idea without writing a prompt | Reduces cognitive friction and avoids switching tools mid-workflow |
+| Solo developer / engineering lead | Get AI assistance scoped to the file currently open | Active-file auto-context means the answer is always relevant to where the user is |
+| Any Specorator user | Understand what is wrong when the chat cannot start | Plain-language degradation states prevent confusion and direct the user to a resolution |
+
+## Jobs to be done
+
+- When I am reading a spec file in Obsidian, I want to ask a question about it, so I can move forward without switching to a separate AI tool.
+- When I want the AI to consider additional files alongside the one I have open, I want to add them from the file menu, so I do not have to paste content manually.
+- When the chat cannot start because my API key is missing, I want a plain explanation and a link to settings, so I can fix it in one step.
+- When the chat cannot start for a technical reason, I want a plain explanation, so I know Specorator is still working even if AI assistance is temporarily unavailable.
+
+---
+
+## Functional requirements (EARS)
+
+### REQ-CCS-001 — API key storage field
+
+- **Pattern:** ubiquitous
+- **Statement:** The system shall provide a password-masked text field in the Obsidian settings tab that accepts the user's Anthropic API key, stores it in the plugin data blob, and never writes it to any vault file.
+- **Acceptance:**
+  - Given the user opens Settings > Specorator.
+  - When the Anthropic key field is rendered.
+  - Then the input type is `password`, autocomplete is `off`, the current stored value is pre-filled (masked), and changes are persisted to the plugin data blob on input.
+- **Priority:** must
+- **Satisfies:** IDEA-CCS-001 (constraints — API key not exposed to vault)
+
+---
+
+### REQ-CCS-002 — API key trimmed on save
+
+- **Pattern:** event-driven
+- **Statement:** WHEN the user saves the API key field, the system shall trim leading and trailing whitespace from the value before persisting it.
+- **Acceptance:**
+  - Given the user types `  sk-ant-abc  ` into the Anthropic key field.
+  - When the field's onChange fires.
+  - Then the stored value is `sk-ant-abc` with no surrounding whitespace.
+- **Priority:** must
+- **Satisfies:** IDEA-CCS-001 (constraints — no configuration surface exposed)
+
+---
+
+### REQ-CCS-003 — SDK startup deferred to layout-ready
+
+- **Pattern:** event-driven
+- **Statement:** WHEN the Obsidian workspace layout is ready, the system shall call `ClaudeCliPort.startup()` to pre-warm the adapter.
+- **Acceptance:**
+  - Given the plugin has loaded and `onLayoutReady` fires.
+  - When `startup()` is called.
+  - Then the adapter attempts to resolve the SDK binary and marks itself available or unavailable; `onload()` is not delayed.
+- **Priority:** must
+- **Satisfies:** RESEARCH-CCS-001 (Technical considerations — Sidebar hosting; RISK-CCS-005)
+
+---
+
+### REQ-CCS-004 — SDK shutdown on plugin unload
+
+- **Pattern:** event-driven
+- **Statement:** WHEN the plugin is unloaded, the system shall call `ClaudeCliPort.shutdown()` synchronously.
+- **Acceptance:**
+  - Given the plugin is being unloaded by Obsidian.
+  - When `onunload()` executes.
+  - Then `shutdown()` is called; it does not throw; `_sdkReady` and `_available` flags are reset.
+- **Priority:** must
+- **Satisfies:** IDEA-CCS-001 (constraints — graceful degradation)
+
+---
+
+### REQ-CCS-005 — Active file auto-context
+
+- **Pattern:** event-driven
+- **Statement:** WHEN the active editor leaf changes, the system shall update the chat store's auto context slot with the path and label of the newly active file.
+- **Acceptance:**
+  - Given a file is open in the editor.
+  - When the user switches to a different file.
+  - Then `chatStore.contextFiles` contains exactly one entry with `isAuto: true` whose `path` matches the newly active file, placed at index 0.
+- **Priority:** must
+- **Satisfies:** IDEA-CCS-001 (success criteria — context-aware responses)
+
+---
+
+### REQ-CCS-006 — Active file cleared when no file is open
+
+- **Pattern:** event-driven
+- **Statement:** WHEN the active editor leaf changes to a state where no markdown file is open, the system shall remove the auto context slot from the chat store.
+- **Acceptance:**
+  - Given an auto context entry exists in `chatStore.contextFiles`.
+  - When `active-leaf-change` fires and `getActiveFile()` returns null.
+  - Then no entry with `isAuto: true` remains in `chatStore.contextFiles`.
+- **Priority:** must
+- **Satisfies:** IDEA-CCS-001 (success criteria — active file context)
+
+---
+
+### REQ-CCS-007 — Chat panel accessible via ribbon and command
+
+- **Pattern:** event-driven
+- **Statement:** WHEN the user clicks the Specorator ribbon icon or runs the "Open panel" command, the system shall open or reveal the Specorator view and navigate to the `/chat` route.
+- **Acceptance:**
+  - Given the Specorator panel is not open.
+  - When the user clicks the ribbon icon.
+  - Then the panel opens in the right sidebar and the chat view is visible.
+- **Priority:** must
+- **Satisfies:** IDEA-CCS-001 (success criteria — always visible side panel)
+
+---
+
+### REQ-CCS-008 — URI handler for open-chat action
+
+- **Pattern:** event-driven
+- **Statement:** WHEN the system receives an `obsidian://specorator?action=open-chat` URI, the system shall activate the Specorator view and navigate to the `/chat` route.
+- **Acceptance:**
+  - Given the plugin is loaded.
+  - When `obsidian://specorator?action=open-chat` is invoked.
+  - Then `activateView()` is called and `navigateTo('/chat')` is dispatched; no error is shown to the user.
+- **Priority:** must
+- **Satisfies:** IDEA-CCS-001 (success criteria — URI handler)
+
+---
+
+### REQ-CCS-009 — Right-click "Add to chat context" menu item
+
+- **Pattern:** event-driven
+- **Statement:** WHEN the user right-clicks a file in the Obsidian file menu, the system shall display an "Add to chat context" menu item that, when clicked, adds the file to the chat store as a manual context entry.
+- **Acceptance:**
+  - Given any vault file is right-clicked.
+  - When "Add to chat context" is clicked.
+  - Then the Specorator view is activated and `chatStore.addContextFile({ path, label, isAuto: false })` is called with the correct file path and name.
+- **Priority:** must
+- **Satisfies:** IDEA-CCS-001 (preliminary scope — file-menu integration)
+
+---
+
+### REQ-CCS-010 — No-duplicate context files
+
+- **Pattern:** unwanted behaviour
+- **Statement:** IF the user attempts to add a file to the context list, THEN the system shall ignore the addition when an entry with the same vault-relative path is already present in the context list.
+- **Acceptance:**
+  - Given `chatStore.contextFiles` already contains an entry with `path = "specs/idea.md"`.
+  - When `addContextFile({ path: "specs/idea.md", label: "idea.md", isAuto: false })` is called.
+  - Then `chatStore.contextFiles.length` is unchanged.
+- **Priority:** must
+- **Satisfies:** IDEA-CCS-001 (preliminary scope — context assembly)
+
+---
+
+### REQ-CCS-011 — Remove manual context file
+
+- **Pattern:** event-driven
+- **Statement:** WHEN the user activates the remove control on a manual context chip, the system shall remove that entry from the context list.
+- **Acceptance:**
+  - Given a manual context chip is visible and the panel is not in the loading state.
+  - When the user clicks or presses Enter/Space on the remove button.
+  - Then the entry is removed from `chatStore.contextFiles` and the chip disappears.
+- **Priority:** must
+- **Satisfies:** IDEA-CCS-001 (preliminary scope — context assembly)
+
+---
+
+### REQ-CCS-012 — Context truncation notice
+
+- **Pattern:** state-driven
+- **Statement:** WHILE `chatStore.truncated` is `true`, the system shall display a plain-language notice informing the user that some content was shortened to fit the message.
+- **Acceptance:**
+  - Given `buildPrompt()` returned `truncated: true` and `chatStore.setResponse()` was called with `wasTruncated: true`.
+  - When the response is displayed.
+  - Then a visible notice is shown that does not use the words "token" or "context window".
+- **Priority:** must
+- **Satisfies:** RESEARCH-CCS-001 (RISK-CCS-008)
+
+---
+
+### REQ-CCS-013 — Send message and display response
+
+- **Pattern:** event-driven
+- **Statement:** WHEN the user sends a non-empty message, the system shall assemble the context prompt, call `ClaudeCliPort.query()`, and display the returned text in the response area.
+- **Acceptance:**
+  - Given the adapter is available, `userText` is non-empty, and `status` is `idle`.
+  - When the user submits the message.
+  - Then `beginRequest()` is called, `ClaudeCliPort.query()` is awaited, and on success `setResponse(text, truncated)` is called, `userText` is cleared, and the response text is visible.
+- **Priority:** must
+- **Satisfies:** IDEA-CCS-001 (success criteria — sending a message)
+
+---
+
+### REQ-CCS-014 — Loading state during query
+
+- **Pattern:** state-driven
+- **Statement:** WHILE a query is in flight, the system shall set `chatStore.status` to `loading` and disable the send control and context remove controls.
+- **Acceptance:**
+  - Given `beginRequest()` has been called and the query has not yet resolved.
+  - When the chat panel renders.
+  - Then the send button is disabled, context chip remove buttons are not rendered, and any loading indicator is visible.
+- **Priority:** must
+- **Satisfies:** IDEA-CCS-001 (success criteria — visible progress)
+
+---
+
+### REQ-CCS-015 — Empty message guard
+
+- **Pattern:** unwanted behaviour
+- **Statement:** IF the user attempts to send a message, THEN the system shall not call `ClaudeCliPort.query()` when `userText` is empty or whitespace-only.
+- **Acceptance:**
+  - Given `userText` is `"   "` (whitespace only).
+  - When the send action fires.
+  - Then `ClaudeCliPort.query()` is not called and `chatStore.status` remains `idle`.
+- **Priority:** must
+- **Satisfies:** IDEA-CCS-001 (preliminary scope — send flow)
+
+---
+
+### REQ-CCS-016 — Error state on query failure or timeout
+
+- **Pattern:** event-driven
+- **Statement:** WHEN `ClaudeCliPort.query()` returns an error result, the system shall set `chatStore.status` to `error`, set `chatStore.errorType` to the appropriate type, and display a plain-language error message without AI or SDK terminology.
+- **Acceptance:**
+  - Given the query returns `ClaudeCliError{ errorCode: 'TIMEOUT' }`.
+  - When the result is processed.
+  - Then `chatStore.errorType === 'timeout'`, the error message shown reads "That took too long. Please try again.", and `userText` is retained.
+- **Priority:** must
+- **Satisfies:** IDEA-CCS-001 (constraints — plain language)
+
+---
+
+### REQ-CCS-017 — userText retained on error
+
+- **Pattern:** state-driven
+- **Statement:** WHILE `chatStore.status` is `error`, the system shall retain the value of `userText` so the user can retry or edit without retyping.
+- **Acceptance:**
+  - Given the user sent `"What should I do next?"` and the query returned an error.
+  - When the error state renders.
+  - Then the text input still contains `"What should I do next?"`.
+- **Priority:** must
+- **Satisfies:** IDEA-CCS-001 (constraints — graceful degradation)
+
+---
+
+### REQ-CCS-018 — API key missing degraded state
+
+- **Pattern:** state-driven
+- **Statement:** WHILE `ClaudeCliPort.isAvailable()` returns false and the stored `anthropicApiKey` is empty, the system shall display the message "Chat is not set up yet." together with a link to the settings screen.
+- **Acceptance:**
+  - Given `isAvailable()` resolves to `false` and `settings.anthropicApiKey` is `""`.
+  - When the chat panel mounts or availability is re-checked.
+  - Then the heading "Chat is not set up yet." is visible, a settings link is rendered, and the message input is not shown.
+- **Priority:** must
+- **Satisfies:** RESEARCH-CCS-001 (RISK-CCS-002); IDEA-CCS-001 (constraints — graceful degradation)
+
+---
+
+### REQ-CCS-019 — SDK unavailable degraded state
+
+- **Pattern:** state-driven
+- **Statement:** WHILE `ClaudeCliPort.isAvailable()` returns false and the stored `anthropicApiKey` is non-empty, the system shall display the message "AI assistant is not available right now." with a plain-language explanation.
+- **Acceptance:**
+  - Given `isAvailable()` resolves to `false` and `settings.anthropicApiKey` is non-empty.
+  - When the chat panel mounts or availability is re-checked.
+  - Then the heading "AI assistant is not available right now." is visible, no message input is shown, and no SDK or binary terminology is used.
+- **Priority:** must
+- **Satisfies:** RESEARCH-CCS-001 (RISK-CCS-001); IDEA-CCS-001 (constraints — graceful degradation)
+
+---
+
+### REQ-CCS-020 — Mobile degraded state
+
+- **Pattern:** state-driven
+- **Statement:** WHILE the plugin is running on a mobile device, the system shall display the message "Chat is available on desktop only." and shall not render the message input.
+- **Acceptance:**
+  - Given `usePlatform().isMobile` is `true`.
+  - When the chat panel mounts.
+  - Then the heading "Chat is available on desktop only." is visible and the rest of the chat UI is not rendered.
+- **Priority:** must
+- **Satisfies:** IDEA-CCS-001 (constraints — graceful degradation)
+
+---
+
+### REQ-CCS-021 — ClaudeCliPort narrow port interface
+
+- **Pattern:** ubiquitous
+- **Statement:** The system shall define `ClaudeCliPort` as a domain-layer interface whose file does not import from `obsidian` or `@anthropic-ai/claude-agent-sdk`, exposing exactly four methods: `query()`, `isAvailable()`, `startup()`, and `shutdown()`.
+- **Acceptance:**
+  - Given any import audit of `src/domain/ports/ClaudeCliPort.ts`.
+  - When the file is statically analysed.
+  - Then no import from `obsidian` or `@anthropic-ai/claude-agent-sdk` is found, and the interface declares exactly the four named methods.
+- **Priority:** must
+- **Satisfies:** IDEA-CCS-001 (constraints — ClaudeCliPort as narrow port per ADR-008)
+
+---
+
+### REQ-CCS-022 — isAvailable() never throws
+
+- **Pattern:** ubiquitous
+- **Statement:** The system shall ensure that `ClaudeCliPort.isAvailable()` never throws; all implementors shall catch internal errors and return `false`.
+- **Acceptance:**
+  - Given any implementor of `ClaudeCliPort` (production or mock).
+  - When `isAvailable()` is called under any condition including adapter startup failure.
+  - Then a boolean is returned without throwing.
+- **Priority:** must
+- **Satisfies:** IDEA-CCS-001 (constraints — stable port seam)
+
+---
+
+### REQ-CCS-023 — MockClaudeCliPort browser stub defaults to unavailable
+
+- **Pattern:** ubiquitous
+- **Statement:** The system shall provide a `MockClaudeCliPort` implementation where `isAvailable()` returns `false` by default, so the standalone browser UI (`npm run dev`) renders the degraded state without a subprocess.
+- **Acceptance:**
+  - Given `MockClaudeCliPort` is instantiated with no arguments.
+  - When `isAvailable()` is awaited.
+  - Then it returns `false`.
+- **Priority:** must
+- **Satisfies:** IDEA-CCS-001 (constraints — works in standalone browser UI)
+
+---
+
+### REQ-CCS-024 — Settings change re-checks availability
+
+- **Pattern:** event-driven
+- **Statement:** WHEN the user saves a change to the Anthropic API key in settings, the system shall call `ClaudeCliPort.isAvailable()` and update the chat panel's availability state without requiring a restart.
+- **Acceptance:**
+  - Given the chat panel is showing the "Chat is not set up yet." degraded state.
+  - When the user enters a valid API key in settings and saves.
+  - Then the settings tab calls `bumpSettingsVersion()` on all open Specorator view leaves, the `settingsVersion` watcher in `ChatSidebar` fires, `isAvailable()` is re-awaited, and the panel re-renders accordingly.
+- **Priority:** must
+- **Satisfies:** RESEARCH-CCS-001 (Technical considerations — API key handling)
+
+---
+
+### REQ-CCS-025 — Context preamble format
+
+- **Pattern:** ubiquitous
+- **Statement:** The system shall assemble the prompt as: preamble `"The following files are provided for context:\n\n"`, followed by one `---\nFile: <path>\n---\n<content>\n\n` block per context file, then `---\n\n`, then the user's message text.
+- **Acceptance:**
+  - Given `buildPrompt("hello", [{ path: "a.md", content: "x", isAuto: true, label: "a.md" }])` is called.
+  - When the result is inspected.
+  - Then `prompt` equals `"The following files are provided for context:\n\n---\nFile: a.md\n---\nx\n\n---\n\nhello"` exactly.
+- **Priority:** must
+- **Satisfies:** RESEARCH-CCS-001 (Q1 — context payload)
+
+---
+
+### REQ-CCS-026 — Token cap enforcement — manual file LIFO removal
+
+- **Pattern:** unwanted behaviour
+- **Statement:** IF the assembled prompt exceeds the 50 000-token character budget, THEN the system shall remove manual context files in reverse-insertion order (LIFO) until the prompt is within budget or all manual files are exhausted.
+- **Acceptance:**
+  - Given two manual files whose combined content causes the prompt to exceed 200 000 characters.
+  - When `buildPrompt()` is called.
+  - Then the last-added manual file is removed first; if budget is met, `truncated` is `true` and the earlier manual file is still present.
+- **Priority:** must
+- **Satisfies:** IDEA-CCS-001 (preliminary scope — context assembly); RESEARCH-CCS-001 (Q1)
+
+---
+
+### REQ-CCS-027 — Token cap enforcement — auto file floor
+
+- **Pattern:** unwanted behaviour
+- **Statement:** IF the prompt still exceeds the character budget after all manual files are removed, THEN the system shall trim the auto file's content from the end, preserving at least 500 characters of that content.
+- **Acceptance:**
+  - Given the auto file content is 5 000 characters and the budget is exceeded with no manual files.
+  - When `buildPrompt()` is called.
+  - Then the auto file content in the assembled prompt is at least 500 characters and the prompt length is within budget.
+- **Priority:** must
+- **Satisfies:** RESEARCH-CCS-001 (Q1 — token cap; MIN_ACTIVE_FILE_CHARS)
+
+---
+
+### REQ-CCS-028 — Obsidian Sync API key disclosure notice
+
+- **Pattern:** ubiquitous
+- **Statement:** The system shall display a notice in the API key settings field description informing the user that if Obsidian Sync is enabled, the API key will be included in the sync.
+- **Acceptance:**
+  - Given the user opens Settings > Specorator and reads the Anthropic key field description.
+  - When the description text is read.
+  - Then it contains a statement that the key will be synced if Obsidian Sync is active, and recommends using a key scoped to personal devices.
+- **Priority:** must
+- **Satisfies:** IDEA-CCS-001 (constraints); `PluginSettings.ts` code comment (C.7)
+
+---
+
+## Non-functional requirements
+
+> Steering documents (`docs/steering/quality.md`, `docs/steering/operations.md`) are stubs at the time of writing. All thresholds below are introduced by this PRD and must be tracked against the code that is already merged to `develop`. Any future update to the steering docs that contradicts these thresholds requires a superseding PRD amendment.
+
+| ID | Category | Requirement | Target |
+|---|---|---|---|
+| NFR-CCS-001 | correctness | `buildPrompt()` is a pure function with no side effects | Verified by unit tests; no I/O or state mutations permitted |
+| NFR-CCS-002 | performance | `ClaudeCliPort.startup()` must not block the `onload()` path | Startup is deferred to `onLayoutReady`; `onload()` completes before startup begins |
+| NFR-CCS-003 | reliability | Query timeout clamped to [1 000, 300 000] ms; default 30 000 ms | Values outside range are silently clamped by the adapter; never exposed in error messages |
+| NFR-CCS-004 | testability | `MockClaudeCliPort` supports configurable `available`, `cannedResponse`, `queryError`, `delayMs`, and `queryLog` | All error modes exercisable in unit tests without subprocess infrastructure |
+| NFR-CCS-005 | security | `anthropicApiKey` must never appear in log output | `LoggerPort` calls in the adapter must not include the key value; `_mapError` must redact auth errors |
+| NFR-CCS-006 | security | API key input masked in settings UI | `inputEl.type = 'password'` and `autocomplete = 'off'` enforced on the settings field |
+| NFR-CCS-007 | reliability | `ClaudeCliPort.shutdown()` must be synchronous and must not throw | Called from Obsidian's synchronous `onunload()` path; fire-and-forget is acceptable |
+| NFR-CCS-008 | correctness | `buildPrompt()` hard-truncates at the character budget as a last resort | Prompt length never exceeds `tokenCap × 4` characters under any input |
+| NFR-CCS-009 | accessibility | Degraded state headings receive programmatic focus on mount | `tabindex="-1"` and `focus()` called on the first heading when the panel is not available |
+| NFR-CCS-010 | accessibility | Context chip remove buttons carry accessible labels | `aria-label="Remove <filename> from context"` present on every remove button |
+| NFR-CCS-011 | portability | `ClaudeCliPort` interface file must not import from `obsidian` or `@anthropic-ai/claude-agent-sdk` | Enforced by ESLint `no-restricted-imports` on domain layer files |
+| NFR-CCS-012 | plain language | No AI terminology, system-prompt references, or methodology jargon in UI copy | "token", "context window", "system prompt", "Claude CLI", "SDK", "subprocess" must not appear in user-visible strings |
+
+---
+
+## Success metrics
+
+- **North star:** Percentage of active Specorator users who send at least one chat message per session within 30 days of the feature shipping.
+- **Supporting — setup completion rate:** Percentage of users who arrive at the API-key-missing degraded state and subsequently enter a valid key within the same session.
+- **Supporting — send success rate:** Percentage of submitted messages that result in a successful response (status transitions to `idle` with non-null `response`), as a proxy for adapter reliability.
+- **Supporting — truncation notice rate:** Percentage of successful responses where `truncated === true`; validate whether the 50 000-token default is appropriate for real vault sizes.
+- **Counter-metric:** Rate of unhandled errors reaching the Obsidian console (i.e., errors not mapped to a `ClaudeCliErrorCode`). An increase indicates the error-mapping coverage in the adapter is incomplete.
+
+---
+
+## Release criteria
+
+- [ ] All `must`-priority functional requirements (REQ-CCS-001 through REQ-CCS-028) have passing acceptance tests.
+- [ ] All NFRs met, with particular attention to NFR-CCS-005 (no key in logs) and NFR-CCS-011 (no forbidden imports on `ClaudeCliPort`).
+- [ ] `npm run verify` passes on `develop` (typecheck, lint, unit tests, build, standalone build).
+- [ ] Unit tests cover `buildPrompt()` with at minimum: zero context files, single auto file within budget, manual file LIFO removal, auto file floor trimming, and hard-truncation fallback.
+- [ ] Unit tests cover `MockClaudeCliPort`: default unavailable, canned success response, each `ClaudeCliErrorCode`, and `delayMs` simulation.
+- [ ] `ChatSidebar` component tests (with PageObject) cover: available ready state, API-key-missing degraded state, SDK-unavailable degraded state, mobile degraded state, send loading state, send success, timeout error, and query_failed error.
+- [ ] No user-visible string contains "token", "context window", "system prompt", "Claude CLI", "SDK", or "subprocess".
+- [ ] The `ClaudeCliPort` interface file passes static import audit (no `obsidian` or `@anthropic-ai/claude-agent-sdk` imports).
+- [ ] QA sign-off on all degraded states against a live Obsidian install (no API key, valid API key, mobile).
+
+---
+
+## Open questions / clarifications
+
+None. All clarifications resolved before acceptance.
+
+---
+
+## Out of scope
+
+The following items are explicitly excluded from this release cycle. They are candidates for v1.x or v2.0 planning.
+
+- Conversation history persistence (vault file or plugin settings).
+- Multi-turn responses (`maxTurns > 1`).
+- Streaming token-by-token rendering (`ClaudeCliPort.queryStream()`).
+- Write-operation proposal and review cards.
+- Stage-aware or persona-aware suggested conversation starters.
+- Layer 1–4 context injection (persona, workflow state, stage metadata).
+- Provider selection, model configuration, or temperature controls.
+- `obsidian://specorator?action=send-message` URI handler (returns "not yet implemented" notice in v1).
+- Multi-agent orchestration integration.
+- Background worker or main-process IPC for API key isolation (RISK-CCS-006 mitigation deferred).
+
+---
+
+## Quality gate
+
+- [x] Goals and non-goals explicit.
+- [x] Personas / stakeholders named.
+- [x] Jobs to be done captured.
+- [x] Every functional requirement uses EARS and has an ID.
+- [x] Acceptance criteria testable.
+- [x] NFRs listed with targets.
+- [x] Success metrics defined (including a counter-metric).
+- [x] Release criteria stated.
+- [x] No open clarifications.

--- a/specs/claude-cli-chat-sidebar/research.md
+++ b/specs/claude-cli-chat-sidebar/research.md
@@ -1,0 +1,234 @@
+---
+id: RESEARCH-CCS-001
+title: "Claude CLI chat sidebar"
+stage: research
+feature: claude-cli-chat-sidebar
+status: complete
+owner: analyst
+inputs:
+  - IDEA-CCS-001
+created: 2026-05-14
+updated: 2026-05-14
+---
+
+# Research — Claude CLI chat sidebar
+
+## Research questions
+
+These carry forward from `idea.md`. Answered against the code that is already on `develop`.
+
+| ID | Question | Status |
+|---|---|---|
+| Q1 | What is the minimum context payload (Layer 0–4) that makes responses meaningfully more relevant without exceeding Claude CLI's context limits for typical vault sizes? | answered |
+| Q2 | How should conversation history be managed across sessions — persisted in the vault, in plugin settings, or kept in memory only? | answered (memory-only, v1 scope) |
+| Q3 | What is the right interaction model for the proposal review card — inline in the chat stream, or a separate review panel? | open — deferred past v1 |
+| Q4 | How should suggested conversation starters be determined per stage — hardcoded per stage slug, or driven by active artifact state? | open — deferred past v1 |
+
+### Q1 — Context payload
+
+`buildPrompt()` (`src/application/chat/buildPrompt.ts`) defines the answer in code.
+
+- **Token cap:** 50 000 tokens (constant `DEFAULT_TOKEN_CAP`).
+- **Character budget:** `tokenCap × 4` = 200 000 chars (4 chars/token approximation).
+- **Active file floor:** 500 chars (`MIN_ACTIVE_FILE_CHARS`). The active file is never trimmed below this floor.
+- **Context sources:** active file (auto, `isAuto: true`, always at index 0) plus user-pinned manual files (`isAuto: false`).
+- **Preamble format:** `"The following files are provided for context:\n\n"` followed by one `---\nFile: <path>\n---\n<content>\n\n` block per file, then `---\n\n` + the user's message.
+
+Multi-layer persona/stage context (the "Layer 0–4" concept from the idea) is not yet assembled by `buildPrompt()`. The function is a pure prompt assembler; persona and workflow-state injection are deferred to a future `buildSystemPrompt()` use case. For v1, only file content and user text are assembled.
+
+### Q2 — Conversation history
+
+`chatStore.ts` stores `response` (last successful text) and `userText` in memory-only Pinia refs. There is no persistence to vault or plugin settings data. History is cleared on `reset()` and on every `beginRequest()` call (`response` is nulled). This is consistent with the idea's "out of scope: conversation history persistence to vault (deferred)".
+
+### Q3 — Proposal review card
+
+Not implemented in v1. Deferred per the idea's out-of-scope list. Open for v2 design.
+
+### Q4 — Stage-aware suggested starters
+
+Not implemented in v1. Deferred. Open for v2 design.
+
+---
+
+## Market / ecosystem
+
+| Solution | Approach | Strengths | Weaknesses | Source |
+|---|---|---|---|---|
+| Cursor AI panel | Native IDE sidebar backed by OpenAI / Anthropic APIs; streaming SSE | First-class UX; deep editor integration | Cursor-only; not embeddable in Obsidian | https://www.cursor.com |
+| Obsidian Copilot plugin | Community plugin; uses OpenAI / other LLM APIs via `fetch`; no subprocess | Works inside Obsidian today; no CLI dependency | No streaming in all versions; provider lock-in via plugin settings exposed to user | https://github.com/logancyang/obsidian-copilot |
+| Obsidian Smart Connections | Embedding-based semantic search + chat; local model option | Vault-aware via embeddings; privacy-friendly | Embedding infra heavy; not suitable for general-purpose agentic chat | https://github.com/brianpetro/obsidian-smart-connections |
+| Claude Code SDK (`@anthropic-ai/claude-agent-sdk`) | Node.js SDK wrapping Claude CLI subprocess; `query()` async generator | Official Anthropic tooling; supports tool calls; subprocess isolation | Requires Node.js runtime and binary resolution; cold-start latency | https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk |
+| Direct Anthropic Messages API (`@anthropic-ai/sdk`) | REST client; streaming via SSE | No subprocess; simple; browser-compatible | No built-in tool-call loop; no MCP plumbing; API key exposed in renderer process | https://www.npmjs.com/package/@anthropic-ai/sdk |
+
+---
+
+## User needs
+
+These are inferred from the problem statement in `idea.md` and the GitHub issues referenced there (#161, #163, #164, #165). No primary user interviews were conducted before implementation began; the feature was driven by maintainer-authored issues.
+
+- Non-technical users (founders, PMs) need to ask open-ended questions without leaving Obsidian and without writing their own prompts. *(issue #161)*
+- Users want AI responses that are aware of what file they are looking at right now, not generic answers. *(issue #163 — active file context)*
+- Users need graceful degradation: if Claude CLI is not set up, the rest of the plugin must still work. *(issue #164 — availability check)*
+- The interface must not expose AI terminology or configuration surface; it must feel like a first-class feature of Specorator. *(idea.md constraints)*
+
+**Assumptions that must be validated post-ship:**
+- The 50 000-token cap is sufficient for typical vault files (< 200 KB) without users ever hitting the trim notice.
+- Cold-start latency on `startup()` (adapter init) is imperceptible because it is deferred to `onLayoutReady`.
+- Users find a single-turn (maxTurns: 1) response adequate for v1; multi-turn is not missed at this stage.
+
+---
+
+## Alternatives considered
+
+### Alternative A — `@anthropic-ai/claude-agent-sdk` (implemented)
+
+The production adapter (`ClaudeCliAdapter`) imports `query` from `@anthropic-ai/claude-agent-sdk` version `^0.2.141` (pinned range in `package.json`). The SDK exposes an async generator. The adapter iterates it in `_runSdkQuery()`, collecting only `message.type === 'result'` frames, and returns the final `message.result` as a string.
+
+Call signature used in the adapter:
+
+```
+sdkQuery({ prompt, options: { maxTurns: 1, abortController: controller } })
+```
+
+- `maxTurns` is fixed at 1 in v1; values > 1 are clamped with a warn log.
+- `abortController` wires the timeout race: an `AbortController` is created per call, and `controller.abort()` is called in the timeout branch and the `finally` block.
+
+Binary resolution uses `require.resolve('@anthropic-ai/claude-agent-sdk/bin/claude')` (injectable for tests via `resolveCliPath` constructor parameter). The resolved path is validated to be absolute before the adapter marks itself ready.
+
+**Pros:**
+- Official Anthropic tooling with subprocess isolation.
+- Supports tool calls and MCP plumbing in future turns (v2 path open).
+- Narrow port means the call site (`ClaudeCliPort`) never imports from the SDK package.
+- The SDK manages subprocess lifecycle; no manual `spawn`/`kill` required.
+
+**Cons:**
+- Requires the CLI binary to be resolvable at runtime; adds a hard npm dependency to the plugin bundle.
+- Cold-start: `startup()` is called in `onLayoutReady`, not immediately, so the first query after a cold boot may incur init latency.
+- The async generator pattern requires iterating to completion to get a result; streaming-to-UI is not exposed in v1 (result is buffered then returned as a string).
+- `^0.2.141` is an early semver range; breaking changes in a 0.x SDK are within semver contract.
+
+### Alternative B — `child_process.spawn` (not taken)
+
+A direct Node.js subprocess calling the `claude` CLI binary via `spawn('claude', ['--print', prompt])` and collecting stdout.
+
+**Pros:**
+- Zero extra npm dependency beyond Node.js builtins.
+- Full control over process lifecycle, stdin/stdout encoding, and streaming.
+
+**Cons:**
+- Requires the `claude` binary to be on `PATH` or a known absolute path — unreliable across OS and install methods.
+- Manual process management: piping, buffering, exit code handling, timeout via `process.kill()`.
+- No access to structured message types; output parsing is fragile.
+- Windows `PATH` resolution differs from Unix; the plugin must handle both.
+- Harder to test: test doubles must mock the Node.js `child_process` module.
+- No forward path to tool calls or MCP without re-implementing what the SDK provides.
+
+### Alternative C — Direct Anthropic Messages REST API (`@anthropic-ai/sdk`)
+
+Use `anthropic.messages.create()` (or the streaming variant) over HTTPS directly from the renderer/plugin process.
+
+**Pros:**
+- Browser-compatible; works in standalone UI without a subprocess.
+- Streaming SSE is supported; tokens arrive incrementally.
+- No binary dependency.
+
+**Cons:**
+- The API key would be read in the renderer process and included in every HTTPS request — a weaker security boundary than subprocess isolation.
+- No built-in tool-call agent loop; each tool call requires manual orchestration.
+- Diverges from the `@anthropic-ai/claude-code` constraint stated explicitly in `idea.md`.
+- MCP wiring (the v2 path) requires additional SDK work not present in the REST client.
+
+---
+
+## Technical considerations
+
+### SDK version stability
+
+`@anthropic-ai/claude-agent-sdk@^0.2.141` is a `0.x` release. The `^` range allows patch and minor bumps but semver does not protect against breaking changes in `0.x`. The `_runSdkQuery` loop depends on the `message.type === 'result'` and `message.result` shape. If the SDK renames these fields in a future `0.x` release, the adapter will silently return `undefined` (caught by the `resultText === undefined` guard and converted to a `QUERY_FAILED` error). Monitor the SDK changelog on npm/GitHub before every version bump.
+
+### Binary path resolution and Windows
+
+`require.resolve('@anthropic-ai/claude-agent-sdk/bin/claude')` resolves the path inside `node_modules` — it does not depend on system `PATH`. This is correct and cross-platform. The `isAbsolute(binaryPath)` check is an additional guard. On Windows, `require.resolve` returns a backslash path; `isAbsolute` from Node's `path` module handles this correctly.
+
+### API key handling
+
+The API key (`settings.anthropicApiKey`) is written to `process.env.ANTHROPIC_API_KEY` in both `startup()` and `query()` (re-read at call time so settings changes take effect without restart). The key value is never logged. The `_mapError` helper redacts authentication errors before surfacing them as `API_KEY_MISSING` codes.
+
+### Timeout and abort
+
+Timeout range is clamped to [1 000, 300 000] ms; default is 30 000 ms. The `AbortController` is created per call and aborted in the `finally` block unconditionally, preventing SDK resource leaks on both success and failure paths.
+
+### Sidebar hosting
+
+The chat panel is routed via Vue Router at the `/chat` path. `SpecoratorView` (Obsidian `ItemView` subclass) hosts the full Vue app; the router hash mode (`createWebHashHistory`) means `/chat` works inside Obsidian's embedded web view without a server. The `ClaudeCliAdapter` instance is passed from `main.ts` into `SpecoratorView` and from there into the Vue app via provide/inject using a dedicated `InjectionKey`.
+
+### File-menu integration
+
+The `file-menu` workspace event is registered in `onload()` via `this.registerEvent(...)`. The handler adds an "Add to chat context" item (icon `message-square-plus`) to every file's right-click menu. On click, `activateView()` is awaited, then `useChatStore(this._specoratorView.pinia).addContextFile(...)` is called. The `isAuto: false` flag is set explicitly; the auto slot is managed separately by the `active-leaf-change` event handler.
+
+### Shutdown path
+
+`this.register(() => { this._claudeCliAdapter?.shutdown() })` registers shutdown as an Obsidian plugin unload callback. `shutdown()` is synchronous and fire-and-forget — it resets `_sdkReady` and `_available` flags; no subprocess kill is needed because the SDK manages process lifecycle internally.
+
+### MockClaudeCliPort (dev and test)
+
+`MockClaudeCliPort` defaults `available = false`, so `npm run dev` renders the degraded state without a subprocess. Tests set `available = true` and control `cannedResponse` / `queryError` / `delayMs`. `queryLog` captures every prompt for assertion. The mock is a plain class with no framework dependency, satisfying the narrow-port contract.
+
+---
+
+## Risks
+
+| ID | Risk | Severity | Likelihood | Mitigation |
+|---|---|---|---|---|
+| RISK-CCS-001 | Claude CLI binary not resolvable (`NOT_INSTALLED`) | high | med | `startup()` catches `require.resolve` failures, sets `_available = false`, logs a warn. UI must render a plain-language install prompt. `isAvailable()` returns false; chat panel is hidden or degraded. |
+| RISK-CCS-002 | `ANTHROPIC_API_KEY` missing or empty at query time | high | med | Checked in both `startup()` and `query()`. Returns `API_KEY_MISSING` error code. Settings tab must surface the key field. The key is re-read at call time, so a settings update takes effect without restart. |
+| RISK-CCS-003 | Query timeout (default 30 s) under slow network or large prompt | med | med | `timeoutMs` is clamped and configurable per call. `TIMEOUT` error code maps to plain-language UI copy. Caller retains `userText` on timeout so the user can retry. |
+| RISK-CCS-004 | SDK `0.x` breaking change — `message.result` field renamed or removed | med | low | Guard `if (resultText === undefined)` converts silently to `QUERY_FAILED`. Pin the `^0.2.141` range and review SDK changelog before upgrades. Add a test that asserts the shape of a real SDK response frame. |
+| RISK-CCS-005 | Cold-start latency perceptible to user on first query | low | med | `startup()` is deferred to `onLayoutReady`, not `onload()`. If the vault opens and the user immediately opens chat before startup completes, `isAvailable()` returns false. The adapter's idempotency guard prevents double startup. |
+| RISK-CCS-006 | `process.env.ANTHROPIC_API_KEY` visible to other Node.js modules in the same process | med | low | This is a property of running in Electron/Node.js. The key is not logged and not exposed to the renderer DOM. No mitigation within the current architecture; v2 could move the API call to a background worker or main-process IPC. |
+| RISK-CCS-007 | Windows path handling edge cases in binary resolution | low | low | `isAbsolute()` guards against relative paths. `require.resolve` is cross-platform. Covered by unit tests with injectable `resolveCliPath`. |
+| RISK-CCS-008 | Context truncation notice confuses non-technical users | low | med | `buildPrompt()` returns `truncated: true`; the store exposes `truncated` ref. UI must render a plain-language trim notice (REQ-CCS-012). Copy must not say "token" or "context window". |
+
+---
+
+## Recommendation
+
+**Alternative A (`@anthropic-ai/claude-agent-sdk`) is the correct choice and is already implemented.**
+
+The rationale:
+
+1. The idea's constraint ("must use `@anthropic-ai/claude-code` SDK") rules out Alternatives B and C directly. Alternative A is the only option that satisfies that constraint.
+2. The narrow `ClaudeCliPort` seam means the SDK is isolated to `ClaudeCliAdapter`; future versions can swap it (e.g., for a streaming adapter in v2) without changing any call site in the application or UI layers.
+3. `require.resolve`-based binary path resolution is more reliable than `PATH`-based lookup (`spawn`) and is cross-platform, including Windows.
+4. The `MockClaudeCliPort` provides a clean test double that covers all error modes without subprocess infrastructure.
+
+**What still needs validating before Requirements are finalised:**
+
+- The 50 000-token default cap and the 4 chars/token approximation should be validated against real vault file sizes from representative users.
+- The `0.x` SDK dependency should be tracked; a renovation task to pin to a `1.x` release once the SDK stabilises would reduce upgrade risk.
+- Streaming-to-UI (token-by-token rendering) is not delivered in v1. If user research confirms that perceived latency on large prompts is a pain point, the port interface will need a `queryStream()` method in v2. The current `ClaudeCliPort.query()` signature does not accommodate streaming without a breaking change.
+- Multi-turn (`maxTurns > 1`) clamping to 1 is logged at warn. If the PM decides multi-turn is in scope for v1.x, the clamp must be lifted and `ClaudeCliAdapter._runSdkQuery()` updated to handle intermediate message frames.
+
+---
+
+## Sources
+
+- @anthropic-ai/claude-agent-sdk on npm — https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk
+- Cursor AI sidebar — https://www.cursor.com
+- Obsidian Copilot plugin — https://github.com/logancyang/obsidian-copilot
+- Obsidian Smart Connections — https://github.com/brianpetro/obsidian-smart-connections
+- Node.js path.isAbsolute documentation — https://nodejs.org/api/path.html#pathisabsolutepath
+- Node.js require.resolve documentation — https://nodejs.org/api/modules.html#requireresolverequest-options
+- @anthropic-ai/sdk (Messages REST client) — https://www.npmjs.com/package/@anthropic-ai/sdk
+
+---
+
+## Quality gate
+
+- [x] Each research question is answered or marked open.
+- [x] Sources cited.
+- [x] >= 2 alternatives explored.
+- [x] User needs supported by evidence (or assumptions explicit).
+- [x] Technical considerations noted.
+- [x] Risks listed with severity.
+- [x] Recommendation made.

--- a/specs/claude-cli-chat-sidebar/spec.md
+++ b/specs/claude-cli-chat-sidebar/spec.md
@@ -1,0 +1,1068 @@
+---
+id: SPEC-CCS-001
+title: "Claude CLI chat sidebar — implementation specification"
+feature: claude-cli-chat-sidebar
+stage: spec
+status: complete
+owner: architect
+inputs:
+  - PRD-CCS-001
+  - DES-CCS-001
+  - ADR-0027
+  - ADR-0028
+created: 2026-05-14
+updated: 2026-05-14
+---
+
+# Implementation Specification — Claude CLI chat sidebar
+
+This document is the implementation-ready contract for the Claude CLI chat sidebar feature as built on the `develop` branch. It documents what was actually built; every section traces back to at least one requirement ID from `requirements.md`.
+
+---
+
+## 1. File structure
+
+All paths are relative to `src/`. Every file listed was introduced or modified by this feature.
+
+| File | Status | Purpose |
+|---|---|---|
+| `domain/ports/ClaudeCliPort.ts` | New | Domain-layer narrow port interface: `ClaudeCliPort`, `ClaudeCliError`, `ClaudeCliErrorCode`, `ClaudeCliQueryOptions` |
+| `domain/settings/PluginSettings.ts` | Modified | Added `anthropicApiKey: string` field and corresponding `DEFAULT_SETTINGS` entry |
+| `application/chat/buildPrompt.ts` | New | Pure function that assembles and budget-trims the prompt string; exports `ContextFile`, `BuildPromptResult`, `buildPrompt()` |
+| `infrastructure/obsidian/ClaudeCliAdapter.ts` | New | Production `ClaudeCliPort` implementation using `@anthropic-ai/claude-agent-sdk` |
+| `infrastructure/mock/MockClaudeCliPort.ts` | New | Configurable test/dev stub implementation of `ClaudeCliPort` |
+| `infrastructure/bridge/ports.ts` | Modified | Added `CLAUDE_CLI_PORT`, `IS_MOBILE_KEY`, `SETTINGS_VERSION_KEY` injection keys |
+| `ui/composables/useClaudeCliPort.ts` | New | Thin `inject(CLAUDE_CLI_PORT)` composable |
+| `ui/composables/usePlatform.ts` | New | `inject(IS_MOBILE_KEY, false)` composable returning `{ isMobile: boolean }` |
+| `ui/stores/chatStore.ts` | New | Pinia store holding all chat panel DTO state and actions |
+| `ui/components/chat/ChatSidebar.vue` | New | Orchestrator component: availability check, send handler, state branching |
+| `ui/components/chat/ChatInput.vue` | New | Textarea + send button; exposes `textareaEl` ref |
+| `ui/components/chat/ChatResponse.vue` | New | Pure display component for six mutually exclusive response states |
+| `ui/components/chat/ContextFileList.vue` | New | Context chip list section with empty-state hint |
+| `ui/components/chat/ContextFileChip.vue` | New | Auto and manual chip variants |
+| `ui/views/ChatSidebarView.vue` | New | Route component for `/chat`; thin shell that mounts `ChatSidebar` |
+| `plugin/main.ts` | Modified | Wires `ClaudeCliAdapter`, file-menu handler, active-leaf-change handler, URI handler, `onLayoutReady` startup call |
+| `plugin/SpecoratorView.ts` | Modified | Provides `CLAUDE_CLI_PORT`, `IS_MOBILE_KEY`, `SETTINGS_VERSION_KEY`; exposes `bumpSettingsVersion()` and `pinia` |
+| `plugin/settings.ts` | Modified | Added `renderAnthropicKeyField()` with password input and `_bumpAllViews()` |
+
+Test files (under `tests/`, mirroring `src/`):
+
+| File | Coverage |
+|---|---|
+| `tests/application/chat/buildPrompt.test.ts` | `buildPrompt()` all algorithm steps |
+| `tests/infrastructure/mock/MockClaudeCliPort.test.ts` | All `MockClaudeCliPort` branches |
+| `tests/ui/stores/chatStore.test.ts` | All store actions and state transitions |
+| `tests/ui/components/chat/ChatSidebar.test.ts` | Component variants, send flow, guards, error paths |
+| `tests/ui/components/chat/ChatSidebar.po.ts` | PageObject for `ChatSidebar` |
+
+---
+
+## 2. Interfaces
+
+### 2.1 `ClaudeCliErrorCode`
+
+Satisfies REQ-CCS-021.
+
+```typescript
+// src/domain/ports/ClaudeCliPort.ts
+
+export type ClaudeCliErrorCode =
+  | 'NOT_INSTALLED'   // Binary could not be resolved or the SDK failed to start
+  | 'API_KEY_MISSING' // ANTHROPIC_API_KEY was empty at query time
+  | 'TIMEOUT'         // No response received within timeoutMs
+  | 'QUERY_FAILED'    // SDK call returned an error or threw an unexpected exception
+```
+
+UI copy mapping (REQ-CCS-016, REQ-CCS-018, REQ-CCS-019):
+
+| Code | Displayed as |
+|---|---|
+| `NOT_INSTALLED` | "AI assistant is not available right now." |
+| `API_KEY_MISSING` | "Chat is not set up yet." |
+| `TIMEOUT` | "That took too long. Please try again." |
+| `QUERY_FAILED` | "Something went wrong. Please try again." |
+
+### 2.2 `ClaudeCliError`
+
+```typescript
+export class ClaudeCliError extends Error {
+  public readonly name = 'ClaudeCliError'
+
+  constructor(
+    public readonly errorCode: ClaudeCliErrorCode,
+    message: string,
+    /** Original SDK or system error. Used for logging only; never surfaced in UI. */
+    public readonly cause?: unknown,
+  ) {
+    super(message)
+    // Restore prototype chain (required for instanceof checks in transpiled code).
+    Object.setPrototypeOf(this, new.target.prototype)
+  }
+}
+```
+
+### 2.3 `ClaudeCliQueryOptions`
+
+Satisfies REQ-CCS-021, NFR-CCS-003.
+
+```typescript
+export interface ClaudeCliQueryOptions {
+  /**
+   * Maximum wall-clock time in milliseconds before the adapter returns
+   * ClaudeCliError{TIMEOUT}. Default: 30 000. Valid range: [1 000, 300 000].
+   * Values outside the range are silently clamped by the adapter.
+   */
+  readonly timeoutMs?: number
+
+  /**
+   * Maximum number of agent turns. Fixed at 1 in v1.
+   * Values > 1 are clamped to 1; the adapter logs a warn.
+   */
+  readonly maxTurns?: number
+}
+```
+
+### 2.4 `ClaudeCliPort`
+
+Satisfies REQ-CCS-021, NFR-CCS-011. The interface file must not import from `obsidian` or `@anthropic-ai/claude-agent-sdk`. It imports only `Result` from `@/domain/shared/Result`.
+
+```typescript
+export interface ClaudeCliPort {
+  /**
+   * Send a fully-assembled prompt string to Claude and return the full text response.
+   * Never throws. Returns Result<string, ClaudeCliError>.
+   * Satisfies REQ-CCS-013, REQ-CCS-016, NFR-CCS-003.
+   */
+  query(
+    prompt: string,
+    options?: ClaudeCliQueryOptions,
+  ): Promise<Result<string, ClaudeCliError>>
+
+  /**
+   * Returns true if the adapter is ready to accept queries.
+   * Returns false for all degraded conditions: missing API key, startup failure,
+   * binary not found, browser/mobile stubs.
+   * Must not throw. Implementors must catch all errors and return false.
+   * Satisfies REQ-CCS-018, REQ-CCS-019, REQ-CCS-022.
+   */
+  isAvailable(): Promise<boolean>
+
+  /**
+   * Pre-warm the subprocess. Called from onLayoutReady() before first user interaction.
+   * Must not throw; log errors internally and return.
+   * Satisfies REQ-CCS-003, NFR-CCS-002.
+   */
+  startup(): Promise<void>
+
+  /**
+   * Terminate the subprocess. Called from onunload() which is synchronous.
+   * Must be synchronous (fire-and-forget is acceptable).
+   * Must not throw.
+   * Satisfies REQ-CCS-004, NFR-CCS-007.
+   */
+  shutdown(): void
+}
+```
+
+### 2.5 `ContextFileEntry`
+
+Plain DTO stored in Pinia. File content is never stored here; it is loaded on demand from `VaultPort.readFile()` at send time.
+
+```typescript
+// src/ui/stores/chatStore.ts
+
+export interface ContextFileEntry {
+  /** Vault-relative path, e.g. "specs/my-feature/requirements.md". Used as unique key. */
+  readonly path: string
+  /** Display name shown in the chip, e.g. "requirements.md". */
+  readonly label: string
+  /**
+   * True if this entry was added automatically from the active Obsidian editor file.
+   * Auto entries: (1) have no remove control, (2) are always placed at index 0,
+   * (3) are replaced as a unit when the active file changes.
+   */
+  readonly isAuto: boolean
+}
+```
+
+### 2.6 `ChatStatus`
+
+```typescript
+// src/ui/stores/chatStore.ts
+
+export type ChatStatus = 'idle' | 'loading' | 'error'
+```
+
+### 2.7 `ChatErrorType`
+
+```typescript
+// src/ui/stores/chatStore.ts
+
+/**
+ * Subset of ClaudeCliErrorCode values tracked by the store for UI rendering.
+ * NOT_INSTALLED and API_KEY_MISSING are handled at the availability-check level,
+ * not in the error state of the panel.
+ */
+export type ChatErrorType = 'timeout' | 'query_failed'
+```
+
+---
+
+## 3. `buildPrompt()` specification
+
+Satisfies REQ-CCS-025, REQ-CCS-026, REQ-CCS-027, NFR-CCS-001, NFR-CCS-008.
+
+### 3.1 Exported types
+
+```typescript
+// src/application/chat/buildPrompt.ts
+
+export interface ContextFile {
+  readonly path: string     // vault-relative path
+  readonly label: string    // display label (filename)
+  readonly isAuto: boolean  // true = active editor file; floor enforced on trim
+  readonly content: string  // raw file content from VaultPort.readFile(); may be ''
+}
+
+export interface BuildPromptResult {
+  readonly prompt: string     // fully assembled prompt to pass to ClaudeCliPort.query()
+  readonly truncated: boolean // true when any content was removed or shortened
+}
+```
+
+### 3.2 Signature
+
+```typescript
+export function buildPrompt(
+  userText: string,
+  contextFiles: ReadonlyArray<ContextFile>,
+  options?: { readonly tokenCap?: number },  // default 50 000
+): BuildPromptResult
+```
+
+### 3.3 Constants
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `DEFAULT_TOKEN_CAP` | `50_000` | Default token ceiling |
+| `CHARS_PER_TOKEN` | `4` | Characters-per-token approximation |
+| `MIN_ACTIVE_FILE_CHARS` | `500` | Minimum characters preserved from the auto file |
+
+`charBudget = tokenCap × 4` (default: `200 000` characters).
+
+### 3.4 Prompt format
+
+When `contextFiles.length > 0`:
+```
+The following files are provided for context:\n\n
+---\nFile: <path>\n---\n<content>\n\n
+[...repeated for each file]
+---\n\n
+<userText>
+```
+
+When `contextFiles.length === 0`: the prompt is `userText` verbatim.
+
+Exact example (REQ-CCS-025):
+```
+buildPrompt("hello", [{ path: "a.md", content: "x", isAuto: true, label: "a.md" }])
+→ "The following files are provided for context:\n\n---\nFile: a.md\n---\nx\n\n---\n\nhello"
+```
+
+### 3.5 Algorithm
+
+Steps execute sequentially. The function returns as soon as a budget-satisfied condition is met.
+
+1. Compute `charBudget = (options?.tokenCap ?? 50_000) × 4`.
+2. Assemble `fullPrompt = assemblePrompt(userText, contextFiles)`.
+3. If `fullPrompt.length <= charBudget` → return `{ prompt: fullPrompt, truncated: false }`.
+4. Separate `autoFiles = contextFiles.filter(f => f.isAuto)` and `manualFiles = [...contextFiles.filter(f => !f.isAuto)]` (mutable copy).
+5. LIFO manual removal: while `assembled.length > charBudget && manualFiles.length > 0`: pop the last element of `manualFiles`, reassemble.
+6. If `assembled.length <= charBudget` → return `{ prompt: assembled, truncated: true }`.
+7. Auto file trim (only if `autoFiles.length > 0`):
+   - `surplus = assembled.length - charBudget`
+   - `trimmedContent = autoFile.content.length - surplus >= MIN_ACTIVE_FILE_CHARS ? autoFile.content.slice(0, autoFile.content.length - surplus) : autoFile.content.slice(0, MIN_ACTIVE_FILE_CHARS)`
+   - Reassemble with trimmed auto file and remaining `manualFiles`.
+8. Hard-truncate: if `assembled.length > charBudget`, `assembled = assembled.slice(0, charBudget)`.
+9. Return `{ prompt: assembled, truncated: true }`.
+
+### 3.6 Pre/post-conditions
+
+| Condition | Requirement |
+|---|---|
+| Pre: `userText` may be any string including empty or whitespace | Callers must guard for empty text (REQ-CCS-015); `buildPrompt` does not throw on empty input |
+| Pre: `contextFiles[0].isAuto === true` if an auto file is present | Caller must enforce ordering; `buildPrompt` reads the first auto file for trimming |
+| Post: `result.prompt.length <= charBudget` | Always satisfied |
+| Post: no I/O, no state mutation | Pure function (NFR-CCS-001) |
+
+### 3.7 Side effects
+
+None. The function is a pure computation.
+
+---
+
+## 4. `useChatStore()` specification
+
+Satisfies REQ-CCS-005, REQ-CCS-006, REQ-CCS-009, REQ-CCS-010, REQ-CCS-011, REQ-CCS-013, REQ-CCS-014, REQ-CCS-016, REQ-CCS-017.
+
+### 4.1 State shape
+
+Store ID: `'chat'`. All fields are Vue `ref<T>`.
+
+| Field | Type | Initial value | Semantics |
+|---|---|---|---|
+| `contextFiles` | `ContextFileEntry[]` | `[]` | Ordered list; auto entry at index 0 when present |
+| `userText` | `string` | `''` | Bound to textarea; cleared on success, retained on error |
+| `response` | `string \| null` | `null` | Last successful response text; null until first success |
+| `status` | `ChatStatus` | `'idle'` | `'idle' \| 'loading' \| 'error'` |
+| `errorType` | `ChatErrorType \| null` | `null` | `'timeout' \| 'query_failed' \| null`; null when not in error state |
+| `truncated` | `boolean` | `false` | True when `buildPrompt()` removed content to stay within the cap |
+
+### 4.2 Actions
+
+#### `addContextFile(file: ContextFileEntry): void`
+
+- Appends `file` to `contextFiles`.
+- No-op if an entry with the same `path` already exists (REQ-CCS-010).
+- Auto files should use `setActiveFile` instead; `addContextFile` does not enforce index-0 placement.
+
+#### `removeContextFile(path: string): void`
+
+- Removes the entry whose `path` matches. No-op if not found (REQ-CCS-011).
+
+#### `setActiveFile(file: ContextFileEntry | null): void`
+
+- Replaces the auto slot (REQ-CCS-005, REQ-CCS-006).
+- Separates manual entries (`isAuto === false`) from the existing list.
+- If `file` is non-null: forces `isAuto = true` on the entry and inserts it at index 0, followed by the manual entries.
+- If `file` is null: sets `contextFiles` to the manual entries only (removes auto entry).
+- Does not affect manual entries.
+
+#### `setUserText(text: string): void`
+
+- Sets `userText` to `text`.
+
+#### `beginRequest(): void`
+
+- Sets `status = 'loading'`. Satisfies REQ-CCS-014.
+- Clears `response` to `null`.
+- Clears `errorType` to `null`.
+- Clears `truncated` to `false`.
+
+#### `setResponse(text: string, wasTruncated: boolean): void`
+
+- Sets `status = 'idle'`. Satisfies REQ-CCS-013 success path.
+- Sets `response = text`.
+- Sets `truncated = wasTruncated`.
+
+#### `setError(type: ChatErrorType): void`
+
+- Sets `status = 'error'`. Satisfies REQ-CCS-016.
+- Sets `errorType = type`.
+- Clears `response` to `null`.
+- Does NOT clear `userText` (REQ-CCS-017).
+
+#### `clearResponse(): void`
+
+- Clears `response` to `null`.
+- Sets `status = 'idle'`, `errorType = null`, `truncated = false`.
+
+#### `reset(): void`
+
+- Restores all fields to their initial values: `contextFiles = []`, `userText = ''`, `response = null`, `status = 'idle'`, `errorType = null`, `truncated = false`.
+
+### 4.3 State transition diagram
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│  ChatStatus state machine                                          │
+│                                                                    │
+│  ┌──────┐  beginRequest()  ┌─────────┐  setResponse()  ┌──────┐  │
+│  │ idle │ ──────────────► │ loading │ ───────────────► │ idle │  │
+│  └──────┘                 └─────────┘                  └──────┘  │
+│     ▲                          │                                   │
+│     │      clearResponse()     │ setError()                       │
+│     │◄────────────────────────┐│                                   │
+│     │                         ▼                                   │
+│  ┌──────┐  clearResponse()  ┌───────┐                             │
+│  │ idle │ ◄──────────────── │ error │                             │
+│  └──────┘                   └───────┘                             │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 5. `ClaudeCliAdapter` specification
+
+Satisfies REQ-CCS-002, REQ-CCS-003, REQ-CCS-004, REQ-CCS-013, REQ-CCS-016, REQ-CCS-022, NFR-CCS-003, NFR-CCS-005, NFR-CCS-007.
+
+### 5.1 Fields
+
+| Field | Type | Purpose |
+|---|---|---|
+| `_available` | `boolean` | True only after `startup()` succeeds. Initial: `false`. |
+| `_sdkReady` | `boolean` | Idempotency guard. Initial: `false`. `shutdown()` resets it. |
+| `_getSettings` | `() => PluginSettings` | Getter for current settings; never stored as a snapshot. |
+| `_logger` | `LoggerPort` | Internal diagnostics; never logs the API key value. |
+| `_resolveCliPath` | `() => string` | Binary path resolver; injectable for testability. Default: `require.resolve('@anthropic-ai/claude-agent-sdk/bin/claude')`. |
+
+### 5.2 `startup(): Promise<void>`
+
+Pre-conditions: none. Post-condition: `_available` and `_sdkReady` reflect the outcome.
+
+Algorithm:
+1. If `_sdkReady === true`, return immediately (idempotent).
+2. Read `key = _getSettings().anthropicApiKey.trim()`.
+3. If `key === ''`: log warn ("anthropicApiKey is empty"), set `_available = false`, return.
+4. Write `process.env.ANTHROPIC_API_KEY = key` (key value never appears in logs).
+5. Call `_resolveCliPath()`. If it throws: log warn ("binary not found"), set `_available = false`, return.
+6. If the resolved path is not absolute (`!isAbsolute(binaryPath)`): log warn ("path not absolute"), set `_available = false`, return.
+7. Set `_sdkReady = true`, `_available = true`. Log info ("adapter ready").
+
+### 5.3 `query(prompt, options?): Promise<Result<string, ClaudeCliError>>`
+
+Never throws. Returns `Result<string, ClaudeCliError>`.
+
+Algorithm:
+1. If `!_available`: return `err(ClaudeCliError(_unavailableCode(), ...))`.
+2. Re-read `currentKey = _getSettings().anthropicApiKey.trim()`.
+3. If `currentKey === ''`: return `err(ClaudeCliError('API_KEY_MISSING', ...))`.
+4. Write `process.env.ANTHROPIC_API_KEY = currentKey`.
+5. `timeoutMs = _clampTimeout(options?.timeoutMs)`.
+6. If `options?.maxTurns > 1`: log warn ("maxTurns clamped to 1 in v1").
+7. Create `AbortController controller`.
+8. Race: `_runSdkQuery(prompt, controller)` vs. a timeout promise that aborts `controller` and rejects with `ClaudeCliError('TIMEOUT', ...)` after `timeoutMs` ms.
+9. On success: return `ok(responseText)`.
+10. On any catch: return `err(_mapError(e, timeoutMs))`.
+11. Finally: `clearTimeout(timeoutId); controller.abort()`.
+
+### 5.4 `isAvailable(): Promise<boolean>`
+
+Returns `_available && _getSettings().anthropicApiKey.trim() !== ''`. Never throws. Satisfies REQ-CCS-022.
+
+### 5.5 `shutdown(): void`
+
+Synchronous. Satisfies NFR-CCS-007.
+- If `_sdkReady === true`: log debug ("shutting down adapter").
+- Set `_sdkReady = false`, `_available = false`.
+- Never throws.
+
+### 5.6 Private helpers
+
+#### `_unavailableCode(): 'API_KEY_MISSING' | 'NOT_INSTALLED'`
+
+Returns `'API_KEY_MISSING'` when `_getSettings().anthropicApiKey.trim() === ''`, otherwise `'NOT_INSTALLED'`.
+
+#### `_clampTimeout(raw?: number): number`
+
+Returns `Math.min(Math.max(raw ?? 30_000, 1_000), 300_000)`. Satisfies NFR-CCS-003.
+
+#### `_runSdkQuery(prompt, controller): Promise<string>`
+
+- Calls `sdkQuery({ prompt, options: { maxTurns: 1, abortController: controller } })`.
+- Iterates the async generator; collects messages where `message.type === 'result' && 'result' in message`.
+- Throws `Error('No result message received from SDK')` if no result message was emitted.
+
+#### `_mapError(e, timeoutMs): ClaudeCliError`
+
+Satisfies NFR-CCS-005 (key value never appears in error messages or logs).
+
+| `e` value | Result |
+|---|---|
+| `ClaudeCliError` with `errorCode === 'TIMEOUT'` | Pass through. Logs warn `{ timeoutMs }` only. |
+| `Error` with message matching `/api.key\|authentication\|401/i` | `ClaudeCliError('API_KEY_MISSING', 'Authentication failed', e)`. Logs warn "API key error" (no key value). |
+| Any other `Error` | `ClaudeCliError('QUERY_FAILED', 'Query failed', e)`. Logs warn with `e.message`. |
+| Unknown non-Error | `ClaudeCliError('QUERY_FAILED', 'Unknown error', e)`. Logs warn "unknown error". |
+
+---
+
+## 6. `MockClaudeCliPort` specification
+
+Satisfies REQ-CCS-023, NFR-CCS-004.
+
+### 6.1 Configuration fields
+
+| Field | Type | Default | Purpose |
+|---|---|---|---|
+| `available` | `boolean` | `false` | Controls `isAvailable()` return value and the no-op branch of `query()` |
+| `cannedResponse` | `string` | `'Mock response from MockClaudeCliPort.'` | Text returned on success |
+| `queryError` | `ClaudeCliError \| null` | `null` | If non-null, `query()` returns this error instead of `cannedResponse` |
+| `delayMs` | `number` | `0` | Artificial delay before `query()` resolves |
+| `queryLog` | `readonly string[]` | `[]` | Append-only log of every prompt string passed to `query()` |
+
+### 6.2 Method behaviour
+
+#### `startup(): Promise<void>`
+
+No-op. Returns `Promise.resolve()`. Never throws.
+
+#### `shutdown(): void`
+
+No-op. Never throws.
+
+#### `isAvailable(): Promise<boolean>`
+
+Returns `Promise.resolve(this.available)`. Never throws.
+
+#### `query(prompt, _options?): Promise<Result<string, ClaudeCliError>>`
+
+1. Appends `prompt` to `queryLog` (always, even when unavailable).
+2. If `!this.available`: return `err(ClaudeCliError('NOT_INSTALLED', 'MockClaudeCliPort: not available'))`.
+3. If `this.delayMs > 0`: `await sleep(this.delayMs)`.
+4. If `this.queryError !== null`: return `err(this.queryError)`.
+5. Return `ok(this.cannedResponse)`.
+
+---
+
+## 7. Component contracts
+
+### 7.1 `ChatSidebarView.vue`
+
+Route component for `/chat`. Thin shell with no props, no emits, no state. Renders `<ChatSidebar />` unconditionally. All logic lives in `ChatSidebar`.
+
+### 7.2 `ChatSidebar.vue`
+
+Satisfies REQ-CCS-005, REQ-CCS-006, REQ-CCS-013, REQ-CCS-014, REQ-CCS-015, REQ-CCS-016, REQ-CCS-017, REQ-CCS-018, REQ-CCS-019, REQ-CCS-020, REQ-CCS-024, NFR-CCS-009.
+
+**Props:** none.
+
+**Emits:** none.
+
+**Injected dependencies:**
+- `CLAUDE_CLI_PORT` → `ClaudeCliPort | undefined`
+- `IS_MOBILE_KEY` → `boolean` (default `false`)
+- `SETTINGS_VERSION_KEY` → `Ref<number>` (default `ref(0)`)
+- `VAULT_PORT`, `WORKSPACE_PORT`, `SETTINGS_PORT`
+
+**Local state:**
+- `available: Ref<boolean>` — result of `claudeCliPort.isAvailable()`
+- `availabilityChecked: Ref<boolean>` — `false` until the first `isAvailable()` call completes; prevents flash of wrong state
+- `apiKeyMissing: Ref<boolean>` — set by reading `settingsPort.getSettings().anthropicApiKey`
+- `containerEl: Ref<HTMLElement | null>` — root element ref for focus management
+- `inputRef: Ref<ChatInput | null>` — ref to the `ChatInput` instance for `textareaEl` access
+
+**Key behaviour:**
+
+1. On `onMounted`:
+   - Calls `claudeCliPort.isAvailable()` and sets `available`.
+   - Sets `availabilityChecked = true`.
+   - Reads the active file from `workspacePort.getActiveFile()` and calls `store.setActiveFile()`.
+   - Subscribes to `workspacePort.onActiveFileChanged(updateActiveFile)`.
+   - After `nextTick`: if `available && !isMobile`, focuses the textarea; otherwise focuses `[data-testid="chat-degraded-heading"]`.
+   - Reads `settingsPort.getSettings().anthropicApiKey` and sets `apiKeyMissing`.
+
+2. On `onUnmounted`: unsubscribes the active-file listener.
+
+3. `watch(settingsVersion, ...)`: re-calls `claudeCliPort.isAvailable()` and updates `available`. Satisfies REQ-CCS-024.
+
+4. `watch(available, ...)` and `watch(availabilityChecked, ...)`: re-reads `apiKeyMissing` when availability transitions to false.
+
+5. Template branching (evaluated top-to-bottom; first match wins):
+   - `v-if="isMobile"` → mobile degraded block (REQ-CCS-020)
+   - `v-else-if="!availabilityChecked"` → empty (blank render; prevents state flash)
+   - `v-else-if="!available && apiKeyMissing"` → no-key degraded block (REQ-CCS-018)
+   - `v-else-if="!available && !apiKeyMissing"` → SDK-unavailable degraded block (REQ-CCS-019)
+   - `v-else` → ready state: title, `ContextFileList`, divider, `ChatInput`, divider, `ChatResponse`
+
+6. `handleSend()`:
+   - Guard: `store.userText.trim()` empty → return (REQ-CCS-015).
+   - Guard: `store.status === 'loading'` → return.
+   - Guard: `!available` → return.
+   - Calls `store.beginRequest()`.
+   - Parallel `VaultPort.readFile()` for all context files; failed reads yield `content: ''`.
+   - Calls `buildPrompt(store.userText, loadedFiles)`.
+   - Calls `claudeCliPort.query(prompt, { timeoutMs: 30_000 })`.
+   - On success: `store.setResponse(text, truncated)`, `store.setUserText('')`, focus textarea.
+   - On `TIMEOUT`: `store.setError('timeout')`, focus textarea.
+   - On other error codes: `store.setError('query_failed')`, focus textarea.
+
+7. `responseState` computed: derives `'idle' | 'loading' | 'success' | 'trimmed-success' | 'timeout' | 'error'` from `store.status`, `store.errorType`, `store.response`, and `store.truncated`.
+
+**data-testid attributes:**
+- `data-testid="chat-sidebar"` on root `<div>`
+- `data-testid="chat-degraded-heading"` on `<h3>` in all three degraded states
+- `data-testid="chat-degraded-settings-link"` on the `RouterLink` in the no-key state
+
+### 7.3 `ChatInput.vue`
+
+Satisfies REQ-CCS-013, REQ-CCS-014, NFR-CCS-010.
+
+**Props:**
+
+| Prop | Type | Required | Semantics |
+|---|---|---|---|
+| `modelValue` | `string` | yes | Bound to textarea `value`; the component is uncontrolled on input |
+| `disabled` | `boolean` | yes | When `true`: textarea becomes `readonly`, send button is `disabled` |
+| `loading` | `boolean` | yes | When `true`: send button shows spinner + "Asking…" label |
+
+**Emits:**
+
+| Event | Payload | When |
+|---|---|---|
+| `update:modelValue` | `string` | On every `input` event on the textarea |
+| `send` | _(none)_ | On send button click or Ctrl+Enter / Cmd+Enter in textarea |
+
+**Exposed ref:** `textareaEl: Ref<HTMLTextAreaElement | null>` — accessible from parent via template ref.
+
+**Key behaviour:**
+- `handleKeydown`: fires `emit('send')` when `event.key === 'Enter' && (event.ctrlKey || event.metaKey)` and `!disabled && !loading`.
+- Send button click: fires `emit('send')` only when `!disabled && !loading`.
+- Spinner span is `aria-hidden="true"`.
+
+**data-testid attributes:**
+- `data-testid="chat-input-textarea"` on `<textarea>`
+- `data-testid="chat-send-button"` on `<button>`
+
+**ARIA:**
+- Textarea: `aria-label="Message"`, `aria-multiline="true"`, `placeholder="Ask anything about your work…"`.
+- Send button: `aria-label="Send message"`. Uses native `disabled` attribute; not in tab order when disabled.
+
+### 7.4 `ChatResponse.vue`
+
+Satisfies REQ-CCS-012, REQ-CCS-013, REQ-CCS-014, REQ-CCS-016.
+
+**Props:**
+
+| Prop | Type | Required | Semantics |
+|---|---|---|---|
+| `state` | `'idle' \| 'loading' \| 'success' \| 'trimmed-success' \| 'timeout' \| 'error'` | yes | Determines which branch renders |
+| `text` | `string` (optional) | no | Response text; used in `success` and `trimmed-success` states |
+
+**Emits:** none.
+
+**State rendering:**
+
+| `state` | Element | ARIA | Content |
+|---|---|---|---|
+| `idle` | `<p>` | none | "(Response will appear here.)" |
+| `loading` | `<div>` | `role="status"` `aria-live="polite"` | "Thinking…" |
+| `trimmed-success` | `<p>` + `<div>` | trim `<p>`: `role="status"` `aria-live="polite"` | Trim notice + `text` prop |
+| `success` | `<div>` | none | `text` prop |
+| `timeout` | `<p>` | `role="alert"` `aria-live="assertive"` | "That took too long. Please try again." |
+| `error` | `<p>` | `role="alert"` `aria-live="assertive"` | "Something went wrong. Please try again." |
+
+**data-testid attributes:**
+- `data-testid="chat-response-idle"` — idle `<p>`
+- `data-testid="chat-response-loading"` — loading `<div>`
+- `data-testid="chat-response-trim-notice"` — trim notice `<p>`
+- `data-testid="chat-response-text"` — success and trimmed-success response `<div>`
+- `data-testid="chat-response-error"` — timeout and generic error `<p>`
+
+### 7.5 `ContextFileList.vue`
+
+Satisfies REQ-CCS-005, REQ-CCS-006, REQ-CCS-009, REQ-CCS-010, REQ-CCS-011, REQ-CCS-014.
+
+**Props:**
+
+| Prop | Type | Required | Semantics |
+|---|---|---|---|
+| `files` | `ReadonlyArray<ContextFileEntry>` | yes | Ordered list of context entries |
+| `disabled` | `boolean` | yes | When `true`, forwarded to `ContextFileChip`; hides remove buttons |
+
+**Emits:**
+
+| Event | Payload | When |
+|---|---|---|
+| `remove` | `{ path: string }` | When a `ContextFileChip` emits `remove` |
+
+**Key behaviour:**
+- Wraps a `<section aria-label="Context for this message.">`.
+- Inner `<ul role="list" aria-label="Context files">` iterates `files` by `file.path` key.
+- Shows empty-state hint when `files.length === 0`.
+
+**data-testid attributes:**
+- `data-testid="context-file-list"` on `<section>`
+- `data-testid="context-file-empty"` on the empty-state `<p>`
+
+### 7.6 `ContextFileChip.vue`
+
+Satisfies REQ-CCS-005, REQ-CCS-009, REQ-CCS-011, REQ-CCS-014, NFR-CCS-010.
+
+**Props:**
+
+| Prop | Type | Required | Semantics |
+|---|---|---|---|
+| `file` | `ContextFileEntry` | yes | The entry to render |
+| `disabled` | `boolean` | yes | When `true`, remove button is not rendered (loading state) |
+
+**Emits:**
+
+| Event | Payload | When |
+|---|---|---|
+| `remove` | _(none)_ | Click, Enter, or Space on the remove button |
+
+**Auto variant** (`file.isAuto === true`):
+- Renders `<span>` with indicator square (`aria-hidden="true"`), `file.label`, `(auto)` suffix (`aria-hidden="true"`), and a visually-hidden `<span class="sr-only">(included automatically)</span>`.
+- No remove button.
+- `data-testid="context-chip-auto"`
+
+**Manual variant** (`file.isAuto === false`):
+- Renders `<span>` with label text and — when `!disabled` — a remove `<button>`.
+- Remove button: `aria-label="Remove ${file.label} from context"`, `data-testid="context-chip-remove"`.
+- `×` glyph inside button is `aria-hidden="true"`.
+- Button fires `emit('remove')` on `click`, `keydown.enter`, and `keydown.space`.
+- `data-testid="context-chip-manual"`
+
+---
+
+## 8. Settings extension
+
+Satisfies REQ-CCS-001, REQ-CCS-002, REQ-CCS-028, NFR-CCS-005, NFR-CCS-006.
+
+### 8.1 `PluginSettings` delta
+
+```typescript
+// src/domain/settings/PluginSettings.ts
+
+interface PluginSettings {
+  // ... existing fields unchanged ...
+
+  /**
+   * Anthropic API key. Written to process.env.ANTHROPIC_API_KEY at adapter startup.
+   * Used solely to initialise ClaudeCliAdapter. Never written to any vault file.
+   * Never logged. Stored in the plugin data blob (Obsidian's this.saveData()).
+   *
+   * Security: Obsidian Sync will include this key if the user has Sync enabled.
+   * A notice in the settings tab informs users (REQ-CCS-028).
+   *
+   * Satisfies REQ-CCS-001, REQ-CCS-002, NFR-CCS-005, NFR-CCS-006.
+   */
+  readonly anthropicApiKey: string
+}
+```
+
+### 8.2 `DEFAULT_SETTINGS` delta
+
+```typescript
+export const DEFAULT_SETTINGS: PluginSettings = {
+  // ... existing defaults unchanged ...
+  anthropicApiKey: '',
+}
+```
+
+The field is stored under the `specorator` sub-key of the plugin data blob via `this.saveData()`. It is not written to any vault file.
+
+### 8.3 Settings UI — `renderAnthropicKeyField()`
+
+Called from `SpecoratorSettingTab.display()` after all module-driven settings.
+
+| Attribute | Value |
+|---|---|
+| Setting name | "Anthropic key" |
+| Description | "Required to use the AI assistant. Stored in this device's plugin settings. If you use Obsidian Sync, your key will be included in the sync — use a key scoped to your personal devices." |
+| Input type | `password` (NFR-CCS-006) |
+| Autocomplete | `off` (NFR-CCS-006) |
+| data-testid | `settings-anthropic-key` |
+| Placeholder | `sk-ant-…` |
+| `onChange` | Trims whitespace before calling `plugin.updateSettings({ anthropicApiKey: value.trim() })`; then calls `_bumpAllViews()` (REQ-CCS-002, REQ-CCS-024) |
+
+`_bumpAllViews()` calls `bumpSettingsVersion()` on every open `SpecoratorView` leaf of type `VIEW_TYPE`.
+
+---
+
+## 9. Plugin wiring — `main.ts` hooks
+
+Satisfies REQ-CCS-003, REQ-CCS-004, REQ-CCS-007, REQ-CCS-008, REQ-CCS-009, REQ-CCS-005, REQ-CCS-006.
+
+### 9.1 `onload()` sequence (pseudocode)
+
+```
+await loadSettings()
+new ObsidianBridge(...)
+new PluginCore(...)
+await core.init(_storedData)
+re-sync settings from blob
+
+// T-CCS-032: Adapter
+_claudeCliAdapter = new ClaudeCliAdapter(() => this.settings, bridge)
+this.register(() => { _claudeCliAdapter.shutdown() })   // REQ-CCS-004
+
+registerView(VIEW_TYPE, leaf => {
+  view = new SpecoratorView(leaf, this, _claudeCliAdapter)
+  _specoratorView = view
+  return view
+})
+
+addRibbonIcon('layout-dashboard', 'Open Specorator', () => activateView())   // REQ-CCS-007
+addCommand({ id: 'open-specorator', name: 'Open panel', callback: activateView })  // REQ-CCS-007
+
+// T-CCS-031: File-menu integration (REQ-CCS-009)
+registerEvent(workspace.on('file-menu', (menu, file) => {
+  menu.addItem(item => {
+    item.setTitle('Add to chat context').setIcon('message-square-plus')
+    item.onClick(() => {
+      activateView().then(() => {
+        if (_specoratorView?.pinia) {
+          useChatStore(_specoratorView.pinia)
+            .addContextFile({ path: file.path, label: file.name, isAuto: false })
+        }
+      })
+    })
+  })
+}))
+
+// T-CCS-034: Active-file tracking (REQ-CCS-005, REQ-CCS-006)
+registerEvent(workspace.on('active-leaf-change', () => {
+  const activeFile = app.workspace.getActiveFile()
+  if (_specoratorView?.pinia) {
+    const store = useChatStore(_specoratorView.pinia)
+    activeFile
+      ? store.setActiveFile({ path: activeFile.path, label: activeFile.name, isAuto: true })
+      : store.setActiveFile(null)
+  }
+}))
+
+// T-CCS-033: URI handler (REQ-CCS-008)
+registerObsidianProtocolHandler('specorator', params => {
+  const searchParams = new URLSearchParams(Object.entries(params))
+  if (core.handleUri(searchParams)) return
+
+  switch params.action:
+    'open-chat' | 'focus-chat' → activateView().then(() => _specoratorView?.navigateTo('/chat'))
+    'send-message' | 'open-workflow' → bridge.showInfo("URI action … is not yet implemented.")
+    else → bridge.showWarning("Unknown Specorator URI action: …")
+})
+
+addSettingTab(new SpecoratorSettingTab(app, this))
+
+// T-CCS-032: Deferred startup (REQ-CCS-003, NFR-CCS-002)
+workspace.onLayoutReady(() => {
+  void _claudeCliAdapter.startup()
+  detectLegacyVaultLayout()
+  if (!settings.onboardingComplete) activateView().then(() => navigateTo('/onboarding'))
+})
+```
+
+### 9.2 `onunload()`
+
+```
+workspace.detachLeavesOfType(VIEW_TYPE)
+bridge.hideAllNotices()
+void core.destroy()
+// adapter.shutdown() fires via registered cleanup from this.register() above
+```
+
+### 9.3 `SpecoratorView.onOpen()` provision
+
+All injection keys provided to the Vue application:
+
+| Key constant | Value provided |
+|---|---|
+| `SETTINGS_PORT` | `bridge` |
+| `VAULT_PORT` | `bridge` |
+| `WORKSPACE_PORT` | `bridge` |
+| `NOTIFICATION_PORT` | `bridge` |
+| `LOGGER_PORT` | `bridge` |
+| `CLAUDE_CLI_PORT` | `this.claudeCliPort` |
+| `COMMUNITY_PLUGIN_PORT` | `bridge` |
+| `IS_MOBILE_KEY` | `Platform.isMobile` |
+| `SETTINGS_VERSION_KEY` | `this._settingsVersion` (a `Ref<number>`) |
+
+`bumpSettingsVersion()` increments `_settingsVersion.value`.
+
+---
+
+## 10. Injection keys
+
+Satisfies REQ-CCS-021, REQ-CCS-024.
+
+```typescript
+// src/infrastructure/bridge/ports.ts
+
+export const CLAUDE_CLI_PORT: InjectionKey<ClaudeCliPort> = Symbol('ClaudeCliPort')
+export const IS_MOBILE_KEY: InjectionKey<boolean> = Symbol('IsMobile')
+/**
+ * Reactive counter provided by SpecoratorView. ChatSidebar watches this to
+ * re-check adapter availability after the API key is saved in Settings.
+ */
+export const SETTINGS_VERSION_KEY: InjectionKey<Ref<number>> = Symbol('settingsVersion')
+```
+
+---
+
+## 11. Observability requirements
+
+Satisfies NFR-CCS-005.
+
+| Event | Level | Details logged | Must NOT log |
+|---|---|---|---|
+| `startup()` — key empty | `warn` | "anthropicApiKey is empty" | Key value |
+| `startup()` — binary not found | `warn` | "binary not found" | Key value |
+| `startup()` — path not absolute | `warn` | "path not absolute" | Key value |
+| `startup()` — success | `info` | "adapter ready" | Key value |
+| `query()` — timeout | `warn` | `{ timeoutMs }` | Key value |
+| `query()` — auth/401 error | `warn` | "API key error" | Key value, error message containing key |
+| `query()` — SDK error | `warn` | `{ error: e.message }` | Key value |
+| `query()` — unknown error | `warn` | "unknown error" | Key value |
+| `shutdown()` — when ready | `debug` | "shutting down adapter" | Key value |
+
+No metrics or distributed traces are emitted by this feature (beyond the LoggerPort calls above). No alerts are registered.
+
+---
+
+## 12. Performance budgets
+
+Inherited from PRD NFRs unless noted.
+
+| Requirement | Target | Source |
+|---|---|---|
+| `onload()` not delayed by adapter startup | `startup()` deferred to `onLayoutReady`; `onload()` completes before startup begins | NFR-CCS-002 |
+| Query timeout | Default 30 000 ms; clamped to [1 000, 300 000] ms | NFR-CCS-003 |
+| `buildPrompt()` prompt length | Never exceeds `tokenCap × 4` characters under any input | NFR-CCS-008 |
+| `shutdown()` | Synchronous; returns immediately (fire-and-forget) | NFR-CCS-007 |
+
+---
+
+## 13. Compatibility
+
+- Backward-compatible: `anthropicApiKey` is added to `PluginSettings` with `DEFAULT_SETTINGS` entry `''`. Existing stored settings without this key deserialise to `''` via the spread merge in `loadSettings()` — no migration needed.
+- No vault schema changes. No new vault files created or read by this feature.
+- `ClaudeCliPort` interface has no version field. Future breaking changes require a new ADR and interface version bump.
+
+---
+
+## 14. Edge cases
+
+| Edge case | Handling |
+|---|---|
+| `userText` is empty or whitespace-only | `handleSend()` returns immediately; `query()` is never called (REQ-CCS-015) |
+| `userText` alone exceeds `charBudget` | `buildPrompt()` hard-truncates to `charBudget`; `truncated = true` (NFR-CCS-008) |
+| Context file read fails (`VaultPort.readFile()` throws) | `tryAsync` wraps the call; a failed read yields `content: ''`; no error surfaced to the user (flow continues) |
+| Same file added twice via right-click | `addContextFile` duplicate guard makes the second call a no-op (REQ-CCS-010) |
+| `setActiveFile` called with an entry where `isAuto: false` | `setActiveFile` forces `isAuto = true` on the stored entry |
+| `startup()` called twice (idempotent) | Early return on `_sdkReady === true` |
+| `startup()` called after `shutdown()` | `_sdkReady` was reset to `false` by `shutdown()`; `startup()` proceeds normally |
+| `isAvailable()` called before `startup()` | Returns `false` (`_available` is `false` at initialisation) |
+| `ClaudeCliPort` not provided (undefined from `inject`) | `handleSend()` calls `store.setError('query_failed')` when `claudeCliPort === undefined` |
+| API key changed in settings while a query is in flight | `query()` re-reads the key at call time; in-flight query uses the key that was live at the moment `query()` was entered |
+| Auto file disappears (file deleted while sidebar open) | `workspacePort.onActiveFileChanged` fires with `null`; `setActiveFile(null)` removes the auto entry |
+| Manual context file deleted while sidebar open | Not detected; the path remains in the store. At send time, `VaultPort.readFile()` fails and yields `content: ''` |
+| `_specoratorView` is null when file-menu item is clicked | Guard `if (_specoratorView?.pinia)` prevents the store call; `addContextFile` is silently skipped |
+| `send` fired while `status === 'loading'` | Guard in `handleSend()` returns immediately; no second query started |
+| `timeoutMs` outside [1 000, 300 000] | Silently clamped by `_clampTimeout()`; never exposed in error messages (NFR-CCS-003) |
+| `maxTurns > 1` passed in options | Clamped to 1; adapter logs a warn; no user-visible effect (design §NG2) |
+| Prompt assembled with zero files and empty `userText` | `buildPrompt()` returns `{ prompt: '', truncated: false }`; guard in `handleSend()` prevents empty text from reaching `buildPrompt()` |
+| Mobile platform | Mobile check in `ChatSidebar` takes precedence over availability check; no input is rendered (REQ-CCS-020) |
+| `availabilityChecked` is `false` | Template renders nothing (blank); prevents flashing wrong state during async `isAvailable()` call |
+| `SETTINGS_VERSION_KEY` not provided | `inject(SETTINGS_VERSION_KEY, ref(0))` falls back to a local `ref(0)`; settings-version watching still works per-component |
+
+---
+
+## 15. Test scenarios
+
+All scenarios are mapped to EARS-pattern requirements. Given/When/Then mirrors the structure used in `tests/`.
+
+### 15.1 `buildPrompt()` — pure function
+
+| ID | REQ | Scenario |
+|---|---|---|
+| TEST-CCS-BP-001 | REQ-CCS-025 | Given `contextFiles` is empty / When `buildPrompt('hello', [])` / Then `prompt === 'hello'` and `truncated === false` |
+| TEST-CCS-BP-002 | REQ-CCS-025 | Given one context file with `path='a.md'`, `content='x'` / When `buildPrompt('hello', [file])` / Then `prompt` equals the exact preamble+section+separator+userText string |
+| TEST-CCS-BP-003 | REQ-CCS-025 | Given multiple files / When assembled / Then files appear in input order, each wrapped in `---\nFile: <path>\n---\n<content>\n\n` |
+| TEST-CCS-BP-004 | REQ-CCS-026 | Given auto + manualA + manualB where combined length exceeds `charBudget` / When `buildPrompt()` / Then manualB (last) is removed first; `truncated === true` |
+| TEST-CCS-BP-005 | REQ-CCS-026 | Given auto + manualA + manualB where even `auto + manualA` exceeds budget / When `buildPrompt()` / Then both manual files are removed; auto file remains |
+| TEST-CCS-BP-006 | REQ-CCS-027 | Given auto file with large content such that removing all manuals still leaves the prompt over budget / When `buildPrompt()` / Then auto file content is trimmed from the end; `truncated === true` |
+| TEST-CCS-BP-007 | REQ-CCS-027 | Given auto file of 1 000 chars and budget pressure / When trimmed / Then auto file content in the prompt is at least `min(500, originalLength)` characters |
+| TEST-CCS-BP-008 | NFR-CCS-008 | Given `userText.length > charBudget` with no context files / When `buildPrompt()` / Then `prompt.length <= charBudget` and `truncated === true` |
+| TEST-CCS-BP-009 | NFR-CCS-001 | Given any inputs / When `buildPrompt()` is called / Then no I/O occurs and no external state is mutated |
+| TEST-CCS-BP-010 | REQ-CCS-025 | Given `tokenCap: 100` / When `buildPrompt('hi', [file])` / Then `prompt.length <= 400` |
+
+### 15.2 `MockClaudeCliPort`
+
+| ID | REQ | Scenario |
+|---|---|---|
+| TEST-CCS-MOCK-001 | REQ-CCS-023 | Given default `MockClaudeCliPort` / When `isAvailable()` is awaited / Then it returns `false` |
+| TEST-CCS-MOCK-002 | NFR-CCS-004 | Given `available = true` and `queryError = null` / When `query('p')` / Then returns `ok(cannedResponse)` and `queryLog` contains `'p'` |
+| TEST-CCS-MOCK-003 | NFR-CCS-004 | Given `available = false` / When `query('p')` / Then returns `err` with `errorCode === 'NOT_INSTALLED'` and `queryLog` contains `'p'` |
+| TEST-CCS-MOCK-004 | NFR-CCS-004 | Given `queryError = new ClaudeCliError('TIMEOUT', ...)` / When `query('p')` / Then returns that exact error |
+| TEST-CCS-MOCK-005 | NFR-CCS-004 | Given `delayMs = 50` / When `query('p')` / Then elapsed time is at least 40 ms |
+| TEST-CCS-MOCK-006 | REQ-CCS-022 | Given any configuration / When `startup()` / Then resolves without throwing |
+| TEST-CCS-MOCK-007 | NFR-CCS-007 | Given any configuration / When `shutdown()` / Then does not throw |
+
+### 15.3 `useChatStore()` — state and actions
+
+| ID | REQ | Scenario |
+|---|---|---|
+| TEST-CCS-STORE-001 | REQ-CCS-005 | Given existing auto entry / When `setActiveFile(newFile)` / Then `contextFiles[0]` is replaced; `isAuto === true` forced |
+| TEST-CCS-STORE-002 | REQ-CCS-006 | Given auto entry + manual entry / When `setActiveFile(null)` / Then auto entry removed; manual entry remains |
+| TEST-CCS-STORE-003 | REQ-CCS-010 | Given `contextFiles` contains `path='notes.md'` / When `addContextFile({ path: 'notes.md', ... })` / Then `contextFiles.length` unchanged |
+| TEST-CCS-STORE-004 | REQ-CCS-011 | Given manual chip exists / When `removeContextFile(path)` / Then entry removed |
+| TEST-CCS-STORE-005 | REQ-CCS-014 | When `beginRequest()` / Then `status === 'loading'`, `response === null`, `errorType === null`, `truncated === false` |
+| TEST-CCS-STORE-006 | REQ-CCS-013 | When `setResponse('text', true)` / Then `status === 'idle'`, `response === 'text'`, `truncated === true` |
+| TEST-CCS-STORE-007 | REQ-CCS-016 | When `setError('timeout')` / Then `status === 'error'`, `errorType === 'timeout'`, `response === null` |
+| TEST-CCS-STORE-008 | REQ-CCS-017 | Given `userText = 'q'` / When `setError('timeout')` / Then `userText` is still `'q'` |
+
+### 15.4 `ChatSidebar` component
+
+| ID | REQ | Scenario |
+|---|---|---|
+| TEST-CCS-004 | REQ-CCS-013 | Given `available = true` / When mounted / Then textarea and send button are rendered |
+| TEST-CCS-012 | REQ-CCS-012 | Given a 210 000-character file as the auto context and `available = true` / When send clicked / Then trim notice `[data-testid="chat-response-trim-notice"]` is visible |
+| TEST-CCS-013 | REQ-CCS-013 | Given `available = true`, `cannedResponse = 'Hello world'` / When send clicked with non-empty text / Then `queryLog.length === 1` and response text contains "Hello world" |
+| TEST-CCS-014 | REQ-CCS-014 | Given `available = true`, `delayMs = 50` / When send clicked / Then before resolve: `[data-testid="chat-response-loading"]` exists and send button is disabled |
+| TEST-CCS-015 | REQ-CCS-015 | Given `available = true` and `store.userText = ''` / When send clicked / Then `queryLog.length === 0` |
+| TEST-CCS-016a | REQ-CCS-016 | Given `queryError = ClaudeCliError('TIMEOUT', ...)` / When send clicked / Then error element contains "That took too long" |
+| TEST-CCS-016b | REQ-CCS-017 | Given `queryError = ClaudeCliError('TIMEOUT', ...)` and text = "my question" / When send clicked / Then `store.userText === 'my question'` |
+| TEST-CCS-018 | REQ-CCS-018 | Given `available = false` and `apiKey = ''` / When mounted / Then degraded heading contains "Chat is not set up yet" and settings link is visible; textarea absent |
+| TEST-CCS-019 | REQ-CCS-019 | Given `available = false` and `apiKey = 'sk-ant-not-empty'` / When mounted / Then degraded heading contains "AI assistant is not available right now" |
+| TEST-CCS-020 | REQ-CCS-020 | Given `IS_MOBILE_KEY = true` / When mounted / Then degraded heading contains "Chat is available on desktop only" and textarea absent |
+
+### 15.5 Additional integration scenarios (EARS-mapped)
+
+| ID | REQ | EARS pattern | Scenario |
+|---|---|---|---|
+| TEST-CCS-INT-001 | REQ-CCS-003 | event-driven | WHEN `onLayoutReady` fires / THEN `ClaudeCliAdapter.startup()` is called; `onload()` has already completed |
+| TEST-CCS-INT-002 | REQ-CCS-004 | event-driven | WHEN `onunload()` executes / THEN `shutdown()` is called; `_sdkReady` and `_available` are `false` |
+| TEST-CCS-INT-003 | REQ-CCS-007 | event-driven | WHEN ribbon icon clicked / THEN `activateView()` opens the Specorator leaf |
+| TEST-CCS-INT-004 | REQ-CCS-008 | event-driven | WHEN `obsidian://specorator?action=open-chat` received / THEN `activateView()` and `navigateTo('/chat')` are called |
+| TEST-CCS-INT-005 | REQ-CCS-009 | event-driven | WHEN right-click "Add to chat context" clicked / THEN `addContextFile({ path, label, isAuto: false })` called; duplicate guard active |
+| TEST-CCS-INT-006 | REQ-CCS-024 | event-driven | WHEN API key saved in settings / THEN `bumpSettingsVersion()` called on all open `SpecoratorView` leaves |
+| TEST-CCS-INT-007 | REQ-CCS-001 | ubiquitous | GIVEN settings tab rendered / WHEN Anthropic key field inspected / THEN `inputEl.type === 'password'` and `autocomplete === 'off'` |
+| TEST-CCS-INT-008 | REQ-CCS-002 | event-driven | WHEN user saves `'  sk-ant-abc  '` in the key field / THEN stored value is `'sk-ant-abc'` |
+
+---
+
+## 16. Requirements coverage
+
+| REQ ID | Covered in spec |
+|---|---|
+| REQ-CCS-001 | §8.3 (settings field), §14 (edge cases), §15.5 TEST-CCS-INT-007 |
+| REQ-CCS-002 | §8.3 `onChange` trim, §15.5 TEST-CCS-INT-008 |
+| REQ-CCS-003 | §5.2 `startup()` deferred, §9.1 `onLayoutReady`, §15.5 TEST-CCS-INT-001 |
+| REQ-CCS-004 | §5.5 `shutdown()`, §9.2, §15.5 TEST-CCS-INT-002 |
+| REQ-CCS-005 | §4.2 `setActiveFile()`, §7.2 `ChatSidebar` mount, §15.3 TEST-CCS-STORE-001 |
+| REQ-CCS-006 | §4.2 `setActiveFile(null)`, §14, §15.3 TEST-CCS-STORE-002 |
+| REQ-CCS-007 | §9.1 ribbon + command, §15.5 TEST-CCS-INT-003 |
+| REQ-CCS-008 | §9.1 URI handler, §15.5 TEST-CCS-INT-004 |
+| REQ-CCS-009 | §4.2 `addContextFile()`, §9.1 file-menu, §15.5 TEST-CCS-INT-005 |
+| REQ-CCS-010 | §4.2 `addContextFile()` duplicate guard, §15.3 TEST-CCS-STORE-003 |
+| REQ-CCS-011 | §4.2 `removeContextFile()`, §15.3 TEST-CCS-STORE-004 |
+| REQ-CCS-012 | §7.2 `responseState` computed, §7.4 `ChatResponse` trimmed-success, §15.4 TEST-CCS-012 |
+| REQ-CCS-013 | §7.2 `handleSend()` success path, §15.4 TEST-CCS-013 |
+| REQ-CCS-014 | §4.2 `beginRequest()`, §7.3 disabled props, §15.4 TEST-CCS-014 |
+| REQ-CCS-015 | §7.2 `handleSend()` guard, §15.4 TEST-CCS-015 |
+| REQ-CCS-016 | §7.2 `handleSend()` error path, §7.4 `ChatResponse` error states, §15.4 TEST-CCS-016a |
+| REQ-CCS-017 | §4.2 `setError()` (no userText clear), §15.3 TEST-CCS-STORE-008, §15.4 TEST-CCS-016b |
+| REQ-CCS-018 | §7.2 template branching no-key, §15.4 TEST-CCS-018 |
+| REQ-CCS-019 | §7.2 template branching SDK-unavailable, §15.4 TEST-CCS-019 |
+| REQ-CCS-020 | §7.2 template branching mobile, §15.4 TEST-CCS-020 |
+| REQ-CCS-021 | §2.4 interface definition (no forbidden imports) |
+| REQ-CCS-022 | §5.4 `isAvailable()` never throws, §15.2 TEST-CCS-MOCK-001 |
+| REQ-CCS-023 | §6.2 `isAvailable()` default false, §15.2 TEST-CCS-MOCK-001 |
+| REQ-CCS-024 | §8.3 `_bumpAllViews()`, §9.3 `bumpSettingsVersion()`, §15.5 TEST-CCS-INT-006 |
+| REQ-CCS-025 | §3.4 prompt format, §15.1 TEST-CCS-BP-001, TEST-CCS-BP-002 |
+| REQ-CCS-026 | §3.5 algorithm step 5, §15.1 TEST-CCS-BP-004, TEST-CCS-BP-005 |
+| REQ-CCS-027 | §3.5 algorithm step 7, §15.1 TEST-CCS-BP-006, TEST-CCS-BP-007 |
+| REQ-CCS-028 | §8.3 settings description text |
+| NFR-CCS-001 | §3.7 no side effects, §15.1 TEST-CCS-BP-009 |
+| NFR-CCS-002 | §9.1 `onLayoutReady` deferred startup, §15.5 TEST-CCS-INT-001 |
+| NFR-CCS-003 | §5.6 `_clampTimeout()`, §2.3 `timeoutMs` range |
+| NFR-CCS-004 | §6 `MockClaudeCliPort` configuration fields, §15.2 |
+| NFR-CCS-005 | §11 observability table, §5.6 `_mapError()` |
+| NFR-CCS-006 | §8.3 `type='password'`, `autocomplete='off'`, §15.5 TEST-CCS-INT-007 |
+| NFR-CCS-007 | §5.5 `shutdown()` synchronous never-throws, §15.2 TEST-CCS-MOCK-007 |
+| NFR-CCS-008 | §3.5 algorithm step 8 hard-truncate, §15.1 TEST-CCS-BP-008 |
+| NFR-CCS-009 | §7.2 focus management on mount (degraded heading focus) |
+| NFR-CCS-010 | §7.6 `ContextFileChip` remove button `aria-label` |
+| NFR-CCS-011 | §2.4 interface file imports only `Result` from domain |
+| NFR-CCS-012 | §7 component copy verified: no "token", "context window", "system prompt", "Claude CLI", "SDK", "subprocess" in any user-visible string |

--- a/specs/claude-cli-chat-sidebar/tasks.md
+++ b/specs/claude-cli-chat-sidebar/tasks.md
@@ -1,0 +1,890 @@
+---
+id: TASKS-CCS-001
+title: Claude CLI chat sidebar — Tasks
+stage: tasks
+feature: claude-cli-chat-sidebar
+status: complete
+owner: planner
+inputs:
+  - PRD-CCS-001
+  - SPEC-CCS-001
+created: 2026-05-14
+updated: 2026-05-14
+---
+
+# Tasks — Claude CLI chat sidebar
+
+> **Retrospective record.** All three PRs are merged to `develop`. This document reconstructs the task breakdown as it was actually executed, derived from `implementation-log.md`, `spec.md`, and `requirements.md`. Status for every task is `completed`.
+
+## Legend
+
+- 🧪 = test task
+- 🔨 = implementation task
+- 📐 = design / scaffolding task
+- 📚 = documentation task
+- 🚀 = release / ops task
+
+---
+
+## PR-1 — Infrastructure
+
+### T-CCS-001 📐 — ClaudeCliPort domain interface
+
+- **Description:** Create `src/domain/ports/ClaudeCliPort.ts` defining `ClaudeCliErrorCode`, `ClaudeCliError`, `ClaudeCliQueryOptions`, and the `ClaudeCliPort` interface. Re-export from `src/domain/ports/index.ts`. Install the `@anthropic-ai/claude-agent-sdk` npm package.
+- **Satisfies:** REQ-CCS-021, REQ-CCS-022, NFR-CCS-011
+- **Owner:** dev
+- **PR group:** PR-1
+- **Depends on:** —
+- **Estimate:** S
+- **Status:** completed (commit `8391d7a`)
+- **Definition of done:**
+  - [x] `ClaudeCliPort.ts` declares exactly four methods: `query`, `isAvailable`, `startup`, `shutdown`.
+  - [x] File contains zero imports from `obsidian` or `@anthropic-ai/claude-agent-sdk`.
+  - [x] `ClaudeCliError` restores prototype chain via `Object.setPrototypeOf(this, new.target.prototype)`.
+  - [x] `ClaudeCliErrorCode` union contains exactly: `NOT_INSTALLED`, `API_KEY_MISSING`, `TIMEOUT`, `QUERY_FAILED`.
+  - [x] Re-exports added to `src/domain/ports/index.ts`.
+  - [x] `@anthropic-ai/claude-agent-sdk` in `package.json` dependencies.
+
+---
+
+### T-CCS-002 🧪 — Tests for ClaudeCliError prototype and error codes
+
+- **Description:** Write unit tests for `ClaudeCliError`: prototype chain integrity (`instanceof` check), `errorCode` field, `message`, optional `cause`, and each error code value.
+- **Satisfies:** REQ-CCS-021, REQ-CCS-022
+- **Owner:** qa
+- **PR group:** PR-1
+- **Depends on:** T-CCS-001
+- **Estimate:** S
+- **Status:** completed (commit `8391d7a`, `tests/domain/ports/ClaudeCliPort.test.ts`, 8 tests)
+- **Definition of done:**
+  - [x] 8 tests in `tests/domain/ports/ClaudeCliPort.test.ts`.
+  - [x] All prototype-chain, errorCode, and cause scenarios covered.
+  - [x] All 8 tests pass.
+
+---
+
+### T-CCS-003 📐 — Install `@anthropic-ai/claude-agent-sdk`
+
+- **Description:** Add SDK dependency to `package.json`; update lockfile. Included in T-CCS-001 commit.
+- **Satisfies:** REQ-CCS-003
+- **Owner:** dev
+- **PR group:** PR-1
+- **Depends on:** —
+- **Estimate:** S
+- **Status:** completed (commit `8391d7a`, part of T-CCS-001)
+- **Definition of done:**
+  - [x] `@anthropic-ai/claude-agent-sdk` present in `package.json` dependencies.
+  - [x] `package-lock.json` updated.
+  - [x] `npm audit --audit-level=high --omit=dev` reports 0 vulnerabilities.
+
+---
+
+### T-CCS-004 🧪 — Tests for buildPrompt algorithm
+
+- **Description:** Write unit tests for `buildPrompt()` covering: empty context files, exact format output for one file, multiple files in order, LIFO manual removal, auto-file trimming, hard-truncation fallback, custom `tokenCap`, and purity (no side effects).
+- **Satisfies:** REQ-CCS-025, REQ-CCS-026, REQ-CCS-027, NFR-CCS-001, NFR-CCS-008
+- **Owner:** qa
+- **PR group:** PR-1
+- **Depends on:** T-CCS-001
+- **Estimate:** S
+- **Status:** completed (commit `ebe9993`, `tests/application/chat/buildPrompt.test.ts`, 13 tests)
+- **Definition of done:**
+  - [x] 13 tests in `tests/application/chat/buildPrompt.test.ts`.
+  - [x] Covers scenarios TEST-CCS-BP-001 through TEST-CCS-BP-010.
+  - [x] All 13 tests pass.
+
+---
+
+### T-CCS-007 🔨 — buildPrompt application service
+
+- **Description:** Implement `src/application/chat/buildPrompt.ts`: `ContextFile` and `BuildPromptResult` types; constants `DEFAULT_TOKEN_CAP`, `CHARS_PER_TOKEN`, `MIN_ACTIVE_FILE_CHARS`; the 8-step LIFO cap algorithm.
+- **Satisfies:** REQ-CCS-025, REQ-CCS-026, REQ-CCS-027, NFR-CCS-001, NFR-CCS-008
+- **Owner:** dev
+- **PR group:** PR-1
+- **Depends on:** T-CCS-004
+- **Estimate:** M
+- **Status:** completed (commit `ebe9993`)
+- **Definition of done:**
+  - [x] T-CCS-004 tests pass.
+  - [x] Algorithm steps 1–9 from SPEC-CCS-001 §3.5 implemented correctly.
+  - [x] `result.prompt.length <= charBudget` holds for all inputs.
+  - [x] Pure function — no I/O, no state mutations.
+  - [x] Lint and type checks green.
+
+---
+
+### T-CCS-005 🔨 — MockClaudeCliPort test double
+
+- **Description:** Implement `src/infrastructure/mock/MockClaudeCliPort.ts` with configurable `available`, `cannedResponse`, `queryError`, `delayMs`, and `queryLog` fields implementing all `ClaudeCliPort` methods. Add ESLint override for `prefer-active-window-timers` on mock infra layer.
+- **Satisfies:** REQ-CCS-022, REQ-CCS-023, NFR-CCS-004
+- **Owner:** dev
+- **PR group:** PR-1
+- **Depends on:** T-CCS-001
+- **Estimate:** S
+- **Status:** completed (commit `ae1bb2c`)
+- **Definition of done:**
+  - [x] `isAvailable()` defaults to `false` (REQ-CCS-023).
+  - [x] `startup()` and `shutdown()` are no-ops that do not throw (NFR-CCS-007).
+  - [x] `query()` appends to `queryLog` even when unavailable.
+  - [x] `queryError`, `delayMs`, and `cannedResponse` control output.
+  - [x] ESLint override scoped to `src/infrastructure/mock/**`.
+
+---
+
+### T-CCS-006 🧪 — Tests for MockClaudeCliPort
+
+- **Description:** Write unit tests for all `MockClaudeCliPort` method branches and field defaults, covering scenarios TEST-CCS-MOCK-001 through TEST-CCS-MOCK-007.
+- **Satisfies:** REQ-CCS-022, REQ-CCS-023, NFR-CCS-004, NFR-CCS-007
+- **Owner:** qa
+- **PR group:** PR-1
+- **Depends on:** T-CCS-005
+- **Estimate:** S
+- **Status:** completed (commit `ae1bb2c`, `tests/infrastructure/mock/MockClaudeCliPort.test.ts`, 13 tests)
+- **Definition of done:**
+  - [x] 13 tests in `tests/infrastructure/mock/MockClaudeCliPort.test.ts`.
+  - [x] All 7 MOCK scenarios (TEST-CCS-MOCK-001 through TEST-CCS-MOCK-007) covered.
+  - [x] All 13 tests pass.
+
+---
+
+### T-CCS-014 🧪 — Tests for ClaudeCliAdapter
+
+- **Description:** Write unit tests for `ClaudeCliAdapter`: startup paths (empty key, resolver throws, success), `isAvailable()`, `query()` (unavailable, success, timeout, error), and `shutdown()` lifecycle.
+- **Satisfies:** REQ-CCS-002, REQ-CCS-003, REQ-CCS-004, REQ-CCS-016, REQ-CCS-022, NFR-CCS-003, NFR-CCS-005, NFR-CCS-007
+- **Owner:** qa
+- **PR group:** PR-1
+- **Depends on:** T-CCS-001
+- **Estimate:** S
+- **Status:** completed (commit `6cf7184`, `tests/infrastructure/obsidian/ClaudeCliAdapter.test.ts`, 16 tests)
+- **Definition of done:**
+  - [x] 16 tests in `tests/infrastructure/obsidian/ClaudeCliAdapter.test.ts`.
+  - [x] Startup paths (empty key, binary not found, success) each have a test.
+  - [x] Timeout, API error, and unknown error paths tested.
+  - [x] Shutdown resets `_sdkReady` and `_available`.
+  - [x] API key value never appears in any logged output (NFR-CCS-005).
+  - [x] All 16 tests pass.
+
+---
+
+### T-CCS-015 🔨 — ClaudeCliAdapter production implementation
+
+- **Description:** Implement `src/infrastructure/obsidian/ClaudeCliAdapter.ts` with injectable `resolveCliPath`; `startup()` sets `ANTHROPIC_API_KEY`; `query()` uses `Promise.race` with `setTimeout` for timeout; private helpers `_unavailableCode`, `_clampTimeout`, `_makeTimeoutPromise`, `_runSdkQuery`, `_mapError`.
+- **Satisfies:** REQ-CCS-002, REQ-CCS-003, REQ-CCS-004, REQ-CCS-016, REQ-CCS-022, NFR-CCS-003, NFR-CCS-005, NFR-CCS-007
+- **Owner:** dev
+- **PR group:** PR-1
+- **Depends on:** T-CCS-014
+- **Estimate:** M
+- **Status:** completed (commit `6cf7184`)
+- **Definition of done:**
+  - [x] T-CCS-014 tests pass.
+  - [x] `startup()` idempotent (early return on `_sdkReady === true`).
+  - [x] `_clampTimeout()` returns value in `[1_000, 300_000]` range (NFR-CCS-003).
+  - [x] `_mapError()` never logs API key value (NFR-CCS-005).
+  - [x] `shutdown()` synchronous; sets `_sdkReady = false`, `_available = false`.
+  - [x] Complexity rule satisfied via 5 private helper methods.
+  - [x] Lint (with `eslint-disable-next-line` for `prefer-active-window-timers`) and type checks green.
+
+---
+
+### T-CCS-011 🔨 — Injection keys and composables
+
+- **Description:** Add `CLAUDE_CLI_PORT` and `IS_MOBILE_KEY` injection keys to `src/infrastructure/bridge/ports.ts`. Create `src/ui/composables/useClaudeCliPort.ts` (strict inject) and `src/ui/composables/usePlatform.ts` (`inject(IS_MOBILE_KEY, false)`).
+- **Satisfies:** REQ-CCS-021, REQ-CCS-020
+- **Owner:** dev
+- **PR group:** PR-1
+- **Depends on:** T-CCS-001
+- **Estimate:** S
+- **Status:** completed (commit `8ff9b13`)
+- **Definition of done:**
+  - [x] `CLAUDE_CLI_PORT: InjectionKey<ClaudeCliPort>` and `IS_MOBILE_KEY: InjectionKey<boolean>` in `ports.ts`.
+  - [x] `useClaudeCliPort()` throws if `CLAUDE_CLI_PORT` is not provided.
+  - [x] `usePlatform()` returns `{ isMobile: boolean }` defaulting to `false`.
+  - [x] No direct import of `obsidian` in composable files (ADR-008).
+
+---
+
+### T-CCS-012 🧪 — Tests for chatStore state machine
+
+- **Description:** Write unit tests for all `useChatStore()` actions and state transitions, including dedup logic, null handling, and reset behavior. Covers scenarios TEST-CCS-STORE-001 through TEST-CCS-STORE-008.
+- **Satisfies:** REQ-CCS-005, REQ-CCS-006, REQ-CCS-009, REQ-CCS-010, REQ-CCS-011, REQ-CCS-013, REQ-CCS-014, REQ-CCS-016, REQ-CCS-017
+- **Owner:** qa
+- **PR group:** PR-1
+- **Depends on:** T-CCS-011
+- **Estimate:** S
+- **Status:** completed (commit `6a291ff`, `tests/ui/stores/chatStore.test.ts`, 30 tests)
+- **Definition of done:**
+  - [x] 30 tests in `tests/ui/stores/chatStore.test.ts`.
+  - [x] All 8 STORE scenarios (TEST-CCS-STORE-001 through TEST-CCS-STORE-008) covered.
+  - [x] `setError()` does not clear `userText` (REQ-CCS-017) verified.
+  - [x] `setActiveFile(null)` removes auto entry and preserves manual entries (REQ-CCS-006) verified.
+  - [x] All 30 tests pass.
+
+---
+
+### T-CCS-013 🔨 — useChatStore Pinia store
+
+- **Description:** Implement `src/ui/stores/chatStore.ts` with state (`contextFiles`, `userText`, `response`, `status`, `errorType`, `truncated`) and all actions per SPEC-CCS-001 §4.
+- **Satisfies:** REQ-CCS-005, REQ-CCS-006, REQ-CCS-009, REQ-CCS-010, REQ-CCS-011, REQ-CCS-013, REQ-CCS-014, REQ-CCS-016, REQ-CCS-017
+- **Owner:** dev
+- **PR group:** PR-1
+- **Depends on:** T-CCS-012
+- **Estimate:** M
+- **Status:** completed (commit `6a291ff`)
+- **Definition of done:**
+  - [x] T-CCS-012 tests pass.
+  - [x] `addContextFile` dedup guard active.
+  - [x] `setActiveFile(file)` forces `isAuto = true`, inserts at index 0.
+  - [x] `setError()` retains `userText`.
+  - [x] `ChatErrorType` is `'timeout' | 'query_failed'` (not full `ClaudeCliErrorCode`).
+  - [x] Lint and type checks green.
+
+---
+
+### T-CCS-008 🔨 — anthropicApiKey settings field
+
+- **Description:** Add `readonly anthropicApiKey: string` to `PluginSettings` interface with `DEFAULT_SETTINGS` entry `''`. Add `renderAnthropicKeyField()` to `src/plugin/settings.ts` (password input, autocomplete off, data-testid, onChange trims and bumps views). Update `loadSettings-migrate.ts` and `core-settings.ts`.
+- **Satisfies:** REQ-CCS-001, REQ-CCS-002, REQ-CCS-028, NFR-CCS-005, NFR-CCS-006
+- **Owner:** dev
+- **PR group:** PR-1
+- **Depends on:** T-CCS-001
+- **Estimate:** S
+- **Status:** completed (commit `636f965`)
+- **Definition of done:**
+  - [x] `anthropicApiKey` field in `PluginSettings` and `DEFAULT_SETTINGS`.
+  - [x] Input `type='password'`, `autocomplete='off'`, `data-testid='settings-anthropic-key'`.
+  - [x] `onChange` trims whitespace before persisting (REQ-CCS-002).
+  - [x] Description text includes Obsidian Sync disclosure (REQ-CCS-028).
+  - [x] `PLUGIN_SETTINGS_KEYS` tripwire updated to include new key.
+  - [x] `anthropicApiKey` absent from `settingsSchema.fields` (per D-CCS-002 — rendered outside module loop).
+
+---
+
+### T-CCS-009 🧪 — Tests for settings anthropicApiKey field
+
+- **Description:** Write tests verifying the API key settings field: field presence in rendered settings, `type='password'`, `data-testid`, and `autocomplete='off'`.
+- **Satisfies:** REQ-CCS-001, NFR-CCS-006
+- **Owner:** qa
+- **PR group:** PR-1
+- **Depends on:** T-CCS-008
+- **Estimate:** S
+- **Status:** completed (commit `636f965`, `tests/plugin/settings.test.ts`, 4 tests)
+- **Definition of done:**
+  - [x] 4 tests in `tests/plugin/settings.test.ts`.
+  - [x] Covers TEST-CCS-INT-007 (password type and autocomplete off).
+  - [x] All 4 tests pass.
+
+---
+
+### T-CCS-010 🧪 — Tests for settings key trimming
+
+- **Description:** Verify that `onChange` stores `'sk-ant-abc'` when the user types `'  sk-ant-abc  '`. Covers TEST-CCS-INT-008.
+- **Satisfies:** REQ-CCS-002
+- **Owner:** qa
+- **PR group:** PR-1
+- **Depends on:** T-CCS-008
+- **Estimate:** S
+- **Status:** completed (commit `636f965`, covered in `tests/plugin/settings.test.ts`)
+- **Definition of done:**
+  - [x] Trimming behaviour verified in test (TEST-CCS-INT-008).
+  - [x] Test passes.
+
+---
+
+### T-CCS-016 🚀 — PR-1 pre-PR gate
+
+- **Description:** Run full pre-PR verification gate on the PR-1 branch: typecheck, lint, test, build, standalone build, audit.
+- **Satisfies:** SPEC-CCS-001 (release criteria)
+- **Owner:** dev
+- **PR group:** PR-1
+- **Depends on:** T-CCS-002, T-CCS-006, T-CCS-007, T-CCS-009, T-CCS-010, T-CCS-013, T-CCS-015
+- **Estimate:** S
+- **Status:** completed (2026-05-14)
+- **Definition of done:**
+  - [x] `npm run typecheck` — pass.
+  - [x] `npm run lint` — 0 errors.
+  - [x] `npm run test` — 713 tests pass (64 files).
+  - [x] `npm run build` — pass (497 modules).
+  - [x] `npm run build:web` — pass (123 modules).
+  - [x] `npm audit --audit-level=high --omit=dev` — 0 vulnerabilities.
+
+---
+
+## PR-2 — UI Components
+
+### T-CCS-017 📐 — i18n strings for chat sidebar
+
+- **Description:** Add all chat sidebar user-visible strings to the i18n translation file. Strings must contain no AI/SDK terminology (NFR-CCS-012): no "token", "context window", "system prompt", "Claude CLI", "SDK", or "subprocess".
+- **Satisfies:** REQ-CCS-012, REQ-CCS-016, REQ-CCS-018, REQ-CCS-019, REQ-CCS-020, NFR-CCS-012
+- **Owner:** dev
+- **PR group:** PR-2
+- **Depends on:** T-CCS-001
+- **Estimate:** S
+- **Status:** completed
+- **Definition of done:**
+  - [x] Error code → display copy mapping implemented per SPEC-CCS-001 §2.1 table.
+  - [x] All four error codes have human-readable copy (REQ-CCS-016, REQ-CCS-018, REQ-CCS-019).
+  - [x] No forbidden AI/SDK terms in any user-visible string (NFR-CCS-012).
+
+---
+
+### T-CCS-018 🔨 — ContextFileChip component
+
+- **Description:** Implement `src/ui/components/chat/ContextFileChip.vue` with auto and manual variants per SPEC-CCS-001 §7.6. Auto variant: no remove button, `(auto)` suffix, `aria-hidden` indicator. Manual variant: remove button with `aria-label="Remove <filename> from context"`.
+- **Satisfies:** REQ-CCS-005, REQ-CCS-009, REQ-CCS-011, REQ-CCS-014, NFR-CCS-010
+- **Owner:** dev
+- **PR group:** PR-2
+- **Depends on:** T-CCS-013, T-CCS-017
+- **Estimate:** S
+- **Status:** completed
+- **Definition of done:**
+  - [x] `data-testid="context-chip-auto"` on auto variant.
+  - [x] `data-testid="context-chip-manual"` on manual variant.
+  - [x] `data-testid="context-chip-remove"` on remove button.
+  - [x] Remove button fires `emit('remove')` on click, Enter, and Space.
+  - [x] Remove button not rendered when `disabled` prop is `true` (REQ-CCS-014).
+  - [x] `aria-label="Remove ${file.label} from context"` present (NFR-CCS-010).
+
+---
+
+### T-CCS-019 🔨 — ContextFileList component
+
+- **Description:** Implement `src/ui/components/chat/ContextFileList.vue` per SPEC-CCS-001 §7.5: `<section aria-label>`, `<ul role="list">`, empty-state hint when `files.length === 0`, `remove` event forwarding.
+- **Satisfies:** REQ-CCS-005, REQ-CCS-006, REQ-CCS-009, REQ-CCS-010, REQ-CCS-011, REQ-CCS-014
+- **Owner:** dev
+- **PR group:** PR-2
+- **Depends on:** T-CCS-018
+- **Estimate:** S
+- **Status:** completed
+- **Definition of done:**
+  - [x] `data-testid="context-file-list"` on `<section>`.
+  - [x] `data-testid="context-file-empty"` on empty-state element.
+  - [x] `<ul role="list">` keyed by `file.path`.
+  - [x] `remove` event forwarded to parent.
+  - [x] Lint and type checks green.
+
+---
+
+### T-CCS-020 🔨 — ChatInput component
+
+- **Description:** Implement `src/ui/components/chat/ChatInput.vue` per SPEC-CCS-001 §7.3: textarea with ARIA attributes, send button, Ctrl+Enter / Cmd+Enter shortcut, `textareaEl` exposed ref.
+- **Satisfies:** REQ-CCS-013, REQ-CCS-014, REQ-CCS-015, NFR-CCS-010
+- **Owner:** dev
+- **PR group:** PR-2
+- **Depends on:** T-CCS-017
+- **Estimate:** S
+- **Status:** completed
+- **Definition of done:**
+  - [x] `data-testid="chat-input-textarea"` on `<textarea>`.
+  - [x] `data-testid="chat-send-button"` on `<button>`.
+  - [x] `aria-label="Message"` and `aria-multiline="true"` on textarea.
+  - [x] `aria-label="Send message"` on button.
+  - [x] `textareaEl` ref exposed via `defineExpose`.
+  - [x] Ctrl+Enter / Cmd+Enter fires `emit('send')` when not disabled.
+  - [x] Button has native `disabled` attribute when `disabled` or `loading` prop is `true`.
+
+---
+
+### T-CCS-021 🔨 — ChatResponse component
+
+- **Description:** Implement `src/ui/components/chat/ChatResponse.vue` per SPEC-CCS-001 §7.4: six mutually exclusive render states (`idle`, `loading`, `success`, `trimmed-success`, `timeout`, `error`) with correct ARIA live-region roles.
+- **Satisfies:** REQ-CCS-012, REQ-CCS-013, REQ-CCS-014, REQ-CCS-016
+- **Owner:** dev
+- **PR group:** PR-2
+- **Depends on:** T-CCS-017
+- **Estimate:** S
+- **Status:** completed
+- **Definition of done:**
+  - [x] `data-testid="chat-response-idle"` on idle state element.
+  - [x] `data-testid="chat-response-loading"` with `role="status"` and `aria-live="polite"`.
+  - [x] `data-testid="chat-response-trim-notice"` with `role="status"` and `aria-live="polite"`.
+  - [x] `data-testid="chat-response-text"` used in success and trimmed-success states.
+  - [x] `data-testid="chat-response-error"` with `role="alert"` and `aria-live="assertive"`.
+  - [x] Timeout error copy: "That took too long. Please try again." (REQ-CCS-016).
+  - [x] Generic error copy: "Something went wrong. Please try again." (REQ-CCS-016).
+
+---
+
+### T-CCS-022 🧪 — ChatSidebar PageObject
+
+- **Description:** Create `tests/ui/components/chat/ChatSidebar.po.ts` class-based PageObject querying exclusively by `data-testid` attributes per ADR-009 testing conventions.
+- **Satisfies:** SPEC-CCS-001 §15.4
+- **Owner:** qa
+- **PR group:** PR-2
+- **Depends on:** T-CCS-018, T-CCS-019, T-CCS-020, T-CCS-021
+- **Estimate:** S
+- **Status:** completed
+- **Definition of done:**
+  - [x] PageObject file `tests/ui/components/chat/ChatSidebar.po.ts` exists.
+  - [x] All element accessors use `data-testid` selectors exclusively (no `.class` or `#id` selectors).
+  - [x] PageObject covers: sidebar root, textarea, send button, loading indicator, response areas, degraded headings, settings link.
+
+---
+
+### T-CCS-023 🧪 — ChatSidebar component tests
+
+- **Description:** Write component tests for `ChatSidebar` using the PageObject, covering all scenarios in SPEC-CCS-001 §15.4: available ready state, send success, send loading, empty-text guard, timeout error, userText retention on error, API-key-missing degraded, SDK-unavailable degraded, mobile degraded, and trim notice.
+- **Satisfies:** REQ-CCS-005, REQ-CCS-012, REQ-CCS-013, REQ-CCS-014, REQ-CCS-015, REQ-CCS-016, REQ-CCS-017, REQ-CCS-018, REQ-CCS-019, REQ-CCS-020
+- **Owner:** qa
+- **PR group:** PR-2
+- **Depends on:** T-CCS-022, T-CCS-013, T-CCS-007
+- **Estimate:** M
+- **Status:** completed (`tests/ui/components/chat/ChatSidebar.test.ts`)
+- **Definition of done:**
+  - [x] All scenarios TEST-CCS-004, TEST-CCS-012 through TEST-CCS-020 covered.
+  - [x] Tests use `MockClaudeCliPort` (not the real adapter).
+  - [x] Tests use PageObject exclusively for element access.
+  - [x] All tests pass.
+
+---
+
+### T-CCS-024 🔨 — ChatSidebar orchestrator component
+
+- **Description:** Implement `src/ui/components/chat/ChatSidebar.vue` per SPEC-CCS-001 §7.2: availability check, five-branch template, `handleSend()` with three guards, `responseState` computed, `settingsVersion` watcher, active-file subscription, focus management.
+- **Satisfies:** REQ-CCS-005, REQ-CCS-006, REQ-CCS-012, REQ-CCS-013, REQ-CCS-014, REQ-CCS-015, REQ-CCS-016, REQ-CCS-017, REQ-CCS-018, REQ-CCS-019, REQ-CCS-020, REQ-CCS-024, NFR-CCS-009
+- **Owner:** dev
+- **PR group:** PR-2
+- **Depends on:** T-CCS-023, T-CCS-019, T-CCS-020, T-CCS-021
+- **Estimate:** M
+- **Status:** completed
+- **Definition of done:**
+  - [x] T-CCS-023 tests pass.
+  - [x] Template branching: mobile → blank → no-key → SDK-unavailable → ready (top-to-bottom priority).
+  - [x] `handleSend()` guards: empty text, loading state, unavailable.
+  - [x] `data-testid="chat-sidebar"`, `data-testid="chat-degraded-heading"`, `data-testid="chat-degraded-settings-link"` present.
+  - [x] `settingsVersion` watcher re-calls `isAvailable()` (REQ-CCS-024).
+  - [x] Degraded heading receives focus on mount when not available (NFR-CCS-009).
+  - [x] Lint and type checks green.
+
+---
+
+### T-CCS-025 🔨 — ChatSidebarView route component
+
+- **Description:** Implement `src/ui/views/ChatSidebarView.vue` as a thin shell (no props, no emits, no state) that renders `<ChatSidebar />`. Register route `/chat` in the Vue Router configuration.
+- **Satisfies:** REQ-CCS-007, REQ-CCS-008
+- **Owner:** dev
+- **PR group:** PR-2
+- **Depends on:** T-CCS-024
+- **Estimate:** S
+- **Status:** completed
+- **Definition of done:**
+  - [x] `ChatSidebarView.vue` contains only `<ChatSidebar />` and required imports.
+  - [x] Route `/chat` registered in router.
+  - [x] Navigation from other routes to `/chat` works.
+
+---
+
+### T-CCS-026 🔨 — Chat nav tab in top navigation
+
+- **Description:** Add a chat nav tab to the plugin's top navigation bar that performs a router push to `/chat` when clicked.
+- **Satisfies:** REQ-CCS-007
+- **Owner:** dev
+- **PR group:** PR-2
+- **Depends on:** T-CCS-025
+- **Estimate:** S
+- **Status:** completed
+- **Definition of done:**
+  - [x] Chat tab visible in navigation bar.
+  - [x] Click navigates to `/chat`.
+  - [x] Tab is always present regardless of availability state.
+
+---
+
+### T-CCS-027 🔨 — CSS for chat sidebar components
+
+- **Description:** Write CSS styles for all chat sidebar components (`ChatSidebar`, `ChatInput`, `ChatResponse`, `ContextFileList`, `ContextFileChip`) consistent with Obsidian design tokens.
+- **Satisfies:** SPEC-CCS-001 §7
+- **Owner:** dev
+- **PR group:** PR-2
+- **Depends on:** T-CCS-024
+- **Estimate:** S
+- **Status:** completed
+- **Definition of done:**
+  - [x] Components render without layout breakage in both Obsidian dark and light themes.
+  - [x] Context chips are visually distinct (auto vs manual variants).
+  - [x] Lint and build green.
+
+---
+
+### T-CCS-028 🚀 — PR-2 pre-PR gate
+
+- **Description:** Run full pre-PR verification gate on the PR-2 branch.
+- **Satisfies:** SPEC-CCS-001 (release criteria)
+- **Owner:** dev
+- **PR group:** PR-2
+- **Depends on:** T-CCS-024, T-CCS-025, T-CCS-026, T-CCS-027
+- **Estimate:** S
+- **Status:** completed
+- **Definition of done:**
+  - [x] `npm run typecheck` — pass.
+  - [x] `npm run lint` — 0 errors.
+  - [x] `npm run test` — all tests pass.
+  - [x] `npm run build` — pass.
+  - [x] `npm run build:web` — pass.
+
+---
+
+## PR-3 — Plugin Integration
+
+### T-CCS-029 🔨 — Bridge stubs for full ClaudeCliPort interface
+
+- **Description:** Add `ClaudeCliPort` method stubs (`query`, `startup`, `shutdown`) to `MockBridge`, `LocalStorageBridge`, and `ObsidianBridge`. `ObsidianBridge.query()` returns `ClaudeCliError{NOT_INSTALLED}` since the real query path goes through `ClaudeCliAdapter` via `CLAUDE_CLI_PORT`.
+- **Satisfies:** REQ-CCS-021, REQ-CCS-022
+- **Owner:** dev
+- **PR group:** PR-3
+- **Depends on:** T-CCS-001
+- **Estimate:** S
+- **Status:** completed (commit `337193c`)
+- **Definition of done:**
+  - [x] All three bridge implementations compile with the updated `ClaudeCliPort` interface.
+  - [x] `MockBridge.query()`, `startup()`, `shutdown()` are no-ops.
+  - [x] `ObsidianBridge.query()` returns `err(ClaudeCliError('NOT_INSTALLED', ...))`.
+  - [x] Typecheck passes.
+
+---
+
+### T-CCS-030 🔨 — SETTINGS_VERSION_KEY injection key
+
+- **Description:** Add `SETTINGS_VERSION_KEY: InjectionKey<Ref<number>>` to `src/infrastructure/bridge/ports.ts`. Remove the local `Symbol` declaration from `ChatSidebar.vue` and import the canonical key instead.
+- **Satisfies:** REQ-CCS-024
+- **Owner:** dev
+- **PR group:** PR-3
+- **Depends on:** T-CCS-011, T-CCS-024
+- **Estimate:** S
+- **Status:** completed (commit `474c112`)
+- **Definition of done:**
+  - [x] `SETTINGS_VERSION_KEY` exported from `src/infrastructure/bridge/ports.ts`.
+  - [x] `ChatSidebar.vue` imports `SETTINGS_VERSION_KEY` from `ports.ts` (no local Symbol).
+  - [x] Typecheck and lint green.
+
+---
+
+### T-CCS-031 🔨 — File-menu "Add to chat context" registration
+
+- **Description:** Register `workspace.on('file-menu')` event in `main.ts` that adds an "Add to chat context" item; on click, activates the view and calls `useChatStore(_specoratorView.pinia).addContextFile(...)`.
+- **Satisfies:** REQ-CCS-009, REQ-CCS-010
+- **Owner:** dev
+- **PR group:** PR-3
+- **Depends on:** T-CCS-013, T-CCS-035
+- **Estimate:** S
+- **Status:** completed (commit `93ffc9b`)
+- **Definition of done:**
+  - [x] File-menu item "Add to chat context" with icon `message-square-plus` registered.
+  - [x] `addContextFile({ path, label, isAuto: false })` called with correct values.
+  - [x] Guard `if (_specoratorView?.pinia)` prevents crash when view is null.
+  - [x] Duplicate guard in `addContextFile` remains active (REQ-CCS-010).
+
+---
+
+### T-CCS-032 🔨 — ClaudeCliAdapter wiring in onload/onLayoutReady
+
+- **Description:** In `main.ts`: instantiate `ClaudeCliAdapter`, register `shutdown()` via `this.register()`, pass adapter to `SpecoratorView` constructor. In `onLayoutReady`, call `_claudeCliAdapter.startup()`.
+- **Satisfies:** REQ-CCS-002, REQ-CCS-003, REQ-CCS-004
+- **Owner:** dev
+- **PR group:** PR-3
+- **Depends on:** T-CCS-015, T-CCS-035
+- **Estimate:** S
+- **Status:** completed (commit `93ffc9b`)
+- **Definition of done:**
+  - [x] `ClaudeCliAdapter` instantiated in `onload()` before `registerView()`.
+  - [x] `this.register(() => { _claudeCliAdapter.shutdown() })` prevents memory leaks on unload (REQ-CCS-004).
+  - [x] `startup()` called inside `workspace.onLayoutReady()` callback, not in `onload()` body (NFR-CCS-002).
+
+---
+
+### T-CCS-033 🔨 — URI handler for open-chat action
+
+- **Description:** Register `obsidian://specorator?action=open-chat` URI handler in `main.ts` that calls `activateView()` then `_specoratorView?.navigateTo('/chat')`. Other unrecognised actions show a `showWarning` notification.
+- **Satisfies:** REQ-CCS-008
+- **Owner:** dev
+- **PR group:** PR-3
+- **Depends on:** T-CCS-035
+- **Estimate:** S
+- **Status:** completed (commit `93ffc9b`)
+- **Definition of done:**
+  - [x] `action=open-chat` and `action=focus-chat` both call `activateView()` and `navigateTo('/chat')`.
+  - [x] `action=send-message` and `action=open-workflow` show "not yet implemented" info notice.
+  - [x] Unknown actions show a warning notification.
+  - [x] No exception thrown for any action value.
+
+---
+
+### T-CCS-034 🔨 — Active-file tracking via active-leaf-change
+
+- **Description:** Register `workspace.on('active-leaf-change')` in `main.ts` that calls `store.setActiveFile({ path, label, isAuto: true })` when a file is active, or `store.setActiveFile(null)` when no file is open.
+- **Satisfies:** REQ-CCS-005, REQ-CCS-006
+- **Owner:** dev
+- **PR group:** PR-3
+- **Depends on:** T-CCS-013, T-CCS-035
+- **Estimate:** S
+- **Status:** completed (commit `93ffc9b`)
+- **Definition of done:**
+  - [x] `active-leaf-change` event handler registered via `this.registerEvent()`.
+  - [x] `setActiveFile()` called with correct `isAuto: true` entry.
+  - [x] `setActiveFile(null)` called when `getActiveFile()` returns null.
+  - [x] Guard `if (_specoratorView?.pinia)` prevents crash when view is null.
+
+---
+
+### T-CCS-035 🔨 — SpecoratorView public API and port provision
+
+- **Description:** Rewrite `src/plugin/SpecoratorView.ts` to accept `claudeCliPort: ClaudeCliPort` as third constructor argument; provide `CLAUDE_CLI_PORT`, `IS_MOBILE_KEY`, `SETTINGS_VERSION_KEY` to the Vue app; expose `pinia`, `navigateTo()`, and `bumpSettingsVersion()` as public members.
+- **Satisfies:** REQ-CCS-024, REQ-CCS-020, SPEC-CCS-001 §9.3
+- **Owner:** dev
+- **PR group:** PR-3
+- **Depends on:** T-CCS-011, T-CCS-030
+- **Estimate:** M
+- **Status:** completed (commit `d8eba99`)
+- **Definition of done:**
+  - [x] Constructor third parameter: `claudeCliPort: ClaudeCliPort`.
+  - [x] `public pinia!: Pinia` set in `onOpen()`.
+  - [x] `private readonly _settingsVersion = ref(0)` reactive counter.
+  - [x] All nine injection keys provided per SPEC-CCS-001 §9.3 table.
+  - [x] `navigateTo(path)` pushes to the stored router instance.
+  - [x] `bumpSettingsVersion()` increments `_settingsVersion.value`.
+  - [x] Lint and type checks green.
+
+---
+
+### T-CCS-036 🔨 — Settings tab API key → bumpSettingsVersion wiring
+
+- **Description:** In `src/plugin/settings.ts`, add `_bumpAllViews()` private method that iterates open `SpecoratorView` leaves and duck-calls `bumpSettingsVersion()`. Wire it into `renderAnthropicKeyField()` `onChange`.
+- **Satisfies:** REQ-CCS-024, REQ-CCS-002
+- **Owner:** dev
+- **PR group:** PR-3
+- **Depends on:** T-CCS-035, T-CCS-008
+- **Estimate:** S
+- **Status:** completed (commit `0d780eb`)
+- **Definition of done:**
+  - [x] `_bumpAllViews()` calls `bumpSettingsVersion()` on every open `SpecoratorView` leaf.
+  - [x] Duck-typing cast avoids circular import between `settings.ts` and `SpecoratorView.ts`.
+  - [x] `onChange` calls `_bumpAllViews()` after saving the trimmed API key.
+  - [x] Covers TEST-CCS-INT-006 (settings change re-checks availability).
+
+---
+
+### T-CCS-037 🔨 — Promote SETTINGS_VERSION_KEY and complete settings version bridge
+
+- **Description:** Combined two-step change: (step 1) promote `SETTINGS_VERSION_KEY` from local ChatSidebar Symbol to `ports.ts`; (step 2) complete the `settings.ts → SpecoratorView → ChatSidebar` reactivity bridge. Tracked as single logical change across commits `474c112` + `0d780eb`.
+- **Satisfies:** REQ-CCS-024, SPEC-CCS-001 §10
+- **Owner:** dev
+- **PR group:** PR-3
+- **Depends on:** T-CCS-030, T-CCS-036
+- **Estimate:** S
+- **Status:** completed (commits `474c112`, `0d780eb`)
+- **Definition of done:**
+  - [x] `SETTINGS_VERSION_KEY` canonical in `ports.ts` (T-CCS-030).
+  - [x] `_bumpAllViews()` triggers `settingsVersion` watcher in `ChatSidebar` (T-CCS-036).
+  - [x] End-to-end flow: key saved in settings → `bumpSettingsVersion()` → `isAvailable()` re-checked → panel re-renders.
+
+---
+
+### T-CCS-038 🧪 — Plugin chat handler unit tests
+
+- **Description:** Write unit tests for the file-menu and active-leaf-change callback logic: `addContextFile` with correct args, dedup guard, `isAuto: false`, `setActiveFile` with index 0, `setActiveFile(null)` on no file, replace existing auto entry, and preserve manual entries.
+- **Satisfies:** REQ-CCS-005, REQ-CCS-006, REQ-CCS-009, REQ-CCS-010
+- **Owner:** qa
+- **PR group:** PR-3
+- **Depends on:** T-CCS-031, T-CCS-034
+- **Estimate:** S
+- **Status:** completed (commit `8e111a8`, `tests/plugin/main.chat-handlers.test.ts`, 9 tests)
+- **Definition of done:**
+  - [x] 9 tests in `tests/plugin/main.chat-handlers.test.ts`.
+  - [x] File-menu scenarios: `addContextFile` called, dedup no-op, `isAuto: false`.
+  - [x] Active-leaf scenarios: `setActiveFile` on new file, null on no file, replace auto, preserve manuals.
+  - [x] All 9 tests pass.
+
+---
+
+### T-CCS-039 🚀 — PR-3 pre-PR gate
+
+- **Description:** Run full pre-PR verification gate on the PR-3 branch (post-merge with PR-2).
+- **Satisfies:** SPEC-CCS-001 (release criteria)
+- **Owner:** dev
+- **PR group:** PR-3
+- **Depends on:** T-CCS-029, T-CCS-030, T-CCS-031, T-CCS-032, T-CCS-033, T-CCS-034, T-CCS-035, T-CCS-036, T-CCS-037, T-CCS-038
+- **Estimate:** S
+- **Status:** completed (2026-05-14)
+- **Definition of done:**
+  - [x] `npm run typecheck` — pass.
+  - [x] `npm run lint` — 0 errors (9 pre-existing warnings).
+  - [x] `npm run test` — 805 tests pass (71 files).
+  - [x] `npm run build` — pass (538 modules).
+  - [x] `npm run build:web` — pass (162 modules).
+
+---
+
+## Dependency graph
+
+```mermaid
+graph TD
+  subgraph PR1["PR-1 — Infrastructure"]
+    T001[T-CCS-001 ClaudeCliPort interface]
+    T002[T-CCS-002 ClaudeCliError tests]
+    T003[T-CCS-003 SDK install]
+    T004[T-CCS-004 buildPrompt tests]
+    T005[T-CCS-005 MockClaudeCliPort]
+    T006[T-CCS-006 MockClaudeCliPort tests]
+    T007[T-CCS-007 buildPrompt impl]
+    T008[T-CCS-008 anthropicApiKey field]
+    T009[T-CCS-009 settings field tests]
+    T010[T-CCS-010 key trimming tests]
+    T011[T-CCS-011 injection keys]
+    T012[T-CCS-012 chatStore tests]
+    T013[T-CCS-013 chatStore impl]
+    T014[T-CCS-014 ClaudeCliAdapter tests]
+    T015[T-CCS-015 ClaudeCliAdapter impl]
+    T016[T-CCS-016 PR-1 gate]
+
+    T001 --> T002
+    T001 --> T003
+    T001 --> T004
+    T004 --> T007
+    T001 --> T005
+    T005 --> T006
+    T001 --> T008
+    T008 --> T009
+    T008 --> T010
+    T001 --> T011
+    T011 --> T012
+    T012 --> T013
+    T001 --> T014
+    T014 --> T015
+    T002 --> T016
+    T006 --> T016
+    T007 --> T016
+    T009 --> T016
+    T010 --> T016
+    T013 --> T016
+    T015 --> T016
+  end
+
+  subgraph PR2["PR-2 — UI Components"]
+    T017[T-CCS-017 i18n strings]
+    T018[T-CCS-018 ContextFileChip]
+    T019[T-CCS-019 ContextFileList]
+    T020[T-CCS-020 ChatInput]
+    T021[T-CCS-021 ChatResponse]
+    T022[T-CCS-022 ChatSidebar PageObject]
+    T023[T-CCS-023 ChatSidebar tests]
+    T024[T-CCS-024 ChatSidebar impl]
+    T025[T-CCS-025 ChatSidebarView]
+    T026[T-CCS-026 chat nav tab]
+    T027[T-CCS-027 CSS]
+    T028[T-CCS-028 PR-2 gate]
+
+    T013 --> T017
+    T017 --> T018
+    T018 --> T019
+    T017 --> T020
+    T017 --> T021
+    T018 --> T022
+    T019 --> T022
+    T020 --> T022
+    T021 --> T022
+    T022 --> T023
+    T013 --> T023
+    T007 --> T023
+    T023 --> T024
+    T019 --> T024
+    T020 --> T024
+    T021 --> T024
+    T024 --> T025
+    T025 --> T026
+    T024 --> T027
+    T024 --> T028
+    T025 --> T028
+    T026 --> T028
+    T027 --> T028
+  end
+
+  subgraph PR3["PR-3 — Plugin Integration"]
+    T029[T-CCS-029 bridge stubs]
+    T030[T-CCS-030 SETTINGS_VERSION_KEY]
+    T031[T-CCS-031 file-menu handler]
+    T032[T-CCS-032 adapter wiring]
+    T033[T-CCS-033 URI handler]
+    T034[T-CCS-034 active-leaf handler]
+    T035[T-CCS-035 SpecoratorView public API]
+    T036[T-CCS-036 settings bumpSettingsVersion]
+    T037[T-CCS-037 settings version bridge]
+    T038[T-CCS-038 plugin handler tests]
+    T039[T-CCS-039 PR-3 gate]
+
+    T001 --> T029
+    T011 --> T030
+    T024 --> T030
+    T013 --> T031
+    T035 --> T031
+    T015 --> T032
+    T035 --> T032
+    T035 --> T033
+    T013 --> T034
+    T035 --> T034
+    T011 --> T035
+    T030 --> T035
+    T035 --> T036
+    T008 --> T036
+    T030 --> T037
+    T036 --> T037
+    T031 --> T038
+    T034 --> T038
+    T029 --> T039
+    T030 --> T039
+    T031 --> T039
+    T032 --> T039
+    T033 --> T039
+    T034 --> T039
+    T035 --> T039
+    T036 --> T039
+    T037 --> T039
+    T038 --> T039
+  end
+
+  T016 --> T017
+  T028 --> T029
+```
+
+## Parallelisable batches
+
+Batches show tasks with no intra-batch dependencies (within each PR group):
+
+**PR-1 Batch A (parallelisable once T-CCS-001 is done):**
+- T-CCS-002 (ClaudeCliError tests)
+- T-CCS-003 (SDK install)
+- T-CCS-004 (buildPrompt tests — prerequisite for T-CCS-007)
+- T-CCS-005 (MockClaudeCliPort — prerequisite for T-CCS-006)
+- T-CCS-008 (settings field — prerequisite for T-CCS-009, T-CCS-010)
+- T-CCS-011 (injection keys — prerequisite for T-CCS-012)
+- T-CCS-014 (adapter tests — prerequisite for T-CCS-015)
+
+**PR-2 Batch A (parallelisable once T-CCS-017 is done):**
+- T-CCS-018 (ContextFileChip)
+- T-CCS-020 (ChatInput)
+- T-CCS-021 (ChatResponse)
+
+**PR-2 Batch B (after T-CCS-018):**
+- T-CCS-019 (ContextFileList)
+
+**PR-3 Batch A (parallelisable once PR-2 gate passes):**
+- T-CCS-029 (bridge stubs)
+- T-CCS-030 (SETTINGS_VERSION_KEY)
+
+**PR-3 Batch B (once T-CCS-035 is done):**
+- T-CCS-031 (file-menu handler)
+- T-CCS-032 (adapter wiring)
+- T-CCS-033 (URI handler)
+- T-CCS-034 (active-leaf handler)
+
+---
+
+## Quality gate
+
+- [x] Each task has estimate S or M (no L).
+- [x] Each task has a stable T-CCS-NNN ID.
+- [x] Each task references at least one requirement or spec ID.
+- [x] Dependencies explicit for all tasks.
+- [x] Each task has a Definition of Done.
+- [x] TDD ordering: test tasks (T-CCS-002, T-CCS-004, T-CCS-006, T-CCS-009, T-CCS-010, T-CCS-012, T-CCS-014, T-CCS-022, T-CCS-023, T-CCS-038) precede the corresponding implementation tasks.
+- [x] Owner assigned per task (dev for implementation, qa for test tasks, dev for gate tasks).
+- [x] All 28 functional requirements (REQ-CCS-001 through REQ-CCS-028) covered by at least one task.
+- [x] All 12 NFRs (NFR-CCS-001 through NFR-CCS-012) covered by at least one task.

--- a/specs/claude-cli-chat-sidebar/workflow-state.md
+++ b/specs/claude-cli-chat-sidebar/workflow-state.md
@@ -5,14 +5,15 @@ area: CCS
 slug: claude-cli-chat-sidebar
 current_stage: implementation
 status: active
-last_updated: 2026-05-14last_agent: pm
+last_updated: 2026-05-14
+last_agent: architect
 createdAt: 2026-05-05T00:00:00+02:00
 updatedAt: 2026-05-14T00:00:00+02:00
 artifacts:
   idea: complete
   research: complete
   requirements: complete
-  design: pending
+  design: complete
   spec: pending
   tasks: pending
   implementation-log: complete
@@ -30,7 +31,7 @@ artifacts:
 | 1 — Idea | complete | `idea.md` | |
 | 2 — Research | complete | `research.md` | |
 | 3 — Requirements | complete | `requirements.md` | |
-| 4 — Design | pending | — | |
+| 4 — Design | complete | `design.md` | Part A (UX), Part B (UI), Part C (Architecture) all complete |
 | 5 — Specification | pending | — | |
 | 6 — Tasks | pending | — | |
 | 7 — Implementation | in-progress | `implementation-log.md` (PR-1, PR-2, PR-3 done) | Pending QA/Review |
@@ -50,6 +51,7 @@ None — PR-1, PR-2, PR-3 all complete. Pending qa/reviewer sign-off.
 | 2026-05-05 | pm | — | Spec entry created to satisfy Phase 4 spec-first gate; idea authored based on #161 |
 | 2026-05-14 | dev | dev (next PR) | PR-1 Infrastructure complete (T-CCS-001–T-CCS-015, T-CCS-016 gate passed). 7 commits on worktree-agent-a61e399c3169d813a. implementation-log.md in-progress (PR-2 sidebar UI and PR-3 MCP wiring remain). |
 | 2026-05-14 | dev | qa | PR-2 Chat UI complete (T-CCS-017–T-CCS-030). PR-3 Plugin Integration complete (T-CCS-031–T-CCS-038). Draft PR open on worktree-agent-af701347fff881022. All gates green: 805 tests pass, typecheck pass, lint 0 errors, build pass. |
+| 2026-05-14 | architect | planner | design.md complete (Parts A+B+C). ADR-0027 and ADR-0028 filed. All 28 functional REQs and all 12 NFRs covered in requirements-coverage tables. Open clarifications: none. Next stage is spec.md (planner assigns dev). |
 
 ## Open clarifications
 

--- a/specs/claude-cli-chat-sidebar/workflow-state.md
+++ b/specs/claude-cli-chat-sidebar/workflow-state.md
@@ -6,7 +6,7 @@ slug: claude-cli-chat-sidebar
 current_stage: implementation
 status: active
 last_updated: 2026-05-14
-last_agent: architect
+last_agent: planner
 createdAt: 2026-05-05T00:00:00+02:00
 updatedAt: 2026-05-14T00:00:00+02:00
 artifacts:
@@ -15,7 +15,7 @@ artifacts:
   requirements: complete
   design: complete
   spec: complete
-  tasks: pending
+  tasks: complete
   implementation-log: complete
   test-plan: pending
   test-report: pending
@@ -33,7 +33,7 @@ artifacts:
 | 3 — Requirements | complete | `requirements.md` | |
 | 4 — Design | complete | `design.md` | Part A (UX), Part B (UI), Part C (Architecture) all complete |
 | 5 — Specification | complete | `spec.md` | Implementation-ready contract derived from develop source |
-| 6 — Tasks | pending | — | |
+| 6 — Tasks | complete | `tasks.md` | 39 tasks reconstructed across PR-1/PR-2/PR-3 |
 | 7 — Implementation | in-progress | `implementation-log.md` (PR-1, PR-2, PR-3 done) | Pending QA/Review |
 | 8 — Testing | pending | — | |
 | 9 — Review | pending | — | |
@@ -53,6 +53,7 @@ None — PR-1, PR-2, PR-3 all complete. Pending qa/reviewer sign-off.
 | 2026-05-14 | dev | qa | PR-2 Chat UI complete (T-CCS-017–T-CCS-030). PR-3 Plugin Integration complete (T-CCS-031–T-CCS-038). Draft PR open on worktree-agent-af701347fff881022. All gates green: 805 tests pass, typecheck pass, lint 0 errors, build pass. |
 | 2026-05-14 | architect | planner | design.md complete (Parts A+B+C). ADR-0027 and ADR-0028 filed. All 28 functional REQs and all 12 NFRs covered in requirements-coverage tables. Open clarifications: none. Next stage is spec.md (planner assigns dev). |
 | 2026-05-14 | architect | planner | spec.md complete. Covers all 28 FRs and 12 NFRs with exact TypeScript interfaces, buildPrompt algorithm, store action contracts, component contracts (props/emits/data-testids), settings extension, plugin wiring pseudocode, and 25+ EARS-mapped test scenarios. No open clarifications. Next stage: tasks (planner) then qa sign-off. |
+| 2026-05-14 | planner | qa | tasks.md complete. 39 tasks across PR-1 (T-CCS-001–T-CCS-016), PR-2 (T-CCS-017–T-CCS-028), PR-3 (T-CCS-031–T-CCS-039) reconstructed from implementation-log.md and spec.md. All 28 FRs and 12 NFRs covered. First ready task for qa review: T-CCS-002 (ClaudeCliError tests) and T-CCS-023 (ChatSidebar component tests). |
 
 ## Open clarifications
 

--- a/specs/claude-cli-chat-sidebar/workflow-state.md
+++ b/specs/claude-cli-chat-sidebar/workflow-state.md
@@ -5,14 +5,13 @@ area: CCS
 slug: claude-cli-chat-sidebar
 current_stage: implementation
 status: active
-last_updated: 2026-05-14
-last_agent: analyst
+last_updated: 2026-05-14last_agent: pm
 createdAt: 2026-05-05T00:00:00+02:00
 updatedAt: 2026-05-14T00:00:00+02:00
 artifacts:
   idea: complete
   research: complete
-  requirements: pending
+  requirements: complete
   design: pending
   spec: pending
   tasks: pending
@@ -30,7 +29,7 @@ artifacts:
 |---|---|---|---|
 | 1 — Idea | complete | `idea.md` | |
 | 2 — Research | complete | `research.md` | |
-| 3 — Requirements | pending | — | |
+| 3 — Requirements | complete | `requirements.md` | |
 | 4 — Design | pending | — | |
 | 5 — Specification | pending | — | |
 | 6 — Tasks | pending | — | |

--- a/specs/claude-cli-chat-sidebar/workflow-state.md
+++ b/specs/claude-cli-chat-sidebar/workflow-state.md
@@ -6,12 +6,12 @@ slug: claude-cli-chat-sidebar
 current_stage: implementation
 status: active
 last_updated: 2026-05-14
-last_agent: dev
+last_agent: analyst
 createdAt: 2026-05-05T00:00:00+02:00
 updatedAt: 2026-05-14T00:00:00+02:00
 artifacts:
   idea: complete
-  research: pending
+  research: complete
   requirements: pending
   design: pending
   spec: pending
@@ -29,7 +29,7 @@ artifacts:
 | Stage | Status | Artifact | Notes |
 |---|---|---|---|
 | 1 — Idea | complete | `idea.md` | |
-| 2 — Research | pending | — | |
+| 2 — Research | complete | `research.md` | |
 | 3 — Requirements | pending | — | |
 | 4 — Design | pending | — | |
 | 5 — Specification | pending | — | |

--- a/specs/claude-cli-chat-sidebar/workflow-state.md
+++ b/specs/claude-cli-chat-sidebar/workflow-state.md
@@ -14,7 +14,7 @@ artifacts:
   research: complete
   requirements: complete
   design: complete
-  spec: pending
+  spec: complete
   tasks: pending
   implementation-log: complete
   test-plan: pending
@@ -32,7 +32,7 @@ artifacts:
 | 2 — Research | complete | `research.md` | |
 | 3 — Requirements | complete | `requirements.md` | |
 | 4 — Design | complete | `design.md` | Part A (UX), Part B (UI), Part C (Architecture) all complete |
-| 5 — Specification | pending | — | |
+| 5 — Specification | complete | `spec.md` | Implementation-ready contract derived from develop source |
 | 6 — Tasks | pending | — | |
 | 7 — Implementation | in-progress | `implementation-log.md` (PR-1, PR-2, PR-3 done) | Pending QA/Review |
 | 8 — Testing | pending | — | |
@@ -52,6 +52,7 @@ None — PR-1, PR-2, PR-3 all complete. Pending qa/reviewer sign-off.
 | 2026-05-14 | dev | dev (next PR) | PR-1 Infrastructure complete (T-CCS-001–T-CCS-015, T-CCS-016 gate passed). 7 commits on worktree-agent-a61e399c3169d813a. implementation-log.md in-progress (PR-2 sidebar UI and PR-3 MCP wiring remain). |
 | 2026-05-14 | dev | qa | PR-2 Chat UI complete (T-CCS-017–T-CCS-030). PR-3 Plugin Integration complete (T-CCS-031–T-CCS-038). Draft PR open on worktree-agent-af701347fff881022. All gates green: 805 tests pass, typecheck pass, lint 0 errors, build pass. |
 | 2026-05-14 | architect | planner | design.md complete (Parts A+B+C). ADR-0027 and ADR-0028 filed. All 28 functional REQs and all 12 NFRs covered in requirements-coverage tables. Open clarifications: none. Next stage is spec.md (planner assigns dev). |
+| 2026-05-14 | architect | planner | spec.md complete. Covers all 28 FRs and 12 NFRs with exact TypeScript interfaces, buildPrompt algorithm, store action contracts, component contracts (props/emits/data-testids), settings extension, plugin wiring pseudocode, and 25+ EARS-mapped test scenarios. No open clarifications. Next stage: tasks (planner) then qa sign-off. |
 
 ## Open clarifications
 


### PR DESCRIPTION
## Summary

Adds all missing spec artifacts for `claude-cli-chat-sidebar` — regenerated from the actual code on `develop` after the implementation PRs were merged.

- `specs/claude-cli-chat-sidebar/research.md` — SDK, context assembly, integration patterns, risks
- `specs/claude-cli-chat-sidebar/requirements.md` — 28 EARS functional requirements + 12 NFRs
- `specs/claude-cli-chat-sidebar/design.md` — UX flows (Part A), component/token/copy inventory (Part B), architecture contracts (Part C)
- `specs/claude-cli-chat-sidebar/spec.md` — implementation-ready interfaces, algorithms, component contracts, 25+ test scenarios
- `specs/claude-cli-chat-sidebar/tasks.md` — 39 retrospective tasks mapped to commits across 3 PRs
- `docs/adr/0027-claude-cli-context-as-single-user-turn.md` — ADR for prompt assembly strategy
- `docs/adr/0028-api-key-field-outside-module-settings-loop.md` — ADR for settings tab rendering

## No code changes
Documentation only. All implementation is already on `develop` via PRs #306, #309, #311, #312.

🤖 Generated with [Claude Code](https://claude.com/claude-code)