### PR TITLE
feat(asm): PR-ASM-3 — session persistence + audit log (T-ASM-044..058)

### DIFF
--- a/specs/agent-sidepanel-mvp/tasks.md
+++ b/specs/agent-sidepanel-mvp/tasks.md
@@ -754,7 +754,7 @@ visible UI surfaces: `SessionResumeIndicator.vue` and
 - **Depends on:** T-ASM-052
 - **Estimate:** S
 - **Definition of done:**
-  - [ ] Three scenarios (present, missing, malformed) covered.
+  - [x] Three scenarios (present, missing, malformed) covered.
 
 ### T-ASM-054 🔨 — Plugin-data blob: read/write `chatThreads` map
 
@@ -765,9 +765,9 @@ visible UI surfaces: `SessionResumeIndicator.vue` and
 - **Depends on:** T-ASM-053
 - **Estimate:** M
 - **Definition of done:**
-  - [ ] T-ASM-053 tests pass.
-  - [ ] Malformed records filtered + logged at `warn` per §11.3.
-  - [ ] Debounced flush prevents disk thrashing.
+  - [x] T-ASM-053 tests pass.
+  - [x] Malformed records filtered + logged at `warn` per §11.3.
+  - [x] Debounced flush prevents disk thrashing.
 
 ### T-ASM-055 🧪 — Tests for `SessionResumeIndicator.vue` and `SubprocessStartingPill.vue`
 

--- a/src/application/chat/FileWriteProposal.ts
+++ b/src/application/chat/FileWriteProposal.ts
@@ -1,0 +1,53 @@
+/**
+ * T-ASM-052 — Placeholder type definitions for the `FileWriteProposal`
+ * aggregate (SPEC-ASM-001 §2.5). The full proposal lifecycle (envelope parse,
+ * path validation, commit) lands in PR-ASM-4; this file declares only the
+ * minimal shape the Pinia chat store (§8.1) needs to track an unresolved
+ * proposal across UI state transitions.
+ *
+ * Satisfies REQ-ASM-041, REQ-ASM-043, REQ-ASM-045.
+ *
+ * Application layer (ADR-001 / ADR-008): no `obsidian` imports.
+ */
+import type { CreateFileEnvelope } from './createFileEnvelopeSchema'
+import type { CommitProposalErrorCode } from './errors'
+
+/**
+ * Lifecycle status of a `FileWriteProposal`. Per SPEC §2.5 the lifecycle is
+ * `pending` → (`accepted` | `rejected` | `failed`); once decided, terminal.
+ * No `committed` value — `accepted` covers a successful commit; `failed`
+ * covers any commit-time error (with the specific reason in `failureReason`).
+ */
+export type FileWriteProposalStatus =
+  | 'pending'
+  | 'accepted'
+  | 'rejected'
+  | 'failed'
+
+/**
+ * A pending or decided file-write proposal originating from an assistant
+ * structured-envelope response. The aggregate is plain DTO so it can cross
+ * the Pinia store boundary (CLAUDE.md Vue conventions).
+ */
+export interface FileWriteProposal {
+  /** Plugin-generated UUID v4; unique per proposal across the session. */
+  readonly proposalId: string
+
+  /** Thread that produced the envelope. */
+  readonly threadId: string
+
+  /** Parsed, schema-validated envelope (§2.4). */
+  readonly envelope: CreateFileEnvelope
+
+  /** Current lifecycle position. */
+  readonly status: FileWriteProposalStatus
+
+  /** ISO 8601 UTC timestamp when the proposal was created. */
+  readonly proposedAt: string
+
+  /** ISO 8601 UTC timestamp when the proposal moved out of `pending`, or `null`. */
+  readonly decidedAt: string | null
+
+  /** Commit-time failure reason; populated when `status === 'failed'`, else `null`. */
+  readonly failureReason: CommitProposalErrorCode | null
+}

--- a/src/application/chat/SessionLog.ts
+++ b/src/application/chat/SessionLog.ts
@@ -1,0 +1,50 @@
+/**
+ * Session-log frontmatter and body block types — SPEC-ASM-001 §2.3.
+ *
+ * The session log is a vault-portable markdown file that mirrors the chat
+ * thread: YAML frontmatter with five named keys followed by a chronological
+ * sequence of `## user` / `## assistant` / `## proposal` blocks.
+ *
+ * Pure types module: no I/O, no `obsidian` imports.
+ *
+ * Satisfies REQ-ASM-033, REQ-ASM-046.
+ */
+
+/**
+ * YAML frontmatter on every session log (REQ-ASM-033).
+ *
+ * - `session_id`  CLI-issued UUID from `system/init`; the file's basename.
+ * - `feature`     Active feature slug at log creation, or `null`.
+ * - `transport`   Which transport produced the conversation. Mirrors
+ *                 `ChatThreadRecord.transport`; `'degraded'` threads are not
+ *                 persisted so they cannot appear here (SPEC-ASM-001 §2.2).
+ * - `created`     ISO 8601 UTC timestamp; set once on first write.
+ * - `updated`     ISO 8601 UTC timestamp; refreshed on every subsequent write
+ *                 so REQ-ASM-034 can assert `updated > created` after a turn.
+ */
+export interface SessionLogFrontmatter {
+  readonly session_id: string
+  readonly feature: string | null
+  readonly transport: 'api-key' | 'subscription'
+  readonly created: string
+  readonly updated: string
+}
+
+/** A single user + assistant exchange in the log body. */
+export interface SessionTurnBlock {
+  readonly kind: 'turn'
+  readonly user: string
+  readonly assistant: string
+  readonly at: string
+}
+
+/** Proposal accept/reject audit row (REQ-ASM-046). */
+export interface SessionProposalBlock {
+  readonly kind: 'proposal'
+  readonly path: string
+  readonly decision: 'accepted' | 'rejected'
+  readonly decidedAt: string
+  readonly rationale: string | null
+}
+
+export type SessionLogBlock = SessionTurnBlock | SessionProposalBlock

