### PR TITLE
fix(security): escape workflow-state title backslashes + ignore inputs/ in CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,9 @@ jobs:
         uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           languages: javascript-typescript
+          config: |
+            paths-ignore:
+              - inputs/**
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4

--- a/src/infrastructure/workflow-state/WorkflowStateDocument.ts
+++ b/src/infrastructure/workflow-state/WorkflowStateDocument.ts
@@ -40,7 +40,7 @@ export function serializeWorkflowState(feature: Feature): string {
 		'---',
 		`id: ${p.id}`,
 		`slug: ${p.slug}`,
-		`feature: "${p.title.replace(/"/g, '\\"')}"`,
+		`feature: "${p.title.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`,
 		`area: "${area}"`,
 		`status: ${p.status}`,
 		`currentStep: ${p.currentStep}`,
@@ -86,7 +86,7 @@ export function parseWorkflowStateFrontmatter(content: string): Partial<Record<s
 }
 
 function parseScalar(raw: string): string {
-	if (raw.startsWith('"')) return raw.slice(1, raw.lastIndexOf('"')).replace(/\\"/g, '"');
+	if (raw.startsWith('"')) return raw.slice(1, raw.lastIndexOf('"')).replace(/\\(["\\])/g, '$1');
 	if (raw.startsWith("'")) return raw.slice(1, raw.lastIndexOf("'")).replace(/''/g, "'");
 	return raw;
 }

--- a/tests/infrastructure/workflow-state/WorkflowStateDocument.test.ts
+++ b/tests/infrastructure/workflow-state/WorkflowStateDocument.test.ts
@@ -65,4 +65,26 @@ describe('WorkflowStateDocument', () => {
 		expect(content).toContain('  idea: complete');
 		expect(deserializeWorkflowState(content)?.id).toBe('serialize-id');
 	});
+
+	it.each([
+		['trailing backslash', 'foo\\'],
+		['embedded backslash', 'a\\b'],
+		['backslash and quote', 'a\\"b'],
+		['double backslash', 'a\\\\b'],
+	])('round-trips a title with %s', (_label, title) => {
+		const feature = Feature.reconstitute({
+			id: 'roundtrip-id',
+			slug: Slug.reconstitute('roundtrip'),
+			title,
+			area: 'RT',
+			status: 'draft',
+			currentStep: 1,
+			createdAt: new Date('2026-05-16T10:00:00.000Z'),
+			updatedAt: new Date('2026-05-16T11:00:00.000Z'),
+		});
+
+		const parsed = deserializeWorkflowState(serializeWorkflowState(feature));
+
+		expect(parsed?.title).toBe(title);
+	});
 });


### PR DESCRIPTION
## Summary

Addresses 8 open CodeQL findings on develop without touching runtime behavior.

- **Alert #17 (high, js/incomplete-sanitization, `WorkflowStateDocument.ts:43`):** `serializeWorkflowState` escaped `"` but not `\`, so a title containing a trailing backslash (`foo\`) corrupted the YAML frontmatter. Fix escapes `\` first then `\"`. `parseScalar` updated to unescape both. Adds parametric round-trip test covering trailing/embedded/double backslash and backslash+quote.
- **Alerts #10-#16 (high/medium, `inputs/specorator-mvp-design-2026-05/Specorator_Screen_v2.html`):** vendored design-mockup HTML, not shipped. Per [`AGENTS.md`](../blob/develop/AGENTS.md) `inputs/` is work-package material. `codeql.yml` init step now sets `paths-ignore: ['inputs/**']` so future vendored mockups don't pile up alerts either.

Out of scope for this PR (already shipped or non-code):
- Alert #18 (Math.random in ChatSidebar) — closed by PR #363.
- Alerts #2 + #3 (Token-Permissions) — closed by PR #361; Scorecard's weekly run will mark them resolved next Sun.
- Scorecard #1, #5, #6, #7, #9 — require repo settings / external programs (branch protection, CII badge, OSS-Fuzz), tracked separately.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (15 pre-existing warnings unrelated)
- [x] `npm run test` — 1410 passed, 116 files (new round-trip test included)
- [x] `npm run build` — clean
- [x] `npm run build:web` — clean
- [x] `npm run docs:api` — clean
- [x] `npm audit --audit-level=high --omit=dev` — 0 vulnerabilities
- [ ] CodeQL run on PR closes alert #17
- [ ] CodeQL run no longer reports `inputs/**` findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)