### PR TITLE
fix(asm): enforce specs-folder prefix in validateProposalPath + rotate thread on transport change

### DIFF
--- a/src/application/chat/validateProposalPath.ts
+++ b/src/application/chat/validateProposalPath.ts
@@ -116,19 +116,30 @@ export function validateProposalPath(
     )
   }
 
-  // 5. Vault-root containment. Compute resolved vs root using POSIX
-  //    normalisation (no filesystem access, no `..` flattening). Because
-  //    step 3 already rejected `..` segments, this check primarily catches
-  //    pathological compositions that survive normalisation.
-  const resolved = posixNormalize(vaultRoot + '/' + path)
-  const root = posixNormalize(vaultRoot + '/')
-  if (!resolved.startsWith(root)) {
-    return err(
-      new PathValidationError(
-        'ESCAPES_VAULT_ROOT',
-        `Path resolves outside the vault root: ${path}`,
-      ),
-    )
+  // 5. Specs-folder containment. The path must be vault-relative AND start
+  //    with the configured specs folder (Codex P1, PR #350). Previously this
+  //    check composed `vaultRoot + '/' + path` and tested the composition's
+  //    prefix — trivially satisfied for any non-`..` relative path, so a
+  //    sibling-folder path slipped through and could write outside `specs/`.
+  //    Now the check is direct: the proposal's path itself must start with
+  //    `<specsFolder>/`. An empty `specsFolder` (vault-root config) accepts
+  //    any non-escaping path. The variable name remains `vaultRoot` for
+  //    backwards compatibility with the historic signature; the semantics
+  //    are "the containment root for proposals" — i.e. the specs folder.
+  const normalisedRoot = posixNormalize(vaultRoot)
+  const normalisedPath = posixNormalize(path)
+  if (normalisedRoot.length > 0) {
+    const requiredPrefix = normalisedRoot.endsWith('/')
+      ? normalisedRoot
+      : normalisedRoot + '/'
+    if (!normalisedPath.startsWith(requiredPrefix)) {
+      return err(
+        new PathValidationError(
+          'ESCAPES_VAULT_ROOT',
+          `Path is not under the configured specs folder '${vaultRoot}': ${path}`,
+        ),
+      )
+    }
   }
 
   // 6. All checks passed.

--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -301,8 +301,16 @@ function resolveActiveThread(args: {
 }): { threadId: string; resumeSessionId: SessionId | undefined; isResumedTurn: boolean } {
   const nowIso = new Date().toISOString()
   let threadId = store.activeThreadId
-  if (threadId === null || !store.chatThreads.has(threadId)) {
-    threadId = threadId ?? generateThreadId()
+  const existing = threadId !== null ? store.chatThreads.get(threadId) : undefined
+  // Rotate when the active thread's transport no longer matches the resolved
+  // transport for this turn (Codex P2, PR #350). Resuming a session id that
+  // was minted under a different transport produces incoherent context and
+  // audit metadata, so we mint a fresh thread instead of carrying state
+  // across the transport boundary.
+  const transportMismatch =
+    existing !== undefined && existing.transport !== args.transport
+  if (threadId === null || existing === undefined || transportMismatch) {
+    threadId = generateThreadId()
     const fresh: ChatThreadRecord = {
       threadId,
       sessionId: null,

--- a/tests/application/chat/validateProposalPath.test.ts
+++ b/tests/application/chat/validateProposalPath.test.ts
@@ -63,9 +63,9 @@ describe('posixNormalize', () => {
 })
 
 describe('validateProposalPath — happy path (TEST-ASM-030 baseline)', () => {
-  it('returns ok(envelope) for a valid vault-relative .md path under the root', () => {
+  it('returns ok(envelope) for a valid path under the configured specs folder', () => {
     const env = envelopeWith('specs/foo/idea.md')
-    const result = validateProposalPath(env, 'workspace')
+    const result = validateProposalPath(env, 'specs')
     expect(result.ok).toBe(true)
     if (result.ok) {
       // Round-trips the original envelope unchanged.
@@ -77,7 +77,30 @@ describe('validateProposalPath — happy path (TEST-ASM-030 baseline)', () => {
     // A literal single dot in a deeper path is not rejected — it is just
     // normalised away when composing the resolved path.
     const env = envelopeWith('specs/foo/idea.md')
-    const result = validateProposalPath(env, 'workspace')
+    const result = validateProposalPath(env, 'specs')
+    expect(result.ok).toBe(true)
+  })
+
+  it("rejects a path NOT under the configured specs folder (Codex P1, PR #350)", () => {
+    // Prior to the fix this would silently pass — the old check composed
+    // the proposed path under the root and tested the composition's
+    // prefix, which was trivially satisfied. Now the path itself must
+    // start with the configured specs folder.
+    const env = envelopeWith('notes/todo.md')
+    const result = validateProposalPath(env, 'specs')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.kind).toBe('ESCAPES_VAULT_ROOT')
+    }
+  })
+
+  it('accepts any non-escaping path when the root is the empty string (vault-root config)', () => {
+    // With an empty specs-folder setting, no prefix is enforced — the
+    // earlier checks (LEADING_SLASH, CONTAINS_DOTDOT, BAD_EXTENSION) are
+    // still active. This preserves backwards compatibility for the
+    // standalone browser UI that doesn't configure a specs folder.
+    const env = envelopeWith('any-file.md')
+    const result = validateProposalPath(env, '')
     expect(result.ok).toBe(true)
   })
 })
@@ -173,25 +196,27 @@ describe('validateProposalPath — BAD_EXTENSION', () => {
   })
 })
 
-describe('validateProposalPath — ESCAPES_VAULT_ROOT', () => {
-  it("returns err(ESCAPES_VAULT_ROOT) when the normalised resolved path does not have the normalised root as prefix", () => {
-    // The ESCAPES_VAULT_ROOT branch in SPEC §3.4 step 5 is a defence-in-depth
-    // guard that fires when `posixNormalize(vaultRoot + '/' + path)` does NOT
-    // start with `posixNormalize(vaultRoot + '/')`. Because step 3 already
-    // rejects any path with a `..` segment, the branch is hard to reach with
-    // a "normal" vault root — but it is reachable when the vault root itself
-    // contains `.` segments that normalise asymmetrically.
-    //
-    // Construction: vaultRoot='.', path='b.md'.
-    //   resolved = posixNormalize('./b.md')  → 'b.md'
-    //   root     = posixNormalize('./')      → '/'   (trailing slash preserved)
-    //   'b.md'.startsWith('/') → false → ESCAPES_VAULT_ROOT.
-    const result = validateProposalPath(envelopeWith('b.md'), '.')
+describe('validateProposalPath — ESCAPES_VAULT_ROOT (Codex P1, PR #350)', () => {
+  it("rejects a sibling-prefix collision (e.g. 'specs2/foo.md' under root 'specs')", () => {
+    // The classic prefix-collision attack: 'specs2' shares a leading
+    // substring with 'specs' but is a sibling directory. The check must
+    // require a trailing slash on the root prefix so 'specs2/foo.md'
+    // does NOT satisfy 'specs/'.
+    const result = validateProposalPath(envelopeWith('specs2/foo.md'), 'specs')
     expect(result.ok).toBe(false)
     if (!result.ok) {
-      expect(result.error).toBeInstanceOf(PathValidationError)
       expect(result.error.kind).toBe('ESCAPES_VAULT_ROOT')
       expect(result.error.errorCode).toBe('PATH_INVALID')
+    }
+  })
+
+  it('rejects a vault-root path when a specs folder is configured', () => {
+    // Even a non-traversal, non-leading-slash path is rejected when it
+    // does not live under the specs folder.
+    const result = validateProposalPath(envelopeWith('todo.md'), 'specs')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.kind).toBe('ESCAPES_VAULT_ROOT')
     }
   })
 })

--- a/tests/ui/components/chat/ChatSidebar.sessionPersistence.test.ts
+++ b/tests/ui/components/chat/ChatSidebar.sessionPersistence.test.ts
@@ -134,6 +134,7 @@ async function mountSidebar(args: {
 		args.resolvedTransportKind ??
 		(args.settings?.transportKind === 'subscription' ? 'subscription' : 'api-key')
 
+	const transportKindRef = ref<TransportKind>(resolvedKind)
 	const wrapper = mount(ChatSidebar, {
 		global: {
 			plugins: [pinia],
@@ -145,14 +146,14 @@ async function mountSidebar(args: {
 				[WORKSPACE_PORT as symbol]: bridge,
 				[SETTINGS_PORT as symbol]: bridge,
 				[LOGGER_PORT as symbol]: bridge,
-				[TRANSPORT_KIND_KEY as symbol]: ref<TransportKind>(resolvedKind),
+				[TRANSPORT_KIND_KEY as symbol]: transportKindRef,
 			},
 		},
 	})
 
 	await flushPromises()
 	const store = useChatStore(pinia)
-	return { wrapper, port, bridge, po: new ChatSidebarPO(wrapper), store }
+	return { wrapper, port, bridge, po: new ChatSidebarPO(wrapper), store, transportKindRef }
 }
 
 async function send(store: ReturnType<typeof useChatStore>, po: ChatSidebarPO, text: string) {
@@ -224,6 +225,43 @@ describe('ChatSidebar — session-persistence wiring (T-ASM-057)', () => {
 		await send(store, po, 'hello')
 		const threadId = store.activeThreadId!
 		expect(store.chatThreads.get(threadId)?.transport).toBe('api-key')
+	})
+
+	it('rotates the active thread when the resolved transport changes (Codex P2, PR #350)', async () => {
+		// Start under subscription transport — first send creates a thread.
+		const { po, store, transportKindRef } = await mountSidebar({
+			settings: { transportKind: 'auto' },
+			resolvedTransportKind: 'subscription',
+		})
+		await send(store, po, 'hello')
+		const firstThreadId = store.activeThreadId!
+		expect(store.chatThreads.get(firstThreadId)?.transport).toBe('subscription')
+
+		// User switches transport between turns (selector resolves to api-key now).
+		transportKindRef.value = 'api-key'
+		await send(store, po, 'second turn')
+
+		// The active thread must have rotated — resuming the previous thread's
+		// sessionId under a different transport would produce incoherent
+		// context and audit metadata.
+		const secondThreadId = store.activeThreadId!
+		expect(secondThreadId).not.toBe(firstThreadId)
+		expect(store.chatThreads.get(secondThreadId)?.transport).toBe('api-key')
+		// The original subscription thread is preserved in the map (history is
+		// not deleted — only the active-thread pointer rotates).
+		expect(store.chatThreads.get(firstThreadId)?.transport).toBe('subscription')
+	})
+
+	it('does NOT rotate when the resolved transport stays the same across sends', async () => {
+		const { po, store } = await mountSidebar({
+			settings: { transportKind: 'auto' },
+			resolvedTransportKind: 'subscription',
+		})
+		await send(store, po, 'first')
+		const firstId = store.activeThreadId!
+		await send(store, po, 'second')
+		const secondId = store.activeThreadId!
+		expect(secondId).toBe(firstId)
 	})
 
 	it('second send on the same thread forwards resumeSessionId and flashes sessionResumed (REQ-ASM-035)', async () => {


### PR DESCRIPTION
## Summary

Two Codex follow-ups surfaced on #350 targeting pre-existing defects on `develop`.

### P1 — Enforce specs-folder prefix in `validateProposalPath`
The step-5 containment check composed `vaultRoot + '/' + path` and tested the composition's prefix against `vaultRoot + '/'`. That was trivially satisfied for any non-`..` relative path, so a proposal like `notes/<random>.md` slipped through and could write outside the configured specs folder. Trust-first defect.

**Fix.** `posixNormalize(path)` must start with `posixNormalize(specsFolder) + '/'`. Sibling-prefix collisions (`specs2/foo.md` under root `specs`) are rejected by the required trailing slash. An empty root (vault-root config) bypasses the prefix check so the standalone browser UI keeps working.

### P2 — Rotate active thread when the resolved transport changes
`resolveActiveThread` reused the active thread regardless of transport. Resuming a sessionId minted under a different transport produced incoherent context + audit metadata.

**Fix.** When `existing.transport !== args.transport`, mint a fresh thread. The original stays in `chatThreads` (history preserved); only the active-thread pointer rotates.

## Test plan

- [x] `validateProposalPath.test.ts`: new "rejects a path NOT under the configured specs folder" case, "accepts any non-escaping path when root is empty" case; ESCAPES_VAULT_ROOT describe block rewritten to exercise sibling-prefix collision + vault-root path under specs config; existing happy-path tests updated to use `'specs'` instead of the vestigial `'workspace'` placeholder.
- [x] `ChatSidebar.sessionPersistence.test.ts`: `mountSidebar` returns `transportKindRef` so tests can flip it between sends. Two new cases: rotates on transport change; does NOT rotate when transport stable.
- [x] `npm run typecheck` → pass.
- [x] `npm run lint` → 0 errors.
- [x] `npm run test` → 1396/1396.

https://claude.ai/code/session_014uvXBSWVU6berqtGKYc6Rh

---
_Generated by [Claude Code](https://claude.ai/code/session_014uvXBSWVU6berqtGKYc6Rh)_