### PR TITLE
chore(security): harden workflows and add CodeQL SAST

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install actionlint
         run: |
           curl -L -o actionlint_1.7.12_linux_amd64.tar.gz \
@@ -44,6 +46,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -77,6 +81,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [develop, demo, main]
+  pull_request:
+    branches: [develop, demo, main]
+  schedule:
+    - cron: '17 6 * * 2'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        with:
+          languages: javascript-typescript
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        with:
+          category: '/language:javascript-typescript'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,8 +3,7 @@ name: Dependabot auto-merge
 on: pull_request
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   auto-merge:
@@ -12,6 +11,9 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Fetch Dependabot metadata
         id: metadata

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Dependency Review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,6 +20,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+-*'
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: release-${{ github.ref }}
@@ -18,12 +18,15 @@ jobs:
     name: Build and publish release
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Verify tag is on main HEAD
         run: |

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -3,7 +3,7 @@ title: Supply-chain hardening policy
 doc_type: policy
 status: active
 owner: maintainers
-last_reviewed: 2026-05-02
+last_reviewed: 2026-05-16
 ---
 
 # Supply-chain hardening policy
@@ -34,6 +34,13 @@ This document records the controls Specorator applies to its dependency graph an
 - Fails the PR check if the diff introduces any dependency with a `high` or `critical` advisory.
 - Fails the PR check if the diff introduces any GPL-family license (`GPL-2.0`, `GPL-3.0`, `AGPL-1.0`, `AGPL-3.0`, in `-only` and `-or-later` variants).
 - Posts a summary comment on the PR when it fails so the author can see the offending package without digging through logs.
+
+### CodeQL static analysis
+
+`.github/workflows/codeql.yml` runs the GitHub CodeQL analyzer for `javascript-typescript` on push and pull request to `develop`, `demo`, and `main`, plus a weekly cron.
+
+- Findings are uploaded to GitHub code-scanning and appear in the Security tab.
+- Treated as advisory: a CodeQL alert does not block merge automatically, but reviewers should triage new high-severity findings before approving.
 
 ### OpenSSF Scorecard
 
@@ -81,6 +88,8 @@ When a PR adds a new runtime dependency (`dependencies` in `package.json`, not `
 ### Workflow / action changes
 
 - Any new `uses:` line must be pinned to a SHA in the same PR that introduces it. CI does not enforce this directly today; reviewers do.
+- Top-level `permissions:` in a workflow is `contents: read` (or stricter). Any `write` scope is declared at the job that needs it, not at the workflow root, so unrelated jobs do not inherit it.
+- Every `actions/checkout` step sets `persist-credentials: false` unless the job needs to push back to the repository, so the `GITHUB_TOKEN` is not left in the runner's git config for subsequent steps.
 - Granting a workflow `write` permission requires an explicit comment in the PR explaining what is written and why a `read` token is insufficient.
 
 ## Threat model assumptions


### PR DESCRIPTION
## Summary

Addresses OpenSSF Scorecard / Security-tab recommendations without changing any runtime code.

- **Token-Permissions:** scope `contents: write` (release.yml) and `contents: write` + `pull-requests: write` (dependabot-auto-merge.yml) to the job that needs them; top-level stays at `contents: read` so unrelated jobs can't inherit a write token.
- **Checkout hygiene:** `persist-credentials: false` on every `actions/checkout` step so `GITHUB_TOKEN` isn't left in the runner's git config for later steps. Previously only scorecard.yml had this.
- **SAST coverage:** new `.github/workflows/codeql.yml` runs CodeQL for `javascript-typescript` on push/PR to `develop`/`demo`/`main` and weekly, so findings flow into code-scanning and Scorecard's SAST check has a signal.
- **Policy doc:** `docs/security/supply-chain.md` now records the CodeQL control, the `persist-credentials` default, and the top-level/job-level permissions split. `last_reviewed` bumped.

All workflows remain SHA-pinned; `node scripts/verify-workflows.js` and `actionlint` both pass.

## Test plan

- [ ] CI green on this PR (workflow-lint, manifest-validation, verify, dependency-review).
- [ ] New `CodeQL / Analyze (javascript-typescript)` check runs and uploads SARIF.
- [ ] No new failures in code-scanning for `develop`.
- [ ] Confirm the next dependabot patch PR still auto-merges (job-scoped write perms still effective).

https://claude.ai/code/session_01JYAV8c1WajX9adEj6jAT8p

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYAV8c1WajX9adEj6jAT8p)_