### PR TITLE
fix(asm): record resolved transport on thread + restrict file-menu to TFile

### DIFF
--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -1,4 +1,4 @@
-import { Plugin, TFolder } from 'obsidian'
+import { Plugin, TFile, TFolder } from 'obsidian'
 // SPEC-ASM-001 §9.1 — `child_process.spawn` is imported statically at the top
 // of this file so the subscription adapter's constructor in `onload()` has no
 // dynamic-import sites. The ESLint guard for unbundled `child_process` is
@@ -234,6 +234,12 @@ export default class SpecoratorPlugin extends Plugin {
     // T-CCS-031: Right-click "Add to chat context" menu item on vault files.
     this.registerEvent(
       this.app.workspace.on('file-menu', (menu, file) => {
+        // Restrict the "Add to chat context" entry to actual files. The
+        // `file-menu` event also fires for folders (TAbstractFile is the
+        // union); adding a folder path would produce a context entry that
+        // fails silently at `readFile` time and wastes prompt budget
+        // (Codex P2, PR #350).
+        if (!(file instanceof TFile)) return
         menu.addItem((item) => {
           item
             .setTitle('Add to chat context')

--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -535,8 +535,16 @@ async function handleSend(): Promise<void> {
   const { slug, systemPromptSuffix } = await computeStagePromptContext(settings.specsFolder)
 
   // ── Session-persistence wiring (T-ASM-057, REQ-ASM-031/034/035/037/040) ──
+  // Use the resolved active transport (from `transportKindRef`), NOT the
+  // raw `settings.transportKind`. Under `transportKind === 'auto'` the
+  // selector may resolve to either subscription or api-key depending on
+  // CLI / API-key availability — recording the setting's raw value here
+  // would persist `'api-key'` even when the turn actually ran through the
+  // subscription adapter, polluting audit logs and resume metadata
+  // (Codex P2, PR #350).
+  const resolvedKind = transportKind.value
   const transport: 'api-key' | 'subscription' =
-    settings.transportKind === 'subscription' ? 'subscription' : 'api-key'
+    resolvedKind === 'subscription' ? 'subscription' : 'api-key'
   const { threadId, resumeSessionId, isResumedTurn } = resolveActiveThread({ slug, transport })
   const onSessionId = (id: SessionId): void => {
     store.captureSessionId(threadId, id)

--- a/tests/plugin/main.chat-handlers.test.ts
+++ b/tests/plugin/main.chat-handlers.test.ts
@@ -11,6 +11,7 @@
  */
 import { describe, it, expect, beforeEach } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
+import { TFile, TFolder } from 'obsidian'
 import { useChatStore } from '@/ui/stores/chatStore'
 
 // ── helpers extracted from main.ts handler logic ─────────────────────────────
@@ -83,6 +84,46 @@ describe('T-CCS-031: file-menu "Add to chat context" handler', () => {
     handleAddToContext(store, { path: 'notes/bar.md', name: 'bar.md' })
 
     expect(store.contextFiles[0].isAuto).toBe(false)
+  })
+
+  describe('TFile / TFolder guard (Codex P2, PR #350)', () => {
+    /**
+     * Mirrors the production guard wired in `main.ts`'s file-menu handler:
+     * the `file-menu` event fires for both files and folders, and the
+     * production code now skips registration when the entry isn't a TFile
+     * so a folder path never ends up as an unreadable context entry.
+     */
+    function registerIfFile(
+      store: ReturnType<typeof useChatStore>,
+      entry: unknown,
+    ): boolean {
+      if (!(entry instanceof TFile)) return false
+      handleAddToContext(store, { path: entry.path, name: entry.name })
+      return true
+    }
+
+    it('adds the entry to context when invoked on a TFile', () => {
+      const store = useChatStore()
+      const file = new TFile()
+      file.path = 'notes/a.md'
+      file.name = 'a.md'
+      const added = registerIfFile(store, file)
+
+      expect(added).toBe(true)
+      expect(store.contextFiles).toHaveLength(1)
+      expect(store.contextFiles[0]).toMatchObject({ path: 'notes/a.md', isAuto: false })
+    })
+
+    it('does NOT add a folder to context (TFolder rejected)', () => {
+      const store = useChatStore()
+      const folder = new TFolder()
+      folder.path = 'notes'
+      folder.name = 'notes'
+      const added = registerIfFile(store, folder)
+
+      expect(added).toBe(false)
+      expect(store.contextFiles).toEqual([])
+    })
   })
 })
 

--- a/tests/ui/components/chat/ChatSidebar.sessionPersistence.test.ts
+++ b/tests/ui/components/chat/ChatSidebar.sessionPersistence.test.ts
@@ -20,7 +20,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { setActivePinia, createPinia } from 'pinia'
-import { defineComponent, nextTick } from 'vue'
+import { defineComponent, nextTick, ref } from 'vue'
 import ChatSidebar from '@/ui/components/chat/ChatSidebar.vue'
 import type { ClaudeCliPort, ClaudeCliQueryOptions } from '@/domain/ports/ClaudeCliPort'
 import { ClaudeCliError } from '@/domain/ports/ClaudeCliPort'
@@ -36,7 +36,9 @@ import {
 	WORKSPACE_PORT,
 	SETTINGS_PORT,
 	LOGGER_PORT,
+	TRANSPORT_KIND_KEY,
 } from '@/infrastructure/bridge/ports'
+import type { TransportKind } from '@/domain/chat/TransportKind'
 import { useChatStore } from '@/ui/stores/chatStore'
 import { ChatSidebarPO } from './ChatSidebar.po'
 import type { PluginSettings } from '@/domain/settings/PluginSettings'
@@ -106,6 +108,15 @@ async function mountSidebar(args: {
 	files?: Record<string, string>
 	activeFile?: { path: string; basename: string; extension: string } | null
 	queryError?: ClaudeCliError | null
+	/**
+	 * Resolved transport kind injected via `TRANSPORT_KIND_KEY` (mirrors
+	 * production: SpecoratorView's selector resolves the setting + CLI
+	 * availability to a concrete kind). Defaults to `'subscription'` when
+	 * `settings.transportKind === 'subscription'`, else `'api-key'`.
+	 * Tests that want to assert the auto-resolved kind can override this
+	 * directly (Codex P2, PR #350).
+	 */
+	resolvedTransportKind?: TransportKind
 } = {}) {
 	const pinia = createPinia()
 	setActivePinia(pinia)
@@ -119,6 +130,10 @@ async function mountSidebar(args: {
 	const bridge = makeBridge(args.files ?? {}, args.settings ?? {})
 	if (args.activeFile !== undefined) bridge.setActiveFile(args.activeFile)
 
+	const resolvedKind: TransportKind =
+		args.resolvedTransportKind ??
+		(args.settings?.transportKind === 'subscription' ? 'subscription' : 'api-key')
+
 	const wrapper = mount(ChatSidebar, {
 		global: {
 			plugins: [pinia],
@@ -130,6 +145,7 @@ async function mountSidebar(args: {
 				[WORKSPACE_PORT as symbol]: bridge,
 				[SETTINGS_PORT as symbol]: bridge,
 				[LOGGER_PORT as symbol]: bridge,
+				[TRANSPORT_KIND_KEY as symbol]: ref<TransportKind>(resolvedKind),
 			},
 		},
 	})
@@ -181,6 +197,30 @@ describe('ChatSidebar — session-persistence wiring (T-ASM-057)', () => {
 
 	it('records transport="api-key" by default when settings.transportKind is not "subscription" (SPEC §7.6)', async () => {
 		const { po, store } = await mountSidebar({})
+		await send(store, po, 'hello')
+		const threadId = store.activeThreadId!
+		expect(store.chatThreads.get(threadId)?.transport).toBe('api-key')
+	})
+
+	it('records the RESOLVED active transport, not the raw setting — auto→subscription (Codex P2, PR #350)', async () => {
+		// settings.transportKind = 'auto' but the selector resolved to
+		// 'subscription' (e.g. no API key configured but the CLI is
+		// available). The thread record must reflect what actually ran,
+		// not the raw setting value.
+		const { po, store } = await mountSidebar({
+			settings: { transportKind: 'auto', anthropicApiKey: '' },
+			resolvedTransportKind: 'subscription',
+		})
+		await send(store, po, 'hello')
+		const threadId = store.activeThreadId!
+		expect(store.chatThreads.get(threadId)?.transport).toBe('subscription')
+	})
+
+	it('records api-key when the resolved kind is api-key under auto mode (mirror of the above)', async () => {
+		const { po, store } = await mountSidebar({
+			settings: { transportKind: 'auto', anthropicApiKey: 'sk-test' },
+			resolvedTransportKind: 'api-key',
+		})
 		await send(store, po, 'hello')
 		const threadId = store.activeThreadId!
 		expect(store.chatThreads.get(threadId)?.transport).toBe('api-key')


### PR DESCRIPTION
## Summary

Two Codex P2 follow-ups surfaced on #350 targeting pre-existing defects on `develop`.

### P2 — Record resolved transport kind on the thread
ChatSidebar previously recorded `thread.transport` from `settings.transportKind`. In `'auto'` mode the selector resolves to either api-key or subscription, but the thread record stamped the raw setting value (always falling through to `'api-key'` because the literal `'auto'` doesn't equal `'subscription'`). Audit logs and resume metadata then disagreed with the actual transport.

**Fix.** Read `transportKind.value` (the resolved kind from the `TRANSPORT_KIND_KEY` ref injected by `SpecoratorView`).

### P2 — Restrict "Add to chat context" file-menu item to TFile
The `file-menu` event fires for both files and folders. Adding a folder path produced a context entry that failed silently at `readFile` time and wasted prompt budget.

**Fix.** `if (!(file instanceof TFile)) return` before registering the menu item.

## Test plan

- [x] `ChatSidebar.sessionPersistence.test.ts`: `mountSidebar` now injects `TRANSPORT_KIND_KEY` (default derived from `settings.transportKind`, overridable via new `resolvedTransportKind` arg). Two new cases: `auto + resolved subscription → 'subscription'`, `auto + resolved api-key → 'api-key'`.
- [x] `main.chat-handlers.test.ts`: new TFile/TFolder guard describe block. TFile registers; TFolder is rejected.
- [x] `npm run typecheck` → pass.
- [x] `npm run lint` → 0 errors.
- [x] `npm run test` → 1391/1391.

https://claude.ai/code/session_014uvXBSWVU6berqtGKYc6Rh

---
_Generated by [Claude Code](https://claude.ai/code/session_014uvXBSWVU6berqtGKYc6Rh)_