### PR TITLE
fix(chat): rotate active thread when feature slug changes between sends

### DIFF
--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -302,14 +302,29 @@ function resolveActiveThread(args: {
   const nowIso = new Date().toISOString()
   let threadId = store.activeThreadId
   const existing = threadId !== null ? store.chatThreads.get(threadId) : undefined
-  // Rotate when the active thread's transport no longer matches the resolved
-  // transport for this turn (Codex P2, PR #350). Resuming a session id that
-  // was minted under a different transport produces incoherent context and
-  // audit metadata, so we mint a fresh thread instead of carrying state
-  // across the transport boundary.
+  // Rotate when the active thread's transport OR feature slug no longer
+  // matches the resolved values for this turn (Codex P2, PR #350).
+  //
+  // - Transport mismatch: resuming a session id that was minted under a
+  //   different transport produces incoherent context and audit metadata.
+  // - Feature mismatch: session-log paths are derived from `thread.feature`,
+  //   so reusing a `specs/foo/` thread for a turn against `specs/bar/`
+  //   would append the bar turn under the foo session log and corrupt
+  //   per-feature traceability + resume metadata.
+  //
+  // In either case we mint a fresh thread rather than carry stale
+  // metadata. The original thread stays in `chatThreads` (history is
+  // preserved); only the active-thread pointer rotates.
   const transportMismatch =
     existing !== undefined && existing.transport !== args.transport
-  if (threadId === null || existing === undefined || transportMismatch) {
+  const featureMismatch =
+    existing !== undefined && existing.feature !== args.slug
+  if (
+    threadId === null ||
+    existing === undefined ||
+    transportMismatch ||
+    featureMismatch
+  ) {
     threadId = generateThreadId()
     const fresh: ChatThreadRecord = {
       threadId,

--- a/tests/ui/components/chat/ChatSidebar.sessionPersistence.test.ts
+++ b/tests/ui/components/chat/ChatSidebar.sessionPersistence.test.ts
@@ -264,6 +264,43 @@ describe('ChatSidebar — session-persistence wiring (T-ASM-057)', () => {
 		expect(secondId).toBe(firstId)
 	})
 
+	it('rotates the active thread when the active feature slug changes (Codex P2, PR #350)', async () => {
+		// First send under feature 'foo' — creates a thread tagged for foo.
+		const { po, store, bridge } = await mountSidebar({
+			settings: { specsFolder: 'specs' },
+			activeFile: { path: 'specs/foo/idea.md', basename: 'idea', extension: 'md' },
+		})
+		await send(store, po, 'hello from foo')
+		const fooThreadId = store.activeThreadId!
+		expect(store.chatThreads.get(fooThreadId)?.feature).toBe('foo')
+
+		// User opens a file under a different feature. The next send must
+		// rotate the active thread — otherwise the session-log path (derived
+		// from `thread.feature`) would write the bar turn under the foo log
+		// and corrupt per-feature traceability.
+		bridge.setActiveFile({ path: 'specs/bar/idea.md', basename: 'idea', extension: 'md' })
+		await flushPromises()
+		await send(store, po, 'hello from bar')
+
+		const barThreadId = store.activeThreadId!
+		expect(barThreadId).not.toBe(fooThreadId)
+		expect(store.chatThreads.get(barThreadId)?.feature).toBe('bar')
+		// History preserved — the foo thread still exists in the map.
+		expect(store.chatThreads.get(fooThreadId)?.feature).toBe('foo')
+	})
+
+	it('does NOT rotate when the feature slug stays the same across sends', async () => {
+		const { po, store } = await mountSidebar({
+			settings: { specsFolder: 'specs' },
+			activeFile: { path: 'specs/foo/idea.md', basename: 'idea', extension: 'md' },
+		})
+		await send(store, po, 'first')
+		const firstId = store.activeThreadId!
+		await send(store, po, 'second')
+		const secondId = store.activeThreadId!
+		expect(secondId).toBe(firstId)
+	})
+
 	it('second send on the same thread forwards resumeSessionId and flashes sessionResumed (REQ-ASM-035)', async () => {
 		const firstId = asSessionId('sess-first-1234567')
 		const { po, port, store } = await mountSidebar({


### PR DESCRIPTION
## Summary

Addresses Codex P2 finding on #350: `resolveActiveThread` in `src/ui/components/chat/ChatSidebar.vue` (~line 312) was only rotating the active thread on a **transport** mismatch. If the active feature slug changed between sends (e.g. user navigates `specs/foo/...` → `specs/bar/...` without switching transport), the existing thread was reused and subsequent session-log appends — whose paths are derived from `thread.feature` — landed under the prior feature's log directory.

Fix: extend the mismatch check in `resolveActiveThread` to cover **both** transport and feature, so a feature-slug change forces a fresh thread (and a fresh session-log target).

## Test plan

- [x] Unit tests: 1404/1404 pass (`npm run test`)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean

## Related

- Follow-up to Codex review on #350 — thread "Rotate active thread when feature slug changes" on `src/ui/components/chat/ChatSidebar.vue` (line ~312, P2).
- Part of the develop → demo promotion sweep for `agent-sidepanel-mvp`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Af3wVsvXtFp78EE2pobMoj)_