### PR TITLE
fix(asm): deferred transport refresh + serialised chat-thread flush queue

### DIFF
--- a/src/plugin/SpecoratorView.ts
+++ b/src/plugin/SpecoratorView.ts
@@ -1,5 +1,5 @@
 import { ItemView, Platform, type WorkspaceLeaf } from 'obsidian'
-import { createApp, ref, type App as VueApp, type Ref } from 'vue'
+import { createApp, ref, watch, type App as VueApp, type Ref } from 'vue'
 import { createPinia, type Pinia } from 'pinia'
 import type { Router } from 'vue-router'
 import { router } from '@/ui/router'
@@ -108,6 +108,19 @@ export class SpecoratorView extends ItemView {
    */
   private readonly _options: SpecoratorViewOptions | null
 
+  /**
+   * Set by `bumpSettingsVersion()` when called mid-turn (status === 'loading').
+   * The watcher installed in `onOpen()` consumes the flag when the chat
+   * status transitions back out of 'loading' and applies the deferred
+   * transport refresh (Codex P1, PR #350). Without this, a settings change
+   * made during a long-running request would silently never apply until
+   * the user saved settings again or reloaded the plugin.
+   */
+  private _pendingSettingsRefresh = false
+
+  /** Disposer for the chat-status watcher; set in `onOpen()`, called in `onClose()`. */
+  private _statusWatchStop: (() => void) | null = null
+
   constructor(
     leaf: WorkspaceLeaf,
     private readonly plugin: SpecoratorPlugin,
@@ -167,6 +180,8 @@ export class SpecoratorView extends ItemView {
     chatStore.$subscribe((_mutation, state) => {
       this.plugin.scheduleChatThreadsPersistence(state.chatThreads)
     })
+
+    this._installPendingRefreshWatcher()
 
     this.vueApp = createApp(AppRoot)
     this.vueApp.use(this.pinia)
@@ -254,6 +269,9 @@ export class SpecoratorView extends ItemView {
     this._routerErrorCleanup?.()
     this._routerErrorCleanup = null
     this._router = null
+    this._statusWatchStop?.()
+    this._statusWatchStop = null
+    this._pendingSettingsRefresh = false
     this.plugin.bridge?.hideAllNotices()
     this.vueApp?.unmount()
     this.vueApp = null
@@ -283,11 +301,49 @@ export class SpecoratorView extends ItemView {
   public bumpSettingsVersion(): void {
     this._settingsVersion.value++
     if (this._isChatLoading()) {
-      // REQ-ASM-003 — skip transport switch while a turn is in flight. The
-      // next `bumpSettingsVersion()` (or the user's next message) will pick
-      // up the new transport on the following call.
+      // REQ-ASM-003 — skip transport switch while a turn is in flight. Record
+      // the deferred-refresh intent; the status watcher in `onOpen()` will
+      // re-invoke `_applyTransportRefresh()` when the turn ends, so the
+      // user's settings change is never silently dropped (Codex P1, PR #350).
+      this._pendingSettingsRefresh = true
       return
     }
+    this._applyTransportRefresh()
+  }
+
+  /**
+   * Install the chat-status watcher that consumes
+   * `_pendingSettingsRefresh` when an in-flight turn ends (Codex P1, PR #350).
+   * Called from `onOpen()`; also re-exposed (public) so unit tests can wire
+   * the watcher manually after seeding `this.pinia` without going through
+   * the full mount path.
+   */
+  public _installPendingRefreshWatcher(): void {
+    if (this.pinia === null) return
+    if (this._statusWatchStop !== null) return
+    const chatStore = useChatStore(this.pinia)
+    this._statusWatchStop = watch(
+      () => chatStore.status,
+      (next, prev) => {
+        if (prev === 'loading' && next !== 'loading' && this._pendingSettingsRefresh) {
+          this._pendingSettingsRefresh = false
+          this._applyTransportRefresh()
+        }
+      },
+      // Sync flush so the deferred refresh applies in the same microtask
+      // that transitions status out of 'loading'. Without this, the
+      // transport could stay stale for an extra event-loop turn (and the
+      // unit test would race the scheduler).
+      { flush: 'sync' },
+    )
+  }
+
+  /**
+   * Run the adapter `startup()` + `_refreshActivePort()` sequence. Extracted
+   * from `bumpSettingsVersion()` so the chat-status watcher can apply a
+   * deferred refresh when an in-flight turn ends (Codex P1, PR #350).
+   */
+  private _applyTransportRefresh(): void {
     // Re-run BOTH adapters' startup so a freshly-configured API key (api-key
     // path) or CLI path (subscription path) updates each port's
     // `isAvailable()` / `isAvailableSync()` before the selector reads it.

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -75,6 +75,14 @@ export default class SpecoratorPlugin extends Plugin {
    * the plugin is disabled would silently fail to persist (Codex P1, PR #346).
    */
   private _pendingChatThreadsSnapshot: ReadonlyMap<string, ChatThreadRecord> | null = null
+  /**
+   * Tail of the chat-thread flush chain. Each new flush is chained off the
+   * previous one's settled promise so writes are strictly serialised: an
+   * older snapshot can never resolve AFTER a newer snapshot and clobber it
+   * (Codex P1, PR #350). Initialised to a settled promise so the first
+   * flush attaches without an extra branch.
+   */
+  private _chatThreadsFlushQueue: Promise<void> = Promise.resolve()
   /** Default debounce window in milliseconds for chatThreads flushes. */
   private static readonly _CHAT_THREADS_FLUSH_DEBOUNCE_MS = 1_000
 
@@ -313,7 +321,13 @@ export default class SpecoratorPlugin extends Plugin {
     if (this._pendingChatThreadsSnapshot !== null) {
       const snapshot = this._pendingChatThreadsSnapshot
       this._pendingChatThreadsSnapshot = null
-      void this._flushChatThreads(snapshot)
+      // Tail-chain so an in-flight debounced flush finishes before this
+      // final write (Codex P1, PR #350). Without this, the final flush
+      // could race a still-resolving prior flush and lose its update.
+      this._chatThreadsFlushQueue = this._chatThreadsFlushQueue
+        .catch(() => undefined)
+        .then(() => this._flushChatThreads(snapshot))
+      void this._chatThreadsFlushQueue
     }
     this.app.workspace.detachLeavesOfType(VIEW_TYPE)
     this.bridge?.hideAllNotices()
@@ -375,7 +389,15 @@ export default class SpecoratorPlugin extends Plugin {
     this._chatThreadsFlushTimer = activeWindow.setTimeout(() => {
       this._chatThreadsFlushTimer = null
       this._pendingChatThreadsSnapshot = null
-      void this._flushChatThreads(snapshot)
+      // Serialise via the tail-chained queue so older snapshots can never
+      // resolve after newer ones (Codex P1, PR #350). `.catch(() => undefined)`
+      // keeps the chain alive past a transient saveData failure — the next
+      // flush should still attempt to write, not be silently swallowed by a
+      // rejected predecessor.
+      this._chatThreadsFlushQueue = this._chatThreadsFlushQueue
+        .catch(() => undefined)
+        .then(() => this._flushChatThreads(snapshot))
+      void this._chatThreadsFlushQueue
     }, SpecoratorPlugin._CHAT_THREADS_FLUSH_DEBOUNCE_MS)
   }
 

--- a/tests/plugin/SpecoratorView.test.ts
+++ b/tests/plugin/SpecoratorView.test.ts
@@ -355,6 +355,37 @@ describe('SpecoratorView.bumpSettingsVersion() mid-turn guard (REQ-ASM-003)', ()
     expect(activePort(view)).not.toBe(fixture.sdkAdapter)
   })
 
+  it('auto-applies the deferred refresh when the turn ends (no manual second bump required) — Codex P1, PR #350', async () => {
+    const fixture = makeFixture(
+      { transportKind: 'auto', anthropicApiKey: '' },
+      /* cliResolved */ false,
+    )
+
+    const view = makeView(fixture)
+    view.pinia = pinia
+    // Install the deferred-refresh watcher the way `onOpen()` would.
+    view._installPendingRefreshWatcher()
+
+    const store = useChatStore(pinia)
+    // Mid-turn settings change.
+    store.beginRequest()
+    fixture.plugin.settings = makeSettings({
+      transportKind: 'auto',
+      anthropicApiKey: 'sk-mid-turn',
+    })
+    view.bumpSettingsVersion()
+    expect(activePort(view)).toBe(fixture.degradedPort)
+
+    // Turn finishes — the watcher MUST automatically apply the deferred
+    // refresh without a second `bumpSettingsVersion()` call.
+    store.setResponse('hello', false)
+    // Allow Vue's reactive scheduler to flush the watcher callback.
+    const { nextTick } = await import('vue')
+    await nextTick()
+
+    expect(activePort(view)).toBe(fixture.sdkAdapter)
+  })
+
   it('picks up the deferred change on the NEXT bump after the turn settles', () => {
     const fixture = makeFixture(
       { transportKind: 'auto', anthropicApiKey: '' },

--- a/tests/plugin/main.chat-threads-flush.test.ts
+++ b/tests/plugin/main.chat-threads-flush.test.ts
@@ -93,6 +93,7 @@ function makePlugin(initialData: Record<string, unknown>): {
   plugin._initialChatThreads = []
   plugin._chatThreadsFlushTimer = null
   plugin._pendingChatThreadsSnapshot = null
+  plugin._chatThreadsFlushQueue = Promise.resolve()
   plugin.loadData = vi.fn(async () => initialData)
   plugin.saveData = vi.fn(async (data: Record<string, unknown>) => {
     state.blob = data
@@ -284,6 +285,81 @@ describe('scheduleChatThreadsPersistence — debounced flush (T-ASM-054)', () =>
 
     // saveData was never called; the blob is whatever was already on disk.
     expect(state.blob).toBeNull()
+  })
+
+  it('serialises flushes so a slow earlier saveData cannot overwrite a newer one (Codex P1, PR #350)', async () => {
+    // Build a plugin with a saveData that records the order it was INVOKED in,
+    // and resolves on demand. Older flushes must complete (resolve) before
+    // newer ones start.
+    const state: SavedState = { blob: null, saveCount: 0 }
+    const plugin = Object.create(SpecoratorPlugin.prototype) as Record<string, unknown>
+    plugin._storedData = { specorator: { locale: 'en' } }
+    plugin._initialChatThreads = []
+    plugin._chatThreadsFlushTimer = null
+    plugin._pendingChatThreadsSnapshot = null
+    plugin._chatThreadsFlushQueue = Promise.resolve()
+    plugin.app = { workspace: { detachLeavesOfType: vi.fn() } }
+    plugin.loadData = vi.fn(async () => ({}))
+
+    const writeOrder: string[] = []
+    const pendingResolvers: Array<() => void> = []
+    plugin.saveData = vi.fn(async (data: Record<string, unknown>) => {
+      const specorator = (data.specorator ?? {}) as Record<string, unknown>
+      const threads = (specorator.chatThreads ?? {}) as Record<string, unknown>
+      const ids = Object.keys(threads).sort().join(',')
+      writeOrder.push(`start:${ids}`)
+      await new Promise<void>((resolve) => pendingResolvers.push(resolve))
+      writeOrder.push(`finish:${ids}`)
+      state.blob = data
+      state.saveCount += 1
+    })
+
+    const view = plugin as unknown as SpecoratorPlugin
+
+    // Schedule snapshot A, fire its debounce, then schedule snapshot B and
+    // fire its debounce. Both saveData calls are awaiting their resolvers.
+    view.scheduleChatThreadsPersistence(new Map([['t1', makeRecord({ threadId: 't1' })]]))
+    await vi.advanceTimersByTimeAsync(1_000)
+    // A has started; its saveData is parked.
+    expect(writeOrder).toEqual(['start:t1'])
+
+    view.scheduleChatThreadsPersistence(
+      new Map([
+        ['t1', makeRecord({ threadId: 't1' })],
+        ['t2', makeRecord({ threadId: 't2', sessionId: asSessionId('s2'), transport: 'api-key' })],
+      ]),
+    )
+    await vi.advanceTimersByTimeAsync(1_000)
+    // Critical: B has NOT started yet — it is queued behind A. The tail-
+    // chain forces B to wait for A's resolution before its saveData runs.
+    expect(writeOrder).toEqual(['start:t1'])
+
+    // Resolve A.
+    pendingResolvers[0]?.()
+    await vi.runAllTimersAsync()
+    await Promise.resolve()
+    await Promise.resolve()
+    // Now B has started.
+    expect(writeOrder).toContain('finish:t1')
+    expect(writeOrder.find((s) => s.startsWith('start:t1,t2'))).toBe('start:t1,t2')
+
+    // Resolve B.
+    pendingResolvers[1]?.()
+    await vi.runAllTimersAsync()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // Final order: A start → A finish → B start → B finish. Last-write-wins
+    // honoured: the persisted blob is B (the newer snapshot), not A.
+    expect(writeOrder).toEqual([
+      'start:t1',
+      'finish:t1',
+      'start:t1,t2',
+      'finish:t1,t2',
+    ])
+    const specorator = state.blob?.specorator as Record<string, unknown>
+    const threads = specorator.chatThreads as Record<string, unknown>
+    expect(Object.keys(threads).sort()).toEqual(['t1', 't2'])
   })
 })
 


### PR DESCRIPTION
## Summary

Two Codex P1 follow-ups surfaced on #350 (develop→demo promotion) targeting concurrency defects on `develop`. Fixing on develop so #350 absorbs them.

### P1 — Apply deferred transport refresh after in-flight turn ends
`SpecoratorView.bumpSettingsVersion()` previously returned early when `status === 'loading'` and never retried. Any settings change made during a long-running request was silently dropped until the user saved settings again or reloaded the plugin.

**Fix.** New `_pendingSettingsRefresh: boolean` flag set mid-turn. A `watch(() => chatStore.status, ...)` installed in `onOpen()` (via the test-exposed `_installPendingRefreshWatcher()`) fires `_applyTransportRefresh()` when status transitions out of `'loading'` AND the flag is set. `flush: 'sync'` so the refresh applies in the same microtask as the status transition. `onClose()` disposes the watcher and clears the flag.

### P1 — Serialise chat-thread flushes
`scheduleChatThreadsPersistence`'s debounce callback previously kicked off `_flushChatThreads(snapshot)` in fire-and-forget mode with no write queue. Two back-to-back flushes on a slow `saveData` could overlap; an older snapshot resolving after a newer one would clobber the newer state.

**Fix.** New `_chatThreadsFlushQueue: Promise<void>` tail. Each new flush is chained off `.catch(() => undefined).then(() => this._flushChatThreads(...))` so writes are strictly serialised. The `.catch` keeps the chain alive past a transient saveData failure. The onunload synchronous-flush path uses the same queue, so a final write waits for any in-flight debounced flush.

## Test plan

- [x] New `SpecoratorView.test.ts`: "auto-applies the deferred refresh when the turn ends (no manual second bump required)" — install watcher, beginRequest, mid-turn bump, setResponse → assert sdkAdapter is active without a second bump.
- [x] New `main.chat-threads-flush.test.ts`: "serialises flushes so a slow earlier saveData cannot overwrite a newer one" — two snapshots with manually-released saveData resolvers; assert invocation order is `A.start → A.finish → B.start → B.finish`.
- [x] `npm run typecheck` → pass.
- [x] `npm run lint` → 0 errors.
- [x] `npm run test` → 1385/1385.

https://claude.ai/code/session_014uvXBSWVU6berqtGKYc6Rh

---
_Generated by [Claude Code](https://claude.ai/code/session_014uvXBSWVU6berqtGKYc6Rh)_