### PR TITLE
fix(asm): bump selector after adapter startup + invalidate writer cache on specs-folder change

### DIFF
--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -295,11 +295,18 @@ export default class SpecoratorPlugin extends Plugin {
     this.app.workspace.onLayoutReady(() => {
       // T-CCS-032 / T-ASM-020 / SPEC-ASM-001 §9.2 — pre-warm both adapters in
       // parallel so startup() does not block onload(). Each adapter handles
-      // its own failures internally (REQ-ASM-009, NFR-ASM-006).
+      // its own failures internally (REQ-ASM-009, NFR-ASM-006). Once startup
+      // resolves, bump the settings version so any already-open
+      // SpecoratorView re-runs `selectTransport()` with the freshly-resolved
+      // CLI availability — without this, a cold-load panel that mounted
+      // before startup finished stays stuck on the initial `isAvailableSync`
+      // snapshot (Codex P1, PR #350).
       void Promise.all([
         this._claudeCliAdapter?.startup(),
         this._subscriptionAdapter?.startup(),
-      ])
+      ]).then(() => {
+        this._specoratorView?.bumpSettingsVersion()
+      })
       this.detectLegacyVaultLayout()
       if (!this.settings.onboardingComplete) {
         void this.activateView()

--- a/src/ui/composables/useSessionLogWriter.ts
+++ b/src/ui/composables/useSessionLogWriter.ts
@@ -39,17 +39,26 @@ export function useSessionLogWriter(): UseSessionLogWriter {
 	const logger = useLoggerPort()
 	const settings = useSettingsPort()
 	let cached: SessionLogWriter | null = null
+	let cachedSpecsFolder: string | null = null
 
 	return {
 		async getWriter(): Promise<SessionLogWriter> {
-			if (cached !== null) return cached
 			const current = await settings.getSettings()
+			// Invalidate the cached writer when the configured specs folder has
+			// changed mid-session (Codex P2, PR #350). Without this, a user
+			// who changes the Specs folder in settings keeps writing session
+			// logs to the old folder while stage/context resolution uses the
+			// new one, splitting history across roots.
+			if (cached !== null && cachedSpecsFolder === current.specsFolder) {
+				return cached
+			}
 			cached = new SessionLogWriter(
 				vault,
 				logger,
 				current.specsFolder,
 				() => new Date().toISOString(),
 			)
+			cachedSpecsFolder = current.specsFolder
 			return cached
 		},
 	}

--- a/tests/ui/composables/useSessionLogWriter.test.ts
+++ b/tests/ui/composables/useSessionLogWriter.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for `useSessionLogWriter` — cache + invalidation on specsFolder change.
+ *
+ * Codex P2 (PR #350): a user who changes the configured Specs folder
+ * mid-session previously kept writing session logs to the old folder
+ * because `getWriter()` memoised the first writer forever. The composable
+ * now invalidates the cache when `settings.specsFolder` differs from the
+ * cached one, so writes follow the user's setting.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { mount } from '@vue/test-utils'
+
+import { useSessionLogWriter } from '@/ui/composables/useSessionLogWriter'
+import {
+	VAULT_PORT,
+	LOGGER_PORT,
+	SETTINGS_PORT,
+} from '@/infrastructure/bridge/ports'
+import { MockBridge } from '@/infrastructure/mock/MockBridge'
+import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
+import type { PluginSettings } from '@/domain/settings/PluginSettings'
+
+function makeBridgeWithSpecsFolder(specsFolder: string): MockBridge {
+	const bridge = new MockBridge()
+	let current: PluginSettings = { ...DEFAULT_SETTINGS, specsFolder }
+	// MockBridge.getSettings is overridable; we read `current` so the test
+	// can mutate the active specs folder between getWriter() calls.
+	bridge.getSettings = async () => current
+	;(bridge as unknown as { __setSpecsFolder: (s: string) => void }).__setSpecsFolder = (
+		s: string,
+	) => {
+		current = { ...current, specsFolder: s }
+	}
+	return bridge
+}
+
+function mountHost(bridge: MockBridge): {
+	wrapper: ReturnType<typeof mount>
+	composable: ReturnType<typeof useSessionLogWriter>
+} {
+	const composableRef: { current: ReturnType<typeof useSessionLogWriter> | null } = {
+		current: null,
+	}
+	const Host = defineComponent({
+		name: 'TestHost',
+		setup() {
+			composableRef.current = useSessionLogWriter()
+			return () => h('div')
+		},
+	})
+	const wrapper = mount(Host, {
+		global: {
+			provide: {
+				[VAULT_PORT as symbol]: bridge,
+				[LOGGER_PORT as symbol]: bridge,
+				[SETTINGS_PORT as symbol]: bridge,
+			},
+		},
+	})
+	if (composableRef.current === null) throw new Error('composable did not run')
+	return { wrapper, composable: composableRef.current }
+}
+
+describe('useSessionLogWriter', () => {
+	beforeEach(() => {
+		// Pinia not required — composable only depends on the three ports.
+	})
+
+	it('memoises the writer across calls when specsFolder is unchanged', async () => {
+		const bridge = makeBridgeWithSpecsFolder('specs')
+		const { composable } = mountHost(bridge)
+
+		const first = await composable.getWriter()
+		const second = await composable.getWriter()
+
+		expect(second).toBe(first)
+	})
+
+	it('returns a NEW writer when specsFolder changes between calls (Codex P2, PR #350)', async () => {
+		const bridge = makeBridgeWithSpecsFolder('specs')
+		const { composable } = mountHost(bridge)
+
+		const before = await composable.getWriter()
+
+		// User changes the Specs folder in settings mid-session.
+		;(bridge as unknown as { __setSpecsFolder: (s: string) => void }).__setSpecsFolder(
+			'docs/specs',
+		)
+
+		const after = await composable.getWriter()
+		expect(after).not.toBe(before)
+	})
+
+	it('does not invalidate when specsFolder is set to the same value again', async () => {
+		const bridge = makeBridgeWithSpecsFolder('specs')
+		const { composable } = mountHost(bridge)
+
+		const before = await composable.getWriter()
+		;(bridge as unknown as { __setSpecsFolder: (s: string) => void }).__setSpecsFolder(
+			'specs',
+		)
+		const after = await composable.getWriter()
+
+		expect(after).toBe(before)
+	})
+})


### PR DESCRIPTION
## Summary

Two more Codex follow-ups surfaced on #350 targeting pre-existing defects on `develop`.

### P1 — Refresh transport selection after adapter startup completes
`onLayoutReady` previously fired both `startup()` calls async without following up. A panel mounted on cold load (before startup finished) selected transport from the initial `isAvailableSync()` snapshot and stayed stuck on degraded for the whole session.

**Fix.** `onLayoutReady` now chains `.then(() => this._specoratorView?.bumpSettingsVersion())` on the `Promise.all` so any already-open view re-runs `selectTransport()` with the freshly-resolved CLI availability.

### P2 — Invalidate cached SessionLogWriter on specs-folder change
`useSessionLogWriter` memoised the first writer forever, capturing `specsFolder` at creation time. After the user changed the Specs folder mid-session, stage/context resolution used the new folder but session-log writes continued under the old one, splitting history.

**Fix.** The composable now tracks the cached `specsFolder` and rebuilds the writer when it differs from the current settings value.

## Test plan

- [x] `tests/ui/composables/useSessionLogWriter.test.ts`: 3 cases — same folder returns same writer; different folder returns new writer; same value again doesn't invalidate.
- [x] `npm run typecheck` → pass.
- [x] `npm run lint` → 0 errors.
- [x] `npm run test` → 1399/1399.

The onLayoutReady → bumpSettingsVersion chain is one line and the post-bump path is already covered by existing `SpecoratorView.bumpSettingsVersion()` tests; not adding a separate plugin-level harness for it.

https://claude.ai/code/session_014uvXBSWVU6berqtGKYc6Rh

---
_Generated by [Claude Code](https://claude.ai/code/session_014uvXBSWVU6berqtGKYc6Rh)_