### PR TITLE
refactor: introduce IWorkflowStateCodec seam to decouple FeatureRepository from YAML format

### DIFF
--- a/docs/adr/0029-workflow-state-codec-seam.md
+++ b/docs/adr/0029-workflow-state-codec-seam.md
@@ -1,0 +1,107 @@
+---
+id: ADR-0029
+title: Introduce IWorkflowStateCodec to decouple FeatureRepository from YAML format
+status: accepted
+date: 2026-05-14
+deciders:
+  - Engineering
+consulted: []
+informed: []
+supersedes: []
+superseded-by: []
+tags: [infrastructure, testing, persistence]
+---
+
+# ADR-0029 — Introduce `IWorkflowStateCodec` to decouple `FeatureRepository` from YAML format
+
+## Status
+
+Accepted
+
+## Context
+
+`FeatureRepository` currently imports two bare free functions from `WorkflowStateDocument.ts`:
+
+```ts
+import {
+  deserializeWorkflowState,
+  serializeWorkflowState,
+} from '../workflow-state/WorkflowStateDocument';
+```
+
+These are called at four `deserialize` and one `serialize` call sites inside the repository. No interface exists between the repository and its codec. This creates two concrete problems:
+
+**Testability gap.** Repository-level invariants — overwrite protection, retry-safe write ordering, error propagation — can only be tested by wiring a full `MockBridge` and relying on the real YAML codec to round-trip correctly. There is no way to test the repository's coordination logic independently from the parser.
+
+**Implicit schema versioning.** The fallback `data.feature ?? data.title` in `validateWorkflowFrontmatter` is an undocumented v1 migration that has already accreted inside the parser. Without a seam, there is no extension point for a versioned `WorkflowStateCodecV2` or schema validation.
+
+## Decision
+
+We introduce `IWorkflowStateCodec` in `src/infrastructure/workflow-state/`:
+
+```ts
+export interface IWorkflowStateCodec {
+  serialize(feature: Feature): string;
+  deserialize(content: string): Feature | null;
+}
+```
+
+We create `WorkflowStateCodec` (same directory) as the default implementation, delegating to the existing `serializeWorkflowState` / `deserializeWorkflowState` free functions in `WorkflowStateDocument.ts`. The free functions themselves are not modified.
+
+We inject the codec into `FeatureRepository` as an optional constructor parameter (third, after the two-arg `(vault, settingsPort)` form established by ADR-adjacent C3 refactor). When omitted, `FeatureRepository` instantiates `WorkflowStateCodec` as the default. All existing construction call sites are zero-change.
+
+```ts
+constructor(
+  private readonly vault: VaultPort,
+  private readonly settingsPort: SettingsPort,
+  codec?: IWorkflowStateCodec,
+) {
+  this.codec = codec ?? new WorkflowStateCodec();
+}
+```
+
+## Considered options
+
+### Option A — `IWorkflowStateCodec` injected into `FeatureRepository` (chosen)
+- Pros: seam is internal to infrastructure; no domain or application layer change; optional parameter keeps all call sites unchanged; enables stub-codec tests.
+- Cons: adds two new files; slight indirection for the default path.
+
+### Option B — Generic type parameter `IFeatureRepository<TCodec>`
+- Pros: makes the codec dependency explicit at the domain contract level.
+- Cons: leaks a persistence format concern into the domain interface; every use case receiving `IFeatureRepository` must supply the type argument; higher ceremony for no benefit at the consumer boundary.
+
+### Option C — Leave the direct import, accept the testability gap
+- Pros: zero new files.
+- Cons: repository coordination tests remain coupled to YAML parsing; schema migration has no clean extension point.
+
+## Consequences
+
+### Positive
+
+- `FeatureRepository` can be tested in isolation with a stub codec — `save()` err path, `findBySlug()` malformed-file behaviour, and retry-safety invariants become independently verifiable.
+- `WorkflowStateDocument.ts` and its free functions are unchanged. `WorkflowStateDocument.test.ts` continues to pass without modification.
+- A future `WorkflowStateCodecV2` can handle schema migration without modifying `FeatureRepository` or any domain layer.
+- The `createStageFile` idempotency invariant (writes stage file before workflow-state so retries are safe) can now be tested with a trivial stub rather than a full file-system round-trip.
+
+### Negative
+
+- Two new files (`IWorkflowStateCodec.ts`, `WorkflowStateCodec.ts`) in `src/infrastructure/workflow-state/`.
+- Developers must remember to inject a stub or use the default in tests.
+
+### Neutral
+
+- ESLint import rules do not need updating — `WorkflowStateDocument.ts` remains importable from infrastructure; only `FeatureRepository` stops depending on it directly.
+- The optional-parameter default pattern is consistent with how `PluginSettings.DEFAULT_SETTINGS` works: a sensible default exists, override is possible for tests.
+
+## Compliance
+
+- `FeatureRepository.ts` must contain no direct imports of `serializeWorkflowState` or `deserializeWorkflowState` after this ADR is implemented. Enforce via a lint rule targeting the specific import path if violations recur.
+- `tests/infrastructure/bridge/FeatureRepository.test.ts` must exist with at least six stub-codec test cases covering: save err path, serialize call count, deserialize null → null return, deserialize null on extant file → throw, idea.md write retry-safety, codec called once per read.
+
+## References
+
+- ADR-001: DDD Layered Architecture (infrastructure must not leak into domain)
+- ADR-008: Narrow Ports (precedent for interface-per-concern in infrastructure)
+- ADR-009: Test Conventions (mirror layout, fake-ports factory)
+- `src/infrastructure/workflow-state/WorkflowStateDocument.ts` (free functions wrapped by this ADR)
+- `src/infrastructure/bridge/FeatureRepository.ts` (primary beneficiary)