--- a/src/application/chat/SessionLogWriter.ts
+++ b/src/application/chat/SessionLogWriter.ts
@@ -1,0 +1,434 @@
+/**
+ * T-ASM-048 — `SessionLogWriter`.
+ *
+ * Application-layer service that mirrors a chat thread to a vault-portable
+ * markdown file under `<specsFolder>/<feature>/sessions/<sessionId>.md` (or
+ * `.specorator/sessions/<sessionId>.md` when no feature is active). The file
+ * has a five-key YAML frontmatter (`session_id`, `feature`, `transport`,
+ * `created`, `updated`) followed by a chronological sequence of `## user`,
+ * `## assistant`, and `## proposal` blocks (SPEC-ASM-001 §2.3, §6.7).
+ *
+ * Behaviour (SPEC-ASM-001 §6.7):
+ *   - Per-log-file mutex (`Map<logPath, Promise<void>>`) serialises writes so
+ *     concurrent `appendUserAssistant` calls on the same thread do not
+ *     interleave (REQ-ASM-040).
+ *   - On the first write to a given path, calls `vault.createFolder` on the
+ *     parent directory (REQ-ASM-038). The call is idempotent at the
+ *     `VaultPort` boundary.
+ *   - If the target path already exists with a *conflicting* `session_id` in
+ *     its frontmatter, the writer appends `-2`, `-3`, … to the file stem until
+ *     a unique path is found and logs `warn` exactly once (REQ-ASM-039).
+ *   - All write failures are caught and routed to `logger.error` with a
+ *     redacted `sessionId` (NFR-ASM-005); `appendUserAssistant` is
+ *     fire-and-forget and never returns a rejected promise. The single
+ *     departure from fire-and-forget is `appendProposalDecision`, which the
+ *     proposal-commit pipeline awaits for its audit row (REQ-ASM-046).
+ *
+ * Trust-first invariant (NFR-ASM-004 / ADR-0031): this class never reads
+ * anything under `~/.claude/`; all I/O is mediated by `VaultPort`.
+ *
+ * Pure application layer (ADR-008): no `obsidian` imports, no `node:fs`. The
+ * file relies only on the narrow `VaultPort` + `LoggerPort` surface and the
+ * pure `resolveSessionLogPath` helper.
+ *
+ * Satisfies REQ-ASM-033, REQ-ASM-034, REQ-ASM-038, REQ-ASM-039, REQ-ASM-040,
+ * REQ-ASM-046, NFR-ASM-002, NFR-ASM-005.
+ */
+
+import type { LoggerPort, VaultPort } from '@/domain/ports'
+import { tryAsync } from '@/domain/shared/tryAsync'
+import type { ChatThreadRecord } from '@/domain/chat/ChatThreadRecord'
+import { resolveSessionLogPath } from '@/application/chat/sessionLogPath'
+
+/**
+ * Minimal proposal shape consumed by `appendProposalDecision`. The full
+ * `FileWriteProposal` aggregate lands in PR-ASM-4; the writer only needs the
+ * envelope's `path` and `rationale` to populate the audit row (REQ-ASM-046).
+ */
+export interface SessionLogProposalInput {
+  readonly envelope: {
+    readonly path: string
+    readonly rationale?: string
+  }
+}
+
+/**
+ * Redact a session id to its first 8 characters (NFR-ASM-005). Returns
+ * `'<none>'` when `null` so log lines remain deterministic. Pure helper, kept
+ * private to the module so callers cannot accidentally surface raw ids.
+ */
+function redactSessionId(sessionId: string | null): string {
+  if (sessionId === null) return '<none>'
+  return sessionId.slice(0, 8)
+}
+
+/** Compute the parent directory of a vault-relative POSIX path. */
+function parentFolder(path: string): string {
+  const idx = path.lastIndexOf('/')
+  return idx === -1 ? '' : path.slice(0, idx)
+}
+
+/**
+ * Replace the file stem with `<stem>-<n>` while preserving the `.md`
+ * extension. `n` is `2`, `3`, … per REQ-ASM-039.
+ */
+function withSuffix(path: string, n: number): string {
+  // The writer only ever produces `.md` files via `resolveSessionLogPath`.
+  // Defensive fallback: if the extension is absent, treat the whole basename
+  // as the stem so the function remains total.
+  const dotIdx = path.lastIndexOf('.')
+  const slashIdx = path.lastIndexOf('/')
+  if (dotIdx === -1 || dotIdx < slashIdx) return `${path}-${n}`
+  return `${path.slice(0, dotIdx)}-${n}${path.slice(dotIdx)}`
+}
+
+/**
+ * Escape a string for inclusion in a YAML single-quoted scalar: literal
+ * single quotes are doubled, all other characters are preserved verbatim.
+ * (Single-quoted YAML strings have no further escape syntax — newlines and
+ * unicode pass through.)
+ */
+function quoteYamlString(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`
+}
+
+/** Serialise the five-key frontmatter exactly as REQ-ASM-033 prescribes. */
+function buildFrontmatter(frontmatter: {
+  readonly session_id: string
+  readonly feature: string | null
+  readonly transport: 'api-key' | 'subscription'
+  readonly created: string
+  readonly updated: string
+}): string {
+  return [
+    '---',
+    `session_id: ${quoteYamlString(frontmatter.session_id)}`,
+    `feature: ${frontmatter.feature === null ? 'null' : quoteYamlString(frontmatter.feature)}`,
+    `transport: ${frontmatter.transport}`,
+    `created: ${quoteYamlString(frontmatter.created)}`,
+    `updated: ${quoteYamlString(frontmatter.updated)}`,
+    '---',
+    '',
+  ].join('\n')
+}
+
+/**
+ * Parse the `session_id` field from a frontmatter block (single-quoted,
+ * double-quoted, or bare). Returns `null` when the file has no frontmatter or
+ * the key is absent — both cases imply the file does *not* belong to a known
+ * session and the conflict-suffix loop should treat the path as colliding.
+ */
+function extractSessionIdFromFrontmatter(content: string): string | null {
+  if (!content.startsWith('---\n') && !content.startsWith('---\r\n')) return null
+  const closeIdx = content.indexOf('\n---', 4)
+  if (closeIdx === -1) return null
+  const block = content.slice(0, closeIdx)
+  // Combine the three alternation branches into one capture group so we get a
+  // single, always-defined string without juggling `match[1] | match[2] | match[3]`.
+  // The outer `(?:…)` strips the value's quotes if present.
+  const match = /^session_id:\s*(?:'([^']*)'|"([^"]*)"|([^\n\r]+))\s*$/m.exec(block)
+  if (!match) return null
+  const captured = (match[0].replace(/^session_id:\s*/, '').trim()).replace(/^['"]|['"]$/g, '')
+  return captured === '' ? null : captured
+}
+
+/** Whether a string already contains a frontmatter opener (`---\n…\n---`). */
+function hasFrontmatter(content: string): boolean {
+  return (
+    (content.startsWith('---\n') || content.startsWith('---\r\n')) &&
+    content.includes('\n---', 4)
+  )
+}
+
+/**
+ * Replace the `updated:` key inside an existing frontmatter block with the
+ * new timestamp. Falls back to a no-op if the frontmatter is malformed — the
+ * append still proceeds so the user's turn is not lost.
+ */
+function rewriteUpdated(content: string, isoTimestamp: string): string {
+  if (!hasFrontmatter(content)) return content
+  const closeIdx = content.indexOf('\n---', 4)
+  if (closeIdx === -1) return content
+  const block = content.slice(0, closeIdx)
+  const rest = content.slice(closeIdx)
+  const newBlock = block.replace(
+    /^updated:.*$/m,
+    `updated: ${quoteYamlString(isoTimestamp)}`,
+  )
+  return newBlock + rest
+}
+
+/** Body text for a `## user` / `## assistant` turn block. */
+function formatTurnBlock(turn: { readonly user: string; readonly assistant: string }, at: string): string {
+  return [
+    `## user`,
+    `<!-- at: ${at} -->`,
+    '',
+    turn.user,
+    '',
+    `## assistant`,
+    `<!-- at: ${at} -->`,
+    '',
+    turn.assistant,
+    '',
+  ].join('\n')
+}
+
+/** Body text for a `## proposal` audit block (REQ-ASM-046). */
+function formatProposalBlock(args: {
+  readonly path: string
+  readonly decision: 'accepted' | 'rejected'
+  readonly decidedAt: string
+  readonly rationale: string | undefined
+}): string {
+  const lines = [
+    `## proposal`,
+    `<!-- decided_at: ${args.decidedAt} -->`,
+    '',
+    `- path: ${args.path}`,
+    `- decision: ${args.decision}`,
+    `- decided_at: ${args.decidedAt}`,
+  ]
+  if (args.rationale !== undefined && args.rationale !== '') {
+    lines.push(`- rationale: ${args.rationale}`)
+  }
+  lines.push('')
+  return lines.join('\n')
+}
+
+/**
+ * Append-only session log writer for the agent side-panel chat.
+ *
+ * Construction is cheap and stateful: each instance owns the per-log-file
+ * mutex map. Tests and the production wiring should share one instance per
+ * Obsidian plugin lifetime so concurrent appends serialise correctly.
+ */
+export class SessionLogWriter {
+  /** Per-log-file write queue. The promise chain serialises appends. */
+  private readonly mutex = new Map<string, Promise<void>>()
+
+  /**
+   * Conflict resolution memoisation: once `session_id=A` has been redirected
+   * from `<base>.md` to `<base>-2.md`, subsequent appends for the same
+   * `sessionId` reuse `<base>-2.md` without re-running the suffix loop.
+   */
+  private readonly resolvedPaths = new Map<string, string>()
+
+  /**
+   * Per-sessionId guard so the conflict warning fires exactly once
+   * (REQ-ASM-039 DoD).
+   */
+  private readonly warnedSessions = new Set<string>()
+
+  constructor(
+    private readonly vault: VaultPort,
+    private readonly logger: LoggerPort,
+    private readonly specsFolder: string,
+    private readonly nowIso: () => string,
+  ) {}
+
+  /**
+   * Idempotent: ensures the parent sessions folder exists. Used by the wiring
+   * code on thread creation. Returns a Result rather than throwing so the
+   * call site stays in the never-throws application-layer style (REQ-ASM-015).
+   */
+  async ensureSessionsFolder(feature: string | null): Promise<void> {
+    const probe = resolveSessionLogPath(feature, '__probe__', this.specsFolder)
+    const folder = parentFolder(probe)
+    if (folder === '') return
+    const result = await tryAsync(() => this.vault.createFolder(folder))
+    if (!result.ok) {
+      // Most VaultPort impls throw when the folder already exists; that is a
+      // success from our point of view. Log at `debug` so the production
+      // surface stays quiet.
+      this.logger.debug('SessionLogWriter.ensureSessionsFolder ignored', {
+        folder,
+        reason: String(result.error.message),
+      })
+    }
+  }
+
+  /**
+   * Fire-and-forget: serialises onto the per-log-file mutex and never rejects.
+   * Errors are routed to `logger.error` with a redacted `sessionId`
+   * (NFR-ASM-005). Callers do **not** await (T-ASM-048 DoD).
+   */
+  appendUserAssistant(
+    thread: ChatThreadRecord,
+    turn: { readonly user: string; readonly assistant: string },
+  ): Promise<void> {
+    return this.enqueue(thread, async (resolvedPath) => {
+      const at = this.nowIso()
+      const exists = await this.vault.fileExists(resolvedPath)
+      if (!exists) {
+        await this.writeFreshFile(resolvedPath, thread, [formatTurnBlock(turn, at)], at)
+        return
+      }
+      const existing = await this.vault.readFile(resolvedPath)
+      const updated = rewriteUpdated(existing, at)
+      const next = `${updated.endsWith('\n') ? updated : `${updated}\n`}${formatTurnBlock(turn, at)}`
+      await this.vault.writeFile(resolvedPath, next)
+    })
+  }
+
+  /**
+   * Appends a `## proposal` audit row. Callers **do** await this (REQ-ASM-046)
+   * — the proposal-commit pipeline treats a missing audit row as a hard
+   * failure. Internal queueing still goes through the same mutex so we keep a
+   * single linearised history per log file.
+   */
+  appendProposalDecision(args: {
+    readonly thread: ChatThreadRecord
+    readonly proposal: SessionLogProposalInput
+    readonly decision: 'accepted' | 'rejected'
+    readonly decidedAt: string
+  }): Promise<void> {
+    return this.enqueue(args.thread, async (resolvedPath) => {
+      const exists = await this.vault.fileExists(resolvedPath)
+      const block = formatProposalBlock({
+        path: args.proposal.envelope.path,
+        decision: args.decision,
+        decidedAt: args.decidedAt,
+        rationale: args.proposal.envelope.rationale,
+      })
+      if (!exists) {
+        await this.writeFreshFile(resolvedPath, args.thread, [block], args.decidedAt)
+        return
+      }
+      const existing = await this.vault.readFile(resolvedPath)
+      const updated = rewriteUpdated(existing, args.decidedAt)
+      const next = `${updated.endsWith('\n') ? updated : `${updated}\n`}${block}`
+      await this.vault.writeFile(resolvedPath, next)
+    })
+  }
+
+  /**
+   * Wraps the `op` in the per-log mutex and a top-level catch that routes
+   * failures to `logger.error`. Resolves the conflict-suffix path once per
+   * sessionId.
+   *
+   * `appendProposalDecision` callers await this promise (REQ-ASM-046);
+   * `appendUserAssistant` callers do not (REQ-ASM-040).
+   */
+  private enqueue(
+    thread: ChatThreadRecord,
+    op: (resolvedPath: string) => Promise<void>,
+  ): Promise<void> {
+    if (thread.sessionId === null) {
+      // No `session_id` captured yet — the writer cannot resolve a path
+      // (RES-ASM-001 §F1). Surface as a debug line and drop the write.
+      this.logger.debug('SessionLogWriter: drop write (no sessionId)', {
+        threadId: thread.threadId,
+      })
+      return Promise.resolve()
+    }
+    const sessionId = thread.sessionId
+    const basePath = resolveSessionLogPath(thread.feature, sessionId, this.specsFolder)
+    const queueKey = basePath
+    const previous = this.mutex.get(queueKey) ?? Promise.resolve()
+    const next = previous
+      .catch(() => {
+        // Prior op failed; we've already logged. Reset the chain so this op
+        // still runs.
+      })
+      .then(async () => {
+        const resolvedPath = await this.resolveConflictSuffix(basePath, sessionId)
+        await this.ensureParentFolder(resolvedPath)
+        await op(resolvedPath)
+      })
+      .catch((thrown: unknown) => {
+        this.logger.error(
+          'SessionLogWriter append failed',
+          thrown instanceof Error ? thrown : new Error(String(thrown)),
+          { redactedSessionId: redactSessionId(sessionId) },
+        )
+      })
+    this.mutex.set(queueKey, next)
+    return next
+  }
+
+  /**
+   * Walk `-2`, `-3`, … suffixes until we find a path that either does not
+   * exist or carries our own `session_id`. Memoised per `sessionId`.
+   */
+  private async resolveConflictSuffix(basePath: string, sessionId: string): Promise<string> {
+    const cached = this.resolvedPaths.get(sessionId)
+    if (cached !== undefined) return cached
+    const exists = await this.vault.fileExists(basePath)
+    if (!exists) {
+      this.resolvedPaths.set(sessionId, basePath)
+      return basePath
+    }
+    const existing = await this.vault.readFile(basePath)
+    const existingSession = extractSessionIdFromFrontmatter(existing)
+    if (existingSession === sessionId) {
+      this.resolvedPaths.set(sessionId, basePath)
+      return basePath
+    }
+    // Conflicting `session_id` (or missing frontmatter): walk the suffix loop.
+    if (!this.warnedSessions.has(sessionId)) {
+      this.warnedSessions.add(sessionId)
+      this.logger.warn('SessionLogWriter: session-id conflict; appending suffix', {
+        basePath,
+        redactedSessionId: redactSessionId(sessionId),
+      })
+    }
+    let n = 2
+    // Bounded to keep tests deterministic; in practice we expect ≤ 1.
+    while (n < 1000) {
+      const candidate = withSuffix(basePath, n)
+      const candidateExists = await this.vault.fileExists(candidate)
+      if (!candidateExists) {
+        this.resolvedPaths.set(sessionId, candidate)
+        return candidate
+      }
+      const candidateContent = await this.vault.readFile(candidate)
+      const candidateSession = extractSessionIdFromFrontmatter(candidateContent)
+      if (candidateSession === sessionId) {
+        this.resolvedPaths.set(sessionId, candidate)
+        return candidate
+      }
+      n += 1
+    }
+    // Defensive: fall back to a UUID-keyed path so we never silently overwrite.
+    const overflow = `${basePath}-${sessionId}`
+    this.resolvedPaths.set(sessionId, overflow)
+    return overflow
+  }
+
+  /** Idempotent parent-folder creation; swallows already-exists errors. */
+  private async ensureParentFolder(path: string): Promise<void> {
+    const folder = parentFolder(path)
+    if (folder === '') return
+    const result = await tryAsync(() => this.vault.createFolder(folder))
+    if (!result.ok) {
+      // Most likely the folder already exists; downgrade to debug.
+      this.logger.debug('SessionLogWriter: createFolder ignored', {
+        folder,
+        reason: String(result.error.message),
+      })
+    }
+  }
+
+  /**
+   * Write a brand-new session log with its frontmatter + one body block.
+   * `at` is reused as both `created` and `updated` on first write so
+   * REQ-ASM-034 (`updated > created`) can hold true on the second write.
+   */
+  private async writeFreshFile(
+    path: string,
+    thread: ChatThreadRecord,
+    blocks: ReadonlyArray<string>,
+    at: string,
+  ): Promise<void> {
+    const fm = buildFrontmatter({
+      session_id: thread.sessionId ?? '',
+      feature: thread.feature,
+      transport: thread.transport,
+      created: at,
+      updated: at,
+    })
+    const body = blocks.join('')
+    await this.vault.writeFile(path, `${fm}\n${body}`)
+  }
+}

--- a/src/application/chat/sessionLogPath.ts
+++ b/src/application/chat/sessionLogPath.ts
@@ -1,0 +1,47 @@
+/**
+ * T-ASM-045 — `resolveSessionLogPath`.
+ *
+ * Pure, deterministic resolver for the vault-relative path of a per-thread
+ * session log. The Specorator chat sidebar mirrors every conversation to a
+ * markdown file in the vault so the chat history survives Obsidian restart,
+ * is grep-able, and rides Obsidian Sync without the plugin's involvement
+ * (REQ-CCS-028; ADR-0031 layer 2).
+ *
+ * Path shape (per REQ-ASM-032 / SPEC-ASM-001 §6.7 / ADR-0031):
+ *
+ *   feature !== null  → `<specsFolder>/<feature>/sessions/<sessionId>.md`
+ *   feature === null  → `.specorator/sessions/<sessionId>.md`
+ *
+ * The null-feature fallback is anchored at the vault root (NOT under
+ * `<specsFolder>`) so a user who has not yet picked an active feature still
+ * gets a deterministic location for chat history. The leading dot keeps the
+ * folder unobtrusive in most Obsidian themes (R-ASM-005 mitigation).
+ *
+ * Pure module: no I/O, no `obsidian` imports, no Node `path` module — the
+ * vault uses POSIX-style forward-slash paths and this resolver mirrors that
+ * convention by concatenating raw segments. Sanitisation of `feature` and
+ * `sessionId` is the caller's responsibility: `feature` is a `Slug`
+ * (validated upstream) and `sessionId` is the CLI-issued `system/init`
+ * UUID (RES-ASM-001 §F1).
+ *
+ * Satisfies REQ-ASM-032.
+ */
+
+/**
+ * Resolve the vault-relative path of a session log.
+ *
+ * @param feature  Active feature slug, or `null` when no feature is active.
+ * @param sessionId  CLI `session_id` (UUID) — used as the file's basename.
+ * @param specsFolder  User's configured specs root (default `'specs'`).
+ * @returns Vault-relative POSIX path with `.md` extension.
+ */
+export function resolveSessionLogPath(
+  feature: string | null,
+  sessionId: string,
+  specsFolder: string,
+): string {
+  if (feature !== null) {
+    return `${specsFolder}/${feature}/sessions/${sessionId}.md`
+  }
+  return `.specorator/sessions/${sessionId}.md`
+}

--- a/src/domain/ports/ClaudeCliPort.ts
+++ b/src/domain/ports/ClaudeCliPort.ts
@@ -71,6 +71,18 @@ export interface ClaudeCliQueryOptions {
    * Satisfies REQ-ASM-035.
    */
   readonly resumeSessionId?: SessionId
+
+  /**
+   * Optional callback invoked exactly once per `query()` call the first time a
+   * non-empty `session_id` is captured from a `system/init` event on the
+   * stream-json wire (REQ-ASM-031). The subscription transport invokes this
+   * synchronously from inside the NDJSON event handler so the caller can
+   * thread the captured id back as `resumeSessionId` on the next turn
+   * (REQ-ASM-035). The SDK adapter ignores it. Implementors must guarantee
+   * a single invocation per turn even if multiple `system/init` events arrive.
+   * Satisfies REQ-ASM-031.
+   */
+  readonly onSessionId?: (sessionId: SessionId) => void
 }
 
 /**

--- a/src/infrastructure/mock/MockClaudeSubprocessAdapter.ts
+++ b/src/infrastructure/mock/MockClaudeSubprocessAdapter.ts
@@ -169,6 +169,18 @@ export class MockClaudeSubprocessAdapter implements ClaudeCliPort {
     this.queryLog.push(prompt)
     this._recordOptions(options)
 
+    // Mirror the real adapter's REQ-ASM-031 contract: invoke onSessionId once
+    // with `cannedSessionId` so tests exercising the capture path see the
+    // same observable as production.
+    if (options?.onSessionId !== undefined && this.cannedSessionId !== null) {
+      try {
+        options.onSessionId(this.cannedSessionId)
+      } catch {
+        // Mock mirrors the real adapter — never let a caller callback throw
+        // out of `query()`.
+      }
+    }
+
     if (this.delayMs > 0) {
       await new Promise<void>((resolve) => setTimeout(resolve, this.delayMs))
     }

--- a/src/infrastructure/obsidian/ClaudeSubprocessAdapter.ts
+++ b/src/infrastructure/obsidian/ClaudeSubprocessAdapter.ts
@@ -120,6 +120,12 @@ interface TurnProc {
   sessionId: SessionId | null
   /** Sticky terminal error (e.g. spawn-error before any stdout). */
   fatal: ClaudeCliError | null
+  /**
+   * Optional caller-supplied callback invoked exactly once when the first
+   * non-empty `session_id` arrives in a `system/init` event (REQ-ASM-031).
+   * Nulled out after the first invocation to enforce the single-fire contract.
+   */
+  onSessionId: ((sessionId: SessionId) => void) | null
 }
 
 interface PendingTurn {
@@ -294,7 +300,7 @@ export class ClaudeSubprocessAdapter implements ClaudeCliPort {
     // Fresh spawn per turn (Codex P1 fix, PR #325). Context continuity is
     // already encoded in `argv` via --resume when the caller supplied
     // `resumeSessionId`; no per-thread state lives on this adapter.
-    const spawned = this._spawnChild(this._binaryPath, argv)
+    const spawned = this._spawnChild(this._binaryPath, argv, options?.onSessionId ?? null)
     if (!spawned.ok) {
       return spawned
     }
@@ -593,6 +599,7 @@ export class ClaudeSubprocessAdapter implements ClaudeCliPort {
   private _spawnChild(
     binaryPath: string,
     argv: readonly string[],
+    onSessionId: ((sessionId: SessionId) => void) | null,
   ): Result<TurnProc, ClaudeCliError> {
     let child: ChildProcess
     try {
@@ -631,6 +638,7 @@ export class ClaudeSubprocessAdapter implements ClaudeCliPort {
       pending: null,
       sessionId: null,
       fatal: null,
+      onSessionId,
     }
 
     this._activeChildren.add(childLike)
@@ -736,11 +744,33 @@ export class ClaudeSubprocessAdapter implements ClaudeCliPort {
     }
   }
 
-  /** REQ-ASM-031 — capture `session_id` from a `system/init` event. */
+  /**
+   * REQ-ASM-031 — capture `session_id` from a `system/init` event and fire
+   * the optional caller-supplied `onSessionId` callback exactly once. The
+   * callback is cleared after the first invocation so a misbehaving CLI that
+   * emits multiple `system/init` events cannot double-call the caller.
+   */
   private _handleSystemInit(proc: TurnProc, event: Record<string, unknown>): void {
     const sid = event.session_id
-    if (typeof sid === 'string' && sid.length > 0) {
-      proc.sessionId = asSessionId(sid)
+    if (typeof sid !== 'string' || sid.length === 0) return
+    const branded = asSessionId(sid)
+    proc.sessionId = branded
+    if (proc.onSessionId !== null) {
+      const cb = proc.onSessionId
+      // Single-fire: drop the reference before invoking so a re-entrant
+      // callback (e.g. one that triggers a synthetic event) cannot recurse.
+      proc.onSessionId = null
+      try {
+        cb(branded)
+      } catch (e: unknown) {
+        // NFR-ASM-005 — never log the session id. Callback failures must not
+        // tear down the turn; surface them only as a debug log.
+        this._logger.debug('subscription.onSessionId.threw', {
+          transport: 'subscription',
+          event: 'onSessionId.threw',
+        })
+        void e
+      }
     }
   }
 

--- a/src/plugin/SpecoratorView.ts
+++ b/src/plugin/SpecoratorView.ts
@@ -24,6 +24,7 @@ import type { ClaudeCliPort } from '@/domain/ports'
 import type { PluginSettings } from '@/domain/settings/PluginSettings'
 import type { TransportSelection } from '@/plugin/transport/TransportSelector'
 import { useChatStore } from '@/ui/stores/chatStore'
+import { mostRecentlyUsedThreadId } from './chatThreadsPersistence'
 import { trySync } from '@/domain/shared/tryAsync'
 import type SpecoratorPlugin from './main'
 
@@ -118,6 +119,21 @@ export class SpecoratorView extends ItemView {
     setLocale(this.plugin.settings.locale as SupportedLocale)
 
     this.pinia = createPinia()
+
+    // SPEC-ASM-001 §9.5 / REQ-ASM-037 — hydrate persisted chat threads into
+    // the Pinia chat store before the view mounts. The plugin decoded the
+    // blob during `loadSettings()`; malformed records were already filtered
+    // out and logged at `warn`. `activeThreadId` is seeded to the most
+    // recently used record so the chat sidebar resumes the user's last
+    // conversation. Subscribe to subsequent mutations so any change to
+    // `chatThreads` triggers a debounced flush back to plugin data.
+    const persisted = this.plugin.getInitialChatThreads()
+    const chatStore = useChatStore(this.pinia)
+    for (const record of persisted) chatStore.upsertThread(record)
+    chatStore.setActiveThreadId(mostRecentlyUsedThreadId(persisted))
+    chatStore.$subscribe((_mutation, state) => {
+      this.plugin.scheduleChatThreadsPersistence(state.chatThreads)
+    })
 
     this.vueApp = createApp(AppRoot)
     this.vueApp.use(this.pinia)

--- a/src/plugin/chatThreadsPersistence.ts
+++ b/src/plugin/chatThreadsPersistence.ts
@@ -1,0 +1,190 @@
+import type { ChatThreadRecord } from '@/domain/chat/ChatThreadRecord'
+import { asSessionId } from '@/domain/chat/SessionId'
+import type { LoggerPort } from '@/domain/ports/LoggerPort'
+
+/**
+ * Pure helpers for the `chatThreads` plugin-data blob defined by
+ * SPEC-ASM-001 §9.3 (REQ-ASM-037, ADR-0031).
+ *
+ * The blob lives under `_storedData.specorator.chatThreads` and serialises the
+ * in-memory `Map<string, ChatThreadRecord>` to a plain `Record<string,
+ * SerialisedChatThreadRecord>` keyed by `threadId`.
+ *
+ * Domain-shape guarantees:
+ *   - Records with missing or wrong-typed `sessionId`, `feature`, `transport`,
+ *     `logPath`, `threadId`, `createdAt`, or `lastUsedAt` are dropped at load
+ *     time and logged at `warn` (SPEC §11.3).
+ *   - `transport === 'degraded'` records are not persisted (degraded threads
+ *     have no resumable session and are user-session-scoped).
+ *
+ * No `obsidian` imports — pure functions consumed by `main.ts`.
+ */
+
+/** JSON-friendly serialisation of a `ChatThreadRecord`. */
+export interface SerialisedChatThreadRecord {
+  readonly threadId: string
+  readonly sessionId: string | null
+  readonly feature: string | null
+  readonly logPath: string
+  readonly transport: 'api-key' | 'subscription'
+  readonly createdAt: string
+  readonly lastUsedAt: string
+}
+
+const PERSISTED_TRANSPORTS: ReadonlySet<string> = new Set(['api-key', 'subscription'])
+
+function isPersistedTransport(value: unknown): value is 'api-key' | 'subscription' {
+  return typeof value === 'string' && PERSISTED_TRANSPORTS.has(value)
+}
+
+type RecordDefect = { field: string; value?: unknown } | null
+
+/** Internal: validate the trio of required string fields (`threadId`, `logPath`, transport). */
+function findIdentityDefect(r: Record<string, unknown>): RecordDefect {
+  if (typeof r.threadId !== 'string' || r.threadId.length === 0) {
+    return { field: 'threadId' }
+  }
+  if (typeof r.logPath !== 'string') return { field: 'logPath' }
+  if (!isPersistedTransport(r.transport)) {
+    return { field: 'transport', value: r.transport }
+  }
+  return null
+}
+
+/** Internal: validate the optional-but-typed (`feature`, `sessionId`) and timestamp fields. */
+function findShapeDefect(r: Record<string, unknown>): RecordDefect {
+  if (r.feature !== null && typeof r.feature !== 'string') {
+    return { field: 'feature' }
+  }
+  if (r.sessionId !== null && typeof r.sessionId !== 'string') {
+    return { field: 'sessionId' }
+  }
+  if (typeof r.createdAt !== 'string' || typeof r.lastUsedAt !== 'string') {
+    return { field: 'timestamps' }
+  }
+  return null
+}
+
+/** Internal: report which required field of a raw record is malformed. */
+function findRecordDefect(r: Record<string, unknown>): RecordDefect {
+  return findIdentityDefect(r) ?? findShapeDefect(r)
+}
+
+/**
+ * Type-guard parsing of one raw record. Returns `null` (and logs once) if the
+ * record is malformed; returns a `ChatThreadRecord` otherwise.
+ *
+ * Required fields per SPEC §2.2: `threadId`, `sessionId` (nullable), `feature`
+ * (nullable), `logPath`, `transport` (∈ {'api-key','subscription'}),
+ * `createdAt`, `lastUsedAt`.
+ */
+export function parseChatThreadRecord(
+  raw: unknown,
+  logger: LoggerPort,
+): ChatThreadRecord | null {
+  if (raw === null || typeof raw !== 'object') {
+    logger.warn('[chatThreads] dropped non-object record', { raw })
+    return null
+  }
+  const r = raw as Record<string, unknown>
+  const defect = findRecordDefect(r)
+  if (defect !== null) {
+    logger.warn(`[chatThreads] dropped record (invalid ${defect.field})`, {
+      threadId: typeof r.threadId === 'string' ? r.threadId : undefined,
+      ...(defect.value !== undefined ? { value: defect.value } : {}),
+    })
+    return null
+  }
+  // Narrowing: `findRecordDefect` ensures all required fields are correctly
+  // typed when it returns `null`.
+  const threadId = r.threadId as string
+  const sessionIdRaw = r.sessionId as string | null
+  const feature = r.feature as string | null
+  const logPath = r.logPath as string
+  const transport = r.transport as 'api-key' | 'subscription'
+  const createdAt = r.createdAt as string
+  const lastUsedAt = r.lastUsedAt as string
+  return {
+    threadId,
+    sessionId: sessionIdRaw === null ? null : asSessionId(sessionIdRaw),
+    feature,
+    logPath,
+    transport,
+    createdAt,
+    lastUsedAt,
+  }
+}
+
+/**
+ * Decode a raw `chatThreads` blob (typically `_storedData.specorator.chatThreads`)
+ * into an array of valid records. Well-formed entries are kept; malformed
+ * entries are filtered out and each filtered entry produces one `warn` log.
+ *
+ * Returns `[]` for `undefined`, `null`, non-object blobs (with one warn for the
+ * non-object case).
+ */
+export function decodeChatThreadsBlob(
+  raw: unknown,
+  logger: LoggerPort,
+): ChatThreadRecord[] {
+  if (raw === undefined || raw === null) return []
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    logger.warn('[chatThreads] blob is not an object — treating as empty', {
+      typeofRaw: typeof raw,
+    })
+    return []
+  }
+  const out: ChatThreadRecord[] = []
+  for (const value of Object.values(raw as Record<string, unknown>)) {
+    const record = parseChatThreadRecord(value, logger)
+    if (record !== null) out.push(record)
+  }
+  return out
+}
+
+/**
+ * Encode a `Map<threadId, ChatThreadRecord>` into the JSON-friendly blob shape.
+ * Filters out records whose transport is not `'api-key'` or `'subscription'`
+ * (e.g. degraded threads are not persisted — SPEC §2.2 / ADR-0031).
+ */
+export function encodeChatThreadsBlob(
+  records: ReadonlyMap<string, ChatThreadRecord>,
+): Record<string, SerialisedChatThreadRecord> {
+  const out: Record<string, SerialisedChatThreadRecord> = {}
+  for (const [threadId, record] of records) {
+    if (!isPersistedTransport(record.transport)) continue
+    out[threadId] = {
+      threadId: record.threadId,
+      sessionId: record.sessionId,
+      feature: record.feature,
+      logPath: record.logPath,
+      transport: record.transport,
+      createdAt: record.createdAt,
+      lastUsedAt: record.lastUsedAt,
+    }
+  }
+  return out
+}
+
+/**
+ * Select the `threadId` whose `lastUsedAt` ISO timestamp is the largest
+ * (lexicographic compare is correct for ISO 8601 UTC). Returns `null` when
+ * `records` is empty.
+ *
+ * Used at hydration time to seed `activeThreadId` (REQ-ASM-037 — last-used
+ * record is restored on Obsidian restart).
+ */
+export function mostRecentlyUsedThreadId(
+  records: ReadonlyArray<ChatThreadRecord>,
+): string | null {
+  if (records.length === 0) return null
+  let bestId = records[0].threadId
+  let bestAt = records[0].lastUsedAt
+  for (let i = 1; i < records.length; i++) {
+    if (records[i].lastUsedAt > bestAt) {
+      bestAt = records[i].lastUsedAt
+      bestId = records[i].threadId
+    }
+  }
+  return bestId
+}

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -59,6 +59,14 @@ export default class SpecoratorPlugin extends Plugin {
   private _initialChatThreads: ReadonlyArray<ChatThreadRecord> = []
   /** Debounced persistence timer for `chatThreads`. SPEC §9.3 / OQ-ASM-T1. */
   private _chatThreadsFlushTimer: number | null = null
+  /**
+   * Latest snapshot scheduled by `scheduleChatThreadsPersistence` but not yet
+   * flushed to plugin data. Kept on the class so `onunload()` can perform a
+   * final synchronous flush before the debounce timer fires — without this,
+   * a message sent within the 1 s debounce window before Obsidian exits or
+   * the plugin is disabled would silently fail to persist (Codex P1, PR #346).
+   */
+  private _pendingChatThreadsSnapshot: ReadonlyMap<string, ChatThreadRecord> | null = null
   /** Default debounce window in milliseconds for chatThreads flushes. */
   private static readonly _CHAT_THREADS_FLUSH_DEBOUNCE_MS = 1_000
 
@@ -278,9 +286,20 @@ export default class SpecoratorPlugin extends Plugin {
   // expected cleanup path despite the obsidianmd/detach-leaves rule's caution.
   // eslint-disable-next-line obsidianmd/detach-leaves
   override onunload(): void {
+    // Cancel the pending debounce — we're about to flush directly below.
     if (this._chatThreadsFlushTimer !== null) {
       activeWindow.clearTimeout(this._chatThreadsFlushTimer)
       this._chatThreadsFlushTimer = null
+    }
+    // Final synchronous flush of any snapshot scheduled within the debounce
+    // window but not yet written. Without this, a message sent immediately
+    // before Obsidian exits / the plugin is disabled would be lost (Codex P1,
+    // PR #346). `_flushChatThreads` is async; onunload() is fire-and-forget
+    // per Obsidian's contract, so void is correct here.
+    if (this._pendingChatThreadsSnapshot !== null) {
+      const snapshot = this._pendingChatThreadsSnapshot
+      this._pendingChatThreadsSnapshot = null
+      void this._flushChatThreads(snapshot)
     }
     this.app.workspace.detachLeavesOfType(VIEW_TYPE)
     this.bridge?.hideAllNotices()
@@ -335,11 +354,13 @@ export default class SpecoratorPlugin extends Plugin {
    */
   scheduleChatThreadsPersistence(records: ReadonlyMap<string, ChatThreadRecord>): void {
     const snapshot = new Map(records)
+    this._pendingChatThreadsSnapshot = snapshot
     if (this._chatThreadsFlushTimer !== null) {
       activeWindow.clearTimeout(this._chatThreadsFlushTimer)
     }
     this._chatThreadsFlushTimer = activeWindow.setTimeout(() => {
       this._chatThreadsFlushTimer = null
+      this._pendingChatThreadsSnapshot = null
       void this._flushChatThreads(snapshot)
     }, SpecoratorPlugin._CHAT_THREADS_FLUSH_DEBOUNCE_MS)
   }

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -11,6 +11,11 @@ import { promoteLegacyFlatSettings } from './loadSettings-migrate'
 import { ensureLeafLoaded } from './leafLoader'
 import { selectTransport } from './transport/TransportSelector'
 import { DEFAULT_SETTINGS, type PluginSettings } from '@/domain/settings/PluginSettings'
+import type { ChatThreadRecord } from '@/domain/chat/ChatThreadRecord'
+import {
+  decodeChatThreadsBlob,
+  encodeChatThreadsBlob,
+} from './chatThreadsPersistence'
 import { ObsidianBridge } from '@/infrastructure/obsidian/ObsidianBridge'
 import { ObsidianMcpServerAdapter } from '@/infrastructure/obsidian/ObsidianMcpServerAdapter'
 import { ObsidianMetadataCacheAdapter } from '@/infrastructure/obsidian/ObsidianMetadataCacheAdapter'
@@ -44,6 +49,18 @@ export default class SpecoratorPlugin extends Plugin {
   private _subscriptionAdapter: ClaudeSubprocessAdapter | null = null
   /** SpecoratorView instance — set when the registered view factory runs. */
   private _specoratorView: SpecoratorView | null = null
+
+  /**
+   * Initial `chatThreads` records hydrated from plugin data at `loadSettings()`
+   * (SPEC-ASM-001 §9.3, ADR-0031). Read by `SpecoratorView.onOpen()` to seed
+   * the Pinia chat store and reset on each successful read. Malformed records
+   * are filtered out at decode time and logged at `warn` (SPEC §11.3).
+   */
+  private _initialChatThreads: ReadonlyArray<ChatThreadRecord> = []
+  /** Debounced persistence timer for `chatThreads`. SPEC §9.3 / OQ-ASM-T1. */
+  private _chatThreadsFlushTimer: number | null = null
+  /** Default debounce window in milliseconds for chatThreads flushes. */
+  private static readonly _CHAT_THREADS_FLUSH_DEBOUNCE_MS = 1_000
 
   async onload(): Promise<void> {
     await this.loadSettings()
@@ -261,6 +278,10 @@ export default class SpecoratorPlugin extends Plugin {
   // expected cleanup path despite the obsidianmd/detach-leaves rule's caution.
   // eslint-disable-next-line obsidianmd/detach-leaves
   override onunload(): void {
+    if (this._chatThreadsFlushTimer !== null) {
+      activeWindow.clearTimeout(this._chatThreadsFlushTimer)
+      this._chatThreadsFlushTimer = null
+    }
     this.app.workspace.detachLeavesOfType(VIEW_TYPE)
     this.bridge?.hideAllNotices()
     // onunload() is synchronous (Obsidian contract). destroy() is fire-and-forget;
@@ -278,6 +299,64 @@ export default class SpecoratorPlugin extends Plugin {
       ...DEFAULT_SETTINGS,
       ...((this._storedData.specorator ?? {}) as Partial<PluginSettings>),
     }
+
+    // SPEC-ASM-001 §9.3 — read the `chatThreads` blob alongside settings so
+    // `SpecoratorView.onOpen()` can hydrate the chat store after the view
+    // mounts. Decoding uses the plugin bridge logger when present (typed once
+    // available in `onload()`); during `loadSettings()` we route warnings to
+    // `console.warn` because `this.bridge` is not yet constructed.
+    const specoratorBlob = (this._storedData.specorator ?? {}) as Record<string, unknown>
+    const chatThreadsBlob = specoratorBlob.chatThreads
+    this._initialChatThreads = decodeChatThreadsBlob(chatThreadsBlob, {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: (msg, ctx) => { console.warn(msg, ctx ?? {}) },
+      error: (msg, ctx) => { console.error(msg, ctx ?? {}) },
+    })
+  }
+
+  /**
+   * Records hydrated from `_storedData.specorator.chatThreads` during
+   * `loadSettings()`. Consumed by `SpecoratorView.onOpen()` (SPEC §9.5 /
+   * REQ-ASM-037) to seed the Pinia chat store.
+   */
+  getInitialChatThreads(): ReadonlyArray<ChatThreadRecord> {
+    return this._initialChatThreads
+  }
+
+  /**
+   * Persists the in-memory `chatThreads` map to plugin data under
+   * `_storedData.specorator.chatThreads` (SPEC §9.3). Filters out
+   * `degraded`-transport records at encode time. Coalesces rapid mutations
+   * via a 1 s debounce (OQ-ASM-T1) to prevent disk thrashing during streaming
+   * turns.
+   *
+   * Satisfies REQ-ASM-037 / T-ASM-054.
+   */
+  scheduleChatThreadsPersistence(records: ReadonlyMap<string, ChatThreadRecord>): void {
+    const snapshot = new Map(records)
+    if (this._chatThreadsFlushTimer !== null) {
+      activeWindow.clearTimeout(this._chatThreadsFlushTimer)
+    }
+    this._chatThreadsFlushTimer = activeWindow.setTimeout(() => {
+      this._chatThreadsFlushTimer = null
+      void this._flushChatThreads(snapshot)
+    }, SpecoratorPlugin._CHAT_THREADS_FLUSH_DEBOUNCE_MS)
+  }
+
+  /**
+   * Internal: write the encoded `chatThreads` blob into `_storedData` while
+   * preserving every other sibling key under `specorator` (PluginSettings,
+   * unrelated module data, etc.) — see SPEC §9.3 coexistence guarantee.
+   */
+  private async _flushChatThreads(
+    records: ReadonlyMap<string, ChatThreadRecord>,
+  ): Promise<void> {
+    const encoded = encodeChatThreadsBlob(records)
+    const currentSpecorator = (this._storedData.specorator ?? {}) as Record<string, unknown>
+    const nextSpecorator = { ...currentSpecorator, chatThreads: encoded }
+    this._storedData = { ...this._storedData, specorator: nextSpecorator }
+    await this.saveData(this._storedData)
   }
 
   async updateSettings(partial: Partial<PluginSettings>): Promise<void> {

--- a/src/ui/AppRoot.vue
+++ b/src/ui/AppRoot.vue
@@ -66,6 +66,24 @@ onUnmounted(() => {
 .specorator-root *::after {
   box-sizing: border-box;
 }
+
+/* Global utility: visually-hidden but screen-reader-readable. Kept here in
+   AppRoot's unscoped <style> block so the SFC-driven build pipeline tracks
+   the rule and emits it into styles.css on every regeneration. Previously
+   lived as plain CSS in styles.css and got pruned on every build:web run
+   (recurring Codex P2). Consumed by ContextFileChip.vue and any other
+   component that surfaces accessible labels without visible text. */
+.specorator-root .sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
 </style>
 
 <!-- Standalone-only variables are imported by main.ts and scoped to .specorator-root.

--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -8,6 +8,7 @@ import { useVaultPort } from '@/ui/composables/useVaultPort'
 import { useWorkspacePort } from '@/ui/composables/useWorkspacePort'
 import { useSettingsPort } from '@/ui/composables/useSettingsPort'
 import { useLoggerPort } from '@/ui/composables/useLoggerPort'
+import { useSessionLogWriter } from '@/ui/composables/useSessionLogWriter'
 import { buildPrompt } from '@/application/chat/buildPrompt'
 import type { ContextFile } from '@/application/chat/buildPrompt'
 import {
@@ -17,9 +18,13 @@ import {
 } from '@/application/chat/assembleSystemPrompt'
 import { buildStagePromptMap } from '@/application/chat/stagePromptMap'
 import { SETTINGS_VERSION_KEY } from '@/infrastructure/bridge/ports'
+import type { SessionId } from '@/domain/chat/SessionId'
+import type { ChatThreadRecord } from '@/domain/chat/ChatThreadRecord'
 import ContextFileList from './ContextFileList.vue'
 import ChatInput from './ChatInput.vue'
 import ChatResponse from './ChatResponse.vue'
+import SubprocessStartingPill from './SubprocessStartingPill.vue'
+import SessionResumeIndicator from './SessionResumeIndicator.vue'
 
 const store = useChatStore()
 const claudeCliPort = useClaudeCliPort()
@@ -28,6 +33,18 @@ const vaultPort = useVaultPort()
 const workspacePort = useWorkspacePort()
 const settingsPort = useSettingsPort()
 const loggerPort = useLoggerPort()
+const sessionLogWriterFactory = useSessionLogWriter()
+
+/**
+ * Generate a UUID for new thread ids. Falls back to a timestamp-keyed value
+ * when `crypto.randomUUID` is missing (older test environments). The fallback
+ * is collision-resistant enough for in-memory thread maps within a session.
+ */
+function generateThreadId(): string {
+  const c = globalThis.crypto as { randomUUID?: () => string } | undefined
+  if (c?.randomUUID !== undefined) return c.randomUUID()
+  return `thread-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+}
 
 /**
  * Frozen stage-prompt descriptor table. Built once per component instance and
@@ -109,32 +126,31 @@ const responseState = computed<ResponseState>(() => {
   return 'idle'
 })
 
-// Send handler
-async function handleSend(): Promise<void> {
-  const text = store.userText.trim()
-  if (!text) return // REQ-CCS-015: empty text guard
-  if (store.status === 'loading') return
-  if (!available.value) return
-
-  store.beginRequest()
-
-  // Stage-aware system-prompt suffix (REQ-ASM-013, REQ-ASM-014, REQ-ASM-018,
-  // REQ-ASM-019). Recomputed every send — no caching. Resolves the active
-  // feature from the current editor file, reads its workflow-state, and
-  // assembles a one-shot stage preamble. Any failure (no active file, file
-  // not under specsFolder, vault read error, malformed frontmatter, unknown
-  // stage) falls back to an empty suffix so the send still proceeds.
-  const settings = await settingsPort.getSettings()
+/**
+ * Compute the stage-aware system-prompt suffix for this send (REQ-ASM-013,
+ * REQ-ASM-014, REQ-ASM-018, REQ-ASM-019). Resolves the active feature from
+ * the current editor file, reads its workflow-state, and assembles a
+ * one-shot stage preamble. Any failure falls back to an empty suffix so
+ * the send still proceeds (REQ-ASM-015).
+ */
+async function computeStagePromptContext(
+  specsFolder: string,
+): Promise<{ slug: string | null; systemPromptSuffix: string }> {
   const activeFile = workspacePort.getActiveFile()
-  const slug = getActiveFeatureSlug(activeFile?.path ?? null, settings.specsFolder)
+  const slug = getActiveFeatureSlug(activeFile?.path ?? null, specsFolder)
   const snapshot =
     slug !== null
-      ? await loadWorkflowStateSnapshot(slug, vaultPort, loggerPort, settings.specsFolder)
+      ? await loadWorkflowStateSnapshot(slug, vaultPort, loggerPort, specsFolder)
       : null
   const systemPromptSuffix = assembleSystemPrompt(snapshot, stagePromptMap)
+  return { slug, systemPromptSuffix }
+}
 
-  // Load file contents for all context files; failed reads yield empty content
-  const loadedFiles: ContextFile[] = await Promise.all(
+/**
+ * Load file contents for all context files; failed reads yield empty content.
+ */
+async function loadContextFileBodies(): Promise<ContextFile[]> {
+  return Promise.all(
     store.contextFiles.map(async (entry) => {
       const readResult = await tryAsync(() => vaultPort.readFile(entry.path))
       return {
@@ -145,30 +161,164 @@ async function handleSend(): Promise<void> {
       }
     }),
   )
+}
 
+/**
+ * Resolve (or lazily create) the active `ChatThreadRecord`. Returns the
+ * thread id and whether this turn carries a resume session id (REQ-ASM-035).
+ */
+function resolveActiveThread(args: {
+  slug: string | null
+  transport: 'api-key' | 'subscription'
+}): { threadId: string; resumeSessionId: SessionId | undefined; isResumedTurn: boolean } {
+  const nowIso = new Date().toISOString()
+  let threadId = store.activeThreadId
+  if (threadId === null || !store.chatThreads.has(threadId)) {
+    threadId = threadId ?? generateThreadId()
+    const fresh: ChatThreadRecord = {
+      threadId,
+      sessionId: null,
+      feature: args.slug,
+      logPath: '',
+      transport: args.transport,
+      createdAt: nowIso,
+      lastUsedAt: nowIso,
+    }
+    store.upsertThread(fresh)
+    store.setActiveThreadId(threadId)
+  }
+  const record = store.chatThreads.get(threadId)
+  const resumeSessionId = record?.sessionId ?? undefined
+  return { threadId, resumeSessionId, isResumedTurn: resumeSessionId !== undefined }
+}
+
+/**
+ * Fire-and-forget mirror of a successful turn to the vault (REQ-ASM-040). The
+ * writer drops the write silently when no `session_id` has been captured yet
+ * (first-ever turn on an `'api-key'` thread). All failures are routed to
+ * `loggerPort.warn` so the chat-send path completes normally.
+ */
+function mirrorTurnToVault(args: {
+  threadId: string
+  userMessage: string
+  assistantResponse: string
+}): void {
+  const thread = store.chatThreads.get(args.threadId)
+  if (thread === undefined) return
+  void sessionLogWriterFactory
+    .getWriter()
+    .then((writer) =>
+      writer.appendUserAssistant(thread, {
+        user: args.userMessage,
+        assistant: args.assistantResponse,
+      }),
+    )
+    .catch((error: unknown) => {
+      loggerPort.warn('SessionLogWriter.appendUserAssistant failed', {
+        threadId: args.threadId,
+        reason: error instanceof Error ? error.message : String(error),
+      })
+    })
+}
+
+/**
+ * Apply success-side store mutations and schedule the vault mirror.
+ */
+function applySuccessfulTurn(args: {
+  threadId: string
+  isResumedTurn: boolean
+  userMessage: string
+  assistantResponse: string
+  truncated: boolean
+}): void {
+  store.setResponse(args.assistantResponse, args.truncated)
+  store.setUserText('')
+  store.markThreadUsed(args.threadId)
+  if (args.isResumedTurn) {
+    // Flash the resume indicator for this turn only (REQ-ASM-035).
+    store.setSessionResumed(true)
+  }
+  mirrorTurnToVault({
+    threadId: args.threadId,
+    userMessage: args.userMessage,
+    assistantResponse: args.assistantResponse,
+  })
+}
+
+// Send handler
+async function handleSend(): Promise<void> {
+  const text = store.userText.trim()
+  if (!text) return // REQ-CCS-015: empty text guard
+  if (store.status === 'loading') return
+  if (!available.value) return
+
+  // Snapshot the raw user text *before* beginRequest() so we can mirror it to
+  // the session log post-turn — beginRequest does not clear userText, but the
+  // success branch below does.
+  const userMessage = store.userText
+
+  store.beginRequest()
+
+  // Stage-aware system-prompt suffix (REQ-ASM-013, REQ-ASM-014, REQ-ASM-018,
+  // REQ-ASM-019). Recomputed every send — no caching. Resolves the active
+  // feature from the current editor file, reads its workflow-state, and
+  // assembles a one-shot stage preamble. Any failure (no active file, file
+  // not under specsFolder, vault read error, malformed frontmatter, unknown
+  // stage) falls back to an empty suffix so the send still proceeds.
+  const settings = await settingsPort.getSettings()
+  const { slug, systemPromptSuffix } = await computeStagePromptContext(settings.specsFolder)
+
+  // ── Session-persistence wiring (T-ASM-057, REQ-ASM-031/034/035/037/040) ──
+  const transport: 'api-key' | 'subscription' =
+    settings.transportKind === 'subscription' ? 'subscription' : 'api-key'
+  const { threadId, resumeSessionId, isResumedTurn } = resolveActiveThread({ slug, transport })
+  const onSessionId = (id: SessionId): void => {
+    store.captureSessionId(threadId, id)
+  }
+
+  const loadedFiles = await loadContextFileBodies()
   const { prompt, truncated } = buildPrompt(store.userText, loadedFiles)
 
-  if (claudeCliPort === undefined) { store.setError('query_failed'); return }
-  const result = await claudeCliPort.query(prompt, {
-    timeoutMs: 30_000,
-    systemPromptSuffix,
-  })
-
-  if (result.ok) {
-    store.setResponse(result.value, truncated)
-    store.setUserText('')
-    await nextTick()
-    focusTextarea()
-  } else {
-    const errorCode = result.error.errorCode
-    if (errorCode === 'TIMEOUT') {
-      store.setError('timeout')
-    } else {
-      store.setError('query_failed')
-    }
-    await nextTick()
-    focusTextarea()
+  if (claudeCliPort === undefined) {
+    store.setError('query_failed')
+    return
   }
+
+  // Cold-spawn pill (R-ASM-003). Cleared on completion or error.
+  store.setCliStartingUp(true)
+  const queryResult = await tryAsync(() =>
+    claudeCliPort.query(prompt, {
+      timeoutMs: 30_000,
+      systemPromptSuffix,
+      resumeSessionId,
+      onSessionId,
+    }),
+  )
+  store.setCliStartingUp(false)
+
+  if (!queryResult.ok) {
+    // `claudeCliPort.query` is contracted never to throw (returns a Result),
+    // but a rogue mock or future regression could; fall back to query_failed.
+    store.setError('query_failed')
+    await nextTick()
+    focusTextarea()
+    return
+  }
+
+  const result = queryResult.value
+  if (result.ok) {
+    applySuccessfulTurn({
+      threadId,
+      isResumedTurn,
+      userMessage,
+      assistantResponse: result.value,
+      truncated,
+    })
+  } else {
+    store.setError(result.error.errorCode === 'TIMEOUT' ? 'timeout' : 'query_failed')
+  }
+  await nextTick()
+  focusTextarea()
 }
 
 function handleRemoveFile(event: { path: string }): void {
@@ -261,7 +411,11 @@ watch(available, async () => {
 
     <!-- Ready state -->
     <template v-else>
-      <h2 class="sp-chat__title">Ask Claude.</h2>
+      <div class="sp-chat__header">
+        <h2 class="sp-chat__title">Ask Claude.</h2>
+        <SessionResumeIndicator :resumed="store.sessionResumed" />
+        <SubprocessStartingPill :visible="store.cliStartingUp" />
+      </div>
 
       <ContextFileList
         :files="store.contextFiles"
@@ -305,6 +459,13 @@ watch(available, async () => {
   font-size: 1.125rem;
   font-weight: 700;
   color: var(--text-normal);
+}
+
+.sp-chat__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .sp-chat__divider {

--- a/src/ui/components/chat/SessionResumeIndicator.vue
+++ b/src/ui/components/chat/SessionResumeIndicator.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+/**
+ * SessionResumeIndicator — small inline badge shown in the chat panel
+ * header when the current thread was resumed from a stored sessionId.
+ *
+ * Satisfies SPEC-ASM-001 §7.3 (REQ-ASM-035, NFR-ASM-001, NFR-ASM-008).
+ * Plain-language copy per DESIGN-ASM-001 §B3:
+ *   chat.subscription.resumeAriaLabel = "Continuing prior conversation"
+ *
+ * The component is purely presentational; the parent (ChatSidebar)
+ * binds `resumed` from `chatStore.sessionResumed`.
+ */
+defineProps<{
+  resumed: boolean
+}>()
+</script>
+
+<template>
+  <span
+    v-if="resumed"
+    class="sp-chat__resume-badge"
+    data-testid="chat-session-resume"
+    aria-label="Continuing prior conversation"
+  >
+    <span
+      aria-hidden="true"
+      class="sp-chat__resume-glyph"
+      data-testid="chat-session-resume-glyph"
+    >↻</span>
+  </span>
+</template>
+
+<style scoped>
+.sp-chat__resume-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 9999px;
+  background: var(--background-modifier-border);
+  color: var(--sp-resume-badge-fg, var(--interactive-accent));
+  font-size: 0.875rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.sp-chat__resume-glyph {
+  display: inline-block;
+}
+</style>

--- a/src/ui/components/chat/SubprocessStartingPill.vue
+++ b/src/ui/components/chat/SubprocessStartingPill.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+/**
+ * SubprocessStartingPill — short-lived pill shown during the Claude CLI
+ * cold-spawn window (≈300–3000 ms on macOS) to mitigate R-ASM-003.
+ *
+ * Satisfies SPEC-ASM-001 §7.2 (REQ-ASM-035, NFR-ASM-001, NFR-ASM-008).
+ * Plain-language copy per DESIGN-ASM-001 §B3:
+ *   chat.subscription.starting = "Starting up the Claude tool…"
+ *
+ * The component is purely presentational; the parent (ChatSidebar)
+ * binds `visible` from `chatStore.cliStartingUp`.
+ */
+defineProps<{
+  visible: boolean
+}>()
+</script>
+
+<template>
+  <span
+    v-if="visible"
+    class="sp-chat__starting-pill"
+    data-testid="chat-subprocess-starting"
+    role="status"
+    aria-live="polite"
+  >
+    Starting up the Claude tool…
+  </span>
+</template>
+
+<style scoped>
+.sp-chat__starting-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 9999px;
+  padding: 0.15rem 0.625rem;
+  background: var(--background-modifier-border);
+  color: var(--text-muted);
+  font-family: var(--font-text);
+  font-size: 0.8125rem;
+  line-height: 1.2;
+}
+</style>

--- a/src/ui/composables/useSessionLogWriter.ts
+++ b/src/ui/composables/useSessionLogWriter.ts
@@ -1,0 +1,56 @@
+/**
+ * T-ASM-057 — `useSessionLogWriter` composable.
+ *
+ * Constructs and memoises a {@link SessionLogWriter} for the active component
+ * tree. The writer is bound to the current `VaultPort` + `LoggerPort` + the
+ * `specsFolder` resolved from {@link SettingsPort.getSettings} (REQ-ASM-038).
+ *
+ * The writer is intentionally created per consumer rather than provided
+ * globally:
+ *   - It carries per-instance mutexes and conflict-suffix memoisation
+ *     (SPEC-ASM-001 §6.7). Sharing across consumers via `provide`/`inject` is
+ *     a future optimisation; in v1 the panel is mounted in a single view so a
+ *     fresh writer per mount is correct.
+ *   - Construction is cheap: no I/O, just three field assignments.
+ *
+ * Returns a small accessor object so callers can fire-and-forget
+ * `appendUserAssistant` from `ChatSidebar.handleSend` without awaiting the
+ * underlying vault writes (REQ-ASM-040).
+ *
+ * Pure UI-layer composable: imports only narrow ports + the application-layer
+ * writer class. No `obsidian` imports.
+ */
+import { SessionLogWriter } from '@/application/chat/SessionLogWriter'
+import { useVaultPort } from '@/ui/composables/useVaultPort'
+import { useLoggerPort } from '@/ui/composables/useLoggerPort'
+import { useSettingsPort } from '@/ui/composables/useSettingsPort'
+
+export interface UseSessionLogWriter {
+	/**
+	 * Returns the lazily-constructed {@link SessionLogWriter}. The writer is
+	 * cached on first call; subsequent calls return the same instance so the
+	 * per-log-file mutex map serialises correctly (REQ-ASM-040).
+	 */
+	getWriter(): Promise<SessionLogWriter>
+}
+
+export function useSessionLogWriter(): UseSessionLogWriter {
+	const vault = useVaultPort()
+	const logger = useLoggerPort()
+	const settings = useSettingsPort()
+	let cached: SessionLogWriter | null = null
+
+	return {
+		async getWriter(): Promise<SessionLogWriter> {
+			if (cached !== null) return cached
+			const current = await settings.getSettings()
+			cached = new SessionLogWriter(
+				vault,
+				logger,
+				current.specsFolder,
+				() => new Date().toISOString(),
+			)
+			return cached
+		},
+	}
+}

--- a/src/ui/stores/chatStore.ts
+++ b/src/ui/stores/chatStore.ts
@@ -1,6 +1,14 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
+import type { ChatThreadRecord } from '@/domain/chat/ChatThreadRecord'
+import type { SessionId } from '@/domain/chat/SessionId'
+import type {
+  FileWriteProposal,
+  FileWriteProposalStatus,
+} from '@/application/chat/FileWriteProposal'
+import type { CommitProposalErrorCode } from '@/application/chat/errors'
+
 /**
  * Plain DTO stored in Pinia. Does NOT include file content — content is loaded
  * on-demand at send time via VaultPort.readFile(). Satisfies D-CCS-005.
@@ -37,7 +45,8 @@ export type ChatErrorType = 'timeout' | 'query_failed'
  * Pinia store for the chat sidebar panel.
  * State holds DTOs only — no domain class instances, no file content in state.
  * Satisfies REQ-CCS-005, REQ-CCS-006, REQ-CCS-009, REQ-CCS-010,
- * REQ-CCS-013, REQ-CCS-014, REQ-CCS-016, SPEC-CCS-001 §4.
+ * REQ-CCS-013, REQ-CCS-014, REQ-CCS-016, SPEC-CCS-001 §4,
+ * and SPEC-ASM-001 §8.1 (REQ-ASM-031, REQ-ASM-035, REQ-ASM-037, REQ-ASM-041).
  */
 export const useChatStore = defineStore('chat', () => {
   /**
@@ -74,6 +83,46 @@ export const useChatStore = defineStore('chat', () => {
    * Cleared by beginRequest(). Drives trim notice in ChatResponse.
    */
   const truncated = ref<boolean>(false)
+
+  // ── ASM additions (SPEC-ASM-001 §8.1) ────────────────────────────────────
+
+  /**
+   * All known chat threads, keyed by `threadId`. Hydrated from
+   * `_storedData.specorator.chatThreads` at view mount (SPEC §9.3) and
+   * mutated by `upsertThread` / `captureSessionId` / `markThreadUsed`.
+   * REQ-ASM-037.
+   */
+  const chatThreads = ref<Map<string, ChatThreadRecord>>(new Map())
+
+  /**
+   * `threadId` of the thread the user is currently viewing, or `null` when no
+   * thread is selected. REQ-ASM-031.
+   */
+  const activeThreadId = ref<string | null>(null)
+
+  /**
+   * Unresolved or recently-decided file-write proposals, keyed by
+   * `proposalId`. REQ-ASM-041.
+   */
+  const proposals = ref<Map<string, FileWriteProposal>>(new Map())
+
+  /**
+   * Accumulated `stream_event` deltas from the active turn. Cleared by
+   * `resetStreaming()` between turns. NFR-ASM-002.
+   */
+  const streamingText = ref<string>('')
+
+  /**
+   * `true` while the subprocess adapter is performing first-run startup;
+   * drives `SubprocessStartingPill`. R-ASM-003.
+   */
+  const cliStartingUp = ref<boolean>(false)
+
+  /**
+   * `true` for the duration of the first turn after the subprocess adapter
+   * resumes a stored session id; drives `SessionResumeIndicator`. REQ-ASM-035.
+   */
+  const sessionResumed = ref<boolean>(false)
 
   // ── Actions ──────────────────────────────────────────────────────────────
 
@@ -162,6 +211,121 @@ export const useChatStore = defineStore('chat', () => {
     status.value = 'idle'
     errorType.value = null
     truncated.value = false
+    chatThreads.value = new Map()
+    activeThreadId.value = null
+    proposals.value = new Map()
+    streamingText.value = ''
+    cliStartingUp.value = false
+    sessionResumed.value = false
+  }
+
+  // ── ASM actions (SPEC-ASM-001 §8.1) ──────────────────────────────────────
+
+  /**
+   * Adds a new `ChatThreadRecord`, or replaces an existing one with the same
+   * `threadId`. REQ-ASM-037.
+   */
+  function upsertThread(record: ChatThreadRecord): void {
+    const next = new Map(chatThreads.value)
+    next.set(record.threadId, record)
+    chatThreads.value = next
+  }
+
+  /**
+   * Switches the active thread. Passing `null` clears the selection. In both
+   * branches the per-thread transient slots (`streamingText`, `sessionResumed`)
+   * are cleared because they describe the previous thread's in-flight turn.
+   * REQ-ASM-031.
+   */
+  function setActiveThreadId(threadId: string | null): void {
+    activeThreadId.value = threadId
+    streamingText.value = ''
+    sessionResumed.value = false
+  }
+
+  /**
+   * Captures the `system/init` session id for an existing thread. No-op if
+   * the thread is unknown — the caller is expected to `upsertThread` first.
+   * REQ-ASM-031, REQ-ASM-037.
+   */
+  function captureSessionId(threadId: string, sessionId: SessionId): void {
+    const existing = chatThreads.value.get(threadId)
+    if (existing === undefined) return
+    const next = new Map(chatThreads.value)
+    next.set(threadId, { ...existing, sessionId })
+    chatThreads.value = next
+  }
+
+  /**
+   * Bumps `lastUsedAt` on the matching thread to "now" (ISO 8601 UTC). No-op
+   * if the thread is unknown. REQ-ASM-037.
+   */
+  function markThreadUsed(threadId: string): void {
+    const existing = chatThreads.value.get(threadId)
+    if (existing === undefined) return
+    const next = new Map(chatThreads.value)
+    next.set(threadId, { ...existing, lastUsedAt: new Date().toISOString() })
+    chatThreads.value = next
+  }
+
+  /**
+   * Appends a streaming-text delta. NFR-ASM-002.
+   */
+  function appendStreamingDelta(delta: string): void {
+    streamingText.value = streamingText.value + delta
+  }
+
+  /**
+   * Clears the streaming-text accumulator and the transient session-resumed
+   * indicator. Called at turn boundaries. NFR-ASM-002, REQ-ASM-035.
+   */
+  function resetStreaming(): void {
+    streamingText.value = ''
+    sessionResumed.value = false
+  }
+
+  /**
+   * Stores a new `FileWriteProposal`. Replaces any prior proposal with the
+   * same `proposalId` (idempotent re-emission is tolerated). REQ-ASM-041.
+   */
+  function addProposal(proposal: FileWriteProposal): void {
+    const next = new Map(proposals.value)
+    next.set(proposal.proposalId, proposal)
+    proposals.value = next
+  }
+
+  /**
+   * Transitions a proposal to a new lifecycle status. Stamps `decidedAt` with
+   * "now" for any non-`pending` status. Records `failureReason` only when the
+   * status transitions to `'failed'`; clears it otherwise. No-op if the
+   * proposal is unknown. REQ-ASM-043, REQ-ASM-045.
+   */
+  function setProposalStatus(
+    proposalId: string,
+    nextStatus: FileWriteProposalStatus,
+    failureReason?: CommitProposalErrorCode,
+  ): void {
+    const existing = proposals.value.get(proposalId)
+    if (existing === undefined) return
+    const decidedAt = nextStatus === 'pending' ? null : new Date().toISOString()
+    const next = new Map(proposals.value)
+    next.set(proposalId, {
+      ...existing,
+      status: nextStatus,
+      decidedAt,
+      failureReason: nextStatus === 'failed' ? (failureReason ?? null) : null,
+    })
+    proposals.value = next
+  }
+
+  /** Sets the subprocess-startup pill flag. R-ASM-003. */
+  function setCliStartingUp(value: boolean): void {
+    cliStartingUp.value = value
+  }
+
+  /** Sets the session-resumed indicator flag. REQ-ASM-035. */
+  function setSessionResumed(value: boolean): void {
+    sessionResumed.value = value
   }
 
   return {
@@ -171,6 +335,12 @@ export const useChatStore = defineStore('chat', () => {
     status,
     errorType,
     truncated,
+    chatThreads,
+    activeThreadId,
+    proposals,
+    streamingText,
+    cliStartingUp,
+    sessionResumed,
     addContextFile,
     removeContextFile,
     setActiveFile,
@@ -180,5 +350,15 @@ export const useChatStore = defineStore('chat', () => {
     setError,
     clearResponse,
     reset,
+    upsertThread,
+    setActiveThreadId,
+    captureSessionId,
+    markThreadUsed,
+    appendStreamingDelta,
+    resetStreaming,
+    addProposal,
+    setProposalStatus,
+    setCliStartingUp,
+    setSessionResumed,
   }
 })

--- a/styles.css
+++ b/styles.css
@@ -1,11 +1,11 @@
 
 /* Screen-reader-only utility — visually hidden but readable by assistive
-   technology. Restored after the PR-ASM-1 build:web regeneration pruned
-   it (Codex P2). Consumed by ContextFileChip.vue and other components
-   that surface accessible labels without visible text. The bundler keeps
-   trimming this rule because no Vue SFC currently declares it inside a
-   scoped <style> block — it lives only as plain CSS, and the
-   SFC-hash-driven pruner doesn't see it as referenced. */
+   technology. Restored after build:web regeneration pruned it again
+   (recurring Codex P2 first seen on PR #325). The bundler keeps trimming
+   this rule because no Vue SFC declares it inside a scoped <style> block —
+   it lives only as plain CSS, and the SFC-hash-driven pruner doesn't see
+   it as referenced. Consumed by ContextFileChip.vue and other components
+   that surface accessible labels without visible text. */
 .specorator-root .sr-only {
   position: absolute;
   width: 1px;
@@ -539,7 +539,36 @@ to { transform: rotate(360deg);
   margin: 0;
 }
 
-.specorator-root :where(.sp-chat-sidebar[data-v-b0475bd3]) {
+.specorator-root :where(.sp-chat__starting-pill[data-v-b2b1ec9e]) {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 9999px;
+  padding: 0.15rem 0.625rem;
+  background: var(--background-modifier-border);
+  color: var(--text-muted);
+  font-family: var(--font-text);
+  font-size: 0.8125rem;
+  line-height: 1.2;
+}
+
+.specorator-root :where(.sp-chat__resume-badge[data-v-4c612904]) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 9999px;
+  background: var(--background-modifier-border);
+  color: var(--sp-resume-badge-fg, var(--interactive-accent));
+  font-size: 0.875rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.specorator-root :where(.sp-chat__resume-glyph[data-v-4c612904]) {
+  display: inline-block;
+}
+
+.specorator-root :where(.sp-chat-sidebar[data-v-ebfc2eb6]) {
   padding: 1rem;
   display: flex;
   flex-direction: column;
@@ -547,18 +576,24 @@ to { transform: rotate(360deg);
   height: 100%;
   box-sizing: border-box;
 }
-.specorator-root :where(.sp-chat__title[data-v-b0475bd3]) {
+.specorator-root :where(.sp-chat__title[data-v-ebfc2eb6]) {
   margin: 0;
   font-size: 1.125rem;
   font-weight: 700;
   color: var(--text-normal);
 }
-.specorator-root :where(.sp-chat__divider[data-v-b0475bd3]) {
+.specorator-root :where(.sp-chat__header[data-v-ebfc2eb6]) {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.specorator-root :where(.sp-chat__divider[data-v-ebfc2eb6]) {
   margin: 0;
   border: none;
   border-top: 1px solid var(--background-modifier-border);
 }
-.specorator-root :where(.sp-chat__degraded[data-v-b0475bd3]) {
+.specorator-root :where(.sp-chat__degraded[data-v-ebfc2eb6]) {
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
   border-radius: 8px;
@@ -567,13 +602,13 @@ to { transform: rotate(360deg);
   flex-direction: column;
   gap: 0.5rem;
 }
-.specorator-root :where(.sp-chat__degraded-heading[data-v-b0475bd3]) {
+.specorator-root :where(.sp-chat__degraded-heading[data-v-ebfc2eb6]) {
   margin: 0;
   font-size: 1rem;
   font-weight: 600;
   color: var(--text-normal);
 }
-.specorator-root :where(.sp-chat__degraded-body[data-v-b0475bd3]) {
+.specorator-root :where(.sp-chat__degraded-body[data-v-ebfc2eb6]) {
   margin: 0;
   font-size: 0.875rem;
   color: var(--text-muted);

--- a/styles.css
+++ b/styles.css
@@ -1,23 +1,4 @@
 
-/* Screen-reader-only utility — visually hidden but readable by assistive
-   technology. Restored after build:web regeneration pruned it again
-   (recurring Codex P2 first seen on PR #325). The bundler keeps trimming
-   this rule because no Vue SFC declares it inside a scoped <style> block —
-   it lives only as plain CSS, and the SFC-hash-driven pruner doesn't see
-   it as referenced. Consumed by ContextFileChip.vue and other components
-   that surface accessible labels without visible text. */
-.specorator-root .sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
 .specorator-root :where(.sp-badge[data-v-a85a8ac3]) {
   display: inline-block;
   padding: 0.1rem 0.5rem;
@@ -920,7 +901,25 @@ to   { opacity: 1; transform: translateY(0);
   box-sizing: border-box;
 }
 
-.specorator-root :where(.sp-app[data-v-8bf3dee4]) {
+/* Global utility: visually-hidden but screen-reader-readable. Kept here in
+   AppRoot's unscoped \3c style> block so the SFC-driven build pipeline tracks
+   the rule and emits it into styles.css on every regeneration. Previously
+   lived as plain CSS in styles.css and got pruned on every build:web run
+   (recurring Codex P2). Consumed by ContextFileChip.vue and any other
+   component that surfaces accessible labels without visible text. */
+.specorator-root .sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.specorator-root :where(.sp-app[data-v-c0ff2e40]) {
   display: flex;
   flex-direction: column;
   height: 100vh;

--- a/tests/application/chat/SessionLogWriter.test.ts
+++ b/tests/application/chat/SessionLogWriter.test.ts
@@ -1,0 +1,407 @@
+/**
+ * T-ASM-046 + T-ASM-047 — `SessionLogWriter`.
+ *
+ * Test plan (REQ-ASM-033, REQ-ASM-034, REQ-ASM-038, REQ-ASM-039, REQ-ASM-040,
+ * REQ-ASM-046, NFR-ASM-005):
+ *
+ *   TEST-ASM-032 — Written file parses as YAML frontmatter with the five
+ *                  named keys plus a `## user` / `## assistant` body.
+ *   TEST-ASM-033 — On a subsequent turn, `writeFile` is called once with the
+ *                  appended content and `updated > created`.
+ *   TEST-ASM-036 — On first write, `createFolder` is invoked once on the
+ *                  parent sessions folder.
+ *   TEST-ASM-037 — Conflicting `session_id` in pre-seeded frontmatter routes
+ *                  the write to `<id>-2.md` and logs `warn` exactly once.
+ *                  Overwrite-suffix loop verified through `-2`, `-3`, `-4`.
+ *   TEST-ASM-038 — A 1 000 ms mocked `writeFile` does not block the call
+ *                  site (fire-and-forget for `appendUserAssistant`).
+ *   Plus: failure path → `logger.error` with a redacted `sessionId` and
+ *   `appendProposalDecision` writes a `## proposal` block (REQ-ASM-046).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { fakeModulePorts, type FakePorts } from '../../__fakes__/fake-ports'
+import { resolveSessionLogPath } from '@/application/chat/sessionLogPath'
+import {
+  SessionLogWriter,
+  type SessionLogProposalInput,
+} from '@/application/chat/SessionLogWriter'
+import type { ChatThreadRecord } from '@/domain/chat/ChatThreadRecord'
+import { asSessionId } from '@/domain/chat/SessionId'
+
+function makeThread(
+  overrides: Partial<Omit<ChatThreadRecord, 'sessionId'>> & {
+    readonly sessionId?: string | null
+  } = {},
+): ChatThreadRecord {
+  const { sessionId, ...rest } = overrides
+  return {
+    threadId: 'thread-1',
+    sessionId: asSessionId('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+    feature: 'foo',
+    logPath: 'specs/foo/sessions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.md',
+    transport: 'subscription',
+    createdAt: '2026-05-14T10:00:00.000Z',
+    lastUsedAt: '2026-05-14T10:00:00.000Z',
+    ...rest,
+    ...(sessionId === undefined
+      ? {}
+      : { sessionId: sessionId === null ? null : asSessionId(sessionId) }),
+  }
+}
+
+function makeWriter(
+  ports: FakePorts,
+  nowIso: () => string = () => '2026-05-14T10:00:00.000Z',
+  specsFolder = 'specs',
+): SessionLogWriter {
+  return new SessionLogWriter(ports.vault, ports.logger, specsFolder, nowIso)
+}
+
+describe('SessionLogWriter.appendUserAssistant — happy path (T-ASM-046)', () => {
+  let ports: FakePorts
+
+  beforeEach(() => {
+    ports = fakeModulePorts()
+  })
+
+  it('first write seeds frontmatter with the five named keys plus user/assistant body (TEST-ASM-032)', async () => {
+    const thread = makeThread()
+    const writer = makeWriter(ports, () => '2026-05-14T10:00:00.000Z')
+
+    await writer.appendUserAssistant(thread, { user: 'hi', assistant: 'hello' })
+
+    const path = resolveSessionLogPath(thread.feature, thread.sessionId!, 'specs')
+    const written = await ports.vault.readFile(path)
+
+    // Frontmatter parses as YAML with the five named keys.
+    expect(written.startsWith('---\n')).toBe(true)
+    const fmEnd = written.indexOf('\n---', 4)
+    expect(fmEnd).toBeGreaterThan(0)
+    const fm = written.slice(4, fmEnd)
+    expect(fm).toMatch(/session_id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'/)
+    expect(fm).toMatch(/feature: 'foo'/)
+    expect(fm).toMatch(/transport: subscription/)
+    expect(fm).toMatch(/created: '2026-05-14T10:00:00\.000Z'/)
+    expect(fm).toMatch(/updated: '2026-05-14T10:00:00\.000Z'/)
+
+    // Body contains the two block headers and the message text.
+    const body = written.slice(fmEnd + 4)
+    expect(body).toContain('## user')
+    expect(body).toContain('## assistant')
+    expect(body).toContain('hi')
+    expect(body).toContain('hello')
+  })
+
+  it('on a subsequent turn, writeFile is called once with appended content and updated > created (TEST-ASM-033)', async () => {
+    const thread = makeThread()
+    const timestamps: ReadonlyArray<string> = [
+      '2026-05-14T10:00:00.000Z',
+      '2026-05-14T10:05:00.000Z',
+    ]
+    let idx = 0
+    const writer = makeWriter(ports, () => {
+      const next = timestamps[idx] ?? '2026-05-14T10:00:00.000Z'
+      idx += 1
+      return next
+    })
+
+    await writer.appendUserAssistant(thread, { user: 'turn1-u', assistant: 'turn1-a' })
+
+    // Spy on writeFile for the second turn so we can count calls precisely.
+    const writeSpy = vi.spyOn(ports.vault, 'writeFile')
+    await writer.appendUserAssistant(thread, { user: 'turn2-u', assistant: 'turn2-a' })
+
+    expect(writeSpy).toHaveBeenCalledTimes(1)
+    const path = resolveSessionLogPath(thread.feature, thread.sessionId!, 'specs')
+    const written = await ports.vault.readFile(path)
+    // Both turns survived.
+    expect(written).toContain('turn1-u')
+    expect(written).toContain('turn1-a')
+    expect(written).toContain('turn2-u')
+    expect(written).toContain('turn2-a')
+    // `updated` advanced; `created` is unchanged.
+    expect(written).toContain("created: '2026-05-14T10:00:00.000Z'")
+    expect(written).toContain("updated: '2026-05-14T10:05:00.000Z'")
+  })
+
+  it('first write under specs/foo/sessions/ calls createFolder once on the parent (TEST-ASM-036)', async () => {
+    const thread = makeThread()
+    const createSpy = vi.spyOn(ports.vault, 'createFolder')
+    const writer = makeWriter(ports)
+
+    await writer.appendUserAssistant(thread, { user: 'a', assistant: 'b' })
+
+    const folderCalls = createSpy.mock.calls.filter(
+      ([p]) => p === 'specs/foo/sessions',
+    )
+    expect(folderCalls.length).toBeGreaterThanOrEqual(1)
+    // The second turn must not re-create the folder unnecessarily (it is fine
+    // for the writer to call `createFolder` again — idempotent at the port —
+    // but the first invocation must have happened at least once).
+    expect(folderCalls.length).toBeLessThanOrEqual(2)
+  })
+
+  it('resolves to the path computed by resolveSessionLogPath', async () => {
+    const thread = makeThread({ sessionId: 'session-xyz', feature: 'bar' })
+    const writer = makeWriter(ports)
+
+    await writer.appendUserAssistant(thread, { user: 'u', assistant: 'a' })
+
+    const path = resolveSessionLogPath('bar', 'session-xyz', 'specs')
+    expect(path).toBe('specs/bar/sessions/session-xyz.md')
+    expect(await ports.vault.fileExists(path)).toBe(true)
+  })
+
+  it('honours a custom specsFolder', async () => {
+    const thread = makeThread({ sessionId: 'sid', feature: 'feat' })
+    const writer = makeWriter(ports, () => '2026-05-14T10:00:00.000Z', 'features')
+
+    await writer.appendUserAssistant(thread, { user: 'u', assistant: 'a' })
+
+    expect(await ports.vault.fileExists('features/feat/sessions/sid.md')).toBe(true)
+  })
+})
+
+describe('SessionLogWriter overwrite suffix (T-ASM-047, TEST-ASM-037)', () => {
+  let ports: FakePorts
+
+  beforeEach(() => {
+    ports = fakeModulePorts()
+  })
+
+  it('routes to <id>-2.md when the target carries a conflicting session_id and logs warn once', async () => {
+    const thread = makeThread({ sessionId: 'mine', feature: 'foo' })
+    const basePath = 'specs/foo/sessions/mine.md'
+    // Pre-seed a colliding file with a different session_id.
+    await ports.vault.writeFile(
+      basePath,
+      [
+        '---',
+        "session_id: 'theirs'",
+        "feature: 'foo'",
+        'transport: subscription',
+        "created: '2026-05-14T08:00:00.000Z'",
+        "updated: '2026-05-14T08:00:00.000Z'",
+        '---',
+        '',
+      ].join('\n'),
+    )
+
+    const writer = makeWriter(ports)
+    await writer.appendUserAssistant(thread, { user: 'u', assistant: 'a' })
+
+    // The original file is untouched.
+    const orig = await ports.vault.readFile(basePath)
+    expect(orig).toContain("session_id: 'theirs'")
+    expect(orig).not.toContain('## user')
+
+    // The suffixed file exists and carries our session_id.
+    const suffixed = await ports.vault.readFile('specs/foo/sessions/mine-2.md')
+    expect(suffixed).toContain("session_id: 'mine'")
+    expect(suffixed).toContain('## user')
+
+    // warn fires exactly once for this session.
+    expect(ports.logger.warn).toHaveBeenCalledTimes(1)
+
+    // Subsequent appends reuse the resolved suffix and do NOT log warn again.
+    await writer.appendUserAssistant(thread, { user: 'u2', assistant: 'a2' })
+    expect(ports.logger.warn).toHaveBeenCalledTimes(1)
+    expect(await ports.vault.readFile('specs/foo/sessions/mine-2.md')).toContain('u2')
+  })
+
+  it('walks the suffix loop through -2, -3, -4 when multiple conflicts pre-exist', async () => {
+    const thread = makeThread({ sessionId: 'mine', feature: 'foo' })
+    const seed = (sid: string): string =>
+      [
+        '---',
+        `session_id: '${sid}'`,
+        "feature: 'foo'",
+        'transport: subscription',
+        "created: '2026-05-14T08:00:00.000Z'",
+        "updated: '2026-05-14T08:00:00.000Z'",
+        '---',
+        '',
+      ].join('\n')
+    await ports.vault.writeFile('specs/foo/sessions/mine.md', seed('a'))
+    await ports.vault.writeFile('specs/foo/sessions/mine-2.md', seed('b'))
+    await ports.vault.writeFile('specs/foo/sessions/mine-3.md', seed('c'))
+
+    const writer = makeWriter(ports)
+    await writer.appendUserAssistant(thread, { user: 'u', assistant: 'a' })
+
+    expect(await ports.vault.fileExists('specs/foo/sessions/mine-4.md')).toBe(true)
+    const four = await ports.vault.readFile('specs/foo/sessions/mine-4.md')
+    expect(four).toContain("session_id: 'mine'")
+    expect(four).toContain('## user')
+    // Originals untouched.
+    expect(await ports.vault.readFile('specs/foo/sessions/mine.md')).toContain("session_id: 'a'")
+    expect(await ports.vault.readFile('specs/foo/sessions/mine-2.md')).toContain("session_id: 'b'")
+    expect(await ports.vault.readFile('specs/foo/sessions/mine-3.md')).toContain("session_id: 'c'")
+  })
+
+  it('reuses the existing file when its frontmatter session_id already matches', async () => {
+    const thread = makeThread({ sessionId: 'mine', feature: 'foo' })
+    await ports.vault.writeFile(
+      'specs/foo/sessions/mine.md',
+      [
+        '---',
+        "session_id: 'mine'",
+        "feature: 'foo'",
+        'transport: subscription',
+        "created: '2026-05-14T08:00:00.000Z'",
+        "updated: '2026-05-14T08:00:00.000Z'",
+        '---',
+        '',
+      ].join('\n'),
+    )
+
+    const writer = makeWriter(ports)
+    await writer.appendUserAssistant(thread, { user: 'u', assistant: 'a' })
+
+    // No suffix file created.
+    expect(await ports.vault.fileExists('specs/foo/sessions/mine-2.md')).toBe(false)
+    const merged = await ports.vault.readFile('specs/foo/sessions/mine.md')
+    expect(merged).toContain('## user')
+    expect(ports.logger.warn).not.toHaveBeenCalled()
+  })
+})
+
+describe('SessionLogWriter fire-and-forget latency (T-ASM-047, TEST-ASM-038)', () => {
+  let ports: FakePorts
+
+  beforeEach(() => {
+    ports = fakeModulePorts()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('appendUserAssistant returns synchronously after enqueueing (caller not blocked on slow writeFile)', async () => {
+    const thread = makeThread()
+    // Replace writeFile with a 1 000 ms-delayed promise to simulate slow I/O.
+    const originalWriteFile = ports.vault.writeFile.bind(ports.vault)
+    vi.spyOn(ports.vault, 'writeFile').mockImplementation(
+      (path: string, content: string): Promise<void> =>
+        new Promise((resolve) => {
+          // eslint-disable-next-line obsidianmd/prefer-active-window-timers
+          setTimeout(() => {
+            void originalWriteFile(path, content).then(resolve)
+          }, 1000)
+        }),
+    )
+
+    const writer = makeWriter(ports)
+    const t0 = performance.now()
+    const pending = writer.appendUserAssistant(thread, { user: 'u', assistant: 'a' })
+    const t1 = performance.now()
+
+    // The synchronous body of the call returns quickly — well under 100 ms.
+    expect(t1 - t0).toBeLessThan(100)
+
+    // Advance the fake timer so the queued write completes.
+    await vi.advanceTimersByTimeAsync(1000)
+    await pending
+  })
+
+  it('serialises concurrent appends per log file via the internal mutex (REQ-ASM-040)', async () => {
+    vi.useRealTimers()
+    const thread = makeThread()
+    const order: string[] = []
+    vi.spyOn(ports.vault, 'writeFile').mockImplementation(async (_p, content) => {
+      // Tag each write by inspecting the body.
+      const tag = content.includes('first-turn') ? 'first' : 'second'
+      order.push(`start-${tag}`)
+      await new Promise((r) => setTimeout(r, 5)) // eslint-disable-line obsidianmd/prefer-active-window-timers
+      order.push(`end-${tag}`)
+    })
+
+    const writer = makeWriter(ports)
+    const a = writer.appendUserAssistant(thread, { user: 'first-turn', assistant: 'a' })
+    const b = writer.appendUserAssistant(thread, { user: 'second-turn', assistant: 'b' })
+    await Promise.all([a, b])
+
+    // The second write must not start before the first finishes.
+    expect(order).toEqual(['start-first', 'end-first', 'start-second', 'end-second'])
+  })
+})
+
+describe('SessionLogWriter error routing (NFR-ASM-005)', () => {
+  let ports: FakePorts
+
+  beforeEach(() => {
+    ports = fakeModulePorts()
+  })
+
+  it('routes VaultPort.writeFile failure to logger.error with a redacted sessionId and never rejects', async () => {
+    const thread = makeThread({ sessionId: 'ffffffff-1111-2222-3333-444444444444' })
+    vi.spyOn(ports.vault, 'writeFile').mockRejectedValue(new Error('disk full'))
+
+    const writer = makeWriter(ports)
+    // Must NOT throw.
+    await expect(
+      writer.appendUserAssistant(thread, { user: 'u', assistant: 'a' }),
+    ).resolves.toBeUndefined()
+
+    expect(ports.logger.error).toHaveBeenCalledTimes(1)
+    const errorCall = (ports.logger.error as ReturnType<typeof vi.fn>).mock.calls[0]
+    const ctx = errorCall[2] as { redactedSessionId: string }
+    expect(ctx.redactedSessionId).toBe('ffffffff')
+    expect(ctx.redactedSessionId).not.toContain('1111')
+  })
+})
+
+describe('SessionLogWriter.appendProposalDecision (REQ-ASM-046)', () => {
+  let ports: FakePorts
+
+  beforeEach(() => {
+    ports = fakeModulePorts()
+  })
+
+  it('appends a ## proposal block with path, decision, decided_at, and rationale', async () => {
+    const thread = makeThread()
+    // Pre-seed the session log so we can verify the append (not seed) path.
+    const writer = makeWriter(ports, () => '2026-05-14T10:00:00.000Z')
+    await writer.appendUserAssistant(thread, { user: 'u', assistant: 'a' })
+
+    const proposal: SessionLogProposalInput = {
+      envelope: { path: 'notes/idea.md', rationale: 'because-spec' },
+    }
+    await writer.appendProposalDecision({
+      thread,
+      proposal,
+      decision: 'accepted',
+      decidedAt: '2026-05-14T10:10:00.000Z',
+    })
+
+    const path = resolveSessionLogPath(thread.feature, thread.sessionId!, 'specs')
+    const written = await ports.vault.readFile(path)
+    expect(written).toContain('## proposal')
+    expect(written).toContain('- path: notes/idea.md')
+    expect(written).toContain('- decision: accepted')
+    expect(written).toContain('- decided_at: 2026-05-14T10:10:00.000Z')
+    expect(written).toContain('- rationale: because-spec')
+  })
+
+  it('appendProposalDecision is awaited inline and surfaces write failures via logger.error', async () => {
+    const thread = makeThread()
+    vi.spyOn(ports.vault, 'writeFile').mockRejectedValue(new Error('boom'))
+
+    const writer = makeWriter(ports)
+    // The DoD says the caller (commitFileWriteProposal in PR-ASM-4) awaits
+    // this promise. The writer itself never rejects — the caller infers
+    // success from logger output or a future Result wrapper.
+    await expect(
+      writer.appendProposalDecision({
+        thread,
+        proposal: { envelope: { path: 'a.md' } },
+        decision: 'rejected',
+        decidedAt: '2026-05-14T10:00:00.000Z',
+      }),
+    ).resolves.toBeUndefined()
+    expect(ports.logger.error).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/application/chat/sessionLogPath.test.ts
+++ b/tests/application/chat/sessionLogPath.test.ts
@@ -1,0 +1,78 @@
+/**
+ * T-ASM-044 — Tests for `resolveSessionLogPath`.
+ *
+ * Covers TEST-ASM-031:
+ *   - Active feature → `<specsFolder>/<feature>/sessions/<sessionId>.md`.
+ *   - Null feature → `.specorator/sessions/<sessionId>.md`.
+ *   - `specsFolder` other than `'specs'` is honoured.
+ *
+ * Pure function under test: no I/O, no `obsidian` imports, deterministic.
+ *
+ * Satisfies REQ-ASM-032 (per SPEC-ASM-001 §6.7 and ADR-0031).
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import { resolveSessionLogPath } from '@/application/chat/sessionLogPath'
+
+describe('resolveSessionLogPath', () => {
+  describe('active-feature branch', () => {
+    it('returns <specsFolder>/<feature>/sessions/<sessionId>.md when a feature is active', () => {
+      // TEST-ASM-031 — active-feature case.
+      expect(resolveSessionLogPath('foo', 'abc', 'specs')).toBe(
+        'specs/foo/sessions/abc.md',
+      )
+    })
+
+    it('honours a custom specsFolder name', () => {
+      // TEST-ASM-031 — `specsFolder` other than `'specs'`.
+      expect(resolveSessionLogPath('foo', 'abc', 'features')).toBe(
+        'features/foo/sessions/abc.md',
+      )
+    })
+
+    it('handles slugs and session ids that contain hyphens', () => {
+      expect(
+        resolveSessionLogPath(
+          'agent-sidepanel-mvp',
+          '550e8400-e29b-41d4-a716-446655440000',
+          'specs',
+        ),
+      ).toBe(
+        'specs/agent-sidepanel-mvp/sessions/550e8400-e29b-41d4-a716-446655440000.md',
+      )
+    })
+  })
+
+  describe('no-feature fallback branch', () => {
+    it('returns .specorator/sessions/<sessionId>.md when feature is null', () => {
+      // TEST-ASM-031 — fallback branch (R-ASM-005 mitigation; ADR-0031 layer 2).
+      expect(resolveSessionLogPath(null, 'abc', 'specs')).toBe(
+        '.specorator/sessions/abc.md',
+      )
+    })
+
+    it('ignores specsFolder when feature is null (fallback path is vault-root anchored)', () => {
+      // The fallback path is `.specorator/sessions/...` regardless of how the
+      // user configured `specsFolder`. REQ-ASM-032 statement is explicit: the
+      // fallback is at the vault root, not under specsFolder.
+      expect(resolveSessionLogPath(null, 'abc', 'features')).toBe(
+        '.specorator/sessions/abc.md',
+      )
+      expect(resolveSessionLogPath(null, 'abc', 'anything-else')).toBe(
+        '.specorator/sessions/abc.md',
+      )
+    })
+  })
+
+  describe('purity', () => {
+    it('returns the same output for the same inputs (no hidden state)', () => {
+      const a = resolveSessionLogPath('foo', 'abc', 'specs')
+      const b = resolveSessionLogPath('foo', 'abc', 'specs')
+      const c = resolveSessionLogPath(null, 'abc', 'specs')
+      const d = resolveSessionLogPath(null, 'abc', 'specs')
+      expect(a).toBe(b)
+      expect(c).toBe(d)
+    })
+  })
+})

--- a/tests/infrastructure/obsidian/ClaudeSubprocessAdapter.test.ts
+++ b/tests/infrastructure/obsidian/ClaudeSubprocessAdapter.test.ts
@@ -508,17 +508,14 @@ describe('ClaudeSubprocessAdapter — query() happy path (REQ-ASM-029/030/031)',
     expect(spawn.calls[0].command).toBe('/fake/bin/claude')
   })
 
-  it('captures session_id from the first system/init event (REQ-ASM-031)', async () => {
+  it('invokes onSessionId exactly once with the captured session_id (REQ-ASM-031, T-ASM-050)', async () => {
     const { adapter, spawn } = makeAdapter({
       resolver: makeResolver('/fake/bin/claude'),
     })
     await adapter.startup()
 
     const onSessionId = vi.fn()
-    const promise = adapter.query('hi', {
-      onSessionId,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any)
+    const promise = adapter.query('hi', { onSessionId })
     await Promise.resolve()
 
     const child = spawn.lastChild()
@@ -530,10 +527,80 @@ describe('ClaudeSubprocessAdapter — query() happy path (REQ-ASM-029/030/031)',
 
     const result = await promise
     expect(result.ok).toBe(true)
-    // The session id must be observable via at least one channel — either the
-    // optional callback or a public adapter getter. The exact mechanism is
-    // left to T-ASM-011; this test asserts the *capture* invariant by
-    // checking the spawn stdout was consumed without error.
+    expect(onSessionId).toHaveBeenCalledTimes(1)
+    expect(onSessionId).toHaveBeenCalledWith('abc-123')
+  })
+
+  it('omits onSessionId invocation when the caller did not supply one (T-ASM-050)', async () => {
+    // Defence-in-depth — the adapter must not synthesise a callback nor
+    // throw when `options.onSessionId` is absent. Asserted via "the test
+    // completes without an unhandled rejection".
+    const { adapter, spawn } = makeAdapter({
+      resolver: makeResolver('/fake/bin/claude'),
+    })
+    await adapter.startup()
+
+    const promise = adapter.query('hi')
+    await Promise.resolve()
+
+    const child = spawn.lastChild()
+    spawn.emitStdout(
+      child,
+      ndjson(systemInit('xyz-9'), resultEvent('ok')),
+    )
+    spawn.closeWith(child, 0)
+
+    const result = await promise
+    expect(result.ok).toBe(true)
+  })
+
+  it('fires onSessionId only once even if multiple system/init events arrive (T-ASM-050)', async () => {
+    // Single-fire contract — a misbehaving CLI emitting two `system/init`
+    // events must not double-call the caller.
+    const { adapter, spawn } = makeAdapter({
+      resolver: makeResolver('/fake/bin/claude'),
+    })
+    await adapter.startup()
+
+    const onSessionId = vi.fn()
+    const promise = adapter.query('hi', { onSessionId })
+    await Promise.resolve()
+
+    const child = spawn.lastChild()
+    spawn.emitStdout(
+      child,
+      ndjson(systemInit('first'), systemInit('second'), resultEvent('ok')),
+    )
+    spawn.closeWith(child, 0)
+
+    const result = await promise
+    expect(result.ok).toBe(true)
+    expect(onSessionId).toHaveBeenCalledTimes(1)
+    expect(onSessionId).toHaveBeenCalledWith('first')
+  })
+
+  it('swallows onSessionId callback errors without failing the turn (T-ASM-050)', async () => {
+    const { adapter, spawn } = makeAdapter({
+      resolver: makeResolver('/fake/bin/claude'),
+    })
+    await adapter.startup()
+
+    const onSessionId = vi.fn(() => {
+      throw new Error('caller bug')
+    })
+    const promise = adapter.query('hi', { onSessionId })
+    await Promise.resolve()
+
+    const child = spawn.lastChild()
+    spawn.emitStdout(
+      child,
+      ndjson(systemInit('abc-123'), resultEvent('ok')),
+    )
+    spawn.closeWith(child, 0)
+
+    const result = await promise
+    expect(result.ok).toBe(true)
+    expect(onSessionId).toHaveBeenCalledTimes(1)
   })
 
   it('returns ok with the result payload after the `result` event (REQ-ASM-030)', async () => {
@@ -849,6 +916,46 @@ describe('ClaudeSubprocessAdapter — resumeSessionId forwarding (REQ-ASM-035)',
     expect(argv).toContain('--resume')
     const idx = argv.indexOf('--resume')
     expect(argv[idx + 1]).toBe('abc-123')
+  })
+
+  it('captured sessionId threaded back as resumeSessionId emits `--resume <id>` on the next turn (TEST-ASM-034, T-ASM-049)', async () => {
+    // Full round-trip: turn 1's `onSessionId` callback hands the captured id
+    // to a caller-managed holder; turn 2's `query()` passes it back as
+    // `options.resumeSessionId`; argv must contain `--resume <id>`.
+    const { adapter, spawn } = makeAdapter({
+      resolver: makeResolver('/fake/bin/claude'),
+    })
+    await adapter.startup()
+
+    let captured: string | null = null
+    const onSessionId = vi.fn((sid: string) => {
+      captured = sid
+    })
+
+    // Turn 1 — no prior session; capture via callback.
+    const p1 = adapter.query('msg-1', { onSessionId })
+    await Promise.resolve()
+    const c1 = spawn.lastChild()
+    spawn.emitStdout(c1, ndjson(systemInit('abc-123'), resultEvent('r-1')))
+    spawn.closeWith(c1, 0)
+    await p1
+
+    expect(captured).toBe('abc-123')
+    expect(spawn.calls[0].args).not.toContain('--resume')
+
+    // Turn 2 — thread the captured id back as resumeSessionId.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const p2 = adapter.query('msg-2', { resumeSessionId: captured as any })
+    await Promise.resolve()
+    const c2 = spawn.lastChild()
+    spawn.emitStdout(c2, ndjson(systemInit('def-456'), resultEvent('r-2')))
+    spawn.closeWith(c2, 0)
+    await p2
+
+    const turn2Argv = spawn.calls[1].args
+    expect(turn2Argv).toContain('--resume')
+    const idx = turn2Argv.indexOf('--resume')
+    expect(turn2Argv[idx + 1]).toBe('abc-123')
   })
 
   it('omits `--resume` when no resumeSessionId is provided (INV-5)', async () => {

--- a/tests/plugin/chatThreadsPersistence.test.ts
+++ b/tests/plugin/chatThreadsPersistence.test.ts
@@ -1,0 +1,393 @@
+/**
+ * T-ASM-053 — Tests for plugin-data hydration of `chatThreads`.
+ *
+ * Covers TEST-ASM-035 (REQ-ASM-037): a `MockBridge` restart with persisted
+ * `chatThreads` rehydrates `useChatStore.chatThreads` with all records and
+ * `activeThreadId` matches the last-used record.
+ *
+ * Scope of this file (SPEC §11.3, ADR-0031):
+ *   - `decodeChatThreadsBlob` — present / missing / malformed input handling.
+ *   - `encodeChatThreadsBlob` — round-trip + degraded-transport filtering.
+ *   - `mostRecentlyUsedThreadId` — last-used selection for `activeThreadId`.
+ *   - Cross-load idempotency: load → save → load returns the same state.
+ *   - Settings + chatThreads coexistence: storing chatThreads doesn't clobber
+ *     the existing `_storedData.specorator` PluginSettings keys.
+ *   - Pinia hydration: `upsertThread` is called once per record on view open;
+ *     `activeThreadId` is seeded from the most-recently-used record.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useChatStore } from '@/ui/stores/chatStore'
+import { asSessionId } from '@/domain/chat/SessionId'
+import type { ChatThreadRecord } from '@/domain/chat/ChatThreadRecord'
+import type { LoggerPort } from '@/domain/ports/LoggerPort'
+import {
+  decodeChatThreadsBlob,
+  encodeChatThreadsBlob,
+  mostRecentlyUsedThreadId,
+  parseChatThreadRecord,
+  type SerialisedChatThreadRecord,
+} from '@/plugin/chatThreadsPersistence'
+
+function makeLogger(): LoggerPort {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }
+}
+
+function makeRecord(overrides: Partial<ChatThreadRecord> = {}): ChatThreadRecord {
+  return {
+    threadId: 'thread-1',
+    sessionId: asSessionId('sess-1'),
+    feature: 'foo',
+    logPath: 'specs/foo/sessions/sess-1.md',
+    transport: 'subscription',
+    createdAt: '2026-05-14T10:00:00.000Z',
+    lastUsedAt: '2026-05-14T10:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('decodeChatThreadsBlob (T-ASM-053 / REQ-ASM-037)', () => {
+  it('returns [] when the blob is undefined (first load: no persisted chatThreads)', () => {
+    const logger = makeLogger()
+    expect(decodeChatThreadsBlob(undefined, logger)).toEqual([])
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('returns [] when the blob is null with no warn (missing key path)', () => {
+    const logger = makeLogger()
+    expect(decodeChatThreadsBlob(null, logger)).toEqual([])
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('returns [] and warns when the blob is not an object (e.g. accidental string)', () => {
+    const logger = makeLogger()
+    expect(decodeChatThreadsBlob('garbage', logger)).toEqual([])
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns [] and warns when the blob is an array (must be a record map)', () => {
+    const logger = makeLogger()
+    expect(decodeChatThreadsBlob([{ threadId: 'a' }], logger)).toEqual([])
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('decodes a well-formed blob keyed by threadId into ChatThreadRecord[]', () => {
+    const logger = makeLogger()
+    const blob: Record<string, SerialisedChatThreadRecord> = {
+      'thread-a': {
+        threadId: 'thread-a',
+        sessionId: 'sess-a',
+        feature: 'alpha',
+        logPath: 'specs/alpha/sessions/sess-a.md',
+        transport: 'subscription',
+        createdAt: '2026-05-14T09:00:00.000Z',
+        lastUsedAt: '2026-05-14T09:30:00.000Z',
+      },
+      'thread-b': {
+        threadId: 'thread-b',
+        sessionId: null,
+        feature: null,
+        logPath: '.specorator/sessions/thread-b.md',
+        transport: 'api-key',
+        createdAt: '2026-05-14T10:00:00.000Z',
+        lastUsedAt: '2026-05-14T10:05:00.000Z',
+      },
+    }
+
+    const out = decodeChatThreadsBlob(blob, logger)
+
+    expect(out).toHaveLength(2)
+    expect(out[0].threadId).toBe('thread-a')
+    expect(out[0].sessionId).toBe('sess-a')
+    expect(out[1].threadId).toBe('thread-b')
+    expect(out[1].sessionId).toBeNull()
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('drops malformed entries and keeps well-formed ones (filtered + warn per drop)', () => {
+    const logger = makeLogger()
+    const blob: Record<string, unknown> = {
+      'good': {
+        threadId: 'good',
+        sessionId: 'sess-good',
+        feature: 'foo',
+        logPath: 'specs/foo/sessions/sess-good.md',
+        transport: 'subscription',
+        createdAt: '2026-05-14T10:00:00.000Z',
+        lastUsedAt: '2026-05-14T10:00:00.000Z',
+      },
+      'missing-transport': {
+        threadId: 'missing-transport',
+        sessionId: 'sess-x',
+        feature: 'foo',
+        logPath: 'specs/foo/sessions/sess-x.md',
+        createdAt: '2026-05-14T10:00:00.000Z',
+        lastUsedAt: '2026-05-14T10:00:00.000Z',
+      },
+      'degraded-transport': {
+        threadId: 'degraded-transport',
+        sessionId: 'sess-d',
+        feature: null,
+        logPath: '.specorator/sessions/sess-d.md',
+        transport: 'degraded',
+        createdAt: '2026-05-14T10:00:00.000Z',
+        lastUsedAt: '2026-05-14T10:00:00.000Z',
+      },
+      'missing-logPath': {
+        threadId: 'missing-logPath',
+        sessionId: null,
+        feature: null,
+        transport: 'api-key',
+        createdAt: '2026-05-14T10:00:00.000Z',
+        lastUsedAt: '2026-05-14T10:00:00.000Z',
+      },
+      'bad-shape': 'not-an-object',
+    }
+
+    const out = decodeChatThreadsBlob(blob, logger)
+
+    expect(out).toHaveLength(1)
+    expect(out[0].threadId).toBe('good')
+    // Four malformed entries → four warn calls.
+    expect(logger.warn).toHaveBeenCalledTimes(4)
+  })
+
+  it('drops a record with non-null but non-string sessionId', () => {
+    const logger = makeLogger()
+    const out = decodeChatThreadsBlob(
+      { x: { ...makeRecord(), sessionId: 123 } },
+      logger,
+    )
+    expect(out).toEqual([])
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('parseChatThreadRecord (T-ASM-053)', () => {
+  it('rejects null', () => {
+    const logger = makeLogger()
+    expect(parseChatThreadRecord(null, logger)).toBeNull()
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects a record with empty threadId', () => {
+    const logger = makeLogger()
+    expect(parseChatThreadRecord({ ...makeRecord(), threadId: '' }, logger)).toBeNull()
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects a record whose feature is neither null nor string', () => {
+    const logger = makeLogger()
+    expect(
+      parseChatThreadRecord({ ...makeRecord(), feature: 42 }, logger),
+    ).toBeNull()
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('encodeChatThreadsBlob (T-ASM-053 / REQ-ASM-037)', () => {
+  it('returns the JSON-friendly record-of-records keyed by threadId', () => {
+    const r1 = makeRecord({ threadId: 'thread-1' })
+    const r2 = makeRecord({ threadId: 'thread-2', transport: 'api-key', sessionId: null })
+    const map = new Map<string, ChatThreadRecord>([
+      ['thread-1', r1],
+      ['thread-2', r2],
+    ])
+
+    const out = encodeChatThreadsBlob(map)
+
+    expect(Object.keys(out)).toEqual(['thread-1', 'thread-2'])
+    expect(out['thread-1'].sessionId).toBe('sess-1')
+    expect(out['thread-2'].sessionId).toBeNull()
+  })
+
+  it('filters out degraded-transport records (NOT persisted)', () => {
+    const persisted = makeRecord({ threadId: 'keep' })
+    // Construct a degraded record via a type-cast to simulate an in-flight
+    // value that should never make it to disk.
+    const degraded = {
+      ...makeRecord({ threadId: 'drop' }),
+      transport: 'degraded',
+    } as unknown as ChatThreadRecord
+
+    const map = new Map<string, ChatThreadRecord>([
+      ['keep', persisted],
+      ['drop', degraded],
+    ])
+
+    const out = encodeChatThreadsBlob(map)
+
+    expect(Object.keys(out)).toEqual(['keep'])
+    expect(out.drop).toBeUndefined()
+  })
+
+  it('returns {} for an empty map', () => {
+    expect(encodeChatThreadsBlob(new Map())).toEqual({})
+  })
+})
+
+describe('mostRecentlyUsedThreadId (T-ASM-053 / REQ-ASM-037)', () => {
+  it('returns null for an empty list', () => {
+    expect(mostRecentlyUsedThreadId([])).toBeNull()
+  })
+
+  it('returns the only id when one record is present', () => {
+    expect(mostRecentlyUsedThreadId([makeRecord({ threadId: 'only' })])).toBe('only')
+  })
+
+  it('returns the id with the largest lastUsedAt timestamp', () => {
+    const records = [
+      makeRecord({ threadId: 'old',    lastUsedAt: '2026-05-14T09:00:00.000Z' }),
+      makeRecord({ threadId: 'newest', lastUsedAt: '2026-05-14T10:00:00.000Z' }),
+      makeRecord({ threadId: 'middle', lastUsedAt: '2026-05-14T09:30:00.000Z' }),
+    ]
+    expect(mostRecentlyUsedThreadId(records)).toBe('newest')
+  })
+})
+
+describe('cross-load round-trip (T-ASM-053 / REQ-ASM-037)', () => {
+  it('save → load returns the same set of records', () => {
+    const logger = makeLogger()
+    const original = new Map<string, ChatThreadRecord>([
+      ['t1', makeRecord({ threadId: 't1', lastUsedAt: '2026-05-14T10:00:00.000Z' })],
+      ['t2', makeRecord({ threadId: 't2', lastUsedAt: '2026-05-14T11:00:00.000Z', transport: 'api-key', sessionId: null })],
+    ])
+
+    const blob = encodeChatThreadsBlob(original)
+    const reloaded = decodeChatThreadsBlob(blob, logger)
+
+    expect(reloaded).toHaveLength(2)
+    expect(reloaded.find((r) => r.threadId === 't1')?.sessionId).toBe('sess-1')
+    expect(reloaded.find((r) => r.threadId === 't2')?.sessionId).toBeNull()
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('load → save → load is idempotent (no warn, same records)', () => {
+    const logger = makeLogger()
+    const seed: Record<string, SerialisedChatThreadRecord> = {
+      a: {
+        threadId: 'a', sessionId: 'sa', feature: 'foo',
+        logPath: 'specs/foo/sessions/sa.md', transport: 'subscription',
+        createdAt: '2026-05-14T08:00:00.000Z', lastUsedAt: '2026-05-14T09:00:00.000Z',
+      },
+    }
+    const first = decodeChatThreadsBlob(seed, logger)
+    const asMap = new Map(first.map((r) => [r.threadId, r]))
+    const second = decodeChatThreadsBlob(encodeChatThreadsBlob(asMap), logger)
+
+    expect(second).toEqual(first)
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+})
+
+describe('pinia hydration (TEST-ASM-035 / REQ-ASM-037)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('hydrates the chatStore by calling upsertThread once per record, order preserved', () => {
+    const logger = makeLogger()
+    const blob = {
+      'old':   { threadId: 'old',   sessionId: 'so', feature: 'foo', logPath: 'specs/foo/sessions/so.md', transport: 'subscription', createdAt: '2026-05-14T08:00:00.000Z', lastUsedAt: '2026-05-14T08:00:00.000Z' },
+      'newest':{ threadId: 'newest',sessionId: 'sn', feature: 'foo', logPath: 'specs/foo/sessions/sn.md', transport: 'subscription', createdAt: '2026-05-14T09:00:00.000Z', lastUsedAt: '2026-05-14T10:00:00.000Z' },
+    }
+    const records = decodeChatThreadsBlob(blob, logger)
+    const store = useChatStore()
+    for (const record of records) {
+      store.upsertThread(record)
+    }
+    store.setActiveThreadId(mostRecentlyUsedThreadId(records))
+
+    expect(store.chatThreads.size).toBe(2)
+    expect(store.chatThreads.get('old')?.threadId).toBe('old')
+    expect(store.chatThreads.get('newest')?.threadId).toBe('newest')
+    expect(store.activeThreadId).toBe('newest')
+  })
+
+  it('first-load: missing blob leaves chatThreads empty and activeThreadId null', () => {
+    const logger = makeLogger()
+    const records = decodeChatThreadsBlob(undefined, logger)
+    const store = useChatStore()
+    for (const record of records) store.upsertThread(record)
+    store.setActiveThreadId(mostRecentlyUsedThreadId(records))
+
+    expect(store.chatThreads.size).toBe(0)
+    expect(store.activeThreadId).toBeNull()
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('malformed entries are dropped and well-formed ones land in the store', () => {
+    const logger = makeLogger()
+    const blob: Record<string, unknown> = {
+      good: {
+        threadId: 'good', sessionId: 'sg', feature: 'foo',
+        logPath: 'specs/foo/sessions/sg.md', transport: 'subscription',
+        createdAt: '2026-05-14T10:00:00.000Z', lastUsedAt: '2026-05-14T10:00:00.000Z',
+      },
+      degraded: {
+        threadId: 'degraded', sessionId: 'sd', feature: null,
+        logPath: '.specorator/sessions/sd.md', transport: 'degraded',
+        createdAt: '2026-05-14T10:00:00.000Z', lastUsedAt: '2026-05-14T10:00:00.000Z',
+      },
+    }
+    const records = decodeChatThreadsBlob(blob, logger)
+    const store = useChatStore()
+    for (const record of records) store.upsertThread(record)
+
+    expect(store.chatThreads.size).toBe(1)
+    expect(store.chatThreads.get('good')).toBeDefined()
+    expect(store.chatThreads.get('degraded')).toBeUndefined()
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('settings + chatThreads coexistence (T-ASM-053 / SPEC §9.3)', () => {
+  it('encode → place under specorator.chatThreads preserves sibling PluginSettings keys', () => {
+    // Simulate the `_storedData` shape main.ts owns.
+    const _storedData: Record<string, unknown> = {
+      specorator: {
+        locale: 'en',
+        specsFolder: 'specs',
+        anthropicApiKey: 'sk-test',
+        claudeCliPath: '/usr/local/bin/claude',
+        transportKind: 'auto',
+      },
+      _moduleVersions: { hello: 1 },
+    }
+
+    const map = new Map<string, ChatThreadRecord>([
+      ['t1', {
+        threadId: 't1', sessionId: asSessionId('s1'), feature: 'foo',
+        logPath: 'specs/foo/sessions/s1.md', transport: 'subscription',
+        createdAt: '2026-05-14T10:00:00.000Z', lastUsedAt: '2026-05-14T10:00:00.000Z',
+      }],
+    ])
+
+    const nextSpecorator: Record<string, unknown> = {
+      ...(_storedData.specorator as Record<string, unknown>),
+      chatThreads: encodeChatThreadsBlob(map),
+    }
+    const nextStored: Record<string, unknown> = { ..._storedData, specorator: nextSpecorator }
+
+    // PluginSettings keys preserved.
+    expect((nextStored.specorator as Record<string, unknown>).locale).toBe('en')
+    expect((nextStored.specorator as Record<string, unknown>).specsFolder).toBe('specs')
+    expect((nextStored.specorator as Record<string, unknown>).anthropicApiKey).toBe('sk-test')
+    expect((nextStored.specorator as Record<string, unknown>).claudeCliPath).toBe('/usr/local/bin/claude')
+    // chatThreads attached as sibling key under specorator.
+    expect((nextStored.specorator as Record<string, unknown>).chatThreads).toEqual({
+      t1: {
+        threadId: 't1', sessionId: 's1', feature: 'foo',
+        logPath: 'specs/foo/sessions/s1.md', transport: 'subscription',
+        createdAt: '2026-05-14T10:00:00.000Z', lastUsedAt: '2026-05-14T10:00:00.000Z',
+      },
+    })
+    // Other top-level module blobs untouched.
+    expect(nextStored._moduleVersions).toEqual({ hello: 1 })
+  })
+})

--- a/tests/plugin/main.chat-threads-flush.test.ts
+++ b/tests/plugin/main.chat-threads-flush.test.ts
@@ -92,11 +92,17 @@ function makePlugin(initialData: Record<string, unknown>): {
   plugin._storedData = { ...initialData }
   plugin._initialChatThreads = []
   plugin._chatThreadsFlushTimer = null
+  plugin._pendingChatThreadsSnapshot = null
   plugin.loadData = vi.fn(async () => initialData)
   plugin.saveData = vi.fn(async (data: Record<string, unknown>) => {
     state.blob = data
     state.saveCount += 1
   })
+  // Stub the minimum App surface that `onunload()` reaches into so the
+  // unload-flush regression tests don't NPE on `app.workspace`. The
+  // detachLeavesOfType call is a no-op for these tests — we're only
+  // exercising the chatThreads flush path.
+  plugin.app = { workspace: { detachLeavesOfType: vi.fn() } }
   return { plugin: plugin as unknown as SpecoratorPlugin, state }
 }
 
@@ -238,6 +244,46 @@ describe('scheduleChatThreadsPersistence — debounced flush (T-ASM-054)', () =>
     const chatThreads = specorator.chatThreads as Record<string, unknown>
     expect(Object.keys(chatThreads)).toEqual(['keep'])
     expect(chatThreads.drop).toBeUndefined()
+  })
+
+  it('flushes the pending snapshot in onunload() before timer fires (Codex P1 regression)', async () => {
+    // Codex P1, PR #346: a message sent within the 1 s debounce window
+    // must be persisted if Obsidian exits or the plugin is disabled before
+    // the timer fires. Prior to the fix, onunload() cleared the timer but
+    // never flushed the pending snapshot — the just-sent thread was lost.
+    const { plugin, state } = makePlugin({ specorator: {} })
+    const recent = makeRecord({ threadId: 'just-sent', transport: 'subscription' })
+
+    plugin.scheduleChatThreadsPersistence(
+      new Map<string, ChatThreadRecord>([['just-sent', recent]]),
+    )
+
+    // Advance time only partially — the debounce hasn't fired yet.
+    await vi.advanceTimersByTimeAsync(500)
+    expect(state.blob).toBeNull()
+
+    // User closes Obsidian. The fix flushes the pending snapshot directly.
+    plugin.onunload()
+    // _flushChatThreads is async (Obsidian's onunload contract is fire-
+    // and-forget, so we use void in the impl) — flush microtasks to
+    // observe the write.
+    await Promise.resolve()
+    await Promise.resolve()
+
+    const specorator = state.blob?.specorator as Record<string, unknown>
+    const chatThreads = specorator.chatThreads as Record<string, unknown>
+    expect(Object.keys(chatThreads)).toEqual(['just-sent'])
+  })
+
+  it('is a no-op in onunload() when no flush is pending', async () => {
+    const { plugin, state } = makePlugin({ specorator: {} })
+
+    // No scheduleChatThreadsPersistence call — no pending snapshot.
+    plugin.onunload()
+    await Promise.resolve()
+
+    // saveData was never called; the blob is whatever was already on disk.
+    expect(state.blob).toBeNull()
   })
 })
 

--- a/tests/plugin/main.chat-threads-flush.test.ts
+++ b/tests/plugin/main.chat-threads-flush.test.ts
@@ -1,0 +1,273 @@
+/**
+ * T-ASM-053 / T-ASM-054 — Persistence-flush tests for the chatThreads blob.
+ *
+ * These tests exercise the debounced save path on the plugin directly, using
+ * fake timers and a minimal plugin shim so we can assert the on-disk blob
+ * shape without booting the Obsidian runtime.
+ *
+ * Covers:
+ *   - Persisted writes land under `_storedData.specorator.chatThreads` (SPEC §9.3).
+ *   - The flush is debounced — rapid mutations coalesce into one `saveData` call.
+ *   - The flush filters out degraded-transport threads (SPEC §2.2, ADR-0031).
+ *   - The flush preserves sibling `specorator.*` keys (settings coexistence).
+ *
+ * The plugin shim is constructed by extending the real `SpecoratorPlugin`
+ * class with stubs for `loadData` / `saveData` and an `activeWindow` shim;
+ * we avoid the full Obsidian boot path that requires a real `App`.
+ *
+ * Satisfies REQ-ASM-037.
+ */
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+
+// `SpecoratorPlugin` (and its `SpecoratorView` import) extends Obsidian's
+// `Plugin` / `ItemView`. The default vitest stub does not export those, so
+// we install minimal shims for this file only.
+vi.mock('obsidian', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('obsidian')
+  return {
+    ...actual,
+    Platform: { isMobile: false },
+    Plugin: class {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      constructor(public app: any, public manifest: any) {}
+      register(_cb: () => void): void { /* no-op */ }
+      addRibbonIcon(): unknown { return null }
+      addCommand(): unknown { return null }
+      addSettingTab(): unknown { return null }
+      registerView(): unknown { return null }
+      registerEvent(): unknown { return null }
+      registerObsidianProtocolHandler(): unknown { return null }
+      async loadData(): Promise<unknown> { return null }
+      async saveData(_data: unknown): Promise<void> { /* no-op */ }
+    },
+    ItemView: class {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      constructor(public leaf: any) {}
+    },
+    PluginSettingTab: class {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      constructor(public app: any, public plugin: any) {}
+    },
+    Setting: class {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      constructor(public containerEl: any) {}
+      setName(): this { return this }
+      setDesc(): this { return this }
+      setHeading(): this { return this }
+      addText(): this { return this }
+      addToggle(): this { return this }
+      addDropdown(): this { return this }
+      addButton(): this { return this }
+      addExtraButton(): this { return this }
+    },
+    Modal: class {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      constructor(public app: any) {}
+      open(): void { /* no-op */ }
+      close(): void { /* no-op */ }
+    },
+  }
+})
+
+import { asSessionId } from '@/domain/chat/SessionId'
+import type { ChatThreadRecord } from '@/domain/chat/ChatThreadRecord'
+import SpecoratorPlugin from '@/plugin/main'
+
+interface SavedState {
+  blob: Record<string, unknown> | null
+  saveCount: number
+}
+
+function makePlugin(initialData: Record<string, unknown>): {
+  plugin: SpecoratorPlugin
+  state: SavedState
+} {
+  const state: SavedState = { blob: null, saveCount: 0 }
+
+  // Build a minimal stand-in. We don't instantiate via `new SpecoratorPlugin(app, manifest)`
+  // because the Obsidian `Plugin` constructor expects a fully-wired App. Instead we
+  // construct a bare object whose prototype is `SpecoratorPlugin.prototype` and
+  // install the two private fields the persistence path touches.
+  const plugin = Object.create(SpecoratorPlugin.prototype) as Record<string, unknown>
+  plugin._storedData = { ...initialData }
+  plugin._initialChatThreads = []
+  plugin._chatThreadsFlushTimer = null
+  plugin.loadData = vi.fn(async () => initialData)
+  plugin.saveData = vi.fn(async (data: Record<string, unknown>) => {
+    state.blob = data
+    state.saveCount += 1
+  })
+  return { plugin: plugin as unknown as SpecoratorPlugin, state }
+}
+
+function makeRecord(overrides: Partial<ChatThreadRecord> = {}): ChatThreadRecord {
+  return {
+    threadId: 'thread-1',
+    sessionId: asSessionId('sess-1'),
+    feature: 'foo',
+    logPath: 'specs/foo/sessions/sess-1.md',
+    transport: 'subscription',
+    createdAt: '2026-05-14T10:00:00.000Z',
+    lastUsedAt: '2026-05-14T10:00:00.000Z',
+    ...overrides,
+  }
+}
+
+// Obsidian exposes `activeWindow` as a global pointing at the active popout
+// window. Under vitest the global is absent, so install a shim that routes
+// through the test environment's `setTimeout` / `clearTimeout`. Using a typed
+// helper keeps the obsidianmd `prefer-active-doc` rule satisfied for the
+// surrounding source while still allowing the shim itself to exist.
+/* eslint-disable obsidianmd/prefer-active-doc */
+interface ActiveWindowShim {
+  setTimeout: (cb: () => void, ms: number) => number
+  clearTimeout: (id: number) => void
+}
+function installActiveWindowShim(): ActiveWindowShim | undefined {
+  const target = globalThis as unknown as { activeWindow?: ActiveWindowShim }
+  const prior = target.activeWindow
+  target.activeWindow = {
+    setTimeout: (cb, ms) => globalThis.setTimeout(cb, ms) as unknown as number,
+    clearTimeout: (id) => { globalThis.clearTimeout(id) },
+  }
+  return prior
+}
+function restoreActiveWindow(prior: ActiveWindowShim | undefined): void {
+  const target = globalThis as unknown as { activeWindow?: ActiveWindowShim }
+  if (prior === undefined) delete target.activeWindow
+  else target.activeWindow = prior
+}
+/* eslint-enable obsidianmd/prefer-active-doc */
+
+describe('scheduleChatThreadsPersistence — debounced flush (T-ASM-054)', () => {
+  let activeWindowRestore: ActiveWindowShim | undefined
+  beforeEach(() => {
+    vi.useFakeTimers()
+    activeWindowRestore = installActiveWindowShim()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    restoreActiveWindow(activeWindowRestore)
+  })
+
+  it('writes a single blob after the 1 s debounce window expires', async () => {
+    const { plugin, state } = makePlugin({
+      specorator: { locale: 'en', specsFolder: 'specs', anthropicApiKey: '' },
+    })
+    const map = new Map<string, ChatThreadRecord>([['t1', makeRecord({ threadId: 't1' })]])
+
+    plugin.scheduleChatThreadsPersistence(map)
+    expect(state.saveCount).toBe(0) // not flushed yet — still inside debounce
+
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(state.saveCount).toBe(1)
+    const specorator = state.blob?.specorator as Record<string, unknown>
+    expect(specorator.chatThreads).toEqual({
+      t1: {
+        threadId: 't1', sessionId: 'sess-1', feature: 'foo',
+        logPath: 'specs/foo/sessions/sess-1.md', transport: 'subscription',
+        createdAt: '2026-05-14T10:00:00.000Z', lastUsedAt: '2026-05-14T10:00:00.000Z',
+      },
+    })
+  })
+
+  it('coalesces rapid mutations into one flush (prevents disk thrashing)', async () => {
+    const { plugin, state } = makePlugin({
+      specorator: { locale: 'en', specsFolder: 'specs' },
+    })
+    plugin.scheduleChatThreadsPersistence(new Map([['t1', makeRecord({ threadId: 't1' })]]))
+    plugin.scheduleChatThreadsPersistence(new Map([['t1', makeRecord({ threadId: 't1' })]]))
+    plugin.scheduleChatThreadsPersistence(new Map([
+      ['t1', makeRecord({ threadId: 't1' })],
+      ['t2', makeRecord({ threadId: 't2', sessionId: asSessionId('s2'), transport: 'api-key' })],
+    ]))
+
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(state.saveCount).toBe(1)
+    const specorator = state.blob?.specorator as Record<string, unknown>
+    const chatThreads = specorator.chatThreads as Record<string, unknown>
+    expect(Object.keys(chatThreads).sort()).toEqual(['t1', 't2'])
+  })
+
+  it('preserves sibling specorator keys (PluginSettings coexistence, SPEC §9.3)', async () => {
+    const { plugin, state } = makePlugin({
+      specorator: {
+        locale: 'en',
+        specsFolder: 'specs',
+        anthropicApiKey: 'sk-test',
+        claudeCliPath: '/usr/local/bin/claude',
+        transportKind: 'auto',
+      },
+      _moduleVersions: { hello: 1 },
+      hello: { showBadge: true },
+    })
+    plugin.scheduleChatThreadsPersistence(new Map([['t1', makeRecord({ threadId: 't1' })]]))
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    const specorator = state.blob?.specorator as Record<string, unknown>
+    expect(specorator.locale).toBe('en')
+    expect(specorator.specsFolder).toBe('specs')
+    expect(specorator.anthropicApiKey).toBe('sk-test')
+    expect(specorator.claudeCliPath).toBe('/usr/local/bin/claude')
+    expect(specorator.transportKind).toBe('auto')
+    // Sibling top-level keys outside `specorator` survive too.
+    expect(state.blob?._moduleVersions).toEqual({ hello: 1 })
+    expect(state.blob?.hello).toEqual({ showBadge: true })
+  })
+
+  it('filters degraded-transport records at flush time (NOT persisted)', async () => {
+    const { plugin, state } = makePlugin({ specorator: {} })
+    const persisted = makeRecord({ threadId: 'keep', transport: 'subscription' })
+    // Simulate an in-memory degraded thread that the store currently holds.
+    const degraded = {
+      ...makeRecord({ threadId: 'drop' }),
+      transport: 'degraded',
+    } as unknown as ChatThreadRecord
+
+    plugin.scheduleChatThreadsPersistence(
+      new Map<string, ChatThreadRecord>([
+        ['keep', persisted],
+        ['drop', degraded],
+      ]),
+    )
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    const specorator = state.blob?.specorator as Record<string, unknown>
+    const chatThreads = specorator.chatThreads as Record<string, unknown>
+    expect(Object.keys(chatThreads)).toEqual(['keep'])
+    expect(chatThreads.drop).toBeUndefined()
+  })
+})
+
+describe('getInitialChatThreads — read path (T-ASM-053)', () => {
+  it('returns the records hydrated by loadSettings()', async () => {
+    const blob = {
+      specorator: {
+        locale: 'en',
+        chatThreads: {
+          't1': {
+            threadId: 't1', sessionId: 's1', feature: 'foo',
+            logPath: 'specs/foo/sessions/s1.md', transport: 'subscription',
+            createdAt: '2026-05-14T08:00:00.000Z', lastUsedAt: '2026-05-14T09:00:00.000Z',
+          },
+        },
+      },
+    }
+    const { plugin } = makePlugin(blob)
+    await plugin.loadSettings()
+
+    const records = plugin.getInitialChatThreads()
+    expect(records).toHaveLength(1)
+    expect(records[0].threadId).toBe('t1')
+    expect(records[0].sessionId).toBe('s1')
+  })
+
+  it('returns [] when no chatThreads key is present (first load)', async () => {
+    const { plugin } = makePlugin({ specorator: { locale: 'en' } })
+    await plugin.loadSettings()
+
+    expect(plugin.getInitialChatThreads()).toEqual([])
+  })
+})

--- a/tests/ui/components/chat/ChatSidebar.sessionPersistence.test.ts
+++ b/tests/ui/components/chat/ChatSidebar.sessionPersistence.test.ts
@@ -1,0 +1,374 @@
+/**
+ * T-ASM-057 — Tests: ChatSidebar wires the session-persistence path through
+ * `handleSend`. After each successful turn the sidebar must:
+ *   1. Upsert a `ChatThreadRecord` for the active thread (REQ-ASM-037).
+ *   2. Forward `resumeSessionId` from the existing thread record when present
+ *      (REQ-ASM-035).
+ *   3. Provide an `onSessionId` callback that calls
+ *      `chatStore.captureSessionId(threadId, sessionId)` (REQ-ASM-031).
+ *   4. Mirror the turn to the vault via
+ *      `SessionLogWriter.appendUserAssistant` — fire-and-forget (REQ-ASM-034,
+ *      REQ-ASM-040).
+ *   5. Toggle `cliStartingUp` around the `query()` call (R-ASM-003).
+ *   6. Flash `sessionResumed` once per resumed turn (REQ-ASM-035).
+ *   7. Render `SubprocessStartingPill` and `SessionResumeIndicator` in the
+ *      sidebar header (SPEC §7.6).
+ *
+ * Satisfies REQ-ASM-031, REQ-ASM-034, REQ-ASM-035, REQ-ASM-037, REQ-ASM-040.
+ * Maps to: TEST-ASM-016, TEST-ASM-032, TEST-ASM-033, TEST-ASM-038.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import { defineComponent, nextTick } from 'vue'
+import ChatSidebar from '@/ui/components/chat/ChatSidebar.vue'
+import type { ClaudeCliPort, ClaudeCliQueryOptions } from '@/domain/ports/ClaudeCliPort'
+import { ClaudeCliError } from '@/domain/ports/ClaudeCliPort'
+import type { Result } from '@/domain/shared/Result'
+import { ok, err } from '@/domain/shared/Result'
+import { asSessionId } from '@/domain/chat/SessionId'
+import type { SessionId } from '@/domain/chat/SessionId'
+import { MockBridge } from '@/infrastructure/mock/MockBridge'
+import {
+	CLAUDE_CLI_PORT,
+	IS_MOBILE_KEY,
+	VAULT_PORT,
+	WORKSPACE_PORT,
+	SETTINGS_PORT,
+	LOGGER_PORT,
+} from '@/infrastructure/bridge/ports'
+import { useChatStore } from '@/ui/stores/chatStore'
+import { ChatSidebarPO } from './ChatSidebar.po'
+import type { PluginSettings } from '@/domain/settings/PluginSettings'
+import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
+
+const RouterLinkStub = defineComponent({
+	props: { to: { type: String, default: '' } },
+	template: '<a :href="to" data-testid="chat-degraded-settings-link"><slot /></a>',
+})
+
+/**
+ * Configurable mock port that:
+ *   - Logs `(prompt, options)` per call for assertion.
+ *   - Optionally invokes `options.onSessionId(scriptedSessionId)` during query
+ *     so tests can simulate the `system/init` capture.
+ *   - Returns a canned response or canned error.
+ */
+class ScriptedClaudeCliPort implements ClaudeCliPort {
+	available = true
+	cannedResponse = 'assistant says hi'
+	queryError: ClaudeCliError | null = null
+	scriptedSessionIds: (SessionId | null)[] = []
+	readonly queryLog: string[] = []
+	readonly optionsLog: (ClaudeCliQueryOptions | undefined)[] = []
+
+	async startup(): Promise<void> {}
+	shutdown(): void {}
+	async isAvailable(): Promise<boolean> {
+		return this.available
+	}
+
+	async query(
+		prompt: string,
+		options?: ClaudeCliQueryOptions,
+	): Promise<Result<string, ClaudeCliError>> {
+		this.queryLog.push(prompt)
+		this.optionsLog.push(options)
+		const callIndex = this.queryLog.length - 1
+		const scripted = this.scriptedSessionIds[callIndex] ?? null
+		if (scripted !== null && options?.onSessionId) {
+			options.onSessionId(scripted)
+		}
+		if (this.queryError !== null) return err(this.queryError)
+		return ok(this.cannedResponse)
+	}
+}
+
+function makeBridge(
+	files: Record<string, string> = {},
+	overrides: Partial<PluginSettings> = {},
+): MockBridge {
+	const bridge = new MockBridge(files)
+	const settings: PluginSettings = {
+		...DEFAULT_SETTINGS,
+		anthropicApiKey: 'sk-ant-test',
+		...overrides,
+	}
+	vi.spyOn(bridge, 'getSettings').mockResolvedValue(settings)
+	return bridge
+}
+
+async function mountSidebar(args: {
+	available?: boolean
+	cannedResponse?: string
+	scriptedSessionIds?: (SessionId | null)[]
+	settings?: Partial<PluginSettings>
+	files?: Record<string, string>
+	activeFile?: { path: string; basename: string; extension: string } | null
+	queryError?: ClaudeCliError | null
+} = {}) {
+	const pinia = createPinia()
+	setActivePinia(pinia)
+
+	const port = new ScriptedClaudeCliPort()
+	port.available = args.available ?? true
+	if (args.cannedResponse !== undefined) port.cannedResponse = args.cannedResponse
+	if (args.scriptedSessionIds !== undefined) port.scriptedSessionIds = args.scriptedSessionIds
+	if (args.queryError !== undefined) port.queryError = args.queryError
+
+	const bridge = makeBridge(args.files ?? {}, args.settings ?? {})
+	if (args.activeFile !== undefined) bridge.setActiveFile(args.activeFile)
+
+	const wrapper = mount(ChatSidebar, {
+		global: {
+			plugins: [pinia],
+			stubs: { RouterLink: RouterLinkStub },
+			provide: {
+				[CLAUDE_CLI_PORT as symbol]: port,
+				[IS_MOBILE_KEY as symbol]: false,
+				[VAULT_PORT as symbol]: bridge,
+				[WORKSPACE_PORT as symbol]: bridge,
+				[SETTINGS_PORT as symbol]: bridge,
+				[LOGGER_PORT as symbol]: bridge,
+			},
+		},
+	})
+
+	await flushPromises()
+	const store = useChatStore(pinia)
+	return { wrapper, port, bridge, po: new ChatSidebarPO(wrapper), store }
+}
+
+async function send(store: ReturnType<typeof useChatStore>, po: ChatSidebarPO, text: string) {
+	store.setUserText(text)
+	await flushPromises()
+	await po.clickSend()
+	await flushPromises()
+}
+
+describe('ChatSidebar — session-persistence wiring (T-ASM-057)', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia())
+	})
+
+	it('first send on a fresh thread upserts a ChatThreadRecord, omits resumeSessionId, and captures the session id (REQ-ASM-031, REQ-ASM-037)', async () => {
+		const scriptedId = asSessionId('sess-abc-12345678')
+		const { po, port, store } = await mountSidebar({
+			scriptedSessionIds: [scriptedId],
+			settings: { transportKind: 'subscription' },
+		})
+
+		expect(store.activeThreadId).toBeNull()
+		await send(store, po, 'hello')
+
+		// upsertThread was called: chatThreads has exactly one entry, and the
+		// store's activeThreadId points at it.
+		expect(store.activeThreadId).not.toBeNull()
+		expect(store.chatThreads.size).toBe(1)
+		const threadId = store.activeThreadId!
+		const record = store.chatThreads.get(threadId)
+		expect(record).toBeDefined()
+		expect(record?.transport).toBe('subscription')
+
+		// First call: no resumeSessionId; onSessionId callback present.
+		expect(port.optionsLog).toHaveLength(1)
+		expect(port.optionsLog[0]?.resumeSessionId).toBeUndefined()
+		expect(typeof port.optionsLog[0]?.onSessionId).toBe('function')
+
+		// Captured session id is now on the thread record.
+		expect(store.chatThreads.get(threadId)?.sessionId).toBe(scriptedId)
+	})
+
+	it('records transport="api-key" by default when settings.transportKind is not "subscription" (SPEC §7.6)', async () => {
+		const { po, store } = await mountSidebar({})
+		await send(store, po, 'hello')
+		const threadId = store.activeThreadId!
+		expect(store.chatThreads.get(threadId)?.transport).toBe('api-key')
+	})
+
+	it('second send on the same thread forwards resumeSessionId and flashes sessionResumed (REQ-ASM-035)', async () => {
+		const firstId = asSessionId('sess-first-1234567')
+		const { po, port, store } = await mountSidebar({
+			scriptedSessionIds: [firstId, firstId],
+		})
+
+		await send(store, po, 'first')
+		expect(port.optionsLog[0]?.resumeSessionId).toBeUndefined()
+
+		// Sanity: session id was captured.
+		const threadId = store.activeThreadId!
+		expect(store.chatThreads.get(threadId)?.sessionId).toBe(firstId)
+
+		// Reset the flag (the resetStreaming or beginRequest paths may or may
+		// not have cleared it depending on store internals; assert relative).
+		store.setSessionResumed(false)
+
+		await send(store, po, 'second')
+		expect(port.optionsLog[1]?.resumeSessionId).toBe(firstId)
+		// The second turn was a resumed turn → sessionResumed should be true
+		// at least after the successful response.
+		expect(store.sessionResumed).toBe(true)
+	})
+
+	it('toggles cliStartingUp around the query call (R-ASM-003)', async () => {
+		// Use a gate to deterministically observe the in-flight cliStartingUp
+		// state without racing against a timer.
+		let release: () => void = () => {}
+		const gate = new Promise<void>((resolve) => {
+			release = resolve
+		})
+		const { po, store, port } = await mountSidebar({})
+		const originalQuery = port.query.bind(port)
+		port.query = async (prompt, options) => {
+			await gate
+			return originalQuery(prompt, options)
+		}
+
+		expect(store.cliStartingUp).toBe(false)
+
+		store.setUserText('go')
+		await flushPromises()
+		const sendPromise = po.clickSend()
+		// Microtasks flushed; query is awaiting the gate now.
+		await flushPromises()
+		expect(store.cliStartingUp).toBe(true)
+
+		release()
+		await sendPromise
+		await flushPromises()
+		await flushPromises()
+		expect(store.cliStartingUp).toBe(false)
+	})
+
+	it('mirrors the turn to the vault via SessionLogWriter.appendUserAssistant (REQ-ASM-034)', async () => {
+		const scriptedId = asSessionId('sess-vault-12345678')
+		const { po, bridge, store } = await mountSidebar({
+			scriptedSessionIds: [scriptedId],
+			cannedResponse: 'ASSISTANT_TURN_BODY',
+		})
+
+		const writeSpy = vi.spyOn(bridge, 'writeFile')
+		await send(store, po, 'USER_TURN_BODY')
+
+		// SessionLogWriter writes are fire-and-forget; flush the
+		// microtask/event queue so the .then chain runs.
+		await flushPromises()
+		await flushPromises()
+
+		const sessionWrites = writeSpy.mock.calls.filter(
+			([path]) => typeof path === 'string' && path.includes('/sessions/'),
+		)
+		expect(sessionWrites.length).toBeGreaterThan(0)
+		const [, content] = sessionWrites[0]
+		expect(content).toContain('USER_TURN_BODY')
+		expect(content).toContain('ASSISTANT_TURN_BODY')
+		expect(content).toContain(scriptedId)
+	})
+
+	it('vault-write failure is non-fatal: chat send still completes and logger.warn fires (REQ-ASM-040)', async () => {
+		const scriptedId = asSessionId('sess-fail-12345678')
+		const { po, bridge, store } = await mountSidebar({
+			scriptedSessionIds: [scriptedId],
+		})
+
+		// Force createFolder + writeFile to reject so the writer's internal
+		// error path triggers. The writer routes to its own LoggerPort first,
+		// but the ChatSidebar's outer `.catch` only fires when the writer's
+		// outer promise rejects — which it does not (writer swallows). So we
+		// also assert the chat-render path completes normally.
+		vi.spyOn(bridge, 'writeFile').mockRejectedValue(new Error('vault offline'))
+
+		await send(store, po, 'hello')
+		await flushPromises()
+		await flushPromises()
+
+		// Send completed normally — store is back to idle with a response.
+		expect(store.status).toBe('idle')
+		expect(store.response).toBe('assistant says hi')
+	})
+
+	it('marks the thread used after a successful turn (REQ-ASM-037)', async () => {
+		// Spy on `Date#toISOString` to deterministically produce two distinct
+		// timestamps — avoids racing real-time millisecond resolution.
+		const isoSpy = vi.spyOn(Date.prototype, 'toISOString')
+		let isoCounter = 0
+		const isoSequence = [
+			'2026-05-14T10:00:00.000Z',
+			'2026-05-14T10:00:00.000Z',
+			'2026-05-14T10:00:01.000Z',
+			'2026-05-14T10:00:01.000Z',
+			'2026-05-14T10:00:02.000Z',
+			'2026-05-14T10:00:02.000Z',
+		]
+		isoSpy.mockImplementation(() => isoSequence[isoCounter++] ?? '2026-05-14T10:00:09.000Z')
+
+		const { po, store } = await mountSidebar({})
+		await send(store, po, 'hello')
+		await flushPromises()
+		const threadId = store.activeThreadId!
+		const beforeBump = store.chatThreads.get(threadId)?.lastUsedAt
+		await send(store, po, 'again')
+		await flushPromises()
+		const afterBump = store.chatThreads.get(threadId)?.lastUsedAt
+		expect(afterBump).toBeDefined()
+		expect(beforeBump).toBeDefined()
+		// `lastUsedAt` is bumped on every successful send; the second value
+		// must be strictly later (lexicographically) than the first.
+		expect(afterBump !== undefined && beforeBump !== undefined && afterBump > beforeBump).toBe(true)
+
+		isoSpy.mockRestore()
+	})
+
+	it('renders SubprocessStartingPill and SessionResumeIndicator slots in the sidebar (SPEC §7.6)', async () => {
+		const { wrapper, store } = await mountSidebar({})
+
+		// Toggle both flags so the v-if-guarded markup renders.
+		store.setCliStartingUp(true)
+		store.setSessionResumed(true)
+		await nextTick()
+
+		expect(wrapper.find('[data-testid="chat-subprocess-starting"]').exists()).toBe(true)
+		expect(wrapper.find('[data-testid="chat-session-resume"]').exists()).toBe(true)
+	})
+
+	it('regression: stage-prompt suffix still flows through alongside the new options (PR-ASM-2 path preserved)', async () => {
+		const slug = 'persist-feature'
+		const workflowState = [
+			'---',
+			`id: 01HXPERSIST`,
+			`slug: ${slug}`,
+			`feature: "${slug}"`,
+			'area: "XX"',
+			'status: in-progress',
+			'currentStep: 4',
+			'current_stage: design',
+			'last_updated: 2026-05-14',
+			'last_agent: ""',
+			'---',
+			'',
+		].join('\n')
+		const { po, port, store } = await mountSidebar({
+			files: { [`specs/${slug}/workflow-state.md`]: workflowState },
+			activeFile: { path: `specs/${slug}/design.md`, basename: 'design', extension: 'md' },
+		})
+
+		await send(store, po, 'hello')
+		const opts = port.optionsLog[0]
+		expect(opts?.systemPromptSuffix).toContain(slug)
+		expect(opts?.systemPromptSuffix).toContain('Design')
+		// Plus the new options threaded through unchanged.
+		expect(typeof opts?.onSessionId).toBe('function')
+	})
+
+	it('query failure still leaves cliStartingUp cleared and store in error state (R-ASM-003 / REQ-CCS-016)', async () => {
+		const { po, store } = await mountSidebar({
+			queryError: new ClaudeCliError('QUERY_FAILED', 'boom'),
+		})
+
+		await send(store, po, 'hello')
+		await flushPromises()
+
+		expect(store.cliStartingUp).toBe(false)
+		expect(store.status).toBe('error')
+	})
+})

--- a/tests/ui/components/chat/SessionResumeIndicator.po.ts
+++ b/tests/ui/components/chat/SessionResumeIndicator.po.ts
@@ -1,0 +1,37 @@
+import type { VueWrapper } from '@vue/test-utils'
+
+export class SessionResumeIndicatorPO {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	private byTid(tid: string) {
+		return `[data-testid="${tid}"]`
+	}
+
+	get rootEl() {
+		return this.wrapper.find(this.byTid('chat-session-resume'))
+	}
+
+	get glyphEl() {
+		return this.wrapper.find(this.byTid('chat-session-resume-glyph'))
+	}
+
+	exists(): boolean {
+		return this.rootEl.exists()
+	}
+
+	ariaLabel(): string | undefined {
+		return this.rootEl.attributes('aria-label')
+	}
+
+	glyphAriaHidden(): string | undefined {
+		return this.glyphEl.attributes('aria-hidden')
+	}
+
+	glyphText(): string {
+		return this.glyphEl.text()
+	}
+
+	rootText(): string {
+		return this.rootEl.text()
+	}
+}

--- a/tests/ui/components/chat/SessionResumeIndicator.test.ts
+++ b/tests/ui/components/chat/SessionResumeIndicator.test.ts
@@ -1,0 +1,82 @@
+/**
+ * T-ASM-055 — Tests: SessionResumeIndicator — visible/hidden binary state,
+ * ARIA label, and aria-hidden glyph (REQ-ASM-035, NFR-ASM-001, NFR-ASM-008).
+ * Mirrors SPEC §7.3 and DESIGN §B3.
+ */
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SessionResumeIndicator from '@/ui/components/chat/SessionResumeIndicator.vue'
+import { SessionResumeIndicatorPO } from './SessionResumeIndicator.po'
+
+function mountIndicator(resumed: boolean) {
+	const wrapper = mount(SessionResumeIndicator, {
+		props: { resumed },
+	})
+	return new SessionResumeIndicatorPO(wrapper)
+}
+
+describe('SessionResumeIndicator', () => {
+	describe('hidden state (resumed === false)', () => {
+		it('does not render the indicator element', () => {
+			const po = mountIndicator(false)
+			expect(po.exists()).toBe(false)
+		})
+	})
+
+	describe('visible state (resumed === true)', () => {
+		it('renders data-testid="chat-session-resume"', () => {
+			const po = mountIndicator(true)
+			expect(po.exists()).toBe(true)
+		})
+
+		it('exposes aria-label with the plain-language resume copy', () => {
+			const po = mountIndicator(true)
+			expect(po.ariaLabel()).toBe('Continuing prior conversation')
+		})
+
+		it('marks the visual glyph as aria-hidden', () => {
+			const po = mountIndicator(true)
+			expect(po.glyphAriaHidden()).toBe('true')
+		})
+
+		it('renders the ↻ glyph as the visible content', () => {
+			const po = mountIndicator(true)
+			expect(po.glyphText()).toBe('↻')
+		})
+
+		it('contains no AI/SDK jargon in aria-label (NFR-CCS-012 inheritance)', () => {
+			const po = mountIndicator(true)
+			const label = (po.ariaLabel() ?? '').toLowerCase()
+			for (const term of [
+				'subprocess',
+				'oauth',
+				'session_id',
+				'stream-json',
+				'schema',
+				'zod',
+				'envelope',
+				'api key',
+				'system prompt',
+				'token',
+			]) {
+				expect(label).not.toContain(term)
+			}
+		})
+	})
+
+	describe('reactive toggle', () => {
+		it('mounts and unmounts the badge when resumed flips', async () => {
+			const wrapper = mount(SessionResumeIndicator, {
+				props: { resumed: false },
+			})
+			const po = new SessionResumeIndicatorPO(wrapper)
+			expect(po.exists()).toBe(false)
+
+			await wrapper.setProps({ resumed: true })
+			expect(po.exists()).toBe(true)
+
+			await wrapper.setProps({ resumed: false })
+			expect(po.exists()).toBe(false)
+		})
+	})
+})

--- a/tests/ui/components/chat/SubprocessStartingPill.po.ts
+++ b/tests/ui/components/chat/SubprocessStartingPill.po.ts
@@ -1,0 +1,29 @@
+import type { VueWrapper } from '@vue/test-utils'
+
+export class SubprocessStartingPillPO {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	private byTid(tid: string) {
+		return `[data-testid="${tid}"]`
+	}
+
+	get rootEl() {
+		return this.wrapper.find(this.byTid('chat-subprocess-starting'))
+	}
+
+	exists(): boolean {
+		return this.rootEl.exists()
+	}
+
+	role(): string | undefined {
+		return this.rootEl.attributes('role')
+	}
+
+	ariaLive(): string | undefined {
+		return this.rootEl.attributes('aria-live')
+	}
+
+	text(): string {
+		return this.rootEl.text()
+	}
+}

--- a/tests/ui/components/chat/SubprocessStartingPill.test.ts
+++ b/tests/ui/components/chat/SubprocessStartingPill.test.ts
@@ -1,0 +1,82 @@
+/**
+ * T-ASM-055 — Tests: SubprocessStartingPill — visible/hidden binary state
+ * and ARIA live region (REQ-ASM-035, NFR-ASM-001, NFR-ASM-008).
+ * Mirrors SPEC §7.2 and DESIGN §B3 (R-ASM-003 mitigation).
+ */
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SubprocessStartingPill from '@/ui/components/chat/SubprocessStartingPill.vue'
+import { SubprocessStartingPillPO } from './SubprocessStartingPill.po'
+
+function mountPill(visible: boolean) {
+	const wrapper = mount(SubprocessStartingPill, {
+		props: { visible },
+	})
+	return new SubprocessStartingPillPO(wrapper)
+}
+
+describe('SubprocessStartingPill', () => {
+	describe('hidden state (visible === false)', () => {
+		it('does not render the pill element', () => {
+			const po = mountPill(false)
+			expect(po.exists()).toBe(false)
+		})
+	})
+
+	describe('visible state (visible === true)', () => {
+		it('renders data-testid="chat-subprocess-starting"', () => {
+			const po = mountPill(true)
+			expect(po.exists()).toBe(true)
+		})
+
+		it('has role="status"', () => {
+			const po = mountPill(true)
+			expect(po.role()).toBe('status')
+		})
+
+		it('has aria-live="polite"', () => {
+			const po = mountPill(true)
+			expect(po.ariaLive()).toBe('polite')
+		})
+
+		it('shows plain-language starting copy', () => {
+			const po = mountPill(true)
+			expect(po.text()).toContain('Starting up the Claude tool')
+		})
+
+		it('contains no AI/SDK jargon in body copy (NFR-CCS-012 inheritance)', () => {
+			const po = mountPill(true)
+			const copy = po.text().toLowerCase()
+			for (const term of [
+				'subprocess',
+				'oauth',
+				'session_id',
+				'stream-json',
+				'schema',
+				'zod',
+				'envelope',
+				'api key',
+				'system prompt',
+				'token',
+			]) {
+				expect(copy).not.toContain(term)
+			}
+		})
+	})
+
+	describe('reactive toggle', () => {
+		it('mounts and unmounts the pill when visible flips', async () => {
+			const wrapper = mount(SubprocessStartingPill, {
+				props: { visible: false },
+			})
+			const po = new SubprocessStartingPillPO(wrapper)
+			expect(po.exists()).toBe(false)
+
+			await wrapper.setProps({ visible: true })
+			expect(po.exists()).toBe(true)
+
+			await wrapper.setProps({ visible: false })
+			expect(po.exists()).toBe(false)
+		})
+	})
+})

--- a/tests/ui/stores/chatStore.test.ts
+++ b/tests/ui/stores/chatStore.test.ts
@@ -2,11 +2,21 @@
  * T-CCS-012 — Tests for useChatStore() — state shape, all actions, deduplication, setActiveFile.
  * Satisfies REQ-CCS-005, REQ-CCS-006, REQ-CCS-009, REQ-CCS-013, REQ-CCS-014, REQ-CCS-016.
  * Maps to: TEST-CCS-009, TEST-CCS-STORE-001, TEST-CCS-STORE-002.
+ *
+ * T-ASM-051 — Tests for the SPEC-ASM-001 §8.1 store extensions
+ * (chatThreads, activeThreadId, proposals, streamingText, cliStartingUp,
+ *  sessionResumed plus the matching actions).
+ * Satisfies REQ-ASM-031, REQ-ASM-035, REQ-ASM-037, REQ-ASM-041, REQ-ASM-043,
+ *           REQ-ASM-045, NFR-ASM-002, R-ASM-003.
  */
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useChatStore } from '@/ui/stores/chatStore'
 import type { ContextFileEntry } from '@/ui/stores/chatStore'
+import { asSessionId } from '@/domain/chat/SessionId'
+import type { ChatThreadRecord } from '@/domain/chat/ChatThreadRecord'
+import type { FileWriteProposal } from '@/application/chat/FileWriteProposal'
+import type { CreateFileEnvelope } from '@/application/chat/createFileEnvelopeSchema'
 
 function makeFile(path: string, label?: string, isAuto = false): ContextFileEntry {
   return { path, label: label ?? path, isAuto }
@@ -245,6 +255,316 @@ describe('useChatStore()', () => {
       expect(store.status).toBe('idle')
       expect(store.errorType).toBeNull()
       expect(store.truncated).toBe(false)
+    })
+  })
+
+  // ── T-ASM-051: SPEC-ASM-001 §8.1 store extensions ─────────────────────────
+  describe('ASM §8.1 extensions', () => {
+    function makeThread(
+      threadId: string,
+      overrides: Partial<ChatThreadRecord> = {},
+    ): ChatThreadRecord {
+      return {
+        threadId,
+        sessionId: null,
+        feature: null,
+        logPath: `specs/_chat/${threadId}.md`,
+        transport: 'subscription',
+        createdAt: '2026-05-14T00:00:00.000Z',
+        lastUsedAt: '2026-05-14T00:00:00.000Z',
+        ...overrides,
+      }
+    }
+
+    function makeEnvelope(
+      path = 'specs/x/idea.md',
+      content = 'body',
+    ): CreateFileEnvelope {
+      return { action: 'createFile', path, content }
+    }
+
+    function makeProposal(
+      proposalId: string,
+      overrides: Partial<FileWriteProposal> = {},
+    ): FileWriteProposal {
+      return {
+        proposalId,
+        threadId: 't1',
+        envelope: makeEnvelope(),
+        status: 'pending',
+        proposedAt: '2026-05-14T00:00:00.000Z',
+        decidedAt: null,
+        failureReason: null,
+        ...overrides,
+      }
+    }
+
+    describe('initial state', () => {
+      it('REQ-ASM-037: chatThreads is an empty Map', () => {
+        const store = useChatStore()
+        expect(store.chatThreads).toBeInstanceOf(Map)
+        expect(store.chatThreads.size).toBe(0)
+      })
+
+      it('REQ-ASM-031: activeThreadId is null', () => {
+        const store = useChatStore()
+        expect(store.activeThreadId).toBeNull()
+      })
+
+      it('REQ-ASM-041: proposals is an empty Map', () => {
+        const store = useChatStore()
+        expect(store.proposals).toBeInstanceOf(Map)
+        expect(store.proposals.size).toBe(0)
+      })
+
+      it('NFR-ASM-002: streamingText is empty string', () => {
+        const store = useChatStore()
+        expect(store.streamingText).toBe('')
+      })
+
+      it('R-ASM-003: cliStartingUp is false', () => {
+        const store = useChatStore()
+        expect(store.cliStartingUp).toBe(false)
+      })
+
+      it('REQ-ASM-035: sessionResumed is false', () => {
+        const store = useChatStore()
+        expect(store.sessionResumed).toBe(false)
+      })
+    })
+
+    describe('upsertThread', () => {
+      it('REQ-ASM-037: adds a new ChatThreadRecord keyed by threadId', () => {
+        const store = useChatStore()
+        const record = makeThread('t1')
+        store.upsertThread(record)
+        expect(store.chatThreads.size).toBe(1)
+        expect(store.chatThreads.get('t1')).toEqual(record)
+      })
+
+      it('replaces an existing record with the same threadId', () => {
+        const store = useChatStore()
+        store.upsertThread(makeThread('t1', { feature: 'a' }))
+        store.upsertThread(makeThread('t1', { feature: 'b' }))
+        expect(store.chatThreads.size).toBe(1)
+        expect(store.chatThreads.get('t1')?.feature).toBe('b')
+      })
+
+      it('keeps unrelated threads intact when upserting another', () => {
+        const store = useChatStore()
+        store.upsertThread(makeThread('t1'))
+        store.upsertThread(makeThread('t2'))
+        expect(store.chatThreads.size).toBe(2)
+        expect(store.chatThreads.has('t1')).toBe(true)
+        expect(store.chatThreads.has('t2')).toBe(true)
+      })
+    })
+
+    describe('setActiveThreadId', () => {
+      it('REQ-ASM-031: switches the active thread', () => {
+        const store = useChatStore()
+        store.setActiveThreadId('t1')
+        expect(store.activeThreadId).toBe('t1')
+      })
+
+      it('clears streamingText and sessionResumed when switching threads', () => {
+        const store = useChatStore()
+        store.appendStreamingDelta('partial reply')
+        store.setSessionResumed(true)
+        store.setActiveThreadId('t2')
+        expect(store.streamingText).toBe('')
+        expect(store.sessionResumed).toBe(false)
+      })
+
+      it('null clears the active thread and still resets transients', () => {
+        const store = useChatStore()
+        store.setActiveThreadId('t1')
+        store.appendStreamingDelta('hi')
+        store.setActiveThreadId(null)
+        expect(store.activeThreadId).toBeNull()
+        expect(store.streamingText).toBe('')
+      })
+    })
+
+    describe('captureSessionId', () => {
+      it('REQ-ASM-031: stores sessionId on the matching ChatThreadRecord', () => {
+        const store = useChatStore()
+        store.upsertThread(makeThread('t1'))
+        store.captureSessionId('t1', asSessionId('sess-abc'))
+        expect(store.chatThreads.get('t1')?.sessionId).toBe('sess-abc')
+      })
+
+      it('is a no-op when the thread is unknown', () => {
+        const store = useChatStore()
+        store.captureSessionId('ghost', asSessionId('sess-xyz'))
+        expect(store.chatThreads.size).toBe(0)
+      })
+    })
+
+    describe('markThreadUsed', () => {
+      it('REQ-ASM-037: updates lastUsedAt on the matching thread', () => {
+        const store = useChatStore()
+        store.upsertThread(
+          makeThread('t1', { lastUsedAt: '2020-01-01T00:00:00.000Z' }),
+        )
+        const before = store.chatThreads.get('t1')!.lastUsedAt
+        store.markThreadUsed('t1')
+        const after = store.chatThreads.get('t1')!.lastUsedAt
+        expect(after).not.toBe(before)
+        expect(new Date(after).getTime()).toBeGreaterThan(
+          new Date(before).getTime(),
+        )
+      })
+
+      it('is a no-op when the thread is unknown', () => {
+        const store = useChatStore()
+        store.markThreadUsed('ghost')
+        expect(store.chatThreads.size).toBe(0)
+      })
+    })
+
+    describe('appendStreamingDelta + resetStreaming', () => {
+      it('NFR-ASM-002: accumulates streaming deltas', () => {
+        const store = useChatStore()
+        store.appendStreamingDelta('Hello ')
+        store.appendStreamingDelta('world')
+        expect(store.streamingText).toBe('Hello world')
+      })
+
+      it('resetStreaming clears streamingText and sessionResumed', () => {
+        const store = useChatStore()
+        store.appendStreamingDelta('partial')
+        store.setSessionResumed(true)
+        store.resetStreaming()
+        expect(store.streamingText).toBe('')
+        expect(store.sessionResumed).toBe(false)
+      })
+    })
+
+    describe('addProposal + setProposalStatus', () => {
+      afterEach(() => {
+        vi.useRealTimers()
+      })
+
+      it('REQ-ASM-041: addProposal stores a proposal keyed by proposalId', () => {
+        const store = useChatStore()
+        const proposal = makeProposal('p1')
+        store.addProposal(proposal)
+        expect(store.proposals.size).toBe(1)
+        expect(store.proposals.get('p1')).toEqual(proposal)
+      })
+
+      it('addProposal replaces a prior proposal with the same id (idempotent)', () => {
+        const store = useChatStore()
+        store.addProposal(makeProposal('p1', { threadId: 'old' }))
+        store.addProposal(makeProposal('p1', { threadId: 'new' }))
+        expect(store.proposals.size).toBe(1)
+        expect(store.proposals.get('p1')?.threadId).toBe('new')
+      })
+
+      it('REQ-ASM-043: setProposalStatus transitions to accepted and stamps decidedAt', () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date('2026-05-14T12:00:00.000Z'))
+        const store = useChatStore()
+        store.addProposal(makeProposal('p1'))
+        store.setProposalStatus('p1', 'accepted')
+        const after = store.proposals.get('p1')!
+        expect(after.status).toBe('accepted')
+        expect(after.decidedAt).toBe('2026-05-14T12:00:00.000Z')
+        expect(after.failureReason).toBeNull()
+      })
+
+      it('REQ-ASM-045: setProposalStatus records failureReason when failed', () => {
+        const store = useChatStore()
+        store.addProposal(makeProposal('p1'))
+        store.setProposalStatus('p1', 'failed', 'WRITE_FAILED')
+        const after = store.proposals.get('p1')!
+        expect(after.status).toBe('failed')
+        expect(after.failureReason).toBe('WRITE_FAILED')
+        expect(after.decidedAt).not.toBeNull()
+      })
+
+      it('setProposalStatus clears failureReason on non-failed transitions', () => {
+        const store = useChatStore()
+        store.addProposal(
+          makeProposal('p1', {
+            status: 'failed',
+            failureReason: 'WRITE_FAILED',
+          }),
+        )
+        store.setProposalStatus('p1', 'rejected')
+        expect(store.proposals.get('p1')?.failureReason).toBeNull()
+      })
+
+      it('setProposalStatus on pending keeps decidedAt null', () => {
+        const store = useChatStore()
+        store.addProposal(
+          makeProposal('p1', {
+            status: 'accepted',
+            decidedAt: '2020-01-01T00:00:00.000Z',
+          }),
+        )
+        store.setProposalStatus('p1', 'pending')
+        expect(store.proposals.get('p1')?.decidedAt).toBeNull()
+      })
+
+      it('setProposalStatus is a no-op when the proposal is unknown', () => {
+        const store = useChatStore()
+        store.setProposalStatus('ghost', 'accepted')
+        expect(store.proposals.size).toBe(0)
+      })
+    })
+
+    describe('setCliStartingUp / setSessionResumed', () => {
+      it('R-ASM-003: setCliStartingUp toggles cliStartingUp', () => {
+        const store = useChatStore()
+        store.setCliStartingUp(true)
+        expect(store.cliStartingUp).toBe(true)
+        store.setCliStartingUp(false)
+        expect(store.cliStartingUp).toBe(false)
+      })
+
+      it('REQ-ASM-035: setSessionResumed toggles sessionResumed', () => {
+        const store = useChatStore()
+        store.setSessionResumed(true)
+        expect(store.sessionResumed).toBe(true)
+        store.setSessionResumed(false)
+        expect(store.sessionResumed).toBe(false)
+      })
+    })
+
+    describe('reset (extended)', () => {
+      it('reset clears all ASM §8.1 slots', () => {
+        const store = useChatStore()
+        store.upsertThread(makeThread('t1'))
+        store.setActiveThreadId('t1')
+        store.addProposal(makeProposal('p1'))
+        store.appendStreamingDelta('hi')
+        store.setCliStartingUp(true)
+        store.setSessionResumed(true)
+        store.reset()
+        expect(store.chatThreads.size).toBe(0)
+        expect(store.activeThreadId).toBeNull()
+        expect(store.proposals.size).toBe(0)
+        expect(store.streamingText).toBe('')
+        expect(store.cliStartingUp).toBe(false)
+        expect(store.sessionResumed).toBe(false)
+      })
+    })
+
+    describe('regression: existing CCS actions still work after ASM additions', () => {
+      it('addContextFile + setUserText + beginRequest + setResponse round-trip', () => {
+        const store = useChatStore()
+        store.addContextFile(makeFile('notes.md'))
+        store.setUserText('ping')
+        store.beginRequest()
+        expect(store.status).toBe('loading')
+        store.setResponse('pong', false)
+        expect(store.status).toBe('idle')
+        expect(store.response).toBe('pong')
+        expect(store.userText).toBe('ping')
+        expect(store.contextFiles).toHaveLength(1)
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary

PR-ASM-3 — the third of five implementation chunks for the **Agent Sidepanel MVP**. Lands **session persistence + audit log**: every chat turn now mirrors to a per-thread session log in the vault, `session_id` is captured from the subscription transport's `system/init` event and threaded back as `--resume <id>` on the next turn, and `chatThreads` survive Obsidian restarts via plugin-data hydration.

Built on top of PR-ASM-1 + PR-ASM-2. Implements **T-ASM-044 through T-ASM-058** of the 85-task plan, leaving two follow-up chunks (PR-ASM-4 file proposals, PR-ASM-5 release polish).

## What's in

| Surface | Files |
|---|---|
| **Session-log path resolver** | `src/application/chat/sessionLogPath.ts` — `(feature, sessionId, specsFolder) → string` per spec §6.7; null-feature fallback under `.specorator/sessions/` (R-ASM-005) |
| **Session-log writer** | `src/application/chat/SessionLogWriter.ts` + `SessionLog.ts` types — fire-and-forget `appendUserAssistant` (REQ-ASM-040), per-log-file mutex serialises concurrent appends, conflict-suffix loop (`-2`/`-3`/...) on `session_id` mismatch, NFR-ASM-005 log redaction (first-8-char sessionId only) |
| **Markdown format** | YAML frontmatter (5 keys: session_id, feature, transport, created, updated) + `## user` / `## assistant` / `## proposal` blocks |
| **`--resume` + session_id capture** | `ClaudeCliQueryOptions.onSessionId` callback (single-fire); `ClaudeSubprocessAdapter` threads through `TurnProc.onSessionId` and fires from `_handleSystemInit`; `MockClaudeSubprocessAdapter` honours it; round-trip test confirms turn 2 argv has `--resume <session-from-turn-1>` |
| **`useChatStore` extensions** | 6 new state slots (`chatThreads`, `activeThreadId`, `proposals`, `streamingText`, `cliStartingUp`, `sessionResumed`) + 10 actions (`upsertThread`, `setActiveThreadId`, `captureSessionId`, `markThreadUsed`, `appendStreamingDelta`, `resetStreaming`, `addProposal`, `setProposalStatus`, `setCliStartingUp`, `setSessionResumed`); `FileWriteProposal` placeholder type in `src/application/chat/` for PR-ASM-4 |
| **Plugin-data persistence** | `src/plugin/chatThreadsPersistence.ts` (decode/encode/parse/mostRecentlyUsedThreadId helpers); `main.ts` reads `_storedData.specorator.chatThreads`, debounces flush (1 s), filters degraded-transport at encode time; `SpecoratorView.onOpen` replays persisted records via `upsertThread`, seeds `activeThreadId`, and `$subscribe`s for writeback |
| **Indicator components** | `SessionResumeIndicator.vue` (`resumed: boolean` → "Continuing prior conversation") + `SubprocessStartingPill.vue` (`visible: boolean` → "Starting up the Claude tool…", R-ASM-003 cold-spawn affordance) |
| **ChatSidebar integration** | `handleSend` upserts thread → forwards `resumeSessionId` from prior turn → registers `onSessionId` callback → toggles `cliStartingUp` → fires `appendUserAssistant` (fire-and-forget) → `markThreadUsed`; layout adds both indicators in the header |
| **Composable** | `src/ui/composables/useSessionLogWriter.ts` — memoised singleton-per-mount so the writer's per-log-file mutex serialises correctly |
| **Spec drift fix** | REQ-ASM-010 was reconciled to short-lived semantics on PR-ASM-1; this PR's docstrings reference the same |

## Discipline

- **Spec is source of truth.** Multiple agents flagged divergences between dispatch briefs and `spec.md` — every time they followed the spec. Documented inline in commits.
- **ADR-008 narrow ports preserved.** `ClaudeCliPort` still has exactly four methods. `onSessionId` is an options-bag extension; `runStructured` from PR-ASM-2 lives on the adapter class only.
- **ADR-004 Result<T,E>** on every fallible signature; `appendUserAssistant` returns `Promise<void>` per REQ-ASM-040 fire-and-forget contract, with errors routed to `logger.error`.
- **Trust-first / ToS posture** preserved — no new `~/.claude/` reads. `SessionLogWriter` goes through `VaultPort` exclusively.
- **Degraded-transport filter** at both encode + decode time so degraded threads never reach plugin data (spec §2.2 / ADR-0031).

## Out of scope

- File-write proposal UI + ConfirmModalPort → **PR-ASM-4** (T-ASM-059..076). The `FileWriteProposal` placeholder + `addProposal`/`setProposalStatus` store actions exist as a seam ready to fill.
- ESLint rule `no-claude-home-reads` + integration test + release polish → **PR-ASM-5** (T-ASM-077..085).

## Test plan

- [x] `npm audit --audit-level=high --omit=dev` — 0 vulnerabilities
- [x] `npm run typecheck` — exit 0
- [x] `npm run lint` — 0 errors (12 pre-existing warnings unchanged)
- [x] `npm run test` — **1247/1247 pass** across 105 files (121 new tests vs. PR-ASM-2 merge)
- [x] `npm run build` — plugin bundle 2.66 MB
- [x] `npm run build:web` — standalone bundle 284 kB
- [x] `.sr-only` utility class present (third restore — recurring CSS-pipeline regression)
- [ ] Manual smoke: send a message, restart the plugin, confirm the chat thread + sessionId are restored from plugin data; send a follow-up message and confirm `--resume <id>` appears in the spawned argv.

## Sibling spec → tasks
- PR-ASM-1 #325 (merged) — subscription transport
- PR-ASM-2 #345 (merged) — stage prompt + structured JSON envelope
- `specs/agent-sidepanel-mvp/tasks.md` — full 85-task plan; this PR covers T-ASM-044..058

https://claude.ai/code/session_014uvXBSWVU6berqtGKYc6Rh

---
_Generated by [Claude Code](https://claude.ai/code/session_014uvXBSWVU6berqtGKYc6Rh)_