### PR TITLE
fix(build): substitute import.meta.url for CJS bundle compatibility

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -99,6 +99,12 @@ export default defineConfig(({ mode }) => {
 			resolve: { alias },
 			define: {
 				'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV ?? 'production'),
+				// Rolldown's CJS output mangles `import.meta.url` to `{}.url` (undefined),
+				// crashing deps that call `createRequire(import.meta.url)` at module top-level
+				// (e.g. @anthropic-ai/claude-agent-sdk). Substitute a runtime expression that
+				// yields a valid file URL for an existing file — `createRequire` and
+				// `fileURLToPath` both accept it.
+				'import.meta.url': 'require("url").pathToFileURL(process.execPath).href',
 			},
 			build: {
 				lib: {


### PR DESCRIPTION
## Summary
- Rolldown CJS output mangles `import.meta.url` -> `{}.url` (undefined), crashing deps that call `createRequire(import.meta.url)` at module top-level.
- `@anthropic-ai/claude-agent-sdk` does this; static import via `src/infrastructure/obsidian/ClaudeCliAdapter.ts` aborted Obsidian plugin load with `TypeError: The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received undefined`.
- Substitute `import.meta.url` via Vite `define` with a runtime expression that yields a valid file URL pointing at `process.execPath` — accepted by both `createRequire` and `fileURLToPath`.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run test` — 1411 / 1411 passing
- [x] `npm run build` — bundle emits `createRequire(require("url").pathToFileURL(process.execPath).href)` at L52817
- [x] Manual: deploy to test vault, reload plugin in Obsidian — loads clean, no TypeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)