--- a/docs/adr/0033-workflow-state-codec-seam.md
+++ b/docs/adr/0033-workflow-state-codec-seam.md
@@ -1,5 +1,5 @@
 ---
-id: ADR-0029
+id: ADR-0033
 title: Introduce IWorkflowStateCodec to decouple FeatureRepository from YAML format
 status: accepted
 date: 2026-05-14
@@ -12,7 +12,7 @@ superseded-by: []
 tags: [infrastructure, testing, persistence]
 ---
 
-# ADR-0029 — Introduce `IWorkflowStateCodec` to decouple `FeatureRepository` from YAML format
+# ADR-0033 — Introduce `IWorkflowStateCodec` to decouple `FeatureRepository` from YAML format
 
 ## Status
 

--- a/src/infrastructure/bridge/FeatureRepository.ts
+++ b/src/infrastructure/bridge/FeatureRepository.ts
@@ -5,10 +5,8 @@ import { getStepMeta } from '@/domain/feature/FeatureStep';
 import type { IFeatureRepository } from '@/domain/feature/IFeatureRepository';
 import type { VaultPort, SettingsPort } from '@/domain/ports';
 import { joinVaultPath } from '../vault/VaultPath';
-import {
-	deserializeWorkflowState,
-	serializeWorkflowState,
-} from '../workflow-state/WorkflowStateDocument';
+import type { IWorkflowStateCodec } from '../workflow-state/IWorkflowStateCodec';
+import { WorkflowStateCodec } from '../workflow-state/WorkflowStateCodec';
 
 const META_FILE = 'workflow-state.md';
 
