### PR TITLE
fix(chat): null pinia in SpecoratorView.onClose to stop stale store mutations

### DIFF
--- a/src/plugin/SpecoratorView.ts
+++ b/src/plugin/SpecoratorView.ts
@@ -275,6 +275,11 @@ export class SpecoratorView extends ItemView {
     this.plugin.bridge?.hideAllNotices()
     this.vueApp?.unmount()
     this.vueApp = null
+    // Drop the Pinia instance so plugin-level workspace handlers that gate on
+    // `this._specoratorView?.pinia` (file-menu, active-leaf-change) stop
+    // mutating a store whose Vue app has been unmounted. A fresh Pinia is
+    // created on the next `onOpen()` (Codex P2, PR #350).
+    this.pinia = null
     return Promise.resolve()
   }
 

--- a/tests/plugin/SpecoratorView.test.ts
+++ b/tests/plugin/SpecoratorView.test.ts
@@ -412,6 +412,25 @@ describe('SpecoratorView.bumpSettingsVersion() mid-turn guard (REQ-ASM-003)', ()
 
     expect(activePort(view)).toBe(fixture.sdkAdapter)
   })
+
+  it('clears `pinia` on close so plugin workspace handlers stop mutating the unmounted store — Codex P2, PR #350', async () => {
+    const fixture = makeFixture(
+      { transportKind: 'auto', anthropicApiKey: '' },
+      /* cliResolved */ false,
+    )
+
+    const view = makeView(fixture)
+    view.pinia = pinia
+    expect(view.pinia).not.toBeNull()
+
+    await view.onClose()
+
+    // Plugin-level `active-leaf-change` / `file-menu` handlers gate on
+    // `this._specoratorView?.pinia`. Nulling the field turns those gates
+    // false so background workspace events do not mutate a store whose Vue
+    // app has been unmounted.
+    expect(view.pinia).toBeNull()
+  })
 })
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Addresses Codex P2 finding on #350: `SpecoratorView.onClose()` unmounted the Vue app but left `this.pinia` populated. Plugin-level workspace handlers in `src/plugin/main.ts` (`file-menu` at line 249 and `active-leaf-change` at line 263) gate on `this._specoratorView?.pinia` — with the field still truthy after close, those handlers kept mutating a Pinia store whose Vue app was already torn down, so background workspace events could update stale chat state and trigger side effects after the panel was closed.

Fix: null `this.pinia` in `onClose()` after unmounting. `onOpen()` already re-creates the Pinia instance on next mount, and internal consumers (`_isChatLoading`, `_installPendingRefreshWatcher`) already guard on `this.pinia === null`. New regression test asserts the close → null invariant.

## Test plan

- [x] New test: `clears pinia on close so plugin workspace handlers stop mutating the unmounted store`
- [x] Unit tests: 1405/1405 pass (`npm run test`)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (only pre-existing warnings)

## Related

- Follow-up to Codex review on #350 — thread "Clear stale Pinia store when the view closes" on `src/plugin/SpecoratorView.ts` (line 277, P2).
- Part of the develop → demo promotion sweep for `agent-sidepanel-mvp`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Af3wVsvXtFp78EE2pobMoj)_