### PR TITLE
fix(chat): route degraded-state setup CTA to Obsidian plugin settings tab

### DIFF
--- a/src/infrastructure/bridge/ports.ts
+++ b/src/infrastructure/bridge/ports.ts
@@ -38,3 +38,16 @@ export const IS_MOBILE_KEY: InjectionKey<boolean> = Symbol('IsMobile')
  * Satisfies D-CCS-003, T-CCS-037.
  */
 export const SETTINGS_VERSION_KEY: InjectionKey<Ref<number>> = Symbol('settingsVersion')
+
+/**
+ * Provided by `SpecoratorView` so `ChatSidebar`'s degraded-state CTA can open
+ * Obsidian's plugin settings tab — the only surface that actually exposes the
+ * Anthropic API key and transport fields. The in-app Vue `/settings` route
+ * does not edit those fields, so routing the recovery CTA there strands users
+ * in the first-run / missing-key case (Codex P2, PR #350).
+ *
+ * The function is provided as a no-op default by callers that do not have
+ * access to Obsidian's `App` (unit tests, standalone browser UI), so consumers
+ * can call it unconditionally.
+ */
+export const OPEN_PLUGIN_SETTINGS_KEY: InjectionKey<() => void> = Symbol('openPluginSettings')

--- a/src/plugin/SpecoratorView.ts
+++ b/src/plugin/SpecoratorView.ts
@@ -17,6 +17,7 @@ import {
   IS_MOBILE_KEY,
   SETTINGS_VERSION_KEY,
   TRANSPORT_KIND_KEY,
+  OPEN_PLUGIN_SETTINGS_KEY,
 } from '@/infrastructure/bridge/ports'
 import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
 import { FeatureService } from '@/application/feature/FeatureService'