@@ -39,10 +37,15 @@ function buildStageStub(
 // ── Repository ────────────────────────────────────────────────────────────────
 
 export class FeatureRepository implements IFeatureRepository {
+	private readonly codec: IWorkflowStateCodec;
+
 	constructor(
 		private readonly vault: VaultPort,
 		private readonly settingsPort: SettingsPort,
-	) {}
+		codec?: IWorkflowStateCodec,
+	) {
+		this.codec = codec ?? new WorkflowStateCodec();
+	}
 
 	private checkedPath(...segments: string[]): string {
 		const path = joinVaultPath(...segments);
@@ -70,7 +73,7 @@ export class FeatureRepository implements IFeatureRepository {
 				const path = this.checkedPath(specsFolder, folder, META_FILE);
 				try {
 					const content = await this.vault.readFile(path);
-					return deserializeWorkflowState(content);
+					return this.codec.deserialize(content);
 				} catch {
 					return null;
 				}
@@ -84,7 +87,7 @@ export class FeatureRepository implements IFeatureRepository {
 		const path = this.metaPath(specsFolder, slug.toString());
 		if (!(await this.vault.fileExists(path))) return null;
 		const content = await this.vault.readFile(path);
-		const feature = deserializeWorkflowState(content);
+		const feature = this.codec.deserialize(content);
 		// File exists but is malformed — throw so callers cannot silently overwrite it.
 		if (feature === null) {
 			throw new Error(`Spec at "${path}" exists but could not be parsed — will not overwrite.`);
@@ -115,7 +118,7 @@ export class FeatureRepository implements IFeatureRepository {
 			await this.vault.createFolder(folder);
 			const path = this.metaPath(specsFolder, feature.slug.toString());
 			const isNew = !(await this.vault.fileExists(path));
-			if (!isNew && deserializeWorkflowState(await this.vault.readFile(path)) === null) {
+			if (!isNew && this.codec.deserialize(await this.vault.readFile(path)) === null) {
 				return err(
 					new Error(`Spec at "${path}" exists but could not be parsed — will not overwrite.`),
 				);
@@ -141,7 +144,7 @@ export class FeatureRepository implements IFeatureRepository {
 					ideaCreated = true;
 				}
 			}
-			await this.vault.writeFile(path, serializeWorkflowState(feature));
+			await this.vault.writeFile(path, this.codec.serialize(feature));
 			return ok({ ideaCreated });
 		} catch (e) {
 			return err(e instanceof Error ? e : new Error(String(e)));

--- a/src/infrastructure/workflow-state/IWorkflowStateCodec.ts
+++ b/src/infrastructure/workflow-state/IWorkflowStateCodec.ts
@@ -1,0 +1,6 @@
+import type { Feature } from '@/domain/feature/Feature';
+
+export interface IWorkflowStateCodec {
+	serialize(feature: Feature): string;
+	deserialize(content: string): Feature | null;
+}

--- a/src/infrastructure/workflow-state/WorkflowStateCodec.ts
+++ b/src/infrastructure/workflow-state/WorkflowStateCodec.ts
@@ -1,0 +1,13 @@
+import type { Feature } from '@/domain/feature/Feature';
+import type { IWorkflowStateCodec } from './IWorkflowStateCodec';
+import { serializeWorkflowState, deserializeWorkflowState } from './WorkflowStateDocument';
+
+export class WorkflowStateCodec implements IWorkflowStateCodec {
+	serialize(feature: Feature): string {
+		return serializeWorkflowState(feature);
+	}
+
+	deserialize(content: string): Feature | null {
+		return deserializeWorkflowState(content);
+	}
+}

--- a/tests/infrastructure/bridge/FeatureRepository.test.ts
+++ b/tests/infrastructure/bridge/FeatureRepository.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Feature, type FeaturePlainObject } from '@/domain/feature/Feature';
+import { Slug } from '@/domain/shared/Slug';
+import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository';
+import type { IWorkflowStateCodec } from '@/infrastructure/workflow-state/IWorkflowStateCodec';
+import { fakeModulePorts, type FakePorts } from '../../__fakes__/fake-ports';
+
+function makeFeature(slugValue = 'dark-mode', title = 'Dark mode'): Feature {
+	const slug = Slug.reconstitute(slugValue);
+	const now = new Date('2026-01-15T00:00:00.000Z');
+	return Feature.reconstitute({
+		id: `id-${slugValue}`,
+		slug,
+		title,
+		area: 'DM',
+		status: 'draft',
+		currentStep: 1,
+		createdAt: now,
+		updatedAt: now,
+	});
+}
+
+/** A minimal but parser-valid workflow-state.md fixture — used to satisfy
+ *  `fileExists` checks in `save()`; the stub codec controls the parsed result. */
+const STUB_STATE_FILE = '---\nstub-content\n---\n';
+
+describe('FeatureRepository (codec seam)', () => {
+	let ports: FakePorts;
+	let codec: IWorkflowStateCodec;
+	let serializeSpy: ReturnType<typeof vi.fn<IWorkflowStateCodec['serialize']>>;
+	let deserializeSpy: ReturnType<typeof vi.fn<IWorkflowStateCodec['deserialize']>>;
+	let repo: FeatureRepository;
+
+	beforeEach(() => {
+		ports = fakeModulePorts();
+		serializeSpy = vi
+			.fn<IWorkflowStateCodec['serialize']>()
+			.mockReturnValue('---\nstub\n---');
+		deserializeSpy = vi.fn<IWorkflowStateCodec['deserialize']>();
+		codec = { serialize: serializeSpy, deserialize: deserializeSpy };
+		repo = new FeatureRepository(ports.vault, ports.settings, codec);
+	});
+
+	it('save() calls codec.serialize exactly once and returns ok with a boolean ideaCreated flag', async () => {
+		const feature = makeFeature();
+
+		const result = await repo.save(feature);
+
+		expect(serializeSpy).toHaveBeenCalledTimes(1);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(typeof result.value.ideaCreated).toBe('boolean');
+			expect(result.value.ideaCreated).toBe(true);
+		}
+	});
+
+	it('save() returns err when codec.serialize throws', async () => {
+		serializeSpy.mockImplementation(() => {
+			throw new Error('boom');
+		});
+		const feature = makeFeature();
+
+		const result = await repo.save(feature);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.message).toBe('boom');
+		}
+	});
+
+	it('save() preserves an existing idea.md and returns ideaCreated:false', async () => {
+		const feature = makeFeature();
+		// Pre-seed idea.md so the save() path detects overwrite-protection.
+		await ports.bridge.writeFile('specs/dark-mode/idea.md', '# pre-existing idea\n');
+
+		const result = await repo.save(feature);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.ideaCreated).toBe(false);
+		}
+		expect(serializeSpy).toHaveBeenCalledTimes(1);
+		// idea.md content was not overwritten.
+		expect(await ports.bridge.readFile('specs/dark-mode/idea.md')).toBe(
+			'# pre-existing idea\n',
+		);
+	});
+
+	it('findBySlug returns null and does not invoke codec when the workflow-state file is missing', async () => {
+		const result = await repo.findBySlug(Slug.reconstitute('absent'));
+
+		expect(result).toBeNull();
+		expect(deserializeSpy).not.toHaveBeenCalled();
+	});
+
+	it('findBySlug throws when an extant file deserializes to null (overwrite-guard)', async () => {
+		await ports.bridge.writeFile('specs/dark-mode/workflow-state.md', STUB_STATE_FILE);
+		deserializeSpy.mockReturnValue(null);
+
+		await expect(repo.findBySlug(Slug.reconstitute('dark-mode'))).rejects.toThrow(
+			/could not be parsed/,
+		);
+		expect(deserializeSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('findAll invokes codec.deserialize exactly once per readable folder', async () => {
+		// Three sibling feature folders, each with a workflow-state.md file.
+		const slugs = ['alpha', 'beta', 'gamma'];
+		for (const s of slugs) {
+			await ports.bridge.writeFile(`specs/${s}/workflow-state.md`, STUB_STATE_FILE);
+		}
+		const stubFeature: FeaturePlainObject = {
+			id: 'stub',
+			slug: 'stub',
+			title: 'Stub',
+			area: 'ST',
+			status: 'draft',
+			currentStep: 1,
+			createdAt: new Date('2026-01-15T00:00:00.000Z'),
+			updatedAt: new Date('2026-01-15T00:00:00.000Z'),
+		};
+		deserializeSpy.mockImplementation(() =>
+			Feature.reconstitute({
+				...stubFeature,
+				slug: Slug.reconstitute(stubFeature.slug),
+			}),
+		);
+
+		const features = await repo.findAll();
+
+		expect(deserializeSpy).toHaveBeenCalledTimes(3);
+		expect(features).toHaveLength(3);
+	});
+});


### PR DESCRIPTION
## Summary

- Introduces `IWorkflowStateCodec` in `src/infrastructure/workflow-state/` — a
  two-method interface (`serialize`/`deserialize`) that decouples `FeatureRepository`
  from the concrete YAML free functions in `WorkflowStateDocument.ts`.
- Adds `WorkflowStateCodec` as the default implementation, wrapping the existing
  free functions with zero logic change.
- Injects the codec into `FeatureRepository` as an optional third constructor
  parameter (default: `new WorkflowStateCodec()`); all existing call sites are
  zero-change.
- Adds `tests/infrastructure/bridge/FeatureRepository.test.ts` with stub-codec
  tests covering repository coordination logic independently of the YAML parser.
- Files `docs/adr/0029-workflow-state-codec-seam.md` documenting the decision
  and the rejected alternative (generic `IFeatureRepository<TCodec>`).

## Ordering dependency

**This PR must be based on the C3 branch or rebased after C3 merges.** C3 changes the `FeatureRepository` constructor from `(vault, notifications, settingsPort)` to `(vault, settingsPort)`. This PR adds the codec as an optional third parameter, yielding the final signature `(vault: VaultPort, settingsPort: SettingsPort, codec?: IWorkflowStateCodec)`.

When C3 has landed, `save()` returns `Result<SaveResult>` not `Result<void>`. Stub-codec tests should assert on `.ok` or `result.value.ideaCreated === true`, not `result.value === undefined`.

## Test plan

- [ ] `npm run typecheck` — no new type errors
- [ ] `npm run lint` — no new lint violations
- [ ] `npm run test` — all existing tests pass; new `FeatureRepository.test.ts` passes
- [ ] `WorkflowStateDocument.test.ts` green (free functions unchanged)
- [ ] `CreateFeatureUseCase.test.ts` green (call sites unaffected)
- [ ] Confirm no remaining direct imports of `serializeWorkflowState`/`deserializeWorkflowState` in `FeatureRepository.ts`
- [ ] `WorkflowStateDocument.ts` diff is empty

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)