### PR TITLE
fix(chat): serialize SessionLogWriter init to prevent duplicate instances

### DIFF
--- a/src/ui/composables/useSessionLogWriter.ts
+++ b/src/ui/composables/useSessionLogWriter.ts
@@ -40,26 +40,44 @@ export function useSessionLogWriter(): UseSessionLogWriter {
 	const settings = useSettingsPort()
 	let cached: SessionLogWriter | null = null
 	let cachedSpecsFolder: string | null = null
+	// Shared in-flight initialization promise (Codex P1, PR #350). Without
+	// this, two concurrent callers each `await settings.getSettings()` before
+	// reading `cached`; both can observe `cached === null` and construct
+	// different SessionLogWriter instances. Because the per-log-file mutex
+	// lives on each writer instance, the two writers do not coordinate locks
+	// and can interleave read/append/write cycles on the same log, dropping
+	// entries. Gating the construction path behind a single Promise ensures
+	// every concurrent caller gets the same writer.
+	let inFlight: Promise<SessionLogWriter> | null = null
 
 	return {
-		async getWriter(): Promise<SessionLogWriter> {
-			const current = await settings.getSettings()
-			// Invalidate the cached writer when the configured specs folder has
-			// changed mid-session (Codex P2, PR #350). Without this, a user
-			// who changes the Specs folder in settings keeps writing session
-			// logs to the old folder while stage/context resolution uses the
-			// new one, splitting history across roots.
-			if (cached !== null && cachedSpecsFolder === current.specsFolder) {
-				return cached
-			}
-			cached = new SessionLogWriter(
-				vault,
-				logger,
-				current.specsFolder,
-				() => new Date().toISOString(),
-			)
-			cachedSpecsFolder = current.specsFolder
-			return cached
+		getWriter(): Promise<SessionLogWriter> {
+			if (inFlight !== null) return inFlight
+			inFlight = (async () => {
+				try {
+					const current = await settings.getSettings()
+					// Invalidate the cached writer when the configured specs folder has
+					// changed mid-session (Codex P2, PR #350). Without this, a user
+					// who changes the Specs folder in settings keeps writing session
+					// logs to the old folder while stage/context resolution uses the
+					// new one, splitting history across roots.
+					if (cached === null || cachedSpecsFolder !== current.specsFolder) {
+						cached = new SessionLogWriter(
+							vault,
+							logger,
+							current.specsFolder,
+							() => new Date().toISOString(),
+						)
+						cachedSpecsFolder = current.specsFolder
+					}
+					return cached
+				} finally {
+					// Clear so a subsequent specsFolder change can be re-detected on
+					// the next call. The cache itself survives across these resets.
+					inFlight = null
+				}
+			})()
+			return inFlight
 		},
 	}
 }

--- a/src/ui/composables/useSessionLogWriter.ts
+++ b/src/ui/composables/useSessionLogWriter.ts
@@ -53,30 +53,31 @@ export function useSessionLogWriter(): UseSessionLogWriter {
 	return {
 		getWriter(): Promise<SessionLogWriter> {
 			if (inFlight !== null) return inFlight
-			inFlight = (async () => {
-				try {
-					const current = await settings.getSettings()
-					// Invalidate the cached writer when the configured specs folder has
-					// changed mid-session (Codex P2, PR #350). Without this, a user
-					// who changes the Specs folder in settings keeps writing session
-					// logs to the old folder while stage/context resolution uses the
-					// new one, splitting history across roots.
-					if (cached === null || cachedSpecsFolder !== current.specsFolder) {
-						cached = new SessionLogWriter(
-							vault,
-							logger,
-							current.specsFolder,
-							() => new Date().toISOString(),
-						)
-						cachedSpecsFolder = current.specsFolder
-					}
-					return cached
-				} finally {
-					// Clear so a subsequent specsFolder change can be re-detected on
-					// the next call. The cache itself survives across these resets.
-					inFlight = null
+			const pending = (async (): Promise<SessionLogWriter> => {
+				const current = await settings.getSettings()
+				// Invalidate the cached writer when the configured specs folder has
+				// changed mid-session (Codex P2, PR #350). Without this, a user
+				// who changes the Specs folder in settings keeps writing session
+				// logs to the old folder while stage/context resolution uses the
+				// new one, splitting history across roots.
+				if (cached === null || cachedSpecsFolder !== current.specsFolder) {
+					cached = new SessionLogWriter(
+						vault,
+						logger,
+						current.specsFolder,
+						() => new Date().toISOString(),
+					)
+					cachedSpecsFolder = current.specsFolder
 				}
+				return cached
 			})()
+			// Clear `inFlight` once construction settles so a subsequent
+			// `specsFolder` change can be re-detected on the next call. `.finally`
+			// preserves both resolution value and rejection, and avoids a raw
+			// try/finally block (`no-restricted-syntax` rule).
+			inFlight = pending.finally(() => {
+				inFlight = null
+			})
 			return inFlight
 		},
 	}

--- a/tests/ui/composables/useSessionLogWriter.test.ts
+++ b/tests/ui/composables/useSessionLogWriter.test.ts
@@ -104,4 +104,28 @@ describe('useSessionLogWriter', () => {
 
 		expect(after).toBe(before)
 	})
+
+	it('returns the same writer instance for concurrent first-time callers (Codex P1, PR #350)', async () => {
+		// Hold settings.getSettings() until both callers are waiting on it. Without
+		// the in-flight serialization, both callers would resume past the await
+		// observing cached === null and construct two different SessionLogWriter
+		// instances — each carrying its own per-file mutex map, so concurrent
+		// appends to the same log could interleave and drop entries.
+		const bridge = new MockBridge()
+		let resolveSettings!: (v: PluginSettings) => void
+		const settingsPromise = new Promise<PluginSettings>((resolve) => {
+			resolveSettings = resolve
+		})
+		bridge.getSettings = () => settingsPromise
+
+		const { composable } = mountHost(bridge)
+		const firstPending = composable.getWriter()
+		const secondPending = composable.getWriter()
+
+		// Both callers are now suspended on the same settings promise.
+		resolveSettings({ ...DEFAULT_SETTINGS, specsFolder: 'specs' })
+
+		const [first, second] = await Promise.all([firstPending, secondPending])
+		expect(second).toBe(first)
+	})
 })


### PR DESCRIPTION
## Summary

Addresses Codex P1 finding on #350: `useSessionLogWriter.getWriter()` awaited `settings.getSettings()` **before** checking the cache. Two concurrent first-time callers could each observe `cached === null` after their respective awaits resolved and each construct a different `SessionLogWriter`. Because the per-log-file mutex map lives on each instance, the two writers did not coordinate locks — concurrent appends to the same session log could interleave read/append/write cycles and drop entries. This shows up in normal flows where a fire-and-forget turn mirror runs alongside a proposal-decision write.

Fix: gate construction behind a shared `inFlight: Promise<SessionLogWriter> | null`. The first caller starts the work; concurrent callers receive the same Promise and the same resolved writer. The flag is cleared after construction so a subsequent `specsFolder` change is still re-detected by the existing invalidation logic.

## Test plan

- [x] New test: `returns the same writer instance for concurrent first-time callers`
- [x] Existing memoise/invalidate/no-op-rebuild tests still pass
- [x] Unit tests: 1405/1405 pass (`npm run test`)
- [x] `npm run typecheck` clean

## Related

- Follow-up to Codex review on #350 — thread "Serialize SessionLogWriter initialization" on `src/ui/composables/useSessionLogWriter.ts` line 50, P1.
- Part of the develop → demo promotion sweep for `agent-sidepanel-mvp`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Af3wVsvXtFp78EE2pobMoj)_