### PR TITLE
feat(agent): UI consume + Stop button for streaming responses (PR-ASV-2-ui)

### DIFF
--- a/src/infrastructure/mock/MockClaudeCliPort.ts
+++ b/src/infrastructure/mock/MockClaudeCliPort.ts
@@ -176,6 +176,13 @@ export class MockClaudeCliPort implements ClaudeCliPort {
 	async *queryStream(prompt: string, options?: ClaudeCliStreamOptions): AsyncIterable<StreamDelta> {
 		this.streamLog.push(prompt);
 		this.streamOptionsLog.push(options);
+		// PR-ASV-2-ui: `ChatSidebar.handleSend` switched from `query()` to
+		// `queryStream()`. Existing tests assert against `queryLog` /
+		// `optionsLog` (the legacy non-streaming log) — mirror to those
+		// arrays so backward-compatible inspection points keep working
+		// without forcing 10+ tests to migrate to `streamLog`.
+		this.queryLog.push(prompt);
+		this.optionsLog.push(options);
 
 		if (!this.available) {
 			yield {

--- a/src/ui/components/agent/MessageList.vue
+++ b/src/ui/components/agent/MessageList.vue
@@ -26,16 +26,26 @@ const messages = computed(() => {
 	return store.messages.get(props.threadId) ?? [];
 });
 
+/**
+ * Streaming in-flight indicator. While `chatStore.status === 'loading'` and
+ * `chatStore.streamingText` is non-empty, the message list appends a
+ * synthetic streaming-assistant bubble to render text deltas as they arrive
+ * (PR-ASV-2-ui). The bubble does not have a stable `ChatMessage.id` because
+ * it is replaced by the real `appendMessage` once the stream resolves.
+ */
+const streamingText = computed<string>(() => store.streamingText);
+const isStreaming = computed<boolean>(
+	() => store.status === 'loading' && streamingText.value.length > 0,
+);
+
 const scrollContainer = ref<HTMLElement | null>(null);
 
-// Watches array length only — appendMessage in Increment 1 never mutates the
-// trailing message in place. Increment 2 (streaming responses, see
-// specs/agent-sidepanel-v2/idea.md "Out of scope" → streaming) will mutate
-// the last assistant message's `text` as deltas arrive; this watcher will
-// need to also observe the last entry's text length, or switch to a deep
-// watch with a debounce, to keep auto-scroll honest during streaming turns.
+// Track BOTH the message-array length AND the streaming-text length so the
+// scroll position follows live deltas during a streaming turn. Without the
+// second observed value, the scroll watcher only fires at turn boundaries
+// (appendMessage) and the user has to scroll manually as Claude streams.
 watch(
-	() => messages.value.length,
+	[() => messages.value.length, () => streamingText.value.length],
 	async () => {
 		await nextTick();
 		const el = scrollContainer.value;
@@ -47,7 +57,7 @@ watch(
 
 <template>
 	<div
-		v-if="messages.length > 0"
+		v-if="messages.length > 0 || isStreaming"
 		ref="scrollContainer"
 		class="sp-agent-messages"
 		data-testid="agent-message-list"
@@ -77,6 +87,23 @@ watch(
 				>
 					{{ t('agent.contextTrimmed') }}
 				</p>
+			</div>
+		</article>
+		<article
+			v-if="isStreaming"
+			class="sp-agent-message sp-agent-message--assistant sp-agent-message--streaming"
+			data-testid="agent-message-streaming"
+		>
+			<header class="sp-agent-message__role">
+				{{ t('agent.roleAssistant') }}
+			</header>
+			<div class="sp-agent-message__body">
+				<pre class="sp-agent-message__text">{{ streamingText }}</pre>
+				<span
+					class="sp-agent-message__cursor"
+					aria-hidden="true"
+					data-testid="agent-message-streaming-cursor"
+				>▍</span>
 			</div>
 		</article>
 	</div>
@@ -160,5 +187,22 @@ watch(
 	margin: 0;
 	font-size: 0.75rem;
 	color: var(--text-faint);
+}
+
+.sp-agent-message--streaming {
+	opacity: 0.95;
+}
+
+.sp-agent-message__cursor {
+	display: inline-block;
+	font-size: 0.875rem;
+	color: var(--text-accent);
+	animation: sp-agent-message__blink 1s steps(2, start) infinite;
+}
+
+@keyframes sp-agent-message__blink {
+	to {
+		visibility: hidden;
+	}
 }
 </style>

--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -27,7 +27,12 @@ import {
 } from '@/infrastructure/bridge/ports';
 import type { SessionId } from '@/domain/chat/SessionId';
 import type { ChatThreadRecord } from '@/domain/chat/ChatThreadRecord';
-import type { ConfirmModalPort, TranslationPort } from '@/domain/ports';
+import type {
+	ConfirmModalPort,
+	TranslationPort,
+	StreamDelta,
+	ClaudeCliErrorCode,
+} from '@/domain/ports';
 import type { TransportKind } from '@/domain/chat/TransportKind';
 import { queryStructured, type StructuredCliCallOptions } from '@/application/chat/queryStructured';
 import { proposeFileWrite } from '@/application/chat/proposeFileWrite';
@@ -137,6 +142,20 @@ const proposalPathErrors = ref<Map<string, PathValidationError>>(new Map());
 
 // Last user turn (for Retry — REQ-ASM-050). Captured on each send.
 const lastUserTurn = ref<string>('');
+
+/**
+ * `AbortController` for the in-flight streaming turn (PR-ASV-2-ui). Non-null
+ * while `handleSend` is consuming `queryStream`; cleared on terminal delta.
+ * Drives the "Stop generation" button: clicking it calls `.abort()` which
+ * propagates through the port's stream options to the underlying adapter
+ * (subprocess kill or SDK abort), then the stream emits a terminal `error`
+ * delta and the handler surfaces a `query_failed` status.
+ */
+const inFlightAbort = ref<AbortController | null>(null);
+
+function handleStopGeneration(): void {
+	inFlightAbort.value?.abort();
+}
 
 /**
  * Proposal IDs whose decision (Accept or Reject) is currently in flight. Used
@@ -657,39 +676,85 @@ async function handleSend(): Promise<void> {
 
 	// Cold-spawn pill (R-ASM-003). Cleared on completion or error.
 	store.setCliStartingUp(true);
-	const queryResult = await tryAsync(() =>
-		claudeCliPort.query(prompt, {
+	// IDEA-ASV-001 Increment 2 (PR-ASV-2-ui): consume the streaming
+	// `queryStream` rather than the non-streaming `query`. Text deltas
+	// accumulate into `store.streamingText` so `MessageList.vue` can
+	// render the in-flight assistant turn live. The exposed
+	// `inFlightAbort` ref lets the Stop button cancel mid-stream.
+	const abortController = new AbortController();
+	inFlightAbort.value = abortController;
+	store.resetStreaming();
+	const streamResult = await consumeStream({
+		stream: claudeCliPort.queryStream(prompt, {
 			timeoutMs: 30_000,
 			systemPromptSuffix,
 			resumeSessionId,
 			onSessionId,
+			signal: abortController.signal,
 		}),
-	);
+		threadId,
+	});
+	inFlightAbort.value = null;
 	store.setCliStartingUp(false);
 
-	if (!queryResult.ok) {
-		// `claudeCliPort.query` is contracted never to throw (returns a Result),
-		// but a rogue mock or future regression could; fall back to query_failed.
-		store.setError('query_failed');
-		await nextTick();
-		focusTextarea();
-		return;
-	}
-
-	const result = queryResult.value;
-	if (result.ok) {
+	if (streamResult.kind === 'success') {
 		applySuccessfulTurn({
 			threadId,
 			isResumedTurn,
 			userMessage,
-			assistantResponse: result.value,
+			assistantResponse: streamResult.text,
 			truncated,
 		});
 	} else {
-		store.setError(result.error.errorCode === 'TIMEOUT' ? 'timeout' : 'query_failed');
+		store.setError(streamResult.errorCode === 'TIMEOUT' ? 'timeout' : 'query_failed');
 	}
+	// Don't call `store.resetStreaming()` here — that also clears
+	// `sessionResumed`, which `applySuccessfulTurn` may have just set
+	// (REQ-ASM-035 flash-once contract). `streamingText` is cleared by the
+	// next turn's `resetStreaming()` at the top of `handleSend`; in the
+	// interim the streaming bubble in `MessageList` is gated on
+	// `store.status === 'loading'` so it stays hidden in the success state.
 	await nextTick();
 	focusTextarea();
+}
+
+/**
+ * Drain `queryStream` to a terminal delta. Accumulates `text` deltas into
+ * `store.streamingText` so `MessageList.vue` can render the in-flight
+ * assistant turn token-by-token. Returns a normalised result describing
+ * how the stream terminated:
+ *   - `success` with the joined text on a `done` delta
+ *   - `error` with the error code on an `error` delta
+ * Never throws — a rogue iterable that throws is treated as `query_failed`.
+ */
+async function consumeStream(args: {
+	stream: AsyncIterable<StreamDelta>;
+	threadId: string;
+}): Promise<{ kind: 'success'; text: string } | { kind: 'error'; errorCode: ClaudeCliErrorCode }> {
+	const chunks: string[] = [];
+	const drained = await tryAsync(async () => {
+		for await (const delta of args.stream) {
+			if (delta.type === 'text') {
+				chunks.push(delta.text);
+				store.appendStreamingDelta(delta.text);
+			} else if (delta.type === 'session-id') {
+				store.captureSessionId(args.threadId, delta.sessionId);
+			} else if (delta.type === 'done') {
+				return { kind: 'done' as const, text: chunks.join('') };
+			} else {
+				// delta.type === 'error' — the only remaining variant.
+				return { kind: 'error' as const, errorCode: delta.error.errorCode };
+			}
+		}
+		return { kind: 'incomplete' as const, text: chunks.join('') };
+	});
+	if (!drained.ok) {
+		return { kind: 'error', errorCode: 'QUERY_FAILED' };
+	}
+	const outcome = drained.value;
+	if (outcome.kind === 'done') return { kind: 'success', text: outcome.text };
+	if (outcome.kind === 'error') return { kind: 'error', errorCode: outcome.errorCode };
+	return { kind: 'error', errorCode: 'QUERY_FAILED' };
 }
 
 /**
@@ -974,6 +1039,16 @@ watch(available, async () => {
 				<SessionResumeIndicator :resumed="store.sessionResumed" />
 				<SubprocessStartingPill :visible="store.cliStartingUp" />
 				<TransportStatusPill :kind="transportKind" />
+				<button
+					v-if="inFlightAbort !== null"
+					type="button"
+					class="sp-chat__stop"
+					data-testid="chat-stop-generation"
+					:aria-label="$t('chat.stopGenerationAriaLabel')"
+					@click="handleStopGeneration"
+				>
+					{{ $t('chat.stopGeneration') }}
+				</button>
 			</div>
 
 			<ContextFileList
@@ -1049,6 +1124,25 @@ watch(available, async () => {
 	margin: 0;
 	border: none;
 	border-top: 1px solid var(--background-modifier-border);
+}
+
+.sp-chat__stop {
+	margin-left: auto;
+	font-size: 0.75rem;
+	font-weight: 500;
+	padding: 0.25rem 0.625rem;
+	border-radius: 4px;
+	border: 1px solid var(--background-modifier-error-border, var(--background-modifier-border));
+	background: var(--background-modifier-error, var(--background-secondary));
+	color: var(--text-on-accent, var(--text-normal));
+	cursor: pointer;
+	transition:
+		background-color 0.15s,
+		border-color 0.15s;
+}
+
+.sp-chat__stop:hover {
+	background: var(--background-modifier-error-hover, var(--interactive-hover));
 }
 
 .sp-chat__degraded {

--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -620,6 +620,14 @@ async function handleSend(): Promise<void> {
 
 	// Clear any prior structured-fail flag at every new send.
 	store.setStructuredFail(false);
+	// Codex P2 on PR #372: reset the streaming buffer BEFORE the structured/
+	// free-text branch split so every new send starts from empty streaming
+	// state. Without this, a previous streamed reply could leave
+	// `streamingText` populated when the next turn is routed through
+	// `handleStructuredSend()` — during that turn `store.status === 'loading'`,
+	// so `MessageList.vue` would treat the stale text as an active stream and
+	// render the old assistant output as the current response.
+	store.resetStreaming();
 
 	store.beginRequest();
 
@@ -683,7 +691,6 @@ async function handleSend(): Promise<void> {
 	// `inFlightAbort` ref lets the Stop button cancel mid-stream.
 	const abortController = new AbortController();
 	inFlightAbort.value = abortController;
-	store.resetStreaming();
 	const streamResult = await consumeStream({
 		stream: claudeCliPort.queryStream(prompt, {
 			timeoutMs: 30_000,

--- a/src/ui/i18n/locales/de.ts
+++ b/src/ui/i18n/locales/de.ts
@@ -134,6 +134,8 @@ export default {
     session: {
       resumeAriaLabel: 'Vorheriges Gespräch wird fortgesetzt',
     },
+    stopGeneration: 'Stopp',
+    stopGenerationAriaLabel: 'Antwortgenerierung stoppen',
     response: {
       structuredFail: 'Der Assistent hat eine unerwartete Antwort zurückgegeben. Bitte versuche es erneut.',
     },

--- a/src/ui/i18n/locales/en.ts
+++ b/src/ui/i18n/locales/en.ts
@@ -131,6 +131,8 @@ export default {
       statusPill: 'Using your installed Claude tool.',
       startingPill: 'Starting up the Claude tool…',
     },
+    stopGeneration: 'Stop',
+    stopGenerationAriaLabel: 'Stop generating the response',
     session: {
       resumeAriaLabel: 'Continuing prior conversation',
     },

--- a/styles.css
+++ b/styles.css
@@ -760,7 +760,7 @@ to   { opacity: 1; transform: translateY(0);
 	font-style: italic;
 }
 
-.specorator-root :where(.sp-agent-messages[data-v-0aef9ad0]) {
+.specorator-root :where(.sp-agent-messages[data-v-289bf981]) {
 	flex: 1 1 auto;
 	min-height: 0;
 	overflow-y: auto;
@@ -769,21 +769,21 @@ to   { opacity: 1; transform: translateY(0);
 	flex-direction: column;
 	gap: 0.75rem;
 }
-.specorator-root :where(.sp-agent-messages--empty[data-v-0aef9ad0]) {
+.specorator-root :where(.sp-agent-messages--empty[data-v-289bf981]) {
 	flex: 0 0 auto;
 	padding: 1.25rem 1rem 0;
 	display: flex;
 	align-items: center;
 	justify-content: center;
 }
-.specorator-root :where(.sp-agent-messages__empty-body[data-v-0aef9ad0]) {
+.specorator-root :where(.sp-agent-messages__empty-body[data-v-289bf981]) {
 	margin: 0;
 	font-size: 0.8125rem;
 	color: var(--text-muted);
 	text-align: center;
 	font-style: italic;
 }
-.specorator-root :where(.sp-agent-message[data-v-0aef9ad0]) {
+.specorator-root :where(.sp-agent-message[data-v-289bf981]) {
 	display: flex;
 	flex-direction: column;
 	gap: 0.25rem;
@@ -792,22 +792,22 @@ to   { opacity: 1; transform: translateY(0);
 	background: var(--background-secondary);
 	border: 1px solid var(--background-modifier-border);
 }
-.specorator-root :where(.sp-agent-message--user[data-v-0aef9ad0]) {
+.specorator-root :where(.sp-agent-message--user[data-v-289bf981]) {
 	background: var(--background-secondary-alt, var(--background-secondary));
 }
-.specorator-root :where(.sp-agent-message__role[data-v-0aef9ad0]) {
+.specorator-root :where(.sp-agent-message__role[data-v-289bf981]) {
 	font-size: 0.6875rem;
 	font-weight: 600;
 	text-transform: uppercase;
 	letter-spacing: 0.04em;
 	color: var(--text-muted);
 }
-.specorator-root :where(.sp-agent-message__body[data-v-0aef9ad0]) {
+.specorator-root :where(.sp-agent-message__body[data-v-289bf981]) {
 	display: flex;
 	flex-direction: column;
 	gap: 0.25rem;
 }
-.specorator-root :where(.sp-agent-message__text[data-v-0aef9ad0]) {
+.specorator-root :where(.sp-agent-message__text[data-v-289bf981]) {
 	margin: 0;
 	font-family: inherit;
 	font-size: 0.875rem;
@@ -815,16 +815,30 @@ to   { opacity: 1; transform: translateY(0);
 	white-space: pre-wrap;
 	word-break: break-word;
 }
-.specorator-root :where(.sp-agent-message__empty[data-v-0aef9ad0]) {
+.specorator-root :where(.sp-agent-message__empty[data-v-289bf981]) {
 	margin: 0;
 	font-size: 0.8125rem;
 	color: var(--text-muted);
 	font-style: italic;
 }
-.specorator-root :where(.sp-agent-message__trim-note[data-v-0aef9ad0]) {
+.specorator-root :where(.sp-agent-message__trim-note[data-v-289bf981]) {
 	margin: 0;
 	font-size: 0.75rem;
 	color: var(--text-faint);
+}
+.specorator-root :where(.sp-agent-message--streaming[data-v-289bf981]) {
+	opacity: 0.95;
+}
+.specorator-root :where(.sp-agent-message__cursor[data-v-289bf981]) {
+	display: inline-block;
+	font-size: 0.875rem;
+	color: var(--text-accent);
+	animation: sp-agent-message__blink-289bf981 1s steps(2, start) infinite;
+}
+@keyframes sp-agent-message__blink-289bf981 {
+to {
+		visibility: hidden;
+}
 }
 
 .specorator-root :where(.sp-chat__chip[data-v-b92cd9d4]) {
@@ -1098,7 +1112,7 @@ to   { opacity: 1; transform: translateY(0);
  * parent: in the agent sidepanel the parent gives ChatSidebar `flex: 0 0
  * auto` and `MessageList` takes the remaining grow space.
  */
-.specorator-root :where(.sp-chat-sidebar[data-v-4fcb94ff]) {
+.specorator-root :where(.sp-chat-sidebar[data-v-bc55d886]) {
 	padding: 1rem;
 	display: flex;
 	flex-direction: column;
@@ -1106,24 +1120,41 @@ to   { opacity: 1; transform: translateY(0);
 	box-sizing: border-box;
 	flex-shrink: 0;
 }
-.specorator-root :where(.sp-chat__title[data-v-4fcb94ff]) {
+.specorator-root :where(.sp-chat__title[data-v-bc55d886]) {
 	margin: 0;
 	font-size: 1.125rem;
 	font-weight: 700;
 	color: var(--text-normal);
 }
-.specorator-root :where(.sp-chat__header[data-v-4fcb94ff]) {
+.specorator-root :where(.sp-chat__header[data-v-bc55d886]) {
 	display: flex;
 	align-items: center;
 	gap: 0.5rem;
 	flex-wrap: wrap;
 }
-.specorator-root :where(.sp-chat__divider[data-v-4fcb94ff]) {
+.specorator-root :where(.sp-chat__divider[data-v-bc55d886]) {
 	margin: 0;
 	border: none;
 	border-top: 1px solid var(--background-modifier-border);
 }
-.specorator-root :where(.sp-chat__degraded[data-v-4fcb94ff]) {
+.specorator-root :where(.sp-chat__stop[data-v-bc55d886]) {
+	margin-left: auto;
+	font-size: 0.75rem;
+	font-weight: 500;
+	padding: 0.25rem 0.625rem;
+	border-radius: 4px;
+	border: 1px solid var(--background-modifier-error-border, var(--background-modifier-border));
+	background: var(--background-modifier-error, var(--background-secondary));
+	color: var(--text-on-accent, var(--text-normal));
+	cursor: pointer;
+	transition:
+		background-color 0.15s,
+		border-color 0.15s;
+}
+.specorator-root :where(.sp-chat__stop[data-v-bc55d886]:hover) {
+	background: var(--background-modifier-error-hover, var(--interactive-hover));
+}
+.specorator-root :where(.sp-chat__degraded[data-v-bc55d886]) {
 	background: var(--background-secondary);
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 8px;
@@ -1132,13 +1163,13 @@ to   { opacity: 1; transform: translateY(0);
 	flex-direction: column;
 	gap: 0.5rem;
 }
-.specorator-root :where(.sp-chat__degraded-heading[data-v-4fcb94ff]) {
+.specorator-root :where(.sp-chat__degraded-heading[data-v-bc55d886]) {
 	margin: 0;
 	font-size: 1rem;
 	font-weight: 600;
 	color: var(--text-normal);
 }
-.specorator-root :where(.sp-chat__degraded-body[data-v-4fcb94ff]) {
+.specorator-root :where(.sp-chat__degraded-body[data-v-bc55d886]) {
 	margin: 0;
 	font-size: 0.875rem;
 	color: var(--text-muted);


### PR DESCRIPTION
## Summary

Final piece of the streaming chain. `ChatSidebar.handleSend` migrates from the non-streaming `query()` to the streaming `queryStream()`, surfacing text deltas in the sidepanel as they arrive.

**Stacked on #371 → #370 → #369 → develop.**

### ChatSidebar.vue

- `handleSend` constructs an `AbortController` per turn, exposes it on a new `inFlightAbort` ref, and threads `signal` through `queryStream`'s options.
- New `consumeStream(stream, threadId)` drains the iterable:
  - `text` deltas accumulate into `store.streamingText` for live render
  - `session-id` delta calls `captureSessionId`
  - `done` → success with joined text
  - `error` → `query_failed` / `timeout`
- Stop button: `handleStopGeneration` calls `inFlightAbort.value?.abort()`. Renders in the header only while a turn is in flight. New i18n keys `chat.stopGeneration` + `chat.stopGenerationAriaLabel` (en + de).
- Removed a stray `store.resetStreaming()` from the success-path tail — it also clears `sessionResumed`, which `applySuccessfulTurn` had just set for the REQ-ASM-035 flash-once contract.

### MessageList.vue

- New in-flight streaming bubble: when `store.status === 'loading'` AND `store.streamingText` is non-empty, an extra assistant-message article renders with the accumulated text + a blinking cursor.
- Scroll watcher now observes BOTH `messages.length` AND `streamingText.length` so the viewport tracks live deltas.

### MockClaudeCliPort

- `queryStream` mirrors prompt + options to `queryLog` / `optionsLog` (legacy non-streaming inspection points) so existing tests asserting against those arrays keep working without migrating to `streamLog`.

### Roadmap

- ✅ PR-ASV-2-port (interface + helper) — #370
- ✅ PR-ASV-2-sdk (real SDK streaming) — #371
- ⏳ PR-ASV-2-subproc (real subprocess streaming) — in flight on `claude/agent-sidepanel-v2-streaming-subproc`
- ✅ **PR-ASV-2-ui (this PR)**

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run test` — 1468/1468 pass
- [x] `npm run build` + `npm run build:web` — both succeed
- [ ] Manual: chat through the api-key transport, observe per-token deltas appearing in the streaming bubble
- [ ] Manual: click Stop mid-stream, confirm the response halts and an error toast appears

https://claude.ai/code/session_01VvXsK3aGp2g4jSpT1py7Mh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvXsK3aGp2g4jSpT1py7Mh)_