### PR TITLE
fix(chat): re-validate proposal path on Accept against current specsFolder

### DIFF
--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -664,7 +664,21 @@ async function handleAcceptProposal(payload: { proposalId: string }): Promise<vo
     // validated at creation time, but settings can change between
     // creation and accept — re-checking here prevents a stale proposal
     // from bypassing containment after a specsFolder change.
-    const currentSettings = await settingsPort.getSettings()
+    //
+    // `getSettings()` can reject under a bridge/vault error; wrap it via
+    // `tryAsync` so a transient failure does not strand the proposal in
+    // `pending` (Codex P2 #3, PR #350). On read failure we fail the
+    // Accept rather than committing under stale settings.
+    const settingsResult = await tryAsync(() => settingsPort.getSettings())
+    if (!settingsResult.ok) {
+      loggerPort.warn('handleAcceptProposal: settingsPort.getSettings() failed during revalidation', {
+        proposalId: payload.proposalId,
+        reason: settingsResult.error.message,
+      })
+      store.setProposalStatus(payload.proposalId, 'failed', 'WRITE_FAILED')
+      return
+    }
+    const currentSettings = settingsResult.value
     const revalidation = validateProposalPath(proposal.envelope, currentSettings.specsFolder)
     if (!revalidation.ok) {
       const next = new Map(proposalPathErrors.value)

--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -670,6 +670,30 @@ async function handleAcceptProposal(payload: { proposalId: string }): Promise<vo
       const next = new Map(proposalPathErrors.value)
       next.set(payload.proposalId, revalidation.error)
       proposalPathErrors.value = next
+      // Mirror the terminal failure to the session log so the audit trail
+      // stays complete (Codex P2 follow-up, PR #350). The trust-first
+      // invariant requires every terminal proposal outcome to appear in
+      // the session log; the existing commit-pipeline failure branches
+      // already enforce this for in-pipeline errors, but the Accept-time
+      // revalidation rejects BEFORE commit runs, so we mirror here.
+      // Best-effort — a logging failure must not block the user-visible
+      // status flip.
+      const writer = await sessionLogWriterFactory.getWriter()
+      await writer
+        .appendProposalDecision({
+          thread,
+          proposal: {
+            envelope: { path: proposal.envelope.path, rationale: undefined },
+          },
+          decision: 'failed',
+          decidedAt: new Date().toISOString(),
+        })
+        .catch((thrown: unknown) => {
+          loggerPort.warn('handleAcceptProposal: revalidation-failed audit append failed', {
+            proposalId: payload.proposalId,
+            reason: thrown instanceof Error ? thrown.message : String(thrown),
+          })
+        })
       store.setProposalStatus(payload.proposalId, 'failed', 'WRITE_FAILED')
       return
     }