@@ -229,6 +230,22 @@ export class SpecoratorView extends ItemView {
     this.vueApp.provide(TRANSPORT_KIND_KEY, this._activeTransportKind)
     this.vueApp.provide(IS_MOBILE_KEY, Platform.isMobile)
     this.vueApp.provide(SETTINGS_VERSION_KEY, this._settingsVersion)
+    // Codex P2 (PR #350): the in-app Vue `/settings` route does not expose
+    // the Anthropic key or transport fields, so the chat-degraded recovery
+    // CTA needs to open Obsidian's plugin settings tab directly. Capture
+    // `App` + plugin id from the plugin instance and bind a no-arg
+    // function ChatSidebar can call from a click handler.
+    this.vueApp.provide(OPEN_PLUGIN_SETTINGS_KEY, () => {
+      // `App.setting` is an Obsidian internal but is the canonical way to
+      // open the settings modal from plugin code; the same pattern is used
+      // by the official `obsidian-tasks` and `dataview` plugins.
+      const setting = (this.plugin.app as unknown as {
+        setting?: { open: () => void; openTabById: (id: string) => void }
+      }).setting
+      if (setting === undefined) return
+      setting.open()
+      setting.openTabById(this.plugin.manifest.id)
+    })
     const featureFeedback = new FeedbackService(bridge, bridge)
     this.vueApp.provide(
       FEATURE_SERVICE_KEY,

--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -23,6 +23,7 @@ import {
   CONFIRM_MODAL_PORT,
   SETTINGS_VERSION_KEY,
   TRANSPORT_KIND_KEY,
+  OPEN_PLUGIN_SETTINGS_KEY,
 } from '@/infrastructure/bridge/ports'
 import type { SessionId } from '@/domain/chat/SessionId'
 import type { ChatThreadRecord } from '@/domain/chat/ChatThreadRecord'
@@ -70,6 +71,14 @@ const sessionLogWriterFactory = useSessionLogWriter()
  */
 const confirmModalPort = inject<ConfirmModalPort | undefined>(CONFIRM_MODAL_PORT, undefined)
 const transportKindRef = inject<Ref<TransportKind> | undefined>(TRANSPORT_KIND_KEY, undefined)
+// Routes the chat-degraded recovery CTA to Obsidian's plugin settings tab
+// (Codex P2, PR #350). Defaults to a no-op so unit tests and the standalone
+// browser UI — which do not have Obsidian's `App` available — can mount the
+// sidebar without crashing when the button is clicked.
+const noopOpenPluginSettings = (): void => {
+  /* default for unit tests and the standalone browser UI */
+}
+const openPluginSettings = inject<() => void>(OPEN_PLUGIN_SETTINGS_KEY, noopOpenPluginSettings)
 
 /**
  * Vue-i18n composable wired to the EN/DE catalogues in `src/ui/i18n/locales/`.
@@ -898,13 +907,14 @@ watch(available, async () => {
       <p class="sp-chat__degraded-body">
         To use this feature, add your Anthropic key in Settings. Your key is stored privately on this device and is never shared.
       </p>
-      <RouterLink
+      <button
+        type="button"
         class="sp-btn sp-btn--secondary sp-btn--md"
-        to="/settings"
         data-testid="chat-degraded-settings-link"
+        @click="openPluginSettings"
       >
         Open settings
-      </RouterLink>
+      </button>
     </div>
 
     <!-- SDK unavailable degraded state (REQ-CCS-019) -->

--- a/src/ui/main.ts
+++ b/src/ui/main.ts
@@ -19,6 +19,7 @@ import {
   LOGGER_PORT,
   CLAUDE_CLI_PORT,
   COMMUNITY_PLUGIN_PORT,
+  OPEN_PLUGIN_SETTINGS_KEY,
 } from '@/infrastructure/bridge/ports'
 import { LocalStorageBridge } from '@/infrastructure/localstorage/LocalStorageBridge'
 import { MockBridge } from '@/infrastructure/mock/MockBridge'
@@ -68,6 +69,15 @@ void bridge.getSettings()
     app.provide(LOGGER_PORT, bridge)
     app.provide(CLAUDE_CLI_PORT, bridge)
     app.provide(COMMUNITY_PLUGIN_PORT, bridge)
+    // The Obsidian build provides this via `SpecoratorView.onOpen()` and
+    // opens the real plugin settings tab. In the standalone browser UI
+    // there is no Obsidian `App`, so route to the in-app Vue `/settings`
+    // page — that's the same destination the previous `<RouterLink>` had,
+    // so this preserves the prior behaviour rather than degrading to a
+    // no-op (Codex P2, PR #365).
+    app.provide(OPEN_PLUGIN_SETTINGS_KEY, () => {
+      void router.push('/settings')
+    })
     const featureFeedback = new FeedbackService(bridge, bridge)
     app.provide(
       FEATURE_SERVICE_KEY,

--- a/tests/ui/components/chat/ChatSidebar.test.ts
+++ b/tests/ui/components/chat/ChatSidebar.test.ts
@@ -135,6 +135,42 @@ describe('ChatSidebar', () => {
 			const { po } = await mountSidebar({ available: false, apiKey: '' })
 			expect(po.hasTextarea()).toBe(false)
 		})
+
+		it('clicking the settings CTA invokes the injected openPluginSettings (Codex P2, PR #350)', async () => {
+			// The in-app Vue `/settings` route does not expose the Anthropic key
+			// or transport fields, so the recovery CTA must call the function
+			// SpecoratorView provides under OPEN_PLUGIN_SETTINGS_KEY — that
+			// function opens Obsidian's plugin settings tab in production.
+			const { OPEN_PLUGIN_SETTINGS_KEY } = await import('@/infrastructure/bridge/ports')
+			const pinia = createPinia()
+			setActivePinia(pinia)
+			const port = new MockClaudeCliPort()
+			port.available = false
+			const bridge = makeBridgeWithApiKey('', {})
+			const openPluginSettings = vi.fn()
+			const wrapper = mount(ChatSidebar, {
+				global: {
+					plugins: [pinia],
+					stubs: { RouterLink: RouterLinkStub },
+					provide: {
+						[CLAUDE_CLI_PORT as symbol]: port,
+						[IS_MOBILE_KEY as symbol]: false,
+						[VAULT_PORT as symbol]: bridge,
+						[WORKSPACE_PORT as symbol]: bridge,
+						[SETTINGS_PORT as symbol]: bridge,
+						[LOGGER_PORT as symbol]: bridge,
+						[OPEN_PLUGIN_SETTINGS_KEY as symbol]: openPluginSettings,
+					},
+				},
+			})
+			await flushPromises()
+
+			const cta = wrapper.find('[data-testid="chat-degraded-settings-link"]')
+			expect(cta.exists()).toBe(true)
+			await cta.trigger('click')
+
+			expect(openPluginSettings).toHaveBeenCalledTimes(1)
+		})
 	})
 
 	describe('TEST-CCS-019: SDK unavailable degraded state', () => {


### PR DESCRIPTION
## Summary

Addresses Codex P2 finding on #350: the chat-degraded recovery CTA in `ChatSidebar.vue` rendered a `<RouterLink to="/settings">`, but `SettingsView.vue` (the in-app Vue page at that route) does not expose `anthropicApiKey` or any transport-kind controls — those fields live exclusively in Obsidian's `PluginSettingTab` (`src/plugin/settings.ts`). In the common first-run / misconfigured-key case users clicked "Open settings", landed on a page with nothing to edit, and remained stuck.

Fix:

1. New `OPEN_PLUGIN_SETTINGS_KEY: InjectionKey<() => void>` in `src/infrastructure/bridge/ports.ts`.
2. `SpecoratorView.onOpen()` provides a function that opens Obsidian's settings modal directly via `app.setting.open()` + `openTabById(manifest.id)` (the same pattern used by `obsidian-tasks` / `dataview`). `App.setting` is an Obsidian internal so the cast is local + commented.
3. `ChatSidebar` injects the function (default: no-op so unit tests and the standalone browser UI don't crash) and binds it to a `<button>` that replaces the dead-end `<RouterLink>`. `data-testid` is unchanged so existing PageObject lookups still resolve.
4. New regression test mounts the sidebar in the degraded state, clicks the CTA, and asserts the injected callback fires.

## Test plan

- [x] New test: `clicking the settings CTA invokes the injected openPluginSettings`
- [x] Existing degraded-state tests still pass
- [x] Unit tests: 1407/1407 pass (`npm run test`)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (only pre-existing warnings)

## Related

- Codex review on #350 — thread "Point setup CTA to a screen that can edit chat credentials" on `src/ui/components/chat/ChatSidebar.vue` line 904, P2.
- Part of the develop → demo promotion sweep for `agent-sidepanel-mvp`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Af3wVsvXtFp78EE2pobMoj)_