### PR TITLE
feat(agent): markdown rendering in MessageList (PR-ASV-7)

### DIFF
--- a/src/ui/components/agent/MarkdownBlock.vue
+++ b/src/ui/components/agent/MarkdownBlock.vue
@@ -200,7 +200,24 @@ function matchLink(source: string, i: number): InlineMatch | null {
 	if (source[i] !== '[') return null;
 	const labelEnd = source.indexOf(']', i + 1);
 	if (labelEnd === -1 || source[labelEnd + 1] !== '(') return null;
-	const hrefEnd = source.indexOf(')', labelEnd + 2);
+	// Codex P2 on PR #373: walk the URL with parenthesis balancing so links
+	// whose href contains parens (e.g. `[spec](https://example.com/foo(bar))`)
+	// don't get truncated at the first `)`. Tracks nesting depth; the
+	// matching close-paren for the outer `(` is depth 0 → -1 transition.
+	let depth = 0;
+	let hrefEnd = -1;
+	for (let j = labelEnd + 2; j < source.length; j++) {
+		const ch = source[j];
+		if (ch === '(') {
+			depth++;
+		} else if (ch === ')') {
+			if (depth === 0) {
+				hrefEnd = j;
+				break;
+			}
+			depth--;
+		}
+	}
 	if (hrefEnd === -1) return null;
 	const label = source.slice(i + 1, labelEnd);
 	const href = source.slice(labelEnd + 2, hrefEnd);

--- a/src/ui/components/agent/MarkdownBlock.vue
+++ b/src/ui/components/agent/MarkdownBlock.vue
@@ -1,0 +1,388 @@
+<script setup lang="ts">
+/**
+ * Renders a markdown string as DOM via Vue's `h()` render function (PR-ASV-7,
+ * agent-sidepanel-v2 D-ASV-5). Used by `MessageList.vue` for both completed
+ * assistant turns and in-flight streaming bubbles, replacing the previous
+ * `<pre>{{ text }}</pre>` plain-text rendering.
+ *
+ * The parser is intentionally small and hand-rolled to avoid an external
+ * dependency for the smallest mergeable PR. It supports the subset Claudian's
+ * plain markdown blocks need:
+ *
+ *   - Paragraphs (blank-line separated)
+ *   - Fenced code blocks (``` … ```), optionally with a language hint
+ *   - Blockquotes (`> …`)
+ *   - Unordered lists (`- ` / `* ` / `+ `)
+ *   - Ordered lists (`1. `)
+ *   - Inline: **bold**, *italic*, `code`, [text](url)
+ *
+ * DOM safety (ADR-008 / project-wide DOM construction rules):
+ *
+ *   - Output is built via `h()`, NOT `v-html` (which is banned by
+ *     `vue/no-v-html`) and NOT `innerHTML` (banned by `no-restricted-properties`).
+ *   - All user text reaches the DOM as `children` strings — Vue escapes them on
+ *     write. Embedded HTML tags such as `<script>` or `<img onerror>` appear as
+ *     literal text content; the browser never parses them.
+ *   - Link `href` values that don't match an http(s)/mailto allowlist are
+ *     emitted without an `href` attribute so they cannot smuggle
+ *     `javascript:` URIs.
+ */
+import { computed, h, type VNode } from 'vue';
+
+const props = defineProps<{
+	/** Raw markdown source to render. May be empty. */
+	text: string;
+}>();
+
+interface ParagraphBlock {
+	type: 'paragraph';
+	text: string;
+}
+
+interface CodeBlock {
+	type: 'code';
+	lang: string | null;
+	text: string;
+}
+
+interface BlockquoteBlock {
+	type: 'blockquote';
+	text: string;
+}
+
+interface ListBlock {
+	type: 'list';
+	ordered: boolean;
+	items: string[];
+}
+
+type Block = ParagraphBlock | CodeBlock | BlockquoteBlock | ListBlock;
+
+interface BlockMatch {
+	block: Block | null;
+	next: number;
+}
+
+const FENCE_OPEN = /^```([\w-]*)\s*$/;
+const FENCE_CLOSE = /^```\s*$/;
+const BLOCKQUOTE = /^>\s?/;
+const UL_ITEM = /^[-*+]\s+/;
+const OL_ITEM = /^\d+\.\s+/;
+
+function isBlockBoundary(line: string): boolean {
+	return (
+		line.trim() === '' ||
+		line.startsWith('```') ||
+		BLOCKQUOTE.test(line) ||
+		UL_ITEM.test(line) ||
+		OL_ITEM.test(line)
+	);
+}
+
+function parseFence(lines: string[], i: number): BlockMatch | null {
+	const m = FENCE_OPEN.exec(lines[i]);
+	if (m === null) return null;
+	const lang = m[1].length > 0 ? m[1] : null;
+	const buf: string[] = [];
+	let j = i + 1;
+	while (j < lines.length && !FENCE_CLOSE.test(lines[j])) {
+		buf.push(lines[j]);
+		j++;
+	}
+	if (j < lines.length) j++; // consume closing fence
+	return { block: { type: 'code', lang, text: buf.join('\n') }, next: j };
+}
+
+function parseBlockquote(lines: string[], i: number): BlockMatch | null {
+	if (!BLOCKQUOTE.test(lines[i])) return null;
+	const buf: string[] = [];
+	let j = i;
+	while (j < lines.length && BLOCKQUOTE.test(lines[j])) {
+		buf.push(lines[j].replace(BLOCKQUOTE, ''));
+		j++;
+	}
+	return { block: { type: 'blockquote', text: buf.join('\n') }, next: j };
+}
+
+function parseList(
+	lines: string[],
+	i: number,
+	pattern: RegExp,
+	ordered: boolean,
+): BlockMatch | null {
+	if (!pattern.test(lines[i])) return null;
+	const items: string[] = [];
+	let j = i;
+	while (j < lines.length && pattern.test(lines[j])) {
+		items.push(lines[j].replace(pattern, ''));
+		j++;
+	}
+	return { block: { type: 'list', ordered, items }, next: j };
+}
+
+function parseParagraph(lines: string[], i: number): BlockMatch {
+	const buf: string[] = [lines[i]];
+	let j = i + 1;
+	while (j < lines.length && !isBlockBoundary(lines[j])) {
+		buf.push(lines[j]);
+		j++;
+	}
+	return { block: { type: 'paragraph', text: buf.join('\n') }, next: j };
+}
+
+/**
+ * Splits the raw markdown source into structural blocks. Fenced code blocks
+ * are captured first so their contents are never re-parsed as paragraphs.
+ */
+function parseBlocks(source: string): Block[] {
+	const blocks: Block[] = [];
+	const lines = source.replace(/\r\n/g, '\n').split('\n');
+	let i = 0;
+
+	while (i < lines.length) {
+		if (lines[i].trim() === '') {
+			i++;
+			continue;
+		}
+
+		const match =
+			parseFence(lines, i) ??
+			parseBlockquote(lines, i) ??
+			parseList(lines, i, UL_ITEM, false) ??
+			parseList(lines, i, OL_ITEM, true) ??
+			parseParagraph(lines, i);
+
+		if (match.block !== null) blocks.push(match.block);
+		i = match.next;
+	}
+
+	return blocks;
+}
+
+/**
+ * Inline token types used by `parseInline`. A "text" token is a plain string
+ * that Vue will HTML-escape on insertion; structural tokens carry already-
+ * parsed children.
+ */
+type InlineToken =
+	| { type: 'text'; text: string }
+	| { type: 'bold'; children: InlineToken[] }
+	| { type: 'italic'; children: InlineToken[] }
+	| { type: 'code'; text: string }
+	| { type: 'link'; href: string; children: InlineToken[] };
+
+/**
+ * Returns the link `href` if it is safe to emit, or `null` to drop the
+ * attribute. Anything outside the http/https/mailto allowlist (notably
+ * `javascript:` and `data:` URIs) is rejected.
+ */
+function safeHref(href: string): string | null {
+	const trimmed = href.trim();
+	if (/^(https?:|mailto:)/i.test(trimmed)) return trimmed;
+	// Allow protocol-relative and root-relative paths.
+	if (trimmed.startsWith('/') || trimmed.startsWith('#')) return trimmed;
+	return null;
+}
+
+interface InlineMatch {
+	token: InlineToken;
+	next: number;
+}
+
+function matchInlineCode(source: string, i: number): InlineMatch | null {
+	if (source[i] !== '`') return null;
+	const end = source.indexOf('`', i + 1);
+	if (end === -1) return null;
+	return { token: { type: 'code', text: source.slice(i + 1, end) }, next: end + 1 };
+}
+
+function matchLink(source: string, i: number): InlineMatch | null {
+	if (source[i] !== '[') return null;
+	const labelEnd = source.indexOf(']', i + 1);
+	if (labelEnd === -1 || source[labelEnd + 1] !== '(') return null;
+	const hrefEnd = source.indexOf(')', labelEnd + 2);
+	if (hrefEnd === -1) return null;
+	const label = source.slice(i + 1, labelEnd);
+	const href = source.slice(labelEnd + 2, hrefEnd);
+	return {
+		token: { type: 'link', href, children: parseInline(label) },
+		next: hrefEnd + 1,
+	};
+}
+
+function matchBold(source: string, i: number): InlineMatch | null {
+	if (source[i] !== '*' || source[i + 1] !== '*') return null;
+	const end = source.indexOf('**', i + 2);
+	if (end === -1) return null;
+	return {
+		token: { type: 'bold', children: parseInline(source.slice(i + 2, end)) },
+		next: end + 2,
+	};
+}
+
+function matchItalic(source: string, i: number): InlineMatch | null {
+	if (source[i] !== '*' || source[i + 1] === '*') return null;
+	const end = source.indexOf('*', i + 1);
+	if (end === -1 || source[end + 1] === '*') return null;
+	return {
+		token: { type: 'italic', children: parseInline(source.slice(i + 1, end)) },
+		next: end + 1,
+	};
+}
+
+/**
+ * Tokenises a single inline span. Order of precedence: inline code, links,
+ * bold, italic. Inline code is captured first so its contents are not
+ * re-parsed (so backtick literals can contain `**` etc).
+ */
+function parseInline(source: string): InlineToken[] {
+	const tokens: InlineToken[] = [];
+	let i = 0;
+	let textBuf = '';
+
+	const flushText = () => {
+		if (textBuf.length > 0) {
+			tokens.push({ type: 'text', text: textBuf });
+			textBuf = '';
+		}
+	};
+
+	while (i < source.length) {
+		const match =
+			matchInlineCode(source, i) ??
+			matchLink(source, i) ??
+			matchBold(source, i) ??
+			matchItalic(source, i);
+		if (match !== null) {
+			flushText();
+			tokens.push(match.token);
+			i = match.next;
+			continue;
+		}
+		textBuf += source[i];
+		i++;
+	}
+
+	flushText();
+	return tokens;
+}
+
+function renderInline(tokens: InlineToken[]): (VNode | string)[] {
+	return tokens.map((tok) => {
+		switch (tok.type) {
+			case 'text':
+				return tok.text;
+			case 'bold':
+				return h('strong', renderInline(tok.children));
+			case 'italic':
+				return h('em', renderInline(tok.children));
+			case 'code':
+				return h('code', { class: 'sp-markdown__code' }, tok.text);
+			case 'link': {
+				const safe = safeHref(tok.href);
+				const attrs: Record<string, string> =
+					safe !== null ? { href: safe, rel: 'noopener noreferrer', target: '_blank' } : {};
+				return h('a', { class: 'sp-markdown__link', ...attrs }, renderInline(tok.children));
+			}
+		}
+	});
+}
+
+function renderBlock(block: Block): VNode {
+	switch (block.type) {
+		case 'paragraph':
+			return h('p', { class: 'sp-markdown__p' }, renderInline(parseInline(block.text)));
+		case 'code': {
+			const codeAttrs: Record<string, string> = { class: 'sp-markdown__pre-code' };
+			if (block.lang !== null) codeAttrs['data-lang'] = block.lang;
+			return h('pre', { class: 'sp-markdown__pre' }, [h('code', codeAttrs, block.text)]);
+		}
+		case 'blockquote':
+			return h(
+				'blockquote',
+				{ class: 'sp-markdown__blockquote' },
+				renderInline(parseInline(block.text)),
+			);
+		case 'list': {
+			const tag = block.ordered ? 'ol' : 'ul';
+			return h(
+				tag,
+				{ class: 'sp-markdown__list' },
+				block.items.map((item) =>
+					h('li', { class: 'sp-markdown__li' }, renderInline(parseInline(item))),
+				),
+			);
+		}
+	}
+}
+
+const blocks = computed<Block[]>(() => parseBlocks(props.text));
+</script>
+
+<template>
+	<div class="sp-markdown" data-testid="agent-markdown-block">
+		<component :is="renderBlock(block)" v-for="(block, index) in blocks" :key="index" />
+	</div>
+</template>
+
+<style scoped>
+.sp-markdown {
+	font-size: 0.875rem;
+	color: var(--text-normal);
+	word-break: break-word;
+}
+
+.sp-markdown :deep(.sp-markdown__p) {
+	margin: 0 0 0.5rem;
+	white-space: pre-wrap;
+}
+
+.sp-markdown :deep(.sp-markdown__p):last-child {
+	margin-bottom: 0;
+}
+
+.sp-markdown :deep(.sp-markdown__pre) {
+	margin: 0 0 0.5rem;
+	padding: 0.5rem 0.625rem;
+	border-radius: 4px;
+	background: var(--background-primary-alt, var(--background-primary));
+	border: 1px solid var(--background-modifier-border);
+	overflow-x: auto;
+	font-size: 0.8125rem;
+}
+
+.sp-markdown :deep(.sp-markdown__pre-code) {
+	font-family: var(--font-monospace, ui-monospace, monospace);
+	white-space: pre;
+}
+
+.sp-markdown :deep(.sp-markdown__code) {
+	padding: 0.05rem 0.25rem;
+	border-radius: 3px;
+	background: var(--background-modifier-border);
+	font-family: var(--font-monospace, ui-monospace, monospace);
+	font-size: 0.85em;
+}
+
+.sp-markdown :deep(.sp-markdown__blockquote) {
+	margin: 0 0 0.5rem;
+	padding: 0.25rem 0.625rem;
+	border-left: 3px solid var(--background-modifier-border);
+	color: var(--text-muted);
+	white-space: pre-wrap;
+}
+
+.sp-markdown :deep(.sp-markdown__list) {
+	margin: 0 0 0.5rem;
+	padding-left: 1.25rem;
+}
+
+.sp-markdown :deep(.sp-markdown__li) {
+	margin: 0 0 0.125rem;
+}
+
+.sp-markdown :deep(.sp-markdown__link) {
+	color: var(--text-accent);
+	text-decoration: underline;
+}
+</style>

--- a/src/ui/components/agent/MessageList.vue
+++ b/src/ui/components/agent/MessageList.vue
@@ -12,6 +12,7 @@
 import { computed, nextTick, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useChatStore } from '@/ui/stores/chatStore';
+import MarkdownBlock from '@/ui/components/agent/MarkdownBlock.vue';
 
 const props = defineProps<{
 	/** Active thread id, or `null` when no thread is selected. */
@@ -44,15 +45,12 @@ const scrollContainer = ref<HTMLElement | null>(null);
 // scroll position follows live deltas during a streaming turn. Without the
 // second observed value, the scroll watcher only fires at turn boundaries
 // (appendMessage) and the user has to scroll manually as Claude streams.
-watch(
-	[() => messages.value.length, () => streamingText.value.length],
-	async () => {
-		await nextTick();
-		const el = scrollContainer.value;
-		if (el === null) return;
-		el.scrollTop = el.scrollHeight;
-	},
-);
+watch([() => messages.value.length, () => streamingText.value.length], async () => {
+	await nextTick();
+	const el = scrollContainer.value;
+	if (el === null) return;
+	el.scrollTop = el.scrollHeight;
+});
 </script>
 
 <template>
@@ -76,7 +74,11 @@ watch(
 				{{ message.role === 'user' ? t('agent.roleUser') : t('agent.roleAssistant') }}
 			</header>
 			<div class="sp-agent-message__body" data-testid="agent-message-body">
-				<pre v-if="message.text.length > 0" class="sp-agent-message__text">{{ message.text }}</pre>
+				<MarkdownBlock
+					v-if="message.text.length > 0"
+					class="sp-agent-message__text"
+					:text="message.text"
+				/>
 				<p v-else class="sp-agent-message__empty" data-testid="agent-message-empty">
 					{{ t('agent.assistantEmpty') }}
 				</p>
@@ -98,12 +100,13 @@ watch(
 				{{ t('agent.roleAssistant') }}
 			</header>
 			<div class="sp-agent-message__body">
-				<pre class="sp-agent-message__text">{{ streamingText }}</pre>
+				<MarkdownBlock class="sp-agent-message__text" :text="streamingText" />
 				<span
 					class="sp-agent-message__cursor"
 					aria-hidden="true"
 					data-testid="agent-message-streaming-cursor"
-				>▍</span>
+					>▍</span
+				>
 			</div>
 		</article>
 	</div>
@@ -172,7 +175,6 @@ watch(
 	font-family: inherit;
 	font-size: 0.875rem;
 	color: var(--text-normal);
-	white-space: pre-wrap;
 	word-break: break-word;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -760,7 +760,58 @@ to   { opacity: 1; transform: translateY(0);
 	font-style: italic;
 }
 
-.specorator-root :where(.sp-agent-messages[data-v-289bf981]) {
+.specorator-root :where(.sp-markdown[data-v-b1397c03]) {
+	font-size: 0.875rem;
+	color: var(--text-normal);
+	word-break: break-word;
+}
+.specorator-root :where(.sp-markdown[data-v-b1397c03] .sp-markdown__p) {
+	margin: 0 0 0.5rem;
+	white-space: pre-wrap;
+}
+.specorator-root :where(.sp-markdown[data-v-b1397c03] .sp-markdown__p:last-child) {
+	margin-bottom: 0;
+}
+.specorator-root :where(.sp-markdown[data-v-b1397c03] .sp-markdown__pre) {
+	margin: 0 0 0.5rem;
+	padding: 0.5rem 0.625rem;
+	border-radius: 4px;
+	background: var(--background-primary-alt, var(--background-primary));
+	border: 1px solid var(--background-modifier-border);
+	overflow-x: auto;
+	font-size: 0.8125rem;
+}
+.specorator-root :where(.sp-markdown[data-v-b1397c03] .sp-markdown__pre-code) {
+	font-family: var(--font-monospace, ui-monospace, monospace);
+	white-space: pre;
+}
+.specorator-root :where(.sp-markdown[data-v-b1397c03] .sp-markdown__code) {
+	padding: 0.05rem 0.25rem;
+	border-radius: 3px;
+	background: var(--background-modifier-border);
+	font-family: var(--font-monospace, ui-monospace, monospace);
+	font-size: 0.85em;
+}
+.specorator-root :where(.sp-markdown[data-v-b1397c03] .sp-markdown__blockquote) {
+	margin: 0 0 0.5rem;
+	padding: 0.25rem 0.625rem;
+	border-left: 3px solid var(--background-modifier-border);
+	color: var(--text-muted);
+	white-space: pre-wrap;
+}
+.specorator-root :where(.sp-markdown[data-v-b1397c03] .sp-markdown__list) {
+	margin: 0 0 0.5rem;
+	padding-left: 1.25rem;
+}
+.specorator-root :where(.sp-markdown[data-v-b1397c03] .sp-markdown__li) {
+	margin: 0 0 0.125rem;
+}
+.specorator-root :where(.sp-markdown[data-v-b1397c03] .sp-markdown__link) {
+	color: var(--text-accent);
+	text-decoration: underline;
+}
+
+.specorator-root :where(.sp-agent-messages[data-v-25c3bb88]) {
 	flex: 1 1 auto;
 	min-height: 0;
 	overflow-y: auto;
@@ -769,21 +820,21 @@ to   { opacity: 1; transform: translateY(0);
 	flex-direction: column;
 	gap: 0.75rem;
 }
-.specorator-root :where(.sp-agent-messages--empty[data-v-289bf981]) {
+.specorator-root :where(.sp-agent-messages--empty[data-v-25c3bb88]) {
 	flex: 0 0 auto;
 	padding: 1.25rem 1rem 0;
 	display: flex;
 	align-items: center;
 	justify-content: center;
 }
-.specorator-root :where(.sp-agent-messages__empty-body[data-v-289bf981]) {
+.specorator-root :where(.sp-agent-messages__empty-body[data-v-25c3bb88]) {
 	margin: 0;
 	font-size: 0.8125rem;
 	color: var(--text-muted);
 	text-align: center;
 	font-style: italic;
 }
-.specorator-root :where(.sp-agent-message[data-v-289bf981]) {
+.specorator-root :where(.sp-agent-message[data-v-25c3bb88]) {
 	display: flex;
 	flex-direction: column;
 	gap: 0.25rem;
@@ -792,50 +843,49 @@ to   { opacity: 1; transform: translateY(0);
 	background: var(--background-secondary);
 	border: 1px solid var(--background-modifier-border);
 }
-.specorator-root :where(.sp-agent-message--user[data-v-289bf981]) {
+.specorator-root :where(.sp-agent-message--user[data-v-25c3bb88]) {
 	background: var(--background-secondary-alt, var(--background-secondary));
 }
-.specorator-root :where(.sp-agent-message__role[data-v-289bf981]) {
+.specorator-root :where(.sp-agent-message__role[data-v-25c3bb88]) {
 	font-size: 0.6875rem;
 	font-weight: 600;
 	text-transform: uppercase;
 	letter-spacing: 0.04em;
 	color: var(--text-muted);
 }
-.specorator-root :where(.sp-agent-message__body[data-v-289bf981]) {
+.specorator-root :where(.sp-agent-message__body[data-v-25c3bb88]) {
 	display: flex;
 	flex-direction: column;
 	gap: 0.25rem;
 }
-.specorator-root :where(.sp-agent-message__text[data-v-289bf981]) {
+.specorator-root :where(.sp-agent-message__text[data-v-25c3bb88]) {
 	margin: 0;
 	font-family: inherit;
 	font-size: 0.875rem;
 	color: var(--text-normal);
-	white-space: pre-wrap;
 	word-break: break-word;
 }
-.specorator-root :where(.sp-agent-message__empty[data-v-289bf981]) {
+.specorator-root :where(.sp-agent-message__empty[data-v-25c3bb88]) {
 	margin: 0;
 	font-size: 0.8125rem;
 	color: var(--text-muted);
 	font-style: italic;
 }
-.specorator-root :where(.sp-agent-message__trim-note[data-v-289bf981]) {
+.specorator-root :where(.sp-agent-message__trim-note[data-v-25c3bb88]) {
 	margin: 0;
 	font-size: 0.75rem;
 	color: var(--text-faint);
 }
-.specorator-root :where(.sp-agent-message--streaming[data-v-289bf981]) {
+.specorator-root :where(.sp-agent-message--streaming[data-v-25c3bb88]) {
 	opacity: 0.95;
 }
-.specorator-root :where(.sp-agent-message__cursor[data-v-289bf981]) {
+.specorator-root :where(.sp-agent-message__cursor[data-v-25c3bb88]) {
 	display: inline-block;
 	font-size: 0.875rem;
 	color: var(--text-accent);
-	animation: sp-agent-message__blink-289bf981 1s steps(2, start) infinite;
+	animation: sp-agent-message__blink-25c3bb88 1s steps(2, start) infinite;
 }
-@keyframes sp-agent-message__blink-289bf981 {
+@keyframes sp-agent-message__blink-25c3bb88 {
 to {
 		visibility: hidden;
 }

--- a/tests/ui/components/agent/MarkdownBlock.po.ts
+++ b/tests/ui/components/agent/MarkdownBlock.po.ts
@@ -1,0 +1,72 @@
+import type { VueWrapper } from '@vue/test-utils';
+
+/**
+ * Page object for `MarkdownBlock.vue` (PR-ASV-7). Tests assert on rendered
+ * element types and (escaped) text content — selectors are tag-based because
+ * the markdown component renders structural HTML rather than carrying
+ * `data-testid` on every emitted node. The wrapper root carries the only
+ * `data-testid` (`agent-markdown-block`) and all other queries are scoped to
+ * descendants of that root.
+ */
+export class MarkdownBlockPO {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	get root() {
+		return this.wrapper.find('[data-testid="agent-markdown-block"]');
+	}
+
+	paragraphs() {
+		return this.root.findAll('p');
+	}
+
+	strongs() {
+		return this.root.findAll('strong');
+	}
+
+	ems() {
+		return this.root.findAll('em');
+	}
+
+	inlineCodes() {
+		// `pre > code` is the fenced-block path; bare `code` (not inside `pre`)
+		// is inline.
+		return this.root.findAll('code').filter((c) => c.element.parentElement?.tagName !== 'PRE');
+	}
+
+	codeBlocks() {
+		return this.root.findAll('pre');
+	}
+
+	links() {
+		return this.root.findAll('a');
+	}
+
+	lists() {
+		return this.root.findAll('ul, ol');
+	}
+
+	unorderedLists() {
+		return this.root.findAll('ul');
+	}
+
+	orderedLists() {
+		return this.root.findAll('ol');
+	}
+
+	listItems() {
+		return this.root.findAll('li');
+	}
+
+	blockquotes() {
+		return this.root.findAll('blockquote');
+	}
+
+	/**
+	 * Returns the raw rendered HTML of the markdown root. Used by safety tests
+	 * to assert that angle brackets in user input survive as `&lt;` / `&gt;`
+	 * entities rather than being injected as live tags.
+	 */
+	html() {
+		return this.root.html();
+	}
+}

--- a/tests/ui/components/agent/MarkdownBlock.test.ts
+++ b/tests/ui/components/agent/MarkdownBlock.test.ts
@@ -97,6 +97,26 @@ describe('MarkdownBlock', () => {
 		expect(links[0].text()).toBe('bad');
 	});
 
+	// Codex P2 on PR #373: previously the parser stopped at the first `)`,
+	// truncating URLs that contain balanced parentheses (common in
+	// Wikipedia / docs URLs).
+	it('parses balanced parentheses inside a link URL', () => {
+		const { po } = mountBlock('See [spec](https://example.com/foo(bar)) here.');
+		const links = po.links();
+		expect(links).toHaveLength(1);
+		expect(links[0].text()).toBe('spec');
+		expect(links[0].attributes('href')).toBe('https://example.com/foo(bar)');
+	});
+
+	it('parses nested balanced parens inside a link URL', () => {
+		const { po } = mountBlock('Read [it](https://en.wikipedia.org/wiki/Foo_(disambiguation)) now.');
+		const links = po.links();
+		expect(links).toHaveLength(1);
+		expect(links[0].attributes('href')).toBe(
+			'https://en.wikipedia.org/wiki/Foo_(disambiguation)',
+		);
+	});
+
 	it('renders an unordered list', () => {
 		const { po } = mountBlock('- one\n- two\n- three');
 		expect(po.unorderedLists()).toHaveLength(1);

--- a/tests/ui/components/agent/MarkdownBlock.test.ts
+++ b/tests/ui/components/agent/MarkdownBlock.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for `MarkdownBlock.vue` (PR-ASV-7, agent-sidepanel-v2 D-ASV-5). Covers
+ * each supported markdown construct (paragraph, bold, italic, inline code,
+ * fenced code, links, lists, blockquote) plus XSS-safety: embedded HTML must
+ * be escaped, never executed. The component is mounted directly because it
+ * has no i18n / store dependencies.
+ */
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import MarkdownBlock from '@/ui/components/agent/MarkdownBlock.vue';
+import { MarkdownBlockPO } from './MarkdownBlock.po';
+
+function mountBlock(text: string) {
+	const wrapper = mount(MarkdownBlock, { props: { text } });
+	return { wrapper, po: new MarkdownBlockPO(wrapper) };
+}
+
+describe('MarkdownBlock', () => {
+	it('renders an empty wrapper for empty text', () => {
+		const { po } = mountBlock('');
+		expect(po.root.exists()).toBe(true);
+		expect(po.paragraphs()).toHaveLength(0);
+		expect(po.codeBlocks()).toHaveLength(0);
+	});
+
+	it('renders a plain paragraph', () => {
+		const { po } = mountBlock('Hello, world.');
+		expect(po.paragraphs()).toHaveLength(1);
+		expect(po.paragraphs()[0].text()).toBe('Hello, world.');
+	});
+
+	it('renders two blank-line separated paragraphs', () => {
+		const { po } = mountBlock('First.\n\nSecond.');
+		expect(po.paragraphs()).toHaveLength(2);
+		expect(po.paragraphs()[0].text()).toBe('First.');
+		expect(po.paragraphs()[1].text()).toBe('Second.');
+	});
+
+	it('renders **bold** spans inside paragraphs', () => {
+		const { po } = mountBlock('Make it **really** clear.');
+		expect(po.strongs()).toHaveLength(1);
+		expect(po.strongs()[0].text()).toBe('really');
+	});
+
+	it('renders *italic* spans inside paragraphs', () => {
+		const { po } = mountBlock('A *small* aside.');
+		expect(po.ems()).toHaveLength(1);
+		expect(po.ems()[0].text()).toBe('small');
+	});
+
+	it('renders `inline code` spans', () => {
+		const { po } = mountBlock('Run `npm test` to verify.');
+		const codes = po.inlineCodes();
+		expect(codes).toHaveLength(1);
+		expect(codes[0].text()).toBe('npm test');
+	});
+
+	it('renders fenced ``` code blocks with their language hint', () => {
+		const { po } = mountBlock('```ts\nconst x = 1;\n```');
+		const blocks = po.codeBlocks();
+		expect(blocks).toHaveLength(1);
+		const codeEl = blocks[0].find('code');
+		expect(codeEl.exists()).toBe(true);
+		expect(codeEl.text()).toBe('const x = 1;');
+		expect(codeEl.attributes('data-lang')).toBe('ts');
+	});
+
+	it('renders fenced code blocks without a language hint', () => {
+		const { po } = mountBlock('```\nplain\n```');
+		const blocks = po.codeBlocks();
+		expect(blocks).toHaveLength(1);
+		const codeEl = blocks[0].find('code');
+		expect(codeEl.attributes('data-lang')).toBeUndefined();
+	});
+
+	it('does NOT reparse markdown inside fenced code blocks', () => {
+		const { po } = mountBlock('```\n**not bold**\n```');
+		expect(po.strongs()).toHaveLength(0);
+		expect(po.codeBlocks()[0].text()).toContain('**not bold**');
+	});
+
+	it('renders links with a safe href and noopener rel', () => {
+		const { po } = mountBlock('See [docs](https://example.com).');
+		const links = po.links();
+		expect(links).toHaveLength(1);
+		expect(links[0].text()).toBe('docs');
+		expect(links[0].attributes('href')).toBe('https://example.com');
+		expect(links[0].attributes('rel')).toBe('noopener noreferrer');
+		expect(links[0].attributes('target')).toBe('_blank');
+	});
+
+	it('drops the href on links with a javascript: URI', () => {
+		const { po } = mountBlock('[bad](javascript:alert(1))');
+		const links = po.links();
+		expect(links).toHaveLength(1);
+		expect(links[0].attributes('href')).toBeUndefined();
+		expect(links[0].text()).toBe('bad');
+	});
+
+	it('renders an unordered list', () => {
+		const { po } = mountBlock('- one\n- two\n- three');
+		expect(po.unorderedLists()).toHaveLength(1);
+		expect(po.orderedLists()).toHaveLength(0);
+		const items = po.listItems();
+		expect(items).toHaveLength(3);
+		expect(items[0].text()).toBe('one');
+	});
+
+	it('renders an ordered list', () => {
+		const { po } = mountBlock('1. first\n2. second');
+		expect(po.orderedLists()).toHaveLength(1);
+		expect(po.listItems()).toHaveLength(2);
+		expect(po.listItems()[1].text()).toBe('second');
+	});
+
+	it('renders a blockquote', () => {
+		const { po } = mountBlock('> a quote\n> continues');
+		expect(po.blockquotes()).toHaveLength(1);
+		expect(po.blockquotes()[0].text()).toContain('a quote');
+		expect(po.blockquotes()[0].text()).toContain('continues');
+	});
+
+	it('escapes embedded <script> tags as literal text', () => {
+		const { po } = mountBlock('<script>alert(1)</script>');
+		// No actual <script> element should be present in the rendered HTML.
+		expect(po.root.findAll('script')).toHaveLength(0);
+		// And the rendered HTML must show escaped angle brackets.
+		const html = po.html();
+		expect(html).toContain('&lt;script&gt;');
+		expect(html).not.toContain('<script>alert(1)</script>');
+	});
+
+	it('does NOT execute an <img onerror> payload', () => {
+		const { po } = mountBlock('<img src=x onerror=alert(1)>');
+		// No <img> element should be created — markdown does not parse raw HTML.
+		expect(po.root.findAll('img')).toHaveLength(0);
+		const html = po.html();
+		expect(html).toContain('&lt;img');
+		expect(html).not.toContain('<img src');
+	});
+
+	it('escapes angle brackets inside fenced code blocks too', () => {
+		const { po } = mountBlock('```\n<script>alert(1)</script>\n```');
+		expect(po.root.findAll('script')).toHaveLength(0);
+		const html = po.html();
+		expect(html).toContain('&lt;script&gt;');
+	});
+});

--- a/tests/ui/components/agent/MessageList.po.ts
+++ b/tests/ui/components/agent/MessageList.po.ts
@@ -30,4 +30,13 @@ export class MessageListPO {
 	emptyAssistantPlaceholders() {
 		return this.wrapper.findAll(this.byTid('agent-message-empty'));
 	}
+
+	/**
+	 * Returns the rendered HTML of all markdown bodies in the active thread.
+	 * Used to assert markdown features (bold, code, code blocks) and to verify
+	 * that potentially unsafe input was escaped.
+	 */
+	markdownBlocks() {
+		return this.wrapper.findAll(this.byTid('agent-markdown-block'));
+	}
 }

--- a/tests/ui/components/agent/MessageList.test.ts
+++ b/tests/ui/components/agent/MessageList.test.ts
@@ -102,6 +102,51 @@ describe('MessageList', () => {
 		expect(po.userMessages()[0].text()).toContain('B-user');
 	});
 
+	it('renders bold markdown in an assistant turn (PR-ASV-7)', () => {
+		const store = useChatStore();
+		const tid = 'thread-bold';
+		store.appendMessage(msg(tid, 'assistant', { text: 'Make it **really** clear.' }));
+		const { po } = mountList(tid);
+		const blocks = po.markdownBlocks();
+		expect(blocks).toHaveLength(1);
+		expect(blocks[0].findAll('strong')).toHaveLength(1);
+		expect(blocks[0].find('strong').text()).toBe('really');
+	});
+
+	it('renders inline code from backticks (PR-ASV-7)', () => {
+		const store = useChatStore();
+		const tid = 'thread-inline-code';
+		store.appendMessage(msg(tid, 'assistant', { text: 'Run `npm test` first.' }));
+		const { po } = mountList(tid);
+		const inline = po
+			.markdownBlocks()[0]
+			.findAll('code')
+			.filter((c) => c.element.parentElement?.tagName !== 'PRE');
+		expect(inline).toHaveLength(1);
+		expect(inline[0].text()).toBe('npm test');
+	});
+
+	it('renders fenced code blocks from triple-backtick fences (PR-ASV-7)', () => {
+		const store = useChatStore();
+		const tid = 'thread-fence';
+		store.appendMessage(msg(tid, 'assistant', { text: '```ts\nconst x = 1;\n```' }));
+		const { po } = mountList(tid);
+		const pre = po.markdownBlocks()[0].findAll('pre');
+		expect(pre).toHaveLength(1);
+		expect(pre[0].find('code').text()).toBe('const x = 1;');
+	});
+
+	it('escapes embedded HTML in message text (PR-ASV-7 XSS safety)', () => {
+		const store = useChatStore();
+		const tid = 'thread-xss';
+		store.appendMessage(msg(tid, 'assistant', { text: '<script>alert(1)</script>' }));
+		const { po } = mountList(tid);
+		const html = po.markdownBlocks()[0].html();
+		expect(html).toContain('&lt;script&gt;');
+		expect(html).not.toContain('<script>alert(1)</script>');
+		expect(po.markdownBlocks()[0].findAll('script')).toHaveLength(0);
+	});
+
 	it('exposes role="log" with the aria-live="polite" hint on the scroll container', () => {
 		const store = useChatStore();
 		const tid = 'thread-aria';


### PR DESCRIPTION
## Summary

Markdown rendering for the agent sidepanel's `MessageList` — replaces the previous `<pre>{{ text }}</pre>` plain-text rendering with a hand-rolled markdown→Vue-VNode renderer. No new runtime dependency.

**Stacked on #372 → #371 → #370 → #369 → develop.**

### New component

`src/ui/components/agent/MarkdownBlock.vue` — small markdown renderer using `h()`. Supports:
- Paragraphs (multi-paragraph)
- `**bold**`, `*italic*`, `` `inline code` ``
- Fenced code blocks (with optional language hint via `data-lang`)
- Ordered + unordered lists
- Blockquotes
- Links (with `javascript:` URI allowlist rejection, `rel="noopener noreferrer" target="_blank"` on safe links)

### MessageList integration

- Imports `MarkdownBlock`, swaps both the assistant-turn `<pre>` AND the streaming-bubble `<pre>` for `<MarkdownBlock :text="…" />`.
- Drops obsolete `white-space: pre-wrap` from `.sp-agent-message__text` (markdown component now governs whitespace per-block).

### DOM safety

- No `v-html`, no `innerHTML` — would fail lint anyway.
- All user-supplied text reaches the DOM as `h()` children → Vue HTML-escapes on write.
- XSS tests confirm `<script>` and `<img onerror=…>` payloads render as escaped text and do not execute.

## Test plan

- [x] **17 new MarkdownBlock unit tests** covering each rendered tag, the link allowlist, and two XSS scenarios.
- [x] **4 new MessageList integration tests** — bold rendering, inline code, fenced code blocks, XSS escape through the full mount path.
- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 errors
- [x] `npm run test` — 1489/1489 pass on the markdown branch

https://claude.ai/code/session_01VvXsK3aGp2g4jSpT1py7Mh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvXsK3aGp2g4jSpT1py7Mh)_