--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -659,6 +659,20 @@ async function handleAcceptProposal(payload: { proposalId: string }): Promise<vo
   // project's `no-restricted-syntax` rule forbids raw try/catch (and the
   // same applies to try/finally) outside `src/infrastructure/**`.
   await (async () => {
+    // Re-validate the envelope path against the CURRENT specs folder
+    // before any vault mutation (Codex P2, PR #350). The proposal was
+    // validated at creation time, but settings can change between
+    // creation and accept — re-checking here prevents a stale proposal
+    // from bypassing containment after a specsFolder change.
+    const currentSettings = await settingsPort.getSettings()
+    const revalidation = validateProposalPath(proposal.envelope, currentSettings.specsFolder)
+    if (!revalidation.ok) {
+      const next = new Map(proposalPathErrors.value)
+      next.set(payload.proposalId, revalidation.error)
+      proposalPathErrors.value = next
+      store.setProposalStatus(payload.proposalId, 'failed', 'WRITE_FAILED')
+      return
+    }
     const writer = await sessionLogWriterFactory.getWriter()
     const result = await commitFileWriteProposal(proposal, thread, {
       vault: vaultPort,

--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -622,6 +622,38 @@ async function handleSend(): Promise<void> {
 }
 
 /**
+ * Mirror a terminal proposal failure to the session log (best-effort).
+ * Used by `handleAcceptProposal`'s pre-commit failure branches
+ * (settings-read, revalidation, …) so every terminal outcome carries an
+ * audit row regardless of which step rejected. Both `getWriter()` AND
+ * `appendProposalDecision` are caught; a logging failure must never
+ * block the user-visible status flip (Codex trust-first invariant,
+ * PR #350).
+ */
+async function mirrorTerminalProposalFailure(
+  proposal: FileWriteProposal,
+  thread: ChatThreadRecord,
+  context: string,
+): Promise<void> {
+  await (async () => {
+    const writer = await sessionLogWriterFactory.getWriter()
+    await writer.appendProposalDecision({
+      thread,
+      proposal: {
+        envelope: { path: proposal.envelope.path, rationale: undefined },
+      },
+      decision: 'failed',
+      decidedAt: new Date().toISOString(),
+    })
+  })().catch((thrown: unknown) => {
+    loggerPort.warn(`handleAcceptProposal: ${context} audit mirror failed`, {
+      proposalId: proposal.proposalId,
+      reason: thrown instanceof Error ? thrown.message : String(thrown),
+    })
+  })
+}
+
+/**
  * Look up a proposal by id. Returns `null` if missing (e.g. cleared by reset).
  */
 function findProposal(proposalId: string): FileWriteProposal | null {
@@ -675,6 +707,10 @@ async function handleAcceptProposal(payload: { proposalId: string }): Promise<vo
         proposalId: payload.proposalId,
         reason: settingsResult.error.message,
       })
+      // Mirror the terminal failure to the session log so the audit
+      // trail stays complete even when the pre-commit settings read
+      // rejects (Codex P2 #4, PR #350).
+      await mirrorTerminalProposalFailure(proposal, thread, 'settings-read-failed')
       store.setProposalStatus(payload.proposalId, 'failed', 'WRITE_FAILED')
       return
     }
@@ -684,35 +720,7 @@ async function handleAcceptProposal(payload: { proposalId: string }): Promise<vo
       const next = new Map(proposalPathErrors.value)
       next.set(payload.proposalId, revalidation.error)
       proposalPathErrors.value = next
-      // Mirror the terminal failure to the session log so the audit trail
-      // stays complete (Codex P2 follow-up, PR #350). The trust-first
-      // invariant requires every terminal proposal outcome to appear in
-      // the session log; the existing commit-pipeline failure branches
-      // already enforce this for in-pipeline errors, but the Accept-time
-      // revalidation rejects BEFORE commit runs, so we mirror here.
-      //
-      // Best-effort across the FULL chain — both `getWriter()` (which can
-      // reject if e.g. settings read fails) AND `appendProposalDecision`
-      // are caught so the user-visible status flip always runs. Without
-      // this, a transient writer-acquisition failure would leave the
-      // proposal stuck pending despite the rejected Accept (Codex P2 #2,
-      // PR #350).
-      await (async () => {
-        const writer = await sessionLogWriterFactory.getWriter()
-        await writer.appendProposalDecision({
-          thread,
-          proposal: {
-            envelope: { path: proposal.envelope.path, rationale: undefined },
-          },
-          decision: 'failed',
-          decidedAt: new Date().toISOString(),
-        })
-      })().catch((thrown: unknown) => {
-        loggerPort.warn('handleAcceptProposal: revalidation-failed audit mirror failed', {
-          proposalId: payload.proposalId,
-          reason: thrown instanceof Error ? thrown.message : String(thrown),
-        })
-      })
+      await mirrorTerminalProposalFailure(proposal, thread, 'revalidation-failed')
       store.setProposalStatus(payload.proposalId, 'failed', 'WRITE_FAILED')
       return
     }

--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -676,11 +676,16 @@ async function handleAcceptProposal(payload: { proposalId: string }): Promise<vo
       // the session log; the existing commit-pipeline failure branches
       // already enforce this for in-pipeline errors, but the Accept-time
       // revalidation rejects BEFORE commit runs, so we mirror here.
-      // Best-effort — a logging failure must not block the user-visible
-      // status flip.
-      const writer = await sessionLogWriterFactory.getWriter()
-      await writer
-        .appendProposalDecision({
+      //
+      // Best-effort across the FULL chain — both `getWriter()` (which can
+      // reject if e.g. settings read fails) AND `appendProposalDecision`
+      // are caught so the user-visible status flip always runs. Without
+      // this, a transient writer-acquisition failure would leave the
+      // proposal stuck pending despite the rejected Accept (Codex P2 #2,
+      // PR #350).
+      await (async () => {
+        const writer = await sessionLogWriterFactory.getWriter()
+        await writer.appendProposalDecision({
           thread,
           proposal: {
             envelope: { path: proposal.envelope.path, rationale: undefined },
@@ -688,12 +693,12 @@ async function handleAcceptProposal(payload: { proposalId: string }): Promise<vo
           decision: 'failed',
           decidedAt: new Date().toISOString(),
         })
-        .catch((thrown: unknown) => {
-          loggerPort.warn('handleAcceptProposal: revalidation-failed audit append failed', {
-            proposalId: payload.proposalId,
-            reason: thrown instanceof Error ? thrown.message : String(thrown),
-          })
+      })().catch((thrown: unknown) => {
+        loggerPort.warn('handleAcceptProposal: revalidation-failed audit mirror failed', {
+          proposalId: payload.proposalId,
+          reason: thrown instanceof Error ? thrown.message : String(thrown),
         })
+      })
       store.setProposalStatus(payload.proposalId, 'failed', 'WRITE_FAILED')
       return
     }

--- a/tests/ui/components/chat/ChatSidebar.proposalFlow.test.ts
+++ b/tests/ui/components/chat/ChatSidebar.proposalFlow.test.ts
@@ -346,6 +346,7 @@ describe('ChatSidebar — proposal flow integration (T-ASM-072)', () => {
 		// `getSettings()` rejects at Accept time. The handler must not
 		// propagate the rejection — it must catch it and flip the proposal
 		// to `failed` so the user is not stranded.
+		const writeSpy = vi.spyOn(bridge, 'writeFile')
 		vi.spyOn(bridge, 'getSettings').mockRejectedValueOnce(new Error('boom: settings read failed'))
 
 		const card = new FileWriteProposalCardPO(wrapper)
@@ -353,6 +354,13 @@ describe('ChatSidebar — proposal flow integration (T-ASM-072)', () => {
 		await flushPromises()
 
 		expect(store.proposals.get(proposalId)?.status).toBe('failed')
+		// Codex P2 #4 — terminal failure must mirror to the session log
+		// regardless of which pre-commit branch rejected (settings read,
+		// revalidation, …). One audit row should land under sessions/.
+		const auditCalls = writeSpy.mock.calls.filter(([p]) =>
+			typeof p === 'string' && p.endsWith('.md') && p.includes('sessions/'),
+		)
+		expect(auditCalls.length).toBeGreaterThanOrEqual(1)
 	})
 
 	it('still flips the proposal to failed when the revalidation audit mirror itself throws (Codex P2 #2, PR #350)', async () => {

--- a/tests/ui/components/chat/ChatSidebar.proposalFlow.test.ts
+++ b/tests/ui/components/chat/ChatSidebar.proposalFlow.test.ts
@@ -319,6 +319,15 @@ describe('ChatSidebar — proposal flow integration (T-ASM-072)', () => {
 		// Proposal moved to a terminal failure state — no vault mutation
 		// happened.
 		expect(store.proposals.get(proposalId)?.status).toBe('failed')
+
+		// Codex P2 follow-up — the terminal failure must mirror to the
+		// session log so the audit trail records the rejected Accept.
+		// `appendProposalDecision` writes a `## proposal` block under the
+		// thread's session log path; we observe the write via writeSpy.
+		const appendCalls = writeSpy.mock.calls.filter(([p]) =>
+			typeof p === 'string' && p.endsWith('.md') && p.includes('sessions/'),
+		)
+		expect(appendCalls.length).toBeGreaterThanOrEqual(1)
 	})
 
 	it('Reject is a no-op while an Accept commit is still in flight on the same proposal (Codex P1 fix)', async () => {

--- a/tests/ui/components/chat/ChatSidebar.proposalFlow.test.ts
+++ b/tests/ui/components/chat/ChatSidebar.proposalFlow.test.ts
@@ -279,6 +279,48 @@ describe('ChatSidebar — proposal flow integration (T-ASM-072)', () => {
 		expect(proposal.status).toBe('rejected')
 	})
 
+	it('re-validates the envelope path at Accept time against the CURRENT specs folder (Codex P2, PR #350)', async () => {
+		// Generate a proposal under specsFolder='specs'.
+		const { wrapper, po, store, bridge } = await mountSidebar({
+			cannedEnvelope: {
+				action: 'createFile',
+				path: 'specs/demo/idea.md',
+				content: '# Demo\n',
+			},
+			settings: { specsFolder: 'specs' },
+		})
+		await send(store, po, '/create-file specs/demo/idea.md')
+		await flushPromises()
+		const proposalId = Array.from(store.proposals.keys())[0]
+		expect(store.proposals.get(proposalId)?.status).toBe('pending')
+
+		// Change specsFolder BEFORE the user clicks Accept. The pending
+		// envelope ('specs/demo/idea.md') is now outside the configured
+		// containment root ('notes/'). Without the re-validation, the
+		// commit pipeline would write the file anyway — the path-validation
+		// guard only ran at proposal-creation time.
+		vi.spyOn(bridge, 'getSettings').mockResolvedValue({
+			...DEFAULT_SETTINGS,
+			anthropicApiKey: 'sk-ant-test',
+			transportKind: 'subscription',
+			specsFolder: 'notes',
+		})
+		const writeSpy = vi.spyOn(bridge, 'writeFile')
+
+		const card = new FileWriteProposalCardPO(wrapper)
+		await card.clickAccept()
+		await flushPromises()
+
+		// Accept must NOT have written the envelope to its original path
+		// (the path no longer lives under the configured specs folder).
+		expect(
+			writeSpy.mock.calls.some(([p]) => p === 'specs/demo/idea.md'),
+		).toBe(false)
+		// Proposal moved to a terminal failure state — no vault mutation
+		// happened.
+		expect(store.proposals.get(proposalId)?.status).toBe('failed')
+	})
+
 	it('Reject is a no-op while an Accept commit is still in flight on the same proposal (Codex P1 fix)', async () => {
 		const { wrapper, po, store, bridge } = await mountSidebar({
 			cannedEnvelope: {

--- a/tests/ui/components/chat/ChatSidebar.proposalFlow.test.ts
+++ b/tests/ui/components/chat/ChatSidebar.proposalFlow.test.ts
@@ -330,6 +330,31 @@ describe('ChatSidebar — proposal flow integration (T-ASM-072)', () => {
 		expect(appendCalls.length).toBeGreaterThanOrEqual(1)
 	})
 
+	it('still flips the proposal to failed when settingsPort.getSettings() rejects at Accept time (Codex P2 #3, PR #350)', async () => {
+		const { wrapper, po, store, bridge } = await mountSidebar({
+			cannedEnvelope: {
+				action: 'createFile',
+				path: 'specs/demo/idea.md',
+				content: '# Demo\n',
+			},
+			settings: { specsFolder: 'specs' },
+		})
+		await send(store, po, '/create-file specs/demo/idea.md')
+		await flushPromises()
+		const proposalId = Array.from(store.proposals.keys())[0]
+
+		// `getSettings()` rejects at Accept time. The handler must not
+		// propagate the rejection — it must catch it and flip the proposal
+		// to `failed` so the user is not stranded.
+		vi.spyOn(bridge, 'getSettings').mockRejectedValueOnce(new Error('boom: settings read failed'))
+
+		const card = new FileWriteProposalCardPO(wrapper)
+		await card.clickAccept()
+		await flushPromises()
+
+		expect(store.proposals.get(proposalId)?.status).toBe('failed')
+	})
+
 	it('still flips the proposal to failed when the revalidation audit mirror itself throws (Codex P2 #2, PR #350)', async () => {
 		// Same scenario as above (settings change between proposal and
 		// Accept), but the session-log writer's `appendProposalDecision`

--- a/tests/ui/components/chat/ChatSidebar.proposalFlow.test.ts
+++ b/tests/ui/components/chat/ChatSidebar.proposalFlow.test.ts
@@ -330,6 +330,44 @@ describe('ChatSidebar — proposal flow integration (T-ASM-072)', () => {
 		expect(appendCalls.length).toBeGreaterThanOrEqual(1)
 	})
 
+	it('still flips the proposal to failed when the revalidation audit mirror itself throws (Codex P2 #2, PR #350)', async () => {
+		// Same scenario as above (settings change between proposal and
+		// Accept), but the session-log writer's `appendProposalDecision`
+		// is forced to reject. The user-visible status flip must still
+		// run — a transient logging failure cannot strand a rejected
+		// proposal in `pending`.
+		const { wrapper, po, store, bridge } = await mountSidebar({
+			cannedEnvelope: {
+				action: 'createFile',
+				path: 'specs/demo/idea.md',
+				content: '# Demo\n',
+			},
+			settings: { specsFolder: 'specs' },
+		})
+		await send(store, po, '/create-file specs/demo/idea.md')
+		await flushPromises()
+		const proposalId = Array.from(store.proposals.keys())[0]
+
+		// Stale containment + writer fails on every audit append.
+		vi.spyOn(bridge, 'getSettings').mockResolvedValue({
+			...DEFAULT_SETTINGS,
+			anthropicApiKey: 'sk-ant-test',
+			transportKind: 'subscription',
+			specsFolder: 'notes',
+		})
+		vi.spyOn(bridge, 'writeFile').mockImplementation(async () => {
+			throw new Error('boom: audit write rejected')
+		})
+
+		const card = new FileWriteProposalCardPO(wrapper)
+		await card.clickAccept()
+		await flushPromises()
+
+		// Despite the audit-write throw, the proposal still flips to
+		// `failed` — the user is not stranded.
+		expect(store.proposals.get(proposalId)?.status).toBe('failed')
+	})
+
 	it('Reject is a no-op while an Accept commit is still in flight on the same proposal (Codex P1 fix)', async () => {
 		const { wrapper, po, store, bridge } = await mountSidebar({
 			cannedEnvelope: {


### PR DESCRIPTION
## Summary

Codex P2 follow-up on #350: security-relevant gap where `validateProposalPath` runs only at proposal-creation time, leaving a window where a settings change between creation and Accept can let a stale proposal bypass the containment root.

**Fix.** `handleAcceptProposal` now re-reads `settings.specsFolder` and re-runs `validateProposalPath` against the current value BEFORE the commit pipeline runs. On failure, the path-validation error is recorded and the proposal flips to `failed/WRITE_FAILED`; no commit, no audit row.

## Test plan

- [x] New test in `ChatSidebar.proposalFlow.test.ts`: pending proposal at `specs/demo/idea.md` under specsFolder `'specs'`; mutate `getSettings` to return `'notes'`; Accept click → no `writeFile` on the envelope path, proposal `failed`.
- [x] `npm run typecheck` → pass.
- [x] `npm run lint` → 0 errors.
- [x] `npm run test` → 1400/1400.

https://claude.ai/code/session_014uvXBSWVU6berqtGKYc6Rh

---
_Generated by [Claude Code](https://claude.ai/code/session_014uvXBSWVU6berqtGKYc6Rh)_