### PR TITLE
fix(plugin): preserve chatThreads when persisting updated settings

### DIFF
--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -400,7 +400,16 @@ export default class SpecoratorPlugin extends Plugin {
     await this.core?.notifySettingsChanged('specorator', merged)
     const validated = (this.core?.getModuleSettings('specorator') ?? merged) as PluginSettings
     this.settings = validated
-    this._storedData = { ...this._storedData, specorator: { ...validated } }
+    // Merge into the existing specorator blob rather than overwriting it.
+    // Sibling keys under `specorator` (e.g. `chatThreads` from
+    // `_persistChatThreads`) must survive a settings save (Codex P1, PR #350);
+    // a bare `{ ...validated }` here would drop them and the next plugin
+    // reload couldn't restore prior chat sessions.
+    const currentSpecorator = (this._storedData.specorator ?? {}) as Record<string, unknown>
+    this._storedData = {
+      ...this._storedData,
+      specorator: { ...currentSpecorator, ...validated },
+    }
     await this.saveData(this._storedData)
   }
 

--- a/tests/plugin/main.chat-threads-flush.test.ts
+++ b/tests/plugin/main.chat-threads-flush.test.ts
@@ -317,3 +317,77 @@ describe('getInitialChatThreads — read path (T-ASM-053)', () => {
     expect(plugin.getInitialChatThreads()).toEqual([])
   })
 })
+
+describe('updateSettings preserves sibling keys under specorator (Codex P1, PR #350)', () => {
+  it('does not clobber chatThreads when settings are saved', async () => {
+    // Pre-seed _storedData with both PluginSettings AND a chatThreads blob —
+    // exactly what `_persistChatThreads` writes alongside the settings.
+    const initialData = {
+      specorator: {
+        locale: 'en',
+        specsFolder: 'specs',
+        anthropicApiKey: '',
+        claudeCliPath: '',
+        transportKind: 'auto',
+        chatThreads: {
+          t1: {
+            threadId: 't1',
+            sessionId: 's1',
+            feature: 'foo',
+            logPath: 'specs/foo/sessions/s1.md',
+            transport: 'subscription',
+            createdAt: '2026-05-14T10:00:00.000Z',
+            lastUsedAt: '2026-05-14T10:00:00.000Z',
+          },
+        },
+      },
+    }
+    const { plugin, state } = makePlugin(initialData)
+    await plugin.loadSettings()
+    // Pre-fix the seeded settings on the plugin so `updateSettings`'s base
+    // merge mirrors the production load path.
+    plugin.settings = {
+      ...(plugin.settings as unknown as Record<string, unknown>),
+      ...(initialData.specorator as Record<string, unknown>),
+    } as unknown as typeof plugin.settings
+
+    // Save a settings change. No `core` is wired here, so `getModuleSettings`
+    // returns undefined and the function falls back to the merged settings —
+    // mirrors the production code path's validation fallback.
+    await plugin.updateSettings({ transportKind: 'api-key' })
+
+    // The saved blob must still carry the chatThreads sibling.
+    const saved = state.blob as { specorator?: Record<string, unknown> }
+    expect(saved.specorator).toBeDefined()
+    expect(saved.specorator?.chatThreads).toBeDefined()
+    expect(saved.specorator?.chatThreads).toEqual(initialData.specorator.chatThreads)
+    // And the settings change actually landed.
+    expect(saved.specorator?.transportKind).toBe('api-key')
+  })
+
+  it('overwrites a settings key when partial updates it (still merging — settings keys win over the existing blob)', async () => {
+    const initialData = {
+      specorator: {
+        locale: 'en',
+        specsFolder: 'specs',
+        anthropicApiKey: 'old-key',
+        claudeCliPath: '',
+        transportKind: 'auto',
+      },
+    }
+    const { plugin, state } = makePlugin(initialData)
+    await plugin.loadSettings()
+    plugin.settings = {
+      ...(plugin.settings as unknown as Record<string, unknown>),
+      ...(initialData.specorator as Record<string, unknown>),
+    } as unknown as typeof plugin.settings
+
+    await plugin.updateSettings({ anthropicApiKey: 'new-key' })
+
+    const saved = state.blob as { specorator?: Record<string, unknown> }
+    expect(saved.specorator?.anthropicApiKey).toBe('new-key')
+    // Other settings keys preserved.
+    expect(saved.specorator?.locale).toBe('en')
+    expect(saved.specorator?.specsFolder).toBe('specs')
+  })
+})


### PR DESCRIPTION
## Summary

Codex P1 surfaced on #350 (develop→demo promotion) but the defect lives on `develop` in `src/plugin/main.ts:403`. Fixing on `develop` so #350 absorbs it.

**Bug.** `updateSettings()` previously wrote `specorator: { ...validated }`, replacing the entire `specorator` blob. The sibling `chatThreads` key that `_persistChatThreads()` writes under the same parent was clobbered on every settings save, so the next plugin reload couldn't restore saved sessions.

**Fix.** Merge into the existing blob instead of overwriting:

```ts
const currentSpecorator = (this._storedData.specorator ?? {}) as Record<string, unknown>
this._storedData = {
  ...this._storedData,
  specorator: { ...currentSpecorator, ...validated },
}
```

Settings keys still win over the existing blob (the partial save is honoured); `chatThreads` and any future sibling key survive.

## Test plan

- [x] New test: `updateSettings preserves sibling keys under specorator (Codex P1, PR #350)` — settings change with a pre-seeded `chatThreads` blob; assert `chatThreads` survives the save.
- [x] New test: partial settings update overwrites the changed key while other settings stay intact.
- [x] `npm run typecheck` → pass.
- [x] `npm run lint` → 0 errors.
- [x] `npm run test` → 1383/1383.

https://claude.ai/code/session_014uvXBSWVU6berqtGKYc6Rh

---
_Generated by [Claude Code](https://claude.ai/code/session_014uvXBSWVU6berqtGKYc6Rh)_