### PR TITLE
PR-ASM-5: ESLint rule + integration tests + release polish

### DIFF
--- a/eslint-rules/__tests__/no-claude-home-reads.test.cjs
+++ b/eslint-rules/__tests__/no-claude-home-reads.test.cjs
@@ -38,6 +38,12 @@ ruleTester.run('no-claude-home-reads', rule, {
     "const p = path.join(os.homedir(), '.config')",
     "const p = process.env.HOME + '/.config'",
     "const p = path.join('foo', 'bar', 'baz')",
+    // Identifier-like suffix on `.claude` (e.g. `~/.claude-cli-bin`) is a
+    // different directory and must NOT trip the rule.
+    "const p = '~/.claude-cli-bin'",
+    // Template literal with unrelated quasi after HOME.
+    'const p = `${process.env.HOME}/.config/foo`',
+    'const p = `${os.homedir()}/.config`',
   ],
   invalid: [
     // Pattern 1 — literal `'~/.claude/'`.
@@ -83,6 +89,28 @@ ruleTester.run('no-claude-home-reads', rule, {
     },
     {
       code: "const p = path.join(os.homedir(), '.claude/sessions')",
+      errors: [{ messageId: 'forbidden' }],
+    },
+    // Codex P2 (PR #348) — bare `~/.claude` (no trailing slash) must also fire.
+    {
+      code: "const p = '~/.claude'",
+      errors: [{ messageId: 'forbidden' }],
+    },
+    // Codex P1 (PR #348) — template literal `${process.env.HOME}/.claude`.
+    {
+      code: 'const p = `${process.env.HOME}/.claude`',
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: 'const p = `${process.env.HOME}/.claude/sessions`',
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: 'const p = `${os.homedir()}/.claude`',
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: 'const p = `${os.homedir()}/.claude/sessions`',
       errors: [{ messageId: 'forbidden' }],
     },
   ],

--- a/eslint-rules/__tests__/no-claude-home-reads.test.cjs
+++ b/eslint-rules/__tests__/no-claude-home-reads.test.cjs
@@ -1,0 +1,114 @@
+/**
+ * T-ASM-077 — Tests for the `no-claude-home-reads` ESLint rule.
+ *
+ * Covers TEST-ASM-050 (REQ-ASM-007, NFR-ASM-004). Runs in Node via the
+ * standard ESLint `RuleTester` (CommonJS), not Vitest. Invoked by
+ * `npm run lint:rules` (see package.json).
+ *
+ * Covers the five disallow patterns from SPEC-ASM-001 §13.2:
+ *   1. Literal `'~/.claude/'`.
+ *   2. Literal `'.credentials.json'`.
+ *   3. Literal `'CLAUDE_CODE_OAUTH_TOKEN'`.
+ *   4. `process.env.HOME + '/.claude'` (concatenation).
+ *   5. `path.join(os.homedir(), '.claude')` (call expression).
+ *
+ * Plus an allow-list invariant: unrelated string/path expressions produce
+ * zero violations. The directory-scoped allow-list (tests/**, inputs/**,
+ * docs/**) is enforced by `eslint.config.js`, not by the rule body.
+ */
+
+'use strict'
+
+const { RuleTester } = require('eslint')
+const rule = require('../no-claude-home-reads.cjs')
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+})
+
+ruleTester.run('no-claude-home-reads', rule, {
+  valid: [
+    "const s = 'hello world'",
+    "const p = '/etc/hosts'",
+    "const k = 'claude-cli-path'",
+    "const k = 'anthropicApiKey'",
+    "const p = path.join(os.homedir(), '.config')",
+    "const p = process.env.HOME + '/.config'",
+    "const p = path.join('foo', 'bar', 'baz')",
+  ],
+  invalid: [
+    // Pattern 1 — literal `'~/.claude/'`.
+    {
+      code: "const p = '~/.claude/'",
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: "const p = '~/.claude/sessions'",
+      errors: [{ messageId: 'forbidden' }],
+    },
+    // Pattern 2 — literal `'.credentials.json'`.
+    {
+      code: "const c = '.credentials.json'",
+      errors: [{ messageId: 'forbidden' }],
+    },
+    // Pattern 3 — literal `'CLAUDE_CODE_OAUTH_TOKEN'`.
+    {
+      code: "const t = 'CLAUDE_CODE_OAUTH_TOKEN'",
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: "const v = env['CLAUDE_CODE_OAUTH_TOKEN']",
+      errors: [{ messageId: 'forbidden' }],
+    },
+    // Pattern 4 — `process.env.HOME + '/.claude'` concatenation.
+    {
+      code: "const p = process.env.HOME + '/.claude'",
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: "const p = process.env.HOME + '/.claude/sessions'",
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: "const p = '/.claude/x' + process.env.HOME",
+      errors: [{ messageId: 'forbidden' }],
+    },
+    // Pattern 5 — `path.join(os.homedir(), '.claude', ...)`.
+    {
+      code: "const p = path.join(os.homedir(), '.claude')",
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: "const p = path.join(os.homedir(), '.claude/sessions')",
+      errors: [{ messageId: 'forbidden' }],
+    },
+  ],
+})
+
+// Severity assertion (flat-config form, ESLint 9+). Confirms the rule
+// reports at severity 2 (error) when wired under the host's `error` level.
+const { Linter } = require('eslint')
+const linter = new Linter()
+const sampleResult = linter.verify(
+  "const p = '~/.claude/'",
+  {
+    plugins: { local: { rules: { 'no-claude-home-reads': rule } } },
+    rules: { 'local/no-claude-home-reads': 'error' },
+    languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+  },
+  { filename: 'sample.js' },
+)
+if (sampleResult.length !== 1 || sampleResult[0].severity !== 2) {
+  throw new Error(
+    'T-ASM-077 severity assertion failed: expected one severity-2 (error) violation, got ' +
+      JSON.stringify(sampleResult),
+  )
+}
+
+// eslint-disable-next-line no-console
+console.log(
+  'eslint-rules/no-claude-home-reads: all RuleTester cases + severity assertion passed.',
+)

--- a/eslint-rules/__tests__/no-claude-home-reads.test.cjs
+++ b/eslint-rules/__tests__/no-claude-home-reads.test.cjs
@@ -44,6 +44,10 @@ ruleTester.run('no-claude-home-reads', rule, {
     // Template literal with unrelated quasi after HOME.
     'const p = `${process.env.HOME}/.config/foo`',
     'const p = `${os.homedir()}/.config`',
+    // Unrelated `.join` calls (Array.prototype.join, etc.) must NOT trip.
+    "const s = ['a','b'].join(',')",
+    "const p = path.posix.join(os.homedir(), '.config')",
+    "const p = join('foo', 'bar')",
   ],
   invalid: [
     // Pattern 1 — literal `'~/.claude/'`.
@@ -132,6 +136,39 @@ ruleTester.run('no-claude-home-reads', rule, {
     },
     {
       code: "const p = path.join(os?.homedir(), '.claude')",
+      errors: [{ messageId: 'forbidden' }],
+    },
+    // Codex P1 round 3 (PR #348) — broader HOME / join shapes.
+    // Bracket-property env access.
+    {
+      code: "const p = process['env'].HOME + '/.claude'",
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: "const p = process.env['HOME'] + '/.claude'",
+      errors: [{ messageId: 'forbidden' }],
+    },
+    // Deeper `globalThis.process.env.HOME` chain.
+    {
+      code: "const p = globalThis.process.env.HOME + '/.claude'",
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: 'const p = `${globalThis.process.env.HOME}/.claude`',
+      errors: [{ messageId: 'forbidden' }],
+    },
+    // `path.posix.join` and `path.win32.join` aliases.
+    {
+      code: "const p = path.posix.join(os.homedir(), '.claude')",
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: "const p = path.win32.join(os.homedir(), '.claude')",
+      errors: [{ messageId: 'forbidden' }],
+    },
+    // Destructured `join` from node:path.
+    {
+      code: "const p = join(os.homedir(), '.claude')",
       errors: [{ messageId: 'forbidden' }],
     },
   ],

--- a/eslint-rules/__tests__/no-claude-home-reads.test.cjs
+++ b/eslint-rules/__tests__/no-claude-home-reads.test.cjs
@@ -113,6 +113,27 @@ ruleTester.run('no-claude-home-reads', rule, {
       code: 'const p = `${os.homedir()}/.claude/sessions`',
       errors: [{ messageId: 'forbidden' }],
     },
+    // Codex P1 round 2 (PR #348) — optional-chained HOME lookups.
+    {
+      code: "const p = process.env?.HOME + '/.claude'",
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: 'const p = `${process.env?.HOME}/.claude`',
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: 'const p = `${process?.env.HOME}/.claude`',
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: 'const p = `${os?.homedir()}/.claude`',
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: "const p = path.join(os?.homedir(), '.claude')",
+      errors: [{ messageId: 'forbidden' }],
+    },
   ],
 })
 

--- a/eslint-rules/no-claude-home-reads.cjs
+++ b/eslint-rules/no-claude-home-reads.cjs
@@ -54,23 +54,42 @@ function stringValueOf(node) {
 }
 
 function isProcessEnvHomeNode(node) {
-  // process.env.HOME or process.env['HOME']
-  if (!node || node.type !== 'MemberExpression') return false
+  if (!node) return false
+  // `process.env?.HOME` parses to a `ChainExpression` wrapping the
+  // underlying MemberExpression; unwrap one level so optional-chained
+  // forms aren't a bypass (Codex P1, PR #348).
+  const inner = node.type === 'ChainExpression' ? node.expression : node
+  if (!inner || inner.type !== 'MemberExpression') return false
+  // The `process.env` part can itself be optional-chained
+  // (e.g. `process?.env.HOME`), so unwrap the inner object too.
+  const objectExpr =
+    inner.object.type === 'ChainExpression'
+      ? inner.object.expression
+      : inner.object
   const objectIsProcessEnv =
-    node.object.type === 'MemberExpression' &&
-    node.object.object.type === 'Identifier' &&
-    node.object.object.name === 'process' &&
-    node.object.property.type === 'Identifier' &&
-    node.object.property.name === 'env'
+    objectExpr.type === 'MemberExpression' &&
+    objectExpr.object.type === 'Identifier' &&
+    objectExpr.object.name === 'process' &&
+    objectExpr.property.type === 'Identifier' &&
+    objectExpr.property.name === 'env'
   if (!objectIsProcessEnv) return false
-  if (node.property.type === 'Identifier') return node.property.name === 'HOME'
-  if (isStringLiteral(node.property)) return node.property.value === 'HOME'
+  if (inner.property.type === 'Identifier') return inner.property.name === 'HOME'
+  if (isStringLiteral(inner.property)) return inner.property.value === 'HOME'
   return false
 }
 
 function isOsHomedirCall(node) {
-  if (!node || node.type !== 'CallExpression') return false
-  const callee = node.callee
+  if (!node) return false
+  // Same optional-chain unwrap for `os?.homedir()` (Codex P1, PR #348).
+  const inner = node.type === 'ChainExpression' ? node.expression : node
+  if (!inner || inner.type !== 'CallExpression') return false
+  const calleeRaw = inner.callee
+  // The callee itself may be optional-chained (`os?.homedir`); unwrap.
+  const callee =
+    calleeRaw && calleeRaw.type === 'ChainExpression'
+      ? calleeRaw.expression
+      : calleeRaw
+  if (!callee) return false
   if (
     callee.type === 'MemberExpression' &&
     callee.object.type === 'Identifier' &&

--- a/eslint-rules/no-claude-home-reads.cjs
+++ b/eslint-rules/no-claude-home-reads.cjs
@@ -1,0 +1,174 @@
+/**
+ * T-ASM-078 — `no-claude-home-reads` ESLint rule.
+ *
+ * Bans any code path that would read from Claude Code's local on-disk state
+ * (the OAuth credentials, the session log, environment-tunnelled refresh
+ * tokens). Enforces SPEC-ASM-001 §13.2 and NFR-ASM-004: the plugin must
+ * never touch `~/.claude/` or `.credentials.json`, and must never shell out
+ * with `CLAUDE_CODE_OAUTH_TOKEN` in the spawned environment.
+ *
+ * CommonJS — runs in Node's ESLint host (eslint.config.js loads via
+ * `await import` and `module.exports` round-trips cleanly).
+ *
+ * Patterns flagged:
+ *   1. String literals containing `~/.claude/` (e.g. `'~/.claude/'`).
+ *   2. String literals containing `.credentials.json`.
+ *   3. String literals matching `CLAUDE_CODE_OAUTH_TOKEN`.
+ *   4. `process.env.HOME + '/.claude'` (and similar `.claude` concatenations).
+ *   5. `path.join(os.homedir(), '.claude', ...)`.
+ *
+ * Allow-list: applied at the call-site in `eslint.config.js` — fixtures
+ * under `tests/**`, work packages under `inputs/**`, and prose under
+ * `docs/**` are exempt.
+ */
+
+'use strict'
+
+const FORBIDDEN_LITERAL_PATTERNS = [
+  { regex: /~\/\.claude\//, label: '~/.claude/' },
+  { regex: /\.credentials\.json/, label: '.credentials.json' },
+  { regex: /CLAUDE_CODE_OAUTH_TOKEN/, label: 'CLAUDE_CODE_OAUTH_TOKEN' },
+]
+
+function isStringLiteral(node) {
+  return node && node.type === 'Literal' && typeof node.value === 'string'
+}
+
+function isTemplateLiteral(node) {
+  return node && node.type === 'TemplateLiteral'
+}
+
+function stringValueOf(node) {
+  if (isStringLiteral(node)) return node.value
+  if (isTemplateLiteral(node)) {
+    // Concatenate quasis only — expressions are opaque; the quasis carry the
+    // literal segments the developer typed.
+    return node.quasis.map((q) => q.value.cooked).join('')
+  }
+  return null
+}
+
+function isProcessEnvHomeNode(node) {
+  // process.env.HOME or process.env['HOME']
+  if (!node || node.type !== 'MemberExpression') return false
+  const objectIsProcessEnv =
+    node.object.type === 'MemberExpression' &&
+    node.object.object.type === 'Identifier' &&
+    node.object.object.name === 'process' &&
+    node.object.property.type === 'Identifier' &&
+    node.object.property.name === 'env'
+  if (!objectIsProcessEnv) return false
+  if (node.property.type === 'Identifier') return node.property.name === 'HOME'
+  if (isStringLiteral(node.property)) return node.property.value === 'HOME'
+  return false
+}
+
+function isOsHomedirCall(node) {
+  if (!node || node.type !== 'CallExpression') return false
+  const callee = node.callee
+  if (
+    callee.type === 'MemberExpression' &&
+    callee.object.type === 'Identifier' &&
+    callee.object.name === 'os' &&
+    callee.property.type === 'Identifier' &&
+    callee.property.name === 'homedir'
+  ) {
+    return true
+  }
+  // Also catch destructured `homedir()` if called directly.
+  if (callee.type === 'Identifier' && callee.name === 'homedir') return true
+  return false
+}
+
+function concatenatesClaudeDir(node) {
+  // node is a BinaryExpression with operator '+'.
+  // Returns true if one side is a process.env.HOME / os.homedir() expression
+  // AND the other side is a string containing '.claude'.
+  if (node.type !== 'BinaryExpression' || node.operator !== '+') return false
+  const left = node.left
+  const right = node.right
+  const leftIsHome = isProcessEnvHomeNode(left) || isOsHomedirCall(left)
+  const rightIsHome = isProcessEnvHomeNode(right) || isOsHomedirCall(right)
+  const leftString = stringValueOf(left)
+  const rightString = stringValueOf(right)
+  if (leftIsHome && rightString !== null && rightString.includes('.claude')) return true
+  if (rightIsHome && leftString !== null && leftString.includes('.claude')) return true
+  return false
+}
+
+function isPathJoinClaudeCall(node) {
+  // path.join(os.homedir(), '.claude', ...) or path.join(homedir(), '.claude').
+  if (node.type !== 'CallExpression') return false
+  const callee = node.callee
+  const isPathJoin =
+    callee.type === 'MemberExpression' &&
+    callee.object.type === 'Identifier' &&
+    callee.object.name === 'path' &&
+    callee.property.type === 'Identifier' &&
+    callee.property.name === 'join'
+  if (!isPathJoin) return false
+  const firstArg = node.arguments[0]
+  const secondArg = node.arguments[1]
+  if (firstArg === undefined || secondArg === undefined) return false
+  if (!isOsHomedirCall(firstArg) && !isProcessEnvHomeNode(firstArg)) return false
+  const secondValue = stringValueOf(secondArg)
+  return secondValue !== null && secondValue.includes('.claude')
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Forbid any path/token reference that would read from ~/.claude/ ' +
+        '(SPEC-ASM-001 §13.2, NFR-ASM-004). The plugin must never touch ' +
+        'Claude Code\'s on-disk OAuth state.',
+    },
+    schema: [],
+    messages: {
+      forbidden:
+        '{{label}} references are forbidden: the plugin must never read ' +
+        '~/.claude/ or any Claude Code credential surface ' +
+        '(SPEC-ASM-001 §13.2, NFR-ASM-004).',
+    },
+  },
+  create(context) {
+    function checkStringValue(node, value) {
+      for (const { regex, label } of FORBIDDEN_LITERAL_PATTERNS) {
+        if (regex.test(value)) {
+          context.report({ node, messageId: 'forbidden', data: { label } })
+          return
+        }
+      }
+    }
+    return {
+      Literal(node) {
+        if (typeof node.value !== 'string') return
+        checkStringValue(node, node.value)
+      },
+      TemplateLiteral(node) {
+        const value = stringValueOf(node)
+        if (value === null) return
+        checkStringValue(node, value)
+      },
+      BinaryExpression(node) {
+        if (concatenatesClaudeDir(node)) {
+          context.report({
+            node,
+            messageId: 'forbidden',
+            data: { label: '~/.claude/ (via process.env.HOME / os.homedir() concatenation)' },
+          })
+        }
+      },
+      CallExpression(node) {
+        if (isPathJoinClaudeCall(node)) {
+          context.report({
+            node,
+            messageId: 'forbidden',
+            data: { label: '~/.claude/ (via path.join + os.homedir())' },
+          })
+        }
+      },
+    }
+  },
+}

--- a/eslint-rules/no-claude-home-reads.cjs
+++ b/eslint-rules/no-claude-home-reads.cjs
@@ -53,54 +53,55 @@ function stringValueOf(node) {
   return null
 }
 
-function isProcessEnvHomeNode(node) {
-  if (!node) return false
-  // `process.env?.HOME` parses to a `ChainExpression` wrapping the
-  // underlying MemberExpression; unwrap one level so optional-chained
-  // forms aren't a bypass (Codex P1, PR #348).
-  const inner = node.type === 'ChainExpression' ? node.expression : node
-  if (!inner || inner.type !== 'MemberExpression') return false
-  // The `process.env` part can itself be optional-chained
-  // (e.g. `process?.env.HOME`), so unwrap the inner object too.
-  const objectExpr =
-    inner.object.type === 'ChainExpression'
-      ? inner.object.expression
-      : inner.object
-  const objectIsProcessEnv =
-    objectExpr.type === 'MemberExpression' &&
-    objectExpr.object.type === 'Identifier' &&
-    objectExpr.object.name === 'process' &&
-    objectExpr.property.type === 'Identifier' &&
-    objectExpr.property.name === 'env'
-  if (!objectIsProcessEnv) return false
-  if (inner.property.type === 'Identifier') return inner.property.name === 'HOME'
-  if (isStringLiteral(inner.property)) return inner.property.value === 'HOME'
+/** Strip ChainExpression wrappers (for optional-chained forms). */
+function unwrapChain(node) {
+  let cur = node
+  while (cur && cur.type === 'ChainExpression') cur = cur.expression
+  return cur
+}
+
+/** Returns true if `member.property` resolves to the string `name`, whether
+ *  written as an identifier or as a computed string literal. */
+function isPropertyNamed(member, name) {
+  if (member.property.type === 'Identifier') return member.property.name === name
+  if (isStringLiteral(member.property)) return member.property.value === name
   return false
 }
 
+/** Returns true if `node` ultimately references the global `process`
+ *  identifier — either as a bare `process` or as the tail of a member
+ *  expression like `globalThis.process` / `window.process` (Codex P1, PR #348). */
+function isProcessReference(node) {
+  const cur = unwrapChain(node)
+  if (!cur) return false
+  if (cur.type === 'Identifier' && cur.name === 'process') return true
+  if (cur.type === 'MemberExpression' && isPropertyNamed(cur, 'process')) return true
+  return false
+}
+
+/** Returns true if `node` is any form of `<process>.env`, including
+ *  bracket-property access and deeper chains. */
+function isProcessEnvAccess(node) {
+  const cur = unwrapChain(node)
+  if (!cur || cur.type !== 'MemberExpression') return false
+  if (!isPropertyNamed(cur, 'env')) return false
+  return isProcessReference(cur.object)
+}
+
+function isProcessEnvHomeNode(node) {
+  const cur = unwrapChain(node)
+  if (!cur || cur.type !== 'MemberExpression') return false
+  if (!isPropertyNamed(cur, 'HOME')) return false
+  return isProcessEnvAccess(cur.object)
+}
+
 function isOsHomedirCall(node) {
-  if (!node) return false
-  // Same optional-chain unwrap for `os?.homedir()` (Codex P1, PR #348).
-  const inner = node.type === 'ChainExpression' ? node.expression : node
-  if (!inner || inner.type !== 'CallExpression') return false
-  const calleeRaw = inner.callee
-  // The callee itself may be optional-chained (`os?.homedir`); unwrap.
-  const callee =
-    calleeRaw && calleeRaw.type === 'ChainExpression'
-      ? calleeRaw.expression
-      : calleeRaw
+  const cur = unwrapChain(node)
+  if (!cur || cur.type !== 'CallExpression') return false
+  const callee = unwrapChain(cur.callee)
   if (!callee) return false
-  if (
-    callee.type === 'MemberExpression' &&
-    callee.object.type === 'Identifier' &&
-    callee.object.name === 'os' &&
-    callee.property.type === 'Identifier' &&
-    callee.property.name === 'homedir'
-  ) {
-    return true
-  }
-  // Also catch destructured `homedir()` if called directly.
   if (callee.type === 'Identifier' && callee.name === 'homedir') return true
+  if (callee.type === 'MemberExpression' && isPropertyNamed(callee, 'homedir')) return true
   return false
 }
 
@@ -141,19 +142,27 @@ function templateInterpolatesClaudeDir(node) {
   return false
 }
 
+/**
+ * Returns true if `node` is a call to any `join`-named function: bare
+ * `join(...)` (destructured from `node:path`), `path.join(...)`,
+ * `path.posix.join(...)`, `path.win32.join(...)`, or any chain ending in
+ * `.join` (Codex P1 PR #348 — closes the `path.join`-only bypass).
+ */
+function isJoinCallNode(node) {
+  const cur = unwrapChain(node)
+  if (!cur || cur.type !== 'CallExpression') return false
+  const callee = unwrapChain(cur.callee)
+  if (!callee) return false
+  if (callee.type === 'Identifier' && callee.name === 'join') return true
+  if (callee.type === 'MemberExpression' && isPropertyNamed(callee, 'join')) return true
+  return false
+}
+
 function isPathJoinClaudeCall(node) {
-  // path.join(os.homedir(), '.claude', ...) or path.join(homedir(), '.claude').
-  if (node.type !== 'CallExpression') return false
-  const callee = node.callee
-  const isPathJoin =
-    callee.type === 'MemberExpression' &&
-    callee.object.type === 'Identifier' &&
-    callee.object.name === 'path' &&
-    callee.property.type === 'Identifier' &&
-    callee.property.name === 'join'
-  if (!isPathJoin) return false
-  const firstArg = node.arguments[0]
-  const secondArg = node.arguments[1]
+  if (!isJoinCallNode(node)) return false
+  const call = unwrapChain(node)
+  const firstArg = call.arguments[0]
+  const secondArg = call.arguments[1]
   if (firstArg === undefined || secondArg === undefined) return false
   if (!isOsHomedirCall(firstArg) && !isProcessEnvHomeNode(firstArg)) return false
   const secondValue = stringValueOf(secondArg)

--- a/eslint-rules/no-claude-home-reads.cjs
+++ b/eslint-rules/no-claude-home-reads.cjs
@@ -25,7 +25,12 @@
 'use strict'
 
 const FORBIDDEN_LITERAL_PATTERNS = [
-  { regex: /~\/\.claude\//, label: '~/.claude/' },
+  // Match both `~/.claude` (bare directory reference) and `~/.claude/`
+  // (path under the directory). Codex P2 PR #348 — without the trailing
+  // slash the literal previously slipped through. The lookahead requires
+  // the next character to be a non-identifier so `~/.claude-foo` won't
+  // false-positive.
+  { regex: /~\/\.claude(?![a-zA-Z0-9_-])/, label: '~/.claude' },
   { regex: /\.credentials\.json/, label: '.credentials.json' },
   { regex: /CLAUDE_CODE_OAUTH_TOKEN/, label: 'CLAUDE_CODE_OAUTH_TOKEN' },
 ]
@@ -96,6 +101,27 @@ function concatenatesClaudeDir(node) {
   return false
 }
 
+/**
+ * Template-literal shape: `${process.env.HOME}/.claude` or
+ * `${os.homedir()}/.claude/sessions`. Returns true when ANY expression in
+ * the template is a HOME-shaped node AND the adjacent quasi (the literal
+ * segment immediately following that expression) starts with `/.claude`
+ * (Codex P1, PR #348 — closes the BinaryExpression-only bypass).
+ */
+function templateInterpolatesClaudeDir(node) {
+  if (node.type !== 'TemplateLiteral') return false
+  for (let i = 0; i < node.expressions.length; i += 1) {
+    const expr = node.expressions[i]
+    if (!isProcessEnvHomeNode(expr) && !isOsHomedirCall(expr)) continue
+    const trailingQuasi = node.quasis[i + 1]
+    if (trailingQuasi === undefined) continue
+    if (/^\/?\.claude(?:\/|$|[^a-zA-Z0-9_-])/.test(trailingQuasi.value.cooked)) {
+      return true
+    }
+  }
+  return false
+}
+
 function isPathJoinClaudeCall(node) {
   // path.join(os.homedir(), '.claude', ...) or path.join(homedir(), '.claude').
   if (node.type !== 'CallExpression') return false
@@ -147,9 +173,29 @@ module.exports = {
         checkStringValue(node, node.value)
       },
       TemplateLiteral(node) {
+        // Pattern A: the literal quasis spell out a forbidden token
+        // (e.g. `~/.claude/foo`). Same surface as a string literal.
         const value = stringValueOf(node)
-        if (value === null) return
-        checkStringValue(node, value)
+        if (value !== null) {
+          for (const { regex, label } of FORBIDDEN_LITERAL_PATTERNS) {
+            if (regex.test(value)) {
+              context.report({ node, messageId: 'forbidden', data: { label } })
+              return
+            }
+          }
+        }
+        // Pattern B: `${process.env.HOME}/.claude` or `${os.homedir()}/.claude`
+        // — the HOME-shaped expression interpolates into a quasi that starts
+        // with `/.claude` (Codex P1, PR #348).
+        if (templateInterpolatesClaudeDir(node)) {
+          context.report({
+            node,
+            messageId: 'forbidden',
+            data: {
+              label: '~/.claude/ (via template literal with process.env.HOME / os.homedir())',
+            },
+          })
+        }
       },
       BinaryExpression(node) {
         if (concatenatesClaudeDir(node)) {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'eslint/config';
 import js from '@eslint/js';
@@ -6,6 +7,16 @@ import pluginVue from 'eslint-plugin-vue';
 import obsidianmd from 'eslint-plugin-obsidianmd';
 import tseslint from 'typescript-eslint';
 import globals from 'globals';
+
+// Project-local ESLint rules (T-ASM-078). Loaded via CommonJS `require`
+// because ESLint rules use `module.exports`; this repo's package.json is
+// `"type": "module"` so the rule files use the `.cjs` extension. The
+// `require` call returns `any`; suppress the type-aware lint here because
+// ESLint config is plain JS with no type information for the rule's
+// internal shape.
+const localRequire = createRequire(import.meta.url);
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const noClaudeHomeReadsRule = localRequire('./eslint-rules/no-claude-home-reads.cjs');
 
 const tsconfigRootDir = fileURLToPath(new URL('.', import.meta.url));
 
@@ -103,6 +114,26 @@ export default defineConfig(
 	// rule blocks below can override anything that conflicts with our setup.
 	...obsidianmd.configs.recommended,
 
+	// Project-local rules (T-ASM-078). The `local/no-claude-home-reads` rule
+	// bans every code path that would read from `~/.claude/` or shell out
+	// with `CLAUDE_CODE_OAUTH_TOKEN` in the spawned env (SPEC-ASM-001 §13.2,
+	// NFR-ASM-004). Scoped to `src/**` only — tests, inputs, and docs are
+	// allowed to mention these strings for fixture / documentation purposes.
+	{
+		files: ['src/**/*.ts', 'src/**/*.js', 'src/**/*.vue'],
+		plugins: {
+			local: {
+				rules: {
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+					'no-claude-home-reads': noClaudeHomeReadsRule,
+				},
+			},
+		},
+		rules: {
+			'local/no-claude-home-reads': 'error',
+		},
+	},
+
 	// Wire @typescript-eslint/parser into vue-eslint-parser for <script lang="ts">
 	// and provide browser + node globals so DOM types are recognised
 	{
@@ -149,6 +180,10 @@ export default defineConfig(
 			// Node-side build/release scripts: not part of the type-aware lint
 			// surface (they run in Node, not in the plugin/UI build).
 			'scripts/**',
+			// Project-local ESLint rules and their RuleTester suite. CommonJS
+			// .cjs files; the type-aware TS rules can't lint them (no
+			// tsconfig coverage). Validated by `npm run lint:rules`.
+			'eslint-rules/**',
 			'version-bump.js',
 			// Sub-projects under sites/ have their own ESLint setups.
 			'sites/**',

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"typecheck": "vue-tsc --noEmit -p tsconfig.lint.json",
 		"lint": "eslint .",
 		"lint:fix": "eslint . --fix",
+		"lint:rules": "node eslint-rules/__tests__/no-claude-home-reads.test.cjs",
 		"format": "prettier --write .",
 		"format:check": "prettier --check .",
 		"test": "vitest run --configLoader runner --project unit",

--- a/specs/agent-sidepanel-mvp/implementation-log.md
+++ b/specs/agent-sidepanel-mvp/implementation-log.md
@@ -1,0 +1,177 @@
+# Implementation Log — `agent-sidepanel-mvp`
+
+Per-PR record of what landed and which REQ-ASM IDs closed. Satisfies
+SPEC-ASM-001 §13.1 (traceability).
+
+---
+
+## PR-ASM-1 — Subscription adapter + transport selector (#325)
+
+**Scope.** Two-transport spawn surface (subscription vs. api-key), the
+narrow `ClaudeCliPort` extension, the `selectTransport` policy, the
+`buildSubprocessArgs` argv builder, `ClaudeBinaryResolver`, the
+production `ClaudeSubprocessAdapter` (long-lived → short-lived
+spawn-per-turn after Codex P1 #3), the `MockClaudeSubprocessAdapter`
+mirror, settings + `ClaudeCliPathField`, the `degradedClaudeCliPort`
+sentinel, and the plugin-side wiring in `main.ts`.
+
+**REQ-ASM IDs closed:** REQ-ASM-001 (TransportKind), REQ-ASM-002
+(transport selector), REQ-ASM-003 (subscription argv shape), REQ-ASM-004
+(api-key argv shape), REQ-ASM-005 (binary resolver), REQ-ASM-006
+(subscription adapter contract), REQ-ASM-007 (`~/.claude/` never read),
+REQ-ASM-008 (transport pill data contract), REQ-ASM-009 (`isAvailable`
+never throws), REQ-ASM-010 (one spawn per turn — short-lived per
+Codex P1 #3 / spec §4.5), REQ-ASM-011 (no `--bare`), REQ-ASM-012 (resume
+sessionId argv), REQ-ASM-013 (timeout budget), REQ-ASM-014 (settings
+shape), REQ-ASM-015 (settings migration), REQ-ASM-031 (sessionId
+capture callback contract).
+
+**Codex P1 fixes.** SpecoratorView provide swapped to a Proxy ref
+forwarder; `_handleClose` purges dead threads via `threadKey`; transport
+arch changed to short-lived spawn-per-turn with `--resume` chaining;
+`startup()` re-resolves the binary path when the resolver returns a new
+result.
+
+---
+
+## PR-ASM-2 — Stage prompt + structured envelope (#345)
+
+**Scope.** `assembleSystemPrompt` + `stagePromptMap`, the Zod 4
+`createFileEnvelopeSchema` (with `z.toJSONSchema` instead of the
+zod-to-json-schema package), `parseStructuredEnvelope`,
+`validateProposalPath`, the `SubscriptionCapable` type seam and the
+`queryStructured` wrapper with the `runStructured` capability check,
+ChatSidebar stage-prompt wiring, and the `ChatResponse`
+`structured-fail` state.
+
+**REQ-ASM IDs closed:** REQ-ASM-013 (stage preamble lookup), REQ-ASM-014
+(stage map keyed by workflow slug), REQ-ASM-018 (one-shot preamble
+per send), REQ-ASM-019 (recomputed per send — no stale cache),
+REQ-ASM-021 (structured argv invariants: `--output-format json
+--json-schema`), REQ-ASM-022 (envelope schema strict), REQ-ASM-023
+(envelope rejection mapped to EnvelopeParseError), REQ-ASM-024
+(`structured-fail` state — never quote raw output), REQ-ASM-025
+(parse-error UX — separate from CLI errors), REQ-ASM-049 (capability
+check `isSubscriptionCapable`).
+
+**Codex P1 fixes.** `..` backslash-form path-traversal rejection in
+`validateProposalPath`.
+
+---
+
+## PR-ASM-3 — Session persistence + indicators (#346)
+
+**Scope.** `resolveSessionLogPath` (deterministic per-feature),
+`SessionLogWriter` with `appendUserAssistant` (fire-and-forget,
+REQ-ASM-040) and `appendProposalDecision` (load-bearing,
+REQ-ASM-046), `--resume <sessionId>` argv wiring + `onSessionId`
+capture callback on the free-text path, `useChatStore` extensions for
+`chatThreads` + `captureSessionId` + `proposals`, plugin-data
+hydration for `chatThreads`, `SessionResumeIndicator` and
+`SubprocessStartingPill` components, and the `ChatSidebar`
+session-persistence wiring.
+
+**REQ-ASM IDs closed:** REQ-ASM-027 (session-log file path scheme),
+REQ-ASM-028 (per-feature session log), REQ-ASM-029 (NDJSON line-by-line
+parser), REQ-ASM-030 (subprocess exit-code error mapping), REQ-ASM-031
+(session id capture across both paths), REQ-ASM-032 (`--resume` argv
+forwarded verbatim), REQ-ASM-033 (resumed-turn user-side suppression
+in the log), REQ-ASM-034 (session id hot-restore on plugin reload),
+REQ-ASM-035 (resumeSessionId forwarded via argv only — never env),
+REQ-ASM-036 (no `fs` reads outside the vault), REQ-ASM-037
+(session-log writer queueing model), REQ-ASM-038 (append-only writer
+contract), REQ-ASM-039 (writer uses VaultPort exclusively), REQ-ASM-040
+(fire-and-forget user-assistant turn mirror), REQ-ASM-046 (audit row
+load-bearing on Accept).
+
+**Codex P1 fixes.** `onunload()` now synchronously flushes the pending
+chatThreads snapshot. `.sr-only` root-cause fix moved into AppRoot.vue
+to survive `build:web`.
+
+---
+
+## PR-ASM-4 — FileWriteProposal flow (#347)
+
+**Scope.** `ConfirmModalPort` + injection key, Obsidian + Mock confirm
+modal adapters, `proposeFileWrite` (read-only existence/preview),
+`commitFileWriteProposal` (the sole vault-mutation path for an LLM
+proposal — NFR-ASM-011), `rejectFileWriteProposal`,
+`FileWriteProposalCard.vue` (five mutually-exclusive render states),
+`TransportStatusPill.vue`, ChatSidebar proposal-flow wiring with the
+shared `inFlightDecisions` concurrency guard, i18n keys for every
+proposal-flow surface, and `SpecoratorView` provision of
+`CONFIRM_MODAL_PORT` + `TRANSPORT_KIND_KEY`.
+
+**REQ-ASM IDs closed:** REQ-ASM-041 (proposal aggregate DTO),
+REQ-ASM-042 (proposal lifecycle states), REQ-ASM-043 (Accept writes
+exactly one file via VaultPort), REQ-ASM-044 (overwrite gate via
+ConfirmModalPort), REQ-ASM-045 (Reject never mutates the vault),
+REQ-ASM-046 (audit row mirrored to session log on every terminal
+state), REQ-ASM-047 (folder creation derived from envelope path),
+REQ-ASM-048 (path-invalid card state), REQ-ASM-049 (capability check
+re-used at the structured call site), REQ-ASM-050 (Retry resubmits
+the proposal-specific `originPrompt`).
+
+**Codex feedback fixes.**
+- P1: SessionLogWriter rethrows on failure; new `SessionLogNoSessionError`
+  for missing session id; commit pipeline now surfaces `SESSION_LOG_FAILED`
+  reliably.
+- P1: structured branch now captures `session_id` via the `onSessionId`
+  callback so `thread.sessionId !== null` before `appendProposalDecision`
+  runs.
+- P1: re-entrant Accept guard via module-scoped `inFlightDecisions: Set<string>`,
+  shared with Reject so a cross-decision race produces exactly one terminal.
+- P1: Reject blocked while Accept is in flight on the same proposal.
+- P1: derive parent folder from `envelope.path` so REQ-ASM-047 is actually
+  reachable for the strict structured schema; normalise `\` to `/` in the
+  derivation.
+- P2 cluster: every terminal-failure exit (`fileExists` reject, `createFolder`
+  reject, `writeFile` reject) now mirrors a `decision: 'failed'` audit row;
+  `inFlightDecisions` released via `Promise.finally` even on throw;
+  `responseState` reorders so actionable pending proposals take precedence
+  over `error`/`timeout`/`structuredFail` banners (with path-invalid
+  proposals excluded since they have no Accept/Reject controls); structured
+  proposal turns forward `buildPrompt`'s `truncated` flag instead of
+  hardcoding `false`; subscription-transport degraded state shows
+  CLI-install guidance instead of the API-key copy; `confirmModal` is
+  optional in `CommitFileWriteDeps` (overwrite-gate only) so Accept on
+  fresh paths succeeds without the port; `STRUCTURED_OUTPUT_GUARD_SUFFIX`
+  appended in `queryStructured` so every structured call inherits the
+  JSON-only instruction.
+
+---
+
+## PR-ASM-5 — ESLint rule + integration tests + release polish
+
+**Scope.** Custom ESLint rule `local/no-claude-home-reads` (wired into
+`eslint.config.js` and validated by `npm run lint:rules`), the runtime
+no-`~/.claude/`-fs-reads integration test, the static grep audit
+(`.credentials.json`, `~/.claude/`, `CLAUDE_CODE_OAUTH_TOKEN`), the
+`ClaudeSubprocessAdapter` completion-telemetry shape test (with the
+matching emission added in the adapter), the CCS-inheritance audit, and
+the final pre-PR gate sweep against the SPEC §13.4 release-blockers
+checklist.
+
+**REQ-ASM IDs closed:** REQ-ASM-007 (now lint-enforced by the new rule),
+REQ-ASM-036 (now also runtime-enforced via `tests/integration/no-claude-home.test.ts`),
+REQ-ASM-051 (auto-context populated under subscription transport),
+REQ-ASM-052 (auto-context cleared on `setActiveFile(null)`),
+REQ-ASM-053 (file-menu action uses the same store action).
+
+**Cross-references — ADRs that govern this scope.**
+- ADR-0027 — Subscription-via-CLI architecture (read by PR-ASM-1).
+- ADR-0028 — Stage-prompt assembly + structured envelope schema (PR-ASM-2).
+- ADR-0029 — Session-log file scheme + load-bearing audit row (PR-ASM-3).
+- ADR-0030 — Trust-first vault-mutation invariant (PR-ASM-4).
+- ADR-0031 — `~/.claude/` never read (NFR-ASM-004); enforced by
+  `local/no-claude-home-reads` + the static grep audit (PR-ASM-5).
+- ADR-0032 — Telemetry-shape contract (NFR-ASM-005, NFR-ASM-012);
+  verified by `ClaudeSubprocessAdapter.telemetry.test.ts` (PR-ASM-5).
+
+**Release-blockers checklist (§13.4) — verified in this PR.**
+1. `'--bare'` never appears in argv (TEST-ASM-006). ✅
+2. Vault writes only from `commitFileWriteProposal` (TEST-ASM-047 + grep). ✅
+3. `STRUCTURED_PARSE_FAILED` never surfaces raw output (TEST-ASM-029, TEST-ASM-082). ✅
+4. Session-log writes are fire-and-forget on the critical path; only
+   `appendProposalDecision` is awaited. ✅
+5. Forbidden i18n terms absent (T-ASM-074 forbidden-terms test). ✅

--- a/src/infrastructure/obsidian/ClaudeSubprocessAdapter.ts
+++ b/src/infrastructure/obsidian/ClaudeSubprocessAdapter.ts
@@ -126,6 +126,8 @@ interface TurnProc {
    * Nulled out after the first invocation to enforce the single-fire contract.
    */
   onSessionId: ((sessionId: SessionId) => void) | null
+  /** Monotonic clock at spawn time — used for completion-telemetry durationMs (T-ASM-081). */
+  startTimeMs: number
 }
 
 interface PendingTurn {
@@ -422,6 +424,9 @@ export class ClaudeSubprocessAdapter implements ClaudeCliPort {
     timeoutMs: number,
     options: StructuredCliCallOptions,
   ): Promise<Result<StructuredCliRawResult, ClaudeCliError>> {
+    const startTimeMs = Date.now()
+    let capturedSessionId: SessionId | null = null
+    let lastExitCode: number | null = null
     return new Promise<Result<StructuredCliRawResult, ClaudeCliError>>((resolve) => {
       let stdoutBuffer = ''
       let settled = false
@@ -432,6 +437,12 @@ export class ClaudeSubprocessAdapter implements ClaudeCliPort {
         // eslint-disable-next-line obsidianmd/prefer-active-window-timers -- infra layer, no Obsidian context
         clearTimeout(timeoutHandle)
         this._activeChildren.delete(child)
+        this._emitCompletionTelemetry({
+          kind: 'structured',
+          sessionId: capturedSessionId,
+          startTimeMs,
+          exitCode: lastExitCode,
+        })
         resolve(r)
       }
 
@@ -479,20 +490,24 @@ export class ClaudeSubprocessAdapter implements ClaudeCliPort {
       child.on('close', (...args: unknown[]) => {
         if (settled) return
         const exitCode = typeof args[0] === 'number' ? args[0] : null
+        lastExitCode = exitCode
         const parsed = this._parseStructuredStdout(stdoutBuffer, exitCode)
         // REQ-ASM-031 / REQ-ASM-046 — surface `session_id` to the caller so the
         // structured branch can capture it on the active thread before the
         // promise resolves. Best-effort: an `options.onSessionId` callback
         // throwing must not derail the structured result.
-        if (parsed.ok && options.onSessionId !== undefined) {
+        if (parsed.ok) {
           const sid = this._extractStructuredSessionId(stdoutBuffer)
           if (sid !== null) {
-            try {
-              options.onSessionId(sid)
-            } catch {
-              // NFR-ASM-005 — never log the session id. Callback failures must
-              // not tear down the structured turn; suppressed silently here
-              // (a misbehaving caller cannot be observed by this adapter).
+            capturedSessionId = sid
+            if (options.onSessionId !== undefined) {
+              try {
+                options.onSessionId(sid)
+              } catch {
+                // NFR-ASM-005 — never log the session id. Callback failures must
+                // not tear down the structured turn; suppressed silently here
+                // (a misbehaving caller cannot be observed by this adapter).
+              }
             }
           }
         }
@@ -679,6 +694,7 @@ export class ClaudeSubprocessAdapter implements ClaudeCliPort {
       sessionId: null,
       fatal: null,
       onSessionId,
+      startTimeMs: Date.now(),
     }
 
     this._activeChildren.add(childLike)
@@ -857,6 +873,12 @@ export class ClaudeSubprocessAdapter implements ClaudeCliPort {
    */
   private _handleClose(proc: TurnProc, exitCode: number | null): void {
     this._activeChildren.delete(proc.child)
+    this._emitCompletionTelemetry({
+      kind: 'query',
+      sessionId: proc.sessionId,
+      startTimeMs: proc.startTimeMs,
+      exitCode,
+    })
 
     const pending = proc.pending
     if (pending !== null) {
@@ -881,6 +903,31 @@ export class ClaudeSubprocessAdapter implements ClaudeCliPort {
 
     // No readline interface to close — stdout listeners detach with the
     // EventEmitter as the underlying process is torn down.
+  }
+
+  /**
+   * Emit a single completion-telemetry debug event (T-ASM-081, NFR-ASM-005,
+   * NFR-ASM-012). The payload shape is fixed:
+   *
+   *   { transport: 'subscription', sessionId: '<redacted>' | null,
+   *     durationMs: number, exitCode: number | null }
+   *
+   * No prompt body, no binary path, no `$HOME`. The session id is
+   * deliberately redacted to the literal `'<redacted>'` when present —
+   * telemetry only needs to know "a session was attached", not the value.
+   */
+  private _emitCompletionTelemetry(args: {
+    readonly kind: 'query' | 'structured'
+    readonly sessionId: SessionId | null
+    readonly startTimeMs: number
+    readonly exitCode: number | null
+  }): void {
+    this._logger.debug(`subscription.${args.kind}.complete`, {
+      transport: 'subscription',
+      sessionId: args.sessionId === null ? null : '<redacted>',
+      durationMs: Date.now() - args.startTimeMs,
+      exitCode: args.exitCode,
+    })
   }
 
   /** SPEC §4.3 — SIGTERM, then SIGKILL after a short grace window. */

--- a/tests/infrastructure/obsidian/ClaudeSubprocessAdapter.telemetry.test.ts
+++ b/tests/infrastructure/obsidian/ClaudeSubprocessAdapter.telemetry.test.ts
@@ -1,0 +1,223 @@
+/**
+ * T-ASM-081 — Telemetry-shape unit test for `ClaudeSubprocessAdapter`.
+ *
+ * Satisfies NFR-ASM-005 (no PII in logs) + NFR-ASM-012 (telemetry shape).
+ * Asserts that every `LoggerPort.debug` payload emitted from the
+ * `subscription.*.complete` events conforms exactly to:
+ *
+ *   { transport: 'subscription', sessionId: '<redacted>' | null,
+ *     durationMs: number, exitCode: number | null }
+ *
+ * — no prompt body, no binary path, no `$HOME`, no raw session UUID.
+ *
+ * Two paths are covered: `query` (streaming NDJSON) and `runStructured`
+ * (one-shot JSON-mode subprocess). Both must emit ONE completion-telemetry
+ * event per turn with the canonical shape.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+
+import type { LoggerPort } from '@/domain/ports/LoggerPort'
+import type { PluginSettings } from '@/domain/settings/PluginSettings'
+import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
+import { ClaudeSubprocessAdapter } from '@/infrastructure/obsidian/ClaudeSubprocessAdapter'
+
+interface FakeChild extends EventEmitter {
+  stdout: EventEmitter
+  stderr: EventEmitter
+  stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }
+  kill: ReturnType<typeof vi.fn>
+  killed: boolean
+  exitCode: number | null
+}
+
+function makeChild(): FakeChild {
+  return Object.assign(new EventEmitter(), {
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    stdin: { write: vi.fn(), end: vi.fn() },
+    kill: vi.fn(function (this: FakeChild) {
+      this.killed = true
+    }),
+    killed: false,
+    exitCode: null,
+  }) as FakeChild
+}
+
+interface LogEntry {
+  level: 'debug' | 'info' | 'warn' | 'error'
+  message: string
+  context?: Record<string, unknown>
+}
+
+function makeLogger(): LoggerPort & { entries: LogEntry[] } {
+  const entries: LogEntry[] = []
+  return {
+    entries,
+    debug(message, context) {
+      entries.push({ level: 'debug', message, context })
+    },
+    info(message, context) {
+      entries.push({ level: 'info', message, context })
+    },
+    warn(message, context) {
+      entries.push({ level: 'warn', message, context })
+    },
+    error(message, _error, context) {
+      entries.push({ level: 'error', message, context })
+    },
+  }
+}
+
+function makeSettings(): PluginSettings {
+  return { ...DEFAULT_SETTINGS, transportKind: 'subscription' }
+}
+
+function makeAdapter(spawnFn: ReturnType<typeof vi.fn>) {
+  const logger = makeLogger()
+  const adapter = new ClaudeSubprocessAdapter({
+    getSettings: () => makeSettings(),
+    logger,
+    resolveCliPath: vi.fn(async () => '/fake/bin/claude'),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    spawn: spawnFn as any,
+    now: () => Date.now(),
+  })
+  return { adapter, logger }
+}
+
+const FORBIDDEN_TELEMETRY_KEYS = ['prompt', 'binaryPath', 'binary_path', 'HOME']
+const PAYLOAD_KEY_ALLOW_LIST = new Set([
+  'transport',
+  'sessionId',
+  'durationMs',
+  'exitCode',
+])
+
+function assertCanonicalShape(entry: LogEntry): void {
+  expect(entry.level).toBe('debug')
+  expect(entry.message).toMatch(/^subscription\.(query|structured)\.complete$/)
+  expect(entry.context).toBeDefined()
+  const ctx = entry.context!
+
+  // Exact-shape: only the four sanctioned keys.
+  for (const key of Object.keys(ctx)) {
+    expect(PAYLOAD_KEY_ALLOW_LIST.has(key), `unexpected telemetry key: ${key}`).toBe(true)
+  }
+  // Defence-in-depth: NFR-ASM-005 / NFR-ASM-012 forbidden surfaces.
+  for (const forbidden of FORBIDDEN_TELEMETRY_KEYS) {
+    expect(ctx, `forbidden key "${forbidden}" leaked into telemetry`).not.toHaveProperty(forbidden)
+  }
+
+  expect(ctx.transport).toBe('subscription')
+  // sessionId is either null (no session captured) or the literal redaction
+  // marker — NEVER the raw UUID.
+  expect(ctx.sessionId === null || ctx.sessionId === '<redacted>').toBe(true)
+  expect(typeof ctx.durationMs).toBe('number')
+  expect(ctx.exitCode === null || typeof ctx.exitCode === 'number').toBe(true)
+}
+
+describe('T-ASM-081 — ClaudeSubprocessAdapter telemetry shape', () => {
+  it('runStructured emits exactly one subscription.structured.complete event with the canonical shape', async () => {
+    const child = makeChild()
+    const spawnFn = vi.fn(() => child)
+    const { adapter, logger } = makeAdapter(spawnFn)
+    await adapter.startup()
+
+    const sessionId = '11111111-2222-3333-4444-555555555555'
+    const structuredBody = JSON.stringify({
+      result: 'ok',
+      structured_output: { action: 'createFile', path: 'specs/demo/idea.md', content: '#\n' },
+      session_id: sessionId,
+    })
+
+    const promptBody = 'unique-prompt-marker-zzqx-7f3a1b'
+    const pending = adapter.runStructured(promptBody, {})
+    // Drive the close on the next microtask so the subprocess wiring settles.
+    queueMicrotask(() => {
+      child.stdout.emit('data', Buffer.from(structuredBody, 'utf8'))
+      child.exitCode = 0
+      child.emit('close', 0, null)
+    })
+    const result = await pending
+    expect(result.ok).toBe(true)
+
+    const completions = logger.entries.filter(
+      (e) => e.level === 'debug' && e.message === 'subscription.structured.complete',
+    )
+    expect(completions).toHaveLength(1)
+    assertCanonicalShape(completions[0])
+
+    const ctx = completions[0].context!
+    expect(ctx.sessionId).toBe('<redacted>')
+    expect(ctx.exitCode).toBe(0)
+    expect(ctx.durationMs).toBeGreaterThanOrEqual(0)
+    // Defence-in-depth: prompt body never appears (NFR-ASM-005).
+    const serialised = JSON.stringify(ctx)
+    expect(serialised).not.toContain(promptBody)
+    // The raw UUID must never appear in the payload.
+    expect(serialised).not.toContain(sessionId)
+  })
+
+  it('runStructured with no session_id in the response emits sessionId: null', async () => {
+    const child = makeChild()
+    const spawnFn = vi.fn(() => child)
+    const { adapter, logger } = makeAdapter(spawnFn)
+    await adapter.startup()
+
+    const structuredBody = JSON.stringify({
+      result: 'ok',
+      structured_output: { action: 'createFile', path: 'root-file.md', content: '#\n' },
+    })
+
+    const pending = adapter.runStructured('p', {})
+    queueMicrotask(() => {
+      child.stdout.emit('data', Buffer.from(structuredBody, 'utf8'))
+      child.exitCode = 0
+      child.emit('close', 0, null)
+    })
+    await pending
+
+    const completion = logger.entries.find(
+      (e) => e.level === 'debug' && e.message === 'subscription.structured.complete',
+    )
+    expect(completion).toBeDefined()
+    assertCanonicalShape(completion!)
+    expect(completion!.context!.sessionId).toBeNull()
+  })
+
+  it('query emits exactly one subscription.query.complete event with the canonical shape', async () => {
+    const child = makeChild()
+    const spawnFn = vi.fn(() => child)
+    const { adapter, logger } = makeAdapter(spawnFn)
+    await adapter.startup()
+
+    const sessionId = '99999999-aaaa-bbbb-cccc-dddddddddddd'
+    const pending = adapter.query('hello', {})
+    queueMicrotask(() => {
+      // system/init carries the session id; result then closes the turn.
+      const lines = [
+        JSON.stringify({ type: 'system/init', session_id: sessionId }),
+        JSON.stringify({ type: 'assistant/message', text: 'hi' }),
+        JSON.stringify({ type: 'result', result: 'hi' }),
+      ].join('\n') + '\n'
+      child.stdout.emit('data', Buffer.from(lines, 'utf8'))
+      child.exitCode = 0
+      child.emit('close', 0, null)
+    })
+    const result = await pending
+    expect(result.ok).toBe(true)
+
+    const completions = logger.entries.filter(
+      (e) => e.level === 'debug' && e.message === 'subscription.query.complete',
+    )
+    expect(completions).toHaveLength(1)
+    assertCanonicalShape(completions[0])
+
+    const ctx = completions[0].context!
+    expect(ctx.sessionId).toBe('<redacted>')
+    expect(ctx.exitCode).toBe(0)
+    // The raw UUID must never appear in the payload.
+    expect(JSON.stringify(ctx)).not.toContain(sessionId)
+  })
+})

--- a/tests/integration/ccs-inheritance.test.ts
+++ b/tests/integration/ccs-inheritance.test.ts
@@ -1,0 +1,95 @@
+/**
+ * T-ASM-083 — CCS-inheritance audit for REQ-ASM-051 / REQ-ASM-052 / REQ-ASM-053.
+ *
+ * Verifies that the active-file auto-context path inherited from CCS
+ * (REQ-CCS-005 / REQ-CCS-006) still functions under the subscription
+ * transport. This is a pure verification task — no new production code is
+ * introduced.
+ *
+ * Asserts:
+ *   (a) `setActiveFile(file)` populates the context preamble (REQ-ASM-051).
+ *   (b) `setActiveFile(null)` clears it (REQ-ASM-052).
+ *   (c) Manual context entries are preserved when the auto slot toggles.
+ *       The file-menu "Use as chat context" action wires into the same
+ *       store action (REQ-ASM-053) — that wiring lives in `plugin/main.ts`
+ *       and is covered by the plugin tests; here we verify the store-side
+ *       contract is unchanged under `port.kind === 'subscription'`.
+ *
+ * Subscription transport invariant: `port.kind === 'subscription'` is held
+ * throughout the run to ensure the CCS contract is not transport-specific.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { MockClaudeSubprocessAdapter } from '@/infrastructure/mock/MockClaudeSubprocessAdapter'
+import { isSubscriptionCapable } from '@/application/chat/queryStructured'
+import { useChatStore } from '@/ui/stores/chatStore'
+
+describe('TEST-ASM-053 — CCS auto-context inheritance under subscription transport (T-ASM-083)', () => {
+  let port: MockClaudeSubprocessAdapter
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    port = new MockClaudeSubprocessAdapter()
+    port.available = true
+  })
+
+  it('subscription transport invariant: port.kind === "subscription" throughout', () => {
+    expect(isSubscriptionCapable(port)).toBe(true)
+    expect((port as unknown as { kind: string }).kind).toBe('subscription')
+  })
+
+  it('(a) setActiveFile(file) populates the context preamble (REQ-ASM-051)', () => {
+    expect(isSubscriptionCapable(port)).toBe(true)
+    const store = useChatStore()
+    expect(store.contextFiles).toEqual([])
+
+    store.setActiveFile({ path: 'specs/demo/idea.md', label: 'idea.md', isAuto: true })
+
+    expect(store.contextFiles).toHaveLength(1)
+    expect(store.contextFiles[0]).toMatchObject({
+      path: 'specs/demo/idea.md',
+      label: 'idea.md',
+      isAuto: true,
+    })
+  })
+
+  it('(b) setActiveFile(null) clears the auto slot but preserves manuals (REQ-ASM-052)', () => {
+    expect(isSubscriptionCapable(port)).toBe(true)
+    const store = useChatStore()
+    store.addContextFile({ path: 'manual.md', label: 'manual.md', isAuto: false })
+    store.setActiveFile({ path: 'auto.md', label: 'auto.md', isAuto: true })
+    expect(store.contextFiles).toHaveLength(2)
+
+    store.setActiveFile(null)
+
+    // Manual stays; auto is gone.
+    expect(store.contextFiles).toHaveLength(1)
+    expect(store.contextFiles[0]).toMatchObject({ path: 'manual.md', isAuto: false })
+  })
+
+  it('(c) toggling the auto slot replaces only the auto entry — manuals are stable across calls (REQ-ASM-053)', () => {
+    expect(isSubscriptionCapable(port)).toBe(true)
+    const store = useChatStore()
+    store.addContextFile({ path: 'manual-a.md', label: 'manual-a.md', isAuto: false })
+    store.addContextFile({ path: 'manual-b.md', label: 'manual-b.md', isAuto: false })
+
+    // First auto entry.
+    store.setActiveFile({ path: 'auto-1.md', label: 'auto-1.md', isAuto: true })
+    expect(store.contextFiles.filter((f) => f.isAuto)).toHaveLength(1)
+    expect(store.contextFiles.filter((f) => !f.isAuto)).toHaveLength(2)
+
+    // Replace with a different auto entry.
+    store.setActiveFile({ path: 'auto-2.md', label: 'auto-2.md', isAuto: true })
+    const autoEntries = store.contextFiles.filter((f) => f.isAuto)
+    expect(autoEntries).toHaveLength(1)
+    expect(autoEntries[0]?.path).toBe('auto-2.md')
+    // Manuals remain in their original order, unchanged.
+    const manualPaths = store.contextFiles.filter((f) => !f.isAuto).map((f) => f.path)
+    expect(manualPaths).toEqual(['manual-a.md', 'manual-b.md'])
+
+    // Clear the auto slot — only manuals remain.
+    store.setActiveFile(null)
+    expect(store.contextFiles.every((f) => !f.isAuto)).toBe(true)
+    expect(store.contextFiles.map((f) => f.path)).toEqual(['manual-a.md', 'manual-b.md'])
+  })
+})

--- a/tests/integration/credentials-grep-audit.test.ts
+++ b/tests/integration/credentials-grep-audit.test.ts
@@ -1,0 +1,119 @@
+/**
+ * T-ASM-080 — Static grep audit: forbidden credential surfaces never appear
+ * in `src/**`.
+ *
+ * Covers TEST-ASM-052 (NFR-ASM-004). Walks every source file under `src/`
+ * and asserts:
+ *   1. The literal `'.credentials.json'` never appears anywhere — there is
+ *      no reason for production code to mention Claude Code's credential
+ *      file by name.
+ *   2. The substring `~/.claude/` appears only inside argv-string
+ *      assembly (the `buildSubprocessArgs` builder must invoke `claude -p`
+ *      with the user's home tilde-prefix on macOS / Linux; matches are
+ *      explicitly allow-listed below) or in a comment quoting the rule
+ *      itself.
+ *
+ * The ESLint rule `local/no-claude-home-reads` (T-ASM-078) catches
+ * structurally significant occurrences (string literals, concatenations,
+ * `path.join(os.homedir(), '.claude')`). This grep test is the catch-all
+ * for substrings the AST rule can't reach (comments, multi-line strings,
+ * regex bodies) so a regression cannot slip through.
+ */
+import { describe, it, expect } from 'vitest'
+import { promises as fs } from 'node:fs'
+import { resolve, relative } from 'node:path'
+
+// Vitest runs with cwd === project root, so anchor on that rather than
+// `import.meta.url` (which is non-file scheme in the unit project).
+const SRC_ROOT = resolve(process.cwd(), 'src')
+
+async function walk(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true })
+  const files: string[] = []
+  for (const entry of entries) {
+    const full = resolve(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...(await walk(full)))
+    } else if (entry.isFile()) {
+      files.push(full)
+    }
+  }
+  return files
+}
+
+async function readAllSourceFiles(): Promise<{ path: string; body: string }[]> {
+  const files = await walk(SRC_ROOT)
+  // Only inspect text source files — skip binaries/assets if any were ever
+  // added under `src/`.
+  const textExtensions = /\.(ts|js|vue|mjs|cjs|json|md|css)$/u
+  const filtered = files.filter((f) => textExtensions.test(f))
+  return Promise.all(
+    filtered.map(async (path) => ({ path, body: await fs.readFile(path, 'utf8') })),
+  )
+}
+
+describe('TEST-ASM-052 — static grep audit for credential surfaces (T-ASM-080)', () => {
+  it('only documented self-citations are allowed to contain ".credentials.json"', async () => {
+    const sources = await readAllSourceFiles()
+    // Same audit-by-citation pattern as the `~/.claude/` test below — files
+    // here must contain an NFR-ASM-004 or SPEC-ASM-001 §13.2 comment that
+    // documents the file does NOT read the credentials file.
+    const allowList = new Set<string>([
+      'infrastructure/obsidian/ClaudeSubprocessAdapter.ts',
+    ])
+    const offending: string[] = []
+    for (const { path, body } of sources) {
+      if (!body.includes('.credentials.json')) continue
+      const rel = relative(SRC_ROOT, path).replace(/\\/g, '/')
+      if (allowList.has(rel)) continue
+      offending.push(rel)
+    }
+    expect(
+      offending,
+      'No production source file may reference Claude Code\'s credential ' +
+        'file by name unless it is on the allow-list with an NFR-ASM-004 ' +
+        'self-citation.',
+    ).toEqual([])
+  })
+
+  it('only documented self-citations are allowed to mention "~/.claude/"', async () => {
+    const sources = await readAllSourceFiles()
+    const offending: string[] = []
+    // Allow-listed paths: production files whose comments cite NFR-ASM-004
+    // verbatim to document that the file does NOT read from ~/.claude/.
+    // The grep cannot distinguish code from comments cheaply, so the
+    // allow-list takes the file path and we audit-by-citation: any addition
+    // here requires a comment in that file that explicitly references
+    // NFR-ASM-004 or SPEC-ASM-001 §13.2.
+    const allowList = new Set<string>([
+      'infrastructure/obsidian/ClaudeBinaryResolver.ts',
+      'infrastructure/obsidian/ClaudeSubprocessAdapter.ts',
+      'application/chat/SessionLogWriter.ts',
+    ])
+    for (const { path, body } of sources) {
+      if (!body.includes('~/.claude/')) continue
+      const rel = relative(SRC_ROOT, path).replace(/\\/g, '/')
+      if (allowList.has(rel)) continue
+      offending.push(rel)
+    }
+    expect(
+      offending,
+      'No production source file may mention the literal "~/.claude/" ' +
+        'unless it is on the allow-list with an NFR-ASM-004 self-citation. ' +
+        'Adding a file here requires a comment in that file that explicitly ' +
+        'references NFR-ASM-004 or SPEC-ASM-001 §13.2.',
+    ).toEqual([])
+  })
+
+  it('zero source files set CLAUDE_CODE_OAUTH_TOKEN in spawn env', async () => {
+    const sources = await readAllSourceFiles()
+    // Either the literal string or an environment-bag property with that
+    // key (`env: { CLAUDE_CODE_OAUTH_TOKEN: ... }`) is forbidden. The
+    // subscription transport relies on the user's `claude` CLI carrying its
+    // OAuth state itself; the plugin must not tunnel it through env.
+    const offending = sources.filter((s) =>
+      s.body.includes('CLAUDE_CODE_OAUTH_TOKEN'),
+    )
+    expect(offending.map((s) => relative(SRC_ROOT, s.path))).toEqual([])
+  })
+})

--- a/tests/integration/no-claude-home.test.ts
+++ b/tests/integration/no-claude-home.test.ts
@@ -1,0 +1,144 @@
+/**
+ * T-ASM-079 — Runtime integration test: no production `fs` reads under `~/.claude/`.
+ *
+ * Covers TEST-ASM-051 (REQ-ASM-036, NFR-ASM-004). Drives the chat
+ * application-layer happy path through `MockClaudeSubprocessAdapter` and a
+ * MockBridge while every `node:fs` read API is replaced with a recording
+ * spy. Asserts that no read targets any path containing `.claude/`.
+ *
+ * Pairs with the static grep audit (T-ASM-080); together they cover the
+ * non-negotiable invariant that the plugin never touches Claude Code's
+ * on-disk credential surface.
+ */
+import type * as NodeFs from 'node:fs'
+import type * as NodeFsPromises from 'node:fs/promises'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Module-level mocks — `node:fs` exports are non-configurable, so the only
+// way to observe reads is to swap the module before any production code
+// imports it. Each spy records its call into `readCalls`, then returns an
+// empty buffer so callers proceed.
+const readCalls: { path: string; api: string }[] = []
+function record(api: string, first: unknown): void {
+  const path =
+    typeof first === 'string'
+      ? first
+      : first instanceof URL
+        ? first.href
+        : Buffer.isBuffer(first)
+          ? first.toString('utf8')
+          : String(first)
+  readCalls.push({ path, api })
+}
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof NodeFs>('node:fs')
+  return {
+    ...actual,
+    readFileSync: vi.fn((p: unknown, ...rest: unknown[]) => {
+      record('fs.readFileSync', p)
+      return actual.readFileSync(p as never, rest[0] as never)
+    }),
+    readFile: vi.fn((p: unknown, ...rest: unknown[]) => {
+      record('fs.readFile', p)
+      ;(actual.readFile as unknown as (...a: unknown[]) => void)(p, ...rest)
+    }),
+  }
+})
+
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+  return {
+    ...actual,
+    readFile: vi.fn(async (p: unknown, ...rest: unknown[]) => {
+      record('fs.promises.readFile', p)
+      return actual.readFile(p as never, rest[0] as never)
+    }),
+  }
+})
+
+import { setActivePinia, createPinia } from 'pinia'
+import { MockClaudeSubprocessAdapter } from '@/infrastructure/mock/MockClaudeSubprocessAdapter'
+import { fakeModulePorts } from '../__fakes__/fake-ports'
+import { queryStructured } from '@/application/chat/queryStructured'
+import { commitFileWriteProposal } from '@/application/chat/commitFileWriteProposal'
+import { MockConfirmModalPort } from '@/infrastructure/mock/MockConfirmModalPort'
+import { SessionLogWriter } from '@/application/chat/SessionLogWriter'
+import { asSessionId } from '@/domain/chat/SessionId'
+import type { ChatThreadRecord } from '@/domain/chat/ChatThreadRecord'
+import type { FileWriteProposal } from '@/application/chat/FileWriteProposal'
+import type { CreateFileEnvelope } from '@/application/chat/createFileEnvelopeSchema'
+
+describe('TEST-ASM-051 — no production fs reads under ~/.claude/ (T-ASM-079)', () => {
+  beforeEach(() => {
+    readCalls.length = 0
+    setActivePinia(createPinia())
+  })
+
+  function makeThread(): ChatThreadRecord {
+    return {
+      threadId: 'thread-no-claude-home',
+      sessionId: asSessionId('11111111-2222-3333-4444-555555555555'),
+      feature: 'demo',
+      logPath: 'specs/demo/sessions/11111111-2222-3333-4444-555555555555.md',
+      transport: 'subscription',
+      createdAt: '2026-05-15T10:00:00.000Z',
+      lastUsedAt: '2026-05-15T10:00:00.000Z',
+    }
+  }
+
+  function makeProposal(envelope: CreateFileEnvelope): FileWriteProposal {
+    return {
+      proposalId: 'prop-no-claude-home',
+      threadId: 'thread-no-claude-home',
+      envelope,
+      status: 'pending',
+      proposedAt: '2026-05-15T10:00:00.000Z',
+      decidedAt: null,
+      failureReason: null,
+      originPrompt: '/create-file specs/demo/idea.md',
+    }
+  }
+
+  it('the chat application-layer happy path issues zero fs reads against ~/.claude/', async () => {
+    const ports = fakeModulePorts()
+    const adapter = new MockClaudeSubprocessAdapter()
+    adapter.available = true
+    adapter.cannedStructuredEnvelope = {
+      action: 'createFile',
+      path: 'specs/demo/idea.md',
+      content: '# Demo\n',
+    }
+    adapter.cannedSessionId = asSessionId('11111111-2222-3333-4444-555555555555')
+
+    const structured = await queryStructured(adapter, '/create-file specs/demo/idea.md', {
+      systemPromptSuffix: 'preamble',
+    })
+    expect(structured.ok).toBe(true)
+    if (!structured.ok) return
+
+    const proposal = makeProposal(structured.value)
+    const sessionLog = new SessionLogWriter(
+      ports.vault,
+      ports.logger,
+      'specs',
+      () => '2026-05-15T10:00:00.000Z',
+    )
+    const commitResult = await commitFileWriteProposal(proposal, makeThread(), {
+      vault: ports.vault,
+      logger: ports.logger,
+      sessionLog,
+      confirmModal: new MockConfirmModalPort(),
+      i18n: ports.t,
+      nowIso: () => '2026-05-15T10:00:00.000Z',
+    })
+    expect(commitResult.ok).toBe(true)
+
+    // The invariant: no read API call targeted a path that contains
+    // `.claude/`. The chat path uses MockBridge + the mock subprocess
+    // adapter; neither should ever shell out to Claude Code's on-disk
+    // OAuth state.
+    const claudeHomeReads = readCalls.filter((call) => call.path.includes('.claude/'))
+    expect(claudeHomeReads).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Final chunk of the `agent-sidepanel-mvp` orchestration. Cross-cutting hardening:

- **T-ASM-077 + T-ASM-078** — Custom ESLint rule `local/no-claude-home-reads` that bans the five spec'd patterns from `src/**`. RuleTester suite + severity assertion validates the rule; wired into `eslint.config.js`; new `npm run lint:rules` script.
- **T-ASM-079** — Runtime integration test (`tests/integration/no-claude-home.test.ts`) that mocks `node:fs` / `node:fs/promises` and asserts the chat application-layer happy path issues zero reads against `~/.claude/`.
- **T-ASM-080** — Static grep audit (`tests/integration/credentials-grep-audit.test.ts`) for `.credentials.json`, `~/.claude/`, and `CLAUDE_CODE_OAUTH_TOKEN` across `src/**` with a documented self-citation allow-list.
- **T-ASM-081** — Telemetry-shape test for `ClaudeSubprocessAdapter` plus the matching emission (`_emitCompletionTelemetry`): every `subscription.{query,structured}.complete` debug event carries exactly `{ transport, sessionId: '<redacted>' | null, durationMs, exitCode }` — no prompt body, no binary path, no `$HOME`, no raw UUID.
- **T-ASM-082** — Already covered by PR-ASM-2 (`ChatSidebar.proposalFlow.test.ts:402`).
- **T-ASM-083** — CCS-inheritance audit (`tests/integration/ccs-inheritance.test.ts`) confirms REQ-ASM-051/052/053 hold under `port.kind === 'subscription'`. Zero new production code.
- **T-ASM-084** — `specs/agent-sidepanel-mvp/implementation-log.md` summarising every PR-ASM-X with its REQ-ASM IDs closed and ADR-0027..0032 cross-references.
- **T-ASM-085** — Pre-PR gate (`audit / typecheck / lint / lint:rules / test / build / build:web / docs:api`) all green; §13.4 release-blockers checklist verified.

Tests: **1375/1375 pass** (was 1364 on `develop`). Lint: 0 errors / 15 warnings.

## Test plan

- [x] `npm audit --audit-level=high --omit=dev` → 0 vulnerabilities.
- [x] `npm run typecheck` → pass.
- [x] `npm run lint` → 0 errors; `local/no-claude-home-reads` active and silent across `src/**`.
- [x] `npm run lint:rules` → all RuleTester cases + severity assertion pass.
- [x] `npm run test` → 1375/1375 pass.
- [x] `npm run build` → plugin bundle builds clean.
- [x] `npm run build:web` → standalone UI bundle builds clean.
- [x] `npm run docs:api` → TypeDoc emits with 0 errors.
- [x] SPEC §13.4 release-blockers:
  - [x] `'--bare'` never appears in argv (TEST-ASM-006 + grep in `buildSubprocessArgs`).
  - [x] Vault writes only from `commitFileWriteProposal` for LLM proposals (TEST-ASM-047 + NFR-ASM-011 in-file invariant).
  - [x] `STRUCTURED_PARSE_FAILED` never surfaces raw output (TEST-ASM-029 + the existing `chat-response-structured-fail` test).
  - [x] Session-log writes fire-and-forget on the critical path; only `appendProposalDecision` is awaited.
  - [x] Forbidden i18n terms absent (T-ASM-074 forbidden-terms test).

https://claude.ai/code/session_014uvXBSWVU6berqtGKYc6Rh

---
_Generated by [Claude Code](https://claude.ai/code/session_014uvXBSWVU6berqtGKYc6Rh)_