### PR TITLE
fix(chat): drop Math.random fallback in thread/proposal id generation

### DIFF
--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -84,22 +84,20 @@ const inlineTranslator: TranslationPort = {
 }
 
 /**
- * Generate a UUID for new thread / proposal ids. Falls back to a timestamp-keyed
- * value when `crypto.randomUUID` is missing (older test environments). The
- * fallback is collision-resistant enough for in-memory maps within a session.
+ * Generate an id for a new thread / proposal using the Web Crypto API.
+ * `crypto.randomUUID()` is available in every environment this plugin runs in
+ * (Obsidian's Electron, modern browsers for the standalone UI, and Node ≥19
+ * for tests). The previous `Math.random()` fallback was dead code in
+ * production — it only ran when `crypto.randomUUID` was undefined, which
+ * never occurs in supported environments — and CodeQL flagged it as
+ * insecure randomness, so it has been removed (CodeQL alert on PR #350).
  */
-function generateUuid(prefix: string): string {
-  const c = globalThis.crypto as { randomUUID?: () => string } | undefined
-  if (c?.randomUUID !== undefined) return c.randomUUID()
-  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
-}
-
 function generateThreadId(): string {
-  return generateUuid('thread')
+  return globalThis.crypto.randomUUID()
 }
 
 function generateProposalId(): string {
-  return generateUuid('proposal')
+  return globalThis.crypto.randomUUID()
 }
 
 /**


### PR DESCRIPTION
## Summary

Addresses CodeQL "Insecure randomness" alert (#18) raised on PR #350: `generateUuid()` in `ChatSidebar.vue` had a `Math.random()` fallback path used only when `crypto.randomUUID` was unavailable. That branch is dead code in every runtime this plugin supports — Obsidian's Electron, modern browsers (standalone UI), and Node ≥19 (vitest) all expose `crypto.randomUUID()` on `globalThis.crypto`. CodeQL still scans the dead branch and treats it as a security finding.

Fix: drop the helper and call `globalThis.crypto.randomUUID()` directly from `generateThreadId()` and `generateProposalId()`. Same returned format (plain UUID v4) as the production path that has always been taken; no behavioural change.

## Test plan

- [x] Unit tests: 1404/1404 pass (`npm run test`)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (only pre-existing warnings)
- [x] CodeQL alert #18 will clear once this lands on `develop` and the scan re-runs against the promotion PR

## Related

- CodeQL alert on PR #350 → https://github.com/Luis85/specorator/security/code-scanning/18
- Part of the develop → demo promotion sweep for `agent-sidepanel-mvp`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Af3wVsvXtFp78EE2pobMoj)_