### PR TITLE
feat(agent): slash-command palette (PR-ASV-3)

### DIFF
--- a/src/application/chat/builtInSlashCommands.ts
+++ b/src/application/chat/builtInSlashCommands.ts
@@ -1,0 +1,41 @@
+import type { SlashCommand } from '@/domain/chat/SlashCommand';
+
+/**
+ * Built-in slash commands shipped with the agent sidepanel (PR-ASV-3,
+ * D-ASV-2). Frozen so consumers cannot mutate the registry at runtime.
+ *
+ * Order matters: this is the rendering order in the dropdown when the query
+ * matches every entry (e.g. the bare `/` trigger). Keep `/help` last so the
+ * action surface stays oriented toward "do" verbs before "discover" verbs.
+ *
+ * `/advance-stage` is a placeholder (Increment 4 lands the real impl). Showing
+ * it in the palette today is a deliberate discovery surface — users see it,
+ * learn the verb, and the click yields a toast explaining it's not wired up
+ * yet.
+ */
+export const BUILT_IN_SLASH_COMMANDS: readonly SlashCommand[] = Object.freeze([
+	Object.freeze({
+		name: 'clear',
+		description: 'Clear the input box without sending',
+		kind: 'builtin' as const,
+		action: 'clear-input' as const,
+	}),
+	Object.freeze({
+		name: 'new',
+		description: 'Start a new conversation (rotates the active thread)',
+		kind: 'builtin' as const,
+		action: 'new-conversation' as const,
+	}),
+	Object.freeze({
+		name: 'advance-stage',
+		description: 'Advance the active feature to the next stage (coming soon)',
+		kind: 'builtin' as const,
+		action: 'advance-stage' as const,
+	}),
+	Object.freeze({
+		name: 'help',
+		description: 'Show available slash commands',
+		kind: 'builtin' as const,
+		action: 'help' as const,
+	}),
+]);

--- a/src/domain/chat/SlashCommand.ts
+++ b/src/domain/chat/SlashCommand.ts
@@ -1,0 +1,38 @@
+/**
+ * Plain DTO describing an entry in the slash-command palette (PR-ASV-3 of
+ * agent-sidepanel-v2, D-ASV-2). The palette opens when the user types `/` at
+ * position 0 of the textarea or after whitespace, and surfaces a filtered list
+ * of commands the agent sidepanel knows how to dispatch.
+ *
+ * Domain layer (ADR-008): no `obsidian` imports. Built-ins are encoded as
+ * frozen TypeScript values; future variants `'vault'` / `'sdk'` (PR-ASV-6) will
+ * load commands from `.claude/commands/*.md` via `VaultPort` and from the
+ * Anthropic Agent SDK's `supportedCommands()` probe.
+ *
+ * Action ids are kept intentionally narrow — the UI layer maps each id to a
+ * concrete dispatch in `ChatSidebar.vue` / `AgentSidepanelRoot.vue`. Keeping
+ * the action space closed (rather than handing the dropdown a callback) keeps
+ * the domain DTO serialisable for future persistence and lets the test surface
+ * assert against string literals.
+ */
+export interface SlashCommand {
+	/** Command name WITHOUT the leading `/`. Lowercased, kebab-case. */
+	readonly name: string;
+	/** One-line human-readable description shown in the dropdown. */
+	readonly description: string;
+	/** Source of the command. Today only `'builtin'`; vault/SDK land later. */
+	readonly kind: 'builtin';
+	/** Action id dispatched by the UI when the user selects this command. */
+	readonly action: SlashCommandAction;
+}
+
+/**
+ * Closed set of dispatch ids the agent sidepanel understands. Keep this list
+ * in lockstep with the switch in `AgentSidepanelRoot.handleSelectCommand` (and
+ * any future dispatcher).
+ */
+export type SlashCommandAction =
+	| 'clear-input'
+	| 'new-conversation'
+	| 'help'
+	| 'advance-stage';

--- a/src/ui/agent/AgentSidepanelRoot.vue
+++ b/src/ui/agent/AgentSidepanelRoot.vue
@@ -9,10 +9,9 @@
  * sidepanel-only chrome on top.
  *
  * Lifts the chat into its own Obsidian `ItemView` per IDEA-ASV-001 / specs/
- * agent-sidepanel-v2/idea.md. Slash-command palette, `@`-file mentions, and
- * streaming land in Increment 2+.
+ * agent-sidepanel-v2/idea.md. Slash-command palette landed in PR-ASV-3.
  */
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useChatStore } from '@/ui/stores/chatStore';
 import { useNotificationStore } from '@/ui/stores/notificationStore';
 import { onMounted, onUnmounted } from 'vue';
@@ -21,6 +20,8 @@ import ErrorBoundary from '@/ui/components/ErrorBoundary.vue';
 import AgentSidepanelHeader from '@/ui/components/agent/AgentSidepanelHeader.vue';
 import MessageList from '@/ui/components/agent/MessageList.vue';
 import ChatSidebar from '@/ui/components/chat/ChatSidebar.vue';
+import type { SlashCommand } from '@/domain/chat/SlashCommand';
+import { BUILT_IN_SLASH_COMMANDS } from '@/application/chat/builtInSlashCommands';
 
 const store = useChatStore();
 const notificationStore = useNotificationStore();
@@ -32,6 +33,16 @@ const activeFeature = computed(() => {
 	if (tid === null) return null;
 	return store.chatThreads.get(tid)?.feature ?? null;
 });
+
+/**
+ * Whether the inline `/help` panel is open. Toggled by the `'help'` slash
+ * command (PR-ASV-3, D-ASV-2). Lives on the root rather than `ChatSidebar`
+ * because the help panel is a sidepanel-level affordance — it sits above the
+ * chat surface, not inside the input area.
+ */
+const helpOpen = ref(false);
+
+const helpCommands = computed<readonly SlashCommand[]>(() => BUILT_IN_SLASH_COMMANDS);
 
 function onNotice(e: Event): void {
 	const { message, durationMs } = (
@@ -77,6 +88,37 @@ function handleNewConversation(): void {
 	store.setUserText('');
 }
 
+/**
+ * Dispatch a slash-command selection emitted by `ChatSidebar` (PR-ASV-3,
+ * D-ASV-2). The action ids form a closed switch — every variant of
+ * `SlashCommandAction` must have a branch. Future work (vault / SDK commands)
+ * will introduce new action ids that need branches here.
+ */
+function handleSelectCommand(command: SlashCommand): void {
+	switch (command.action) {
+		case 'clear-input':
+			store.setUserText('');
+			return;
+		case 'new-conversation':
+			// Mirror the header button's guard rail so the keyboard-driven
+			// dispatch can't strand an in-flight response on a cleared thread
+			// (Codex P1, PR #369 second review).
+			if (store.status === 'loading') return;
+			handleNewConversation();
+			return;
+		case 'help':
+			helpOpen.value = true;
+			return;
+		case 'advance-stage':
+			notificationStore.addNotice('Not yet implemented in v2', 4000);
+			return;
+	}
+}
+
+function closeHelp(): void {
+	helpOpen.value = false;
+}
+
 onMounted(() => {
 	window.addEventListener('sp:notice', onNotice);
 });
@@ -95,9 +137,42 @@ onUnmounted(() => {
 				:request-in-flight="isRequestInFlight"
 				@new-conversation="handleNewConversation"
 			/>
+			<div
+				v-if="helpOpen"
+				class="sp-agent__help"
+				role="region"
+				aria-label="Slash command help"
+				data-testid="agent-help-panel"
+			>
+				<header class="sp-agent__help-header">
+					<span class="sp-agent__help-title" data-testid="agent-help-title">
+						Available slash commands
+					</span>
+					<button
+						type="button"
+						class="sp-agent__help-close"
+						data-testid="agent-help-close"
+						aria-label="Close help"
+						@click="closeHelp"
+					>
+						Close
+					</button>
+				</header>
+				<ul class="sp-agent__help-list" data-testid="agent-help-list">
+					<li
+						v-for="command in helpCommands"
+						:key="command.name"
+						class="sp-agent__help-item"
+						:data-testid="`agent-help-item-${command.name}`"
+					>
+						<span class="sp-agent__help-name">/{{ command.name }}</span>
+						<span class="sp-agent__help-description">{{ command.description }}</span>
+					</li>
+				</ul>
+			</div>
 			<div class="sp-agent__body">
 				<MessageList :thread-id="activeThreadId" />
-				<ChatSidebar />
+				<ChatSidebar @select-command="handleSelectCommand" />
 			</div>
 		</ErrorBoundary>
 		<AppToast />
@@ -117,5 +192,67 @@ onUnmounted(() => {
 	display: flex;
 	flex-direction: column;
 	min-height: 0;
+}
+
+.sp-agent__help {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	padding: 0.75rem 1rem;
+	background: var(--background-secondary);
+	border-bottom: 1px solid var(--background-modifier-border);
+	flex-shrink: 0;
+}
+
+.sp-agent__help-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
+
+.sp-agent__help-title {
+	font-size: 0.875rem;
+	font-weight: 600;
+	color: var(--text-normal);
+}
+
+.sp-agent__help-close {
+	font-size: 0.75rem;
+	font-weight: 500;
+	padding: 0.2rem 0.5rem;
+	border-radius: 4px;
+	border: 1px solid var(--background-modifier-border);
+	background: var(--background-primary);
+	color: var(--text-normal);
+	cursor: pointer;
+}
+
+.sp-agent__help-close:hover {
+	background: var(--interactive-hover);
+}
+
+.sp-agent__help-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+}
+
+.sp-agent__help-item {
+	display: flex;
+	gap: 0.5rem;
+	font-size: 0.8125rem;
+	color: var(--text-normal);
+}
+
+.sp-agent__help-name {
+	font-weight: 600;
+	min-width: 7rem;
+}
+
+.sp-agent__help-description {
+	color: var(--text-muted);
 }
 </style>

--- a/src/ui/components/chat/ChatInput.vue
+++ b/src/ui/components/chat/ChatInput.vue
@@ -227,22 +227,25 @@ function handlePickerKey(event: KeyboardEvent): boolean {
 	return false;
 }
 
+function tryHandleSendKey(event: KeyboardEvent): boolean {
+	if (event.key !== 'Enter') return false;
+	if (!(event.ctrlKey || event.metaKey)) return false;
+	if (props.disabled || props.loading) return false;
+	event.preventDefault();
+	if (picker.open.value) picker.close();
+	if (palette.isOpen.value) palette.close();
+	emit('send');
+	return true;
+}
+
 function handleKeydown(event: KeyboardEvent): void {
 	// IME-composition guard. `isComposing` is true while a Japanese/Chinese/
 	// Korean IME is mid-composition; pressing Enter to commit must NOT
-	// trigger send / commit-mention / dismiss-palette. `keyCode === 229`
-	// is the legacy IME indicator.
+	// trigger send / commit-mention / dismiss-palette.
 	if (event.isComposing || event.keyCode === 229) return;
 	if (handlePickerKey(event)) return;
 	if (handlePaletteKeydown(event)) return;
-	if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
-		if (!props.disabled && !props.loading) {
-			event.preventDefault();
-			if (picker.open.value) picker.close();
-			if (palette.isOpen.value) palette.close();
-			emit('send');
-		}
-	}
+	tryHandleSendKey(event);
 }
 
 function handleInput(event: Event): void {

--- a/src/ui/components/chat/ChatInput.vue
+++ b/src/ui/components/chat/ChatInput.vue
@@ -100,7 +100,15 @@ function syncPaletteFromTextarea(): void {
 function scrubSlashTrigger(): void {
 	const ta = textareaEl.value;
 	if (ta === null) return;
-	const trigger = detectSlashTrigger(ta.value, ta.selectionStart);
+	// Codex P2 (third pass) on PR #375: use `selectionEnd`, NOT
+	// `selectionStart`. When a selection exists (e.g. after Ctrl+A),
+	// `selectionStart` is `0` while `selectionEnd` is the visual caret
+	// end. The trigger detector slices the prefix up to its caret arg,
+	// so `selectionStart = 0` made it return null and the scrub was a
+	// no-op — `/help` + Ctrl+A + Enter left the slash text behind.
+	// `selectionEnd` is the actual caret position both with and without
+	// a selection, matching `selectionStart` when no range is active.
+	const trigger = detectSlashTrigger(ta.value, ta.selectionEnd);
 	if (trigger === null) return;
 	// Codex P2 (second pass) on PR #375: `detectSlashTrigger` slices to the
 	// CURRENT caret, but the user may have moved the caret left inside the

--- a/src/ui/components/chat/ChatInput.vue
+++ b/src/ui/components/chat/ChatInput.vue
@@ -1,245 +1,341 @@
 <script setup lang="ts">
-import { ref, onBeforeUnmount } from 'vue'
-import { useVaultPort } from '@/ui/composables/useVaultPort'
-import { useMentionPicker } from '@/ui/composables/useMentionPicker'
-import type { MentionCandidate } from '@/application/chat/vaultFileSearch'
-import { basenameOf } from '@/application/chat/vaultFileSearch'
-import MentionDropdown from './MentionDropdown.vue'
+/**
+ * Textarea + send-button input for the chat sidebar. Owns:
+ *   - Slash-command palette trigger detection (PR-ASV-3, D-ASV-2)
+ *   - @-mention picker trigger detection (PR-ASV-4, D-ASV-3)
+ *
+ * Both palettes share the textarea event wiring. Slash palette opens when
+ * the caret is preceded by `/` either at position 0 or after whitespace.
+ * Mention picker opens via `useMentionPicker.handleInput()`.
+ */
+import { ref, onBeforeUnmount } from 'vue';
+import { useVaultPort } from '@/ui/composables/useVaultPort';
+import { useMentionPicker } from '@/ui/composables/useMentionPicker';
+import type { MentionCandidate } from '@/application/chat/vaultFileSearch';
+import { basenameOf } from '@/application/chat/vaultFileSearch';
+import MentionDropdown from './MentionDropdown.vue';
+import type { SlashCommand } from '@/domain/chat/SlashCommand';
+import { useSlashPalette } from '@/ui/composables/useSlashPalette';
+import SlashCommandDropdown from './SlashCommandDropdown.vue';
 
 const props = defineProps<{
-  modelValue: string
-  disabled: boolean
-  loading: boolean
-}>()
+	modelValue: string;
+	disabled: boolean;
+	loading: boolean;
+}>();
 
 const emit = defineEmits<{
-  'update:modelValue': [value: string]
-  send: []
-  /**
-   * Emitted alongside `update:modelValue` when the user accepts a mention
-   * candidate. The consumer is responsible for invoking
-   * `chatStore.addContextFile` so a context-file chip is created
-   * (PR-ASV-4 / D-ASV-3 — the inline token and the chip travel together).
-   */
-  'add-context-file': [candidate: MentionCandidate]
-}>()
+	'update:modelValue': [value: string];
+	send: [];
+	/**
+	 * Emitted alongside `update:modelValue` when the user accepts a mention
+	 * candidate. The consumer is responsible for invoking
+	 * `chatStore.addContextFile` so a context-file chip is created
+	 * (PR-ASV-4 / D-ASV-3 — the inline token and the chip travel together).
+	 */
+	'add-context-file': [candidate: MentionCandidate];
+	'select-command': [command: SlashCommand];
+}>();
 
-const textareaEl = ref<HTMLTextAreaElement | null>(null)
-const vaultPort = useVaultPort()
-const picker = useMentionPicker(vaultPort)
+const textareaEl = ref<HTMLTextAreaElement | null>(null);
+const vaultPort = useVaultPort();
+const picker = useMentionPicker(vaultPort);
+const palette = useSlashPalette();
 
-defineExpose({ textareaEl })
-
-onBeforeUnmount(() => {
-  // Cancel any pending debounce / discard in-flight scans so timer
-  // callbacks do not fire against an unmounted reactive ref.
-  picker.close()
-})
+defineExpose({ textareaEl, palette });
 
 /**
- * Tab / non-modifier Enter handler for the open picker — consume to
- * commit; otherwise let the caller treat the event normally. Split out
- * to keep `handlePickerKey` under the project's complexity budget.
+ * Detect a `/` trigger by scanning backward from the caret. Returns the query
+ * substring (everything after the `/`, no leading slash) when the trigger is
+ * either at position 0 or preceded by whitespace; otherwise `null`.
  */
-function tryCommitFromKey(event: KeyboardEvent): boolean {
-  if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) return false
-  const selection = picker.currentSelection()
-  if (selection === null) return false
-  event.preventDefault()
-  commitMention(selection)
-  return true
+function detectSlashTrigger(value: string, caret: number): string | null {
+	if (caret < 1) return null;
+	const prefix = value.slice(0, caret);
+	const match = /(?:^|\s)\/([^\s]*)$/.exec(prefix);
+	if (match === null) return null;
+	return match[1];
+}
+
+function syncPaletteFromTextarea(): void {
+	const ta = textareaEl.value;
+	if (ta === null) {
+		palette.close();
+		return;
+	}
+	const query = detectSlashTrigger(ta.value, ta.selectionStart);
+	if (query === null) {
+		if (palette.isOpen.value) palette.close();
+		return;
+	}
+	if (palette.isOpen.value) {
+		palette.setQuery(query);
+	} else {
+		palette.open(query);
+	}
+}
+
+function handleSelectFromPalette(command: SlashCommand): void {
+	palette.close();
+	emit('select-command', command);
+	textareaEl.value?.focus();
+}
+
+function handleHighlight(index: number): void {
+	const current = palette.selectedIndex.value;
+	if (current === index) return;
+	palette.navigate(index - current);
 }
 
 /**
- * Picker keyboard handler. Returns `true` if the event was consumed —
- * the caller skips its own send handling in that case. Kept as a
- * separate function so `handleKeydown` stays within the project's
- * complexity budget.
+ * Returns `true` when the keydown was consumed by the palette and the caller
+ * should NOT fall through to send/keystroke handling.
+ */
+function handlePaletteKeydown(event: KeyboardEvent): boolean {
+	if (!palette.isOpen.value) return false;
+	if (event.key === 'ArrowDown') {
+		event.preventDefault();
+		palette.navigate(1);
+		return true;
+	}
+	if (event.key === 'ArrowUp') {
+		event.preventDefault();
+		palette.navigate(-1);
+		return true;
+	}
+	if (event.key === 'Escape') {
+		event.preventDefault();
+		palette.close();
+		return true;
+	}
+	if (event.key === 'Enter' || event.key === 'Tab') {
+		const command = palette.select();
+		if (command !== null) {
+			event.preventDefault();
+			palette.close();
+			emit('select-command', command);
+			return true;
+		}
+	}
+	return false;
+}
+
+onBeforeUnmount(() => {
+	// Cancel any pending debounce / discard in-flight scans so timer
+	// callbacks do not fire against an unmounted reactive ref.
+	picker.close();
+});
+
+/**
+ * Tab / non-modifier Enter handler for the open picker — consume to commit.
+ */
+function tryCommitFromKey(event: KeyboardEvent): boolean {
+	if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) return false;
+	const selection = picker.currentSelection();
+	if (selection === null) return false;
+	event.preventDefault();
+	commitMention(selection);
+	return true;
+}
+
+/**
+ * Picker keyboard handler. Returns `true` if the event was consumed.
  */
 function handlePickerKey(event: KeyboardEvent): boolean {
-  // Codex P2 on PR #376: Escape must dismiss the picker even when the
-  // result list is empty (zero matches OR a scan error cleared results).
-  // The previous guard required BOTH `open` and `hasResults`, so users
-  // were stranded with no keyboard way to leave mention mode until
-  // blur or further text changes.
-  if (!picker.open.value) return false
-  if (event.key === 'Escape') {
-    event.preventDefault()
-    picker.close()
-    return true
-  }
-  // Navigation and commit keys still require results to be useful.
-  if (!picker.hasResults.value) return false
-  if (event.key === 'ArrowDown') {
-    event.preventDefault()
-    picker.moveSelectionDown()
-    return true
-  }
-  if (event.key === 'ArrowUp') {
-    event.preventDefault()
-    picker.moveSelectionUp()
-    return true
-  }
-  if (event.key === 'Tab' || event.key === 'Enter') {
-    return tryCommitFromKey(event)
-  }
-  return false
+	if (!picker.open.value) return false;
+	if (event.key === 'Escape') {
+		event.preventDefault();
+		picker.close();
+		return true;
+	}
+	if (!picker.hasResults.value) return false;
+	if (event.key === 'ArrowDown') {
+		event.preventDefault();
+		picker.moveSelectionDown();
+		return true;
+	}
+	if (event.key === 'ArrowUp') {
+		event.preventDefault();
+		picker.moveSelectionUp();
+		return true;
+	}
+	if (event.key === 'Tab' || event.key === 'Enter') {
+		return tryCommitFromKey(event);
+	}
+	return false;
 }
 
 function handleKeydown(event: KeyboardEvent): void {
-  // IME-composition guard (top-4 from comparative review). `isComposing`
-  // is `true` while a Japanese/Chinese/Korean IME is mid-composition;
-  // pressing Enter to commit the composition must NOT trigger send /
-  // commit-mention / dismiss-picker. `keyCode === 229` is the legacy IME
-  // indicator for older browsers — defence in depth.
-  if (event.isComposing || event.keyCode === 229) return
-  if (handlePickerKey(event)) return
-  if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
-    if (!props.disabled && !props.loading) {
-      event.preventDefault()
-      // Codex P2 on PR #376: close the mention picker before the send.
-      // Without this, the dropdown stays mounted on a now-readonly
-      // textarea during loading, and a subsequent Enter/Tab can commit
-      // a mention mid-request and mutate `modelValue` / `contextFiles`
-      // while the send is in flight — breaking the disabled-input
-      // contract and leaving stale UI behind after submit.
-      if (picker.open.value) picker.close()
-      emit('send')
-    }
-  }
+	// IME-composition guard. `isComposing` is true while a Japanese/Chinese/
+	// Korean IME is mid-composition; pressing Enter to commit must NOT
+	// trigger send / commit-mention / dismiss-palette. `keyCode === 229`
+	// is the legacy IME indicator.
+	if (event.isComposing || event.keyCode === 229) return;
+	if (handlePickerKey(event)) return;
+	if (handlePaletteKeydown(event)) return;
+	if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+		if (!props.disabled && !props.loading) {
+			event.preventDefault();
+			if (picker.open.value) picker.close();
+			if (palette.isOpen.value) palette.close();
+			emit('send');
+		}
+	}
 }
 
 function handleInput(event: Event): void {
-  const ta = event.target as HTMLTextAreaElement
-  emit('update:modelValue', ta.value)
-  picker.handleInput(ta.value, ta.selectionStart)
+	const ta = event.target as HTMLTextAreaElement;
+	emit('update:modelValue', ta.value);
+	picker.handleInput(ta.value, ta.selectionStart);
+	syncPaletteFromTextarea();
+}
+
+function handleClick(): void {
+	syncPaletteFromTextarea();
+}
+
+function handleKeyup(event: KeyboardEvent): void {
+	if (
+		event.key === 'ArrowLeft' ||
+		event.key === 'ArrowRight' ||
+		event.key === 'Home' ||
+		event.key === 'End'
+	) {
+		syncPaletteFromTextarea();
+	}
+}
+
+function handleBlur(): void {
+	if (palette.isOpen.value) palette.close();
+	picker.close();
 }
 
 function commitMention(candidate: MentionCandidate): void {
-  // Codex P2 on PR #376: replace the `@<query>` span using trigger
-  // bounds, NOT the current caret. The picker may stay open while the
-  // user moves the caret with ArrowLeft/ArrowRight; using
-  // `ta.selectionStart` would slice the wrong suffix and leak the old
-  // query (or unrelated text) into the prompt. `picker.atIndex` is the
-  // `@`, and `picker.atIndex + 1 + picker.query.length` is the end of
-  // the detected token at the time the picker last opened/updated.
-  const at = picker.atIndex.value
-  if (at < 0) {
-    picker.close()
-    return
-  }
-  const queryEnd = at + 1 + picker.query.value.length
-  const before = props.modelValue.slice(0, at)
-  const after = props.modelValue.slice(queryEnd)
-  // PR-ASV-4-folders: folders commit as `@<name>/` (no trailing space,
-  // user keeps typing into the folder) and do NOT emit
-  // `add-context-file` — folders aren't context chips, only files are.
-  // Files keep the original `@<filename> ` shape (trailing space) and
-  // still emit the chip-creation event.
-  const token =
-    candidate.kind === 'folder'
-      ? `@${basenameOf(candidate.path)}/`
-      : `@${basenameOf(candidate.path)} `
-  const next = `${before}${token}${after}`
-  emit('update:modelValue', next)
-  if (candidate.kind === 'file') {
-    emit('add-context-file', candidate)
-  }
-  picker.close()
-  // Restore caret after the inserted token. Wrapped in a microtask
-  // because the textarea value updates after the parent re-renders.
-  void Promise.resolve().then(() => {
-    const el = textareaEl.value
-    if (el === null) return
-    const pos = before.length + token.length
-    el.focus()
-    el.setSelectionRange(pos, pos)
-  })
+	const at = picker.atIndex.value;
+	if (at < 0) {
+		picker.close();
+		return;
+	}
+	const queryEnd = at + 1 + picker.query.value.length;
+	const before = props.modelValue.slice(0, at);
+	const after = props.modelValue.slice(queryEnd);
+	// PR-ASV-4-folders: folders commit as `@<name>/` and don't emit a chip.
+	const token =
+		candidate.kind === 'folder'
+			? `@${basenameOf(candidate.path)}/`
+			: `@${basenameOf(candidate.path)} `;
+	const next = `${before}${token}${after}`;
+	emit('update:modelValue', next);
+	if (candidate.kind === 'file') {
+		emit('add-context-file', candidate);
+	}
+	picker.close();
+	void Promise.resolve().then(() => {
+		const el = textareaEl.value;
+		if (el === null) return;
+		const pos = before.length + token.length;
+		el.focus();
+		el.setSelectionRange(pos, pos);
+	});
 }
 
 function onDropdownSelect(candidate: MentionCandidate): void {
-  commitMention(candidate)
+	commitMention(candidate);
 }
 
 function onDropdownHover(index: number): void {
-  picker.setSelectedIndex(index)
+	picker.setSelectedIndex(index);
 }
 </script>
 
 <template>
-  <div class="sp-chat__input-area">
-    <textarea
-      ref="textareaEl"
-      class="sp-chat__textarea"
-      :value="modelValue"
-      :readonly="disabled"
-      :aria-label="'Message'"
-      aria-multiline="true"
-      :aria-expanded="picker.open.value"
-      aria-autocomplete="list"
-      :aria-controls="picker.open.value ? 'mention-dropdown' : undefined"
-      placeholder="Ask anything about your work…"
-      rows="3"
-      data-testid="chat-input-textarea"
-      @input="handleInput"
-      @keydown="handleKeydown"
-      @blur="picker.close()"
-    />
-    <MentionDropdown
-      v-if="picker.open.value"
-      id="mention-dropdown"
-      :results="picker.results.value"
-      :selected-index="picker.selectedIndex.value"
-      @select="onDropdownSelect"
-      @hover="onDropdownHover"
-    />
-    <div class="sp-chat__input-actions">
-      <button
-        type="button"
-        class="sp-btn sp-btn--primary sp-btn--md"
-        :disabled="disabled"
-        aria-label="Send message"
-        data-testid="chat-send-button"
-        @click="!disabled && !loading && emit('send')"
-      >
-        <span v-if="loading" class="sp-btn__spinner" aria-hidden="true" />
-        <span>{{ loading ? 'Asking…' : 'Ask' }}</span>
-      </button>
-    </div>
-  </div>
+	<div class="sp-chat__input-area">
+		<div class="sp-chat__input-wrapper">
+			<SlashCommandDropdown
+				v-if="palette.isOpen.value"
+				:commands="palette.matchedCommands.value"
+				:selected-index="palette.selectedIndex.value"
+				@select="handleSelectFromPalette"
+				@highlight="handleHighlight"
+			/>
+			<textarea
+				ref="textareaEl"
+				class="sp-chat__textarea"
+				:value="modelValue"
+				:readonly="disabled"
+				:aria-label="'Message'"
+				aria-multiline="true"
+				:aria-expanded="picker.open.value"
+				aria-autocomplete="list"
+				:aria-controls="picker.open.value ? 'mention-dropdown' : undefined"
+				placeholder="Ask anything about your work…"
+				rows="3"
+				data-testid="chat-input-textarea"
+				@input="handleInput"
+				@keydown="handleKeydown"
+				@keyup="handleKeyup"
+				@click="handleClick"
+				@blur="handleBlur"
+			/>
+			<MentionDropdown
+				v-if="picker.open.value"
+				id="mention-dropdown"
+				:results="picker.results.value"
+				:selected-index="picker.selectedIndex.value"
+				@select="onDropdownSelect"
+				@hover="onDropdownHover"
+			/>
+		</div>
+		<div class="sp-chat__input-actions">
+			<button
+				type="button"
+				class="sp-btn sp-btn--primary sp-btn--md"
+				:disabled="disabled"
+				aria-label="Send message"
+				data-testid="chat-send-button"
+				@click="!disabled && !loading && emit('send')"
+			>
+				<span v-if="loading" class="sp-btn__spinner" aria-hidden="true" />
+				<span>{{ loading ? 'Asking…' : 'Ask' }}</span>
+			</button>
+		</div>
+	</div>
 </template>
 
 <style scoped>
 .sp-chat__input-area {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  position: relative;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.sp-chat__input-wrapper {
+	position: relative;
 }
 
 .sp-chat__textarea {
-  width: 100%;
-  min-height: 4.5rem;
-  max-height: 8rem;
-  resize: none;
-  overflow-y: auto;
-  padding: 0.4rem 0.75rem;
-  border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
-  background: var(--background-primary);
-  color: var(--text-normal);
-  font-family: var(--font-text);
-  font-size: 0.875rem;
-  box-sizing: border-box;
+	width: 100%;
+	min-height: 4.5rem;
+	max-height: 8rem;
+	resize: none;
+	overflow-y: auto;
+	padding: 0.4rem 0.75rem;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 6px;
+	background: var(--background-primary);
+	color: var(--text-normal);
+	font-family: var(--font-text);
+	font-size: 0.875rem;
+	box-sizing: border-box;
 }
 
 .sp-chat__textarea:focus {
-  outline: none;
-  border-color: var(--interactive-accent);
+	outline: none;
+	border-color: var(--interactive-accent);
 }
 
 .sp-chat__input-actions {
-  display: flex;
-  justify-content: flex-end;
+	display: flex;
+	justify-content: flex-end;
 }
 </style>

--- a/src/ui/components/chat/ChatInput.vue
+++ b/src/ui/components/chat/ChatInput.vue
@@ -49,12 +49,23 @@ defineExpose({ textareaEl, palette });
  * substring (everything after the `/`, no leading slash) when the trigger is
  * either at position 0 or preceded by whitespace; otherwise `null`.
  */
-function detectSlashTrigger(value: string, caret: number): string | null {
+interface SlashTriggerMatch {
+	/** Substring captured after the `/` up to the caret (no leading slash). */
+	readonly query: string;
+	/** Index of the `/` character in the textarea value. */
+	readonly slashIndex: number;
+	/** Caret position at the time of detection (end of the `/<query>` span). */
+	readonly endIndex: number;
+}
+
+function detectSlashTrigger(value: string, caret: number): SlashTriggerMatch | null {
 	if (caret < 1) return null;
 	const prefix = value.slice(0, caret);
 	const match = /(?:^|\s)\/([^\s]*)$/.exec(prefix);
 	if (match === null) return null;
-	return match[1];
+	const query = match[1];
+	const slashIndex = caret - query.length - 1;
+	return { query, slashIndex, endIndex: caret };
 }
 
 function syncPaletteFromTextarea(): void {
@@ -63,19 +74,49 @@ function syncPaletteFromTextarea(): void {
 		palette.close();
 		return;
 	}
-	const query = detectSlashTrigger(ta.value, ta.selectionStart);
-	if (query === null) {
+	const trigger = detectSlashTrigger(ta.value, ta.selectionStart);
+	if (trigger === null) {
 		if (palette.isOpen.value) palette.close();
 		return;
 	}
 	if (palette.isOpen.value) {
-		palette.setQuery(query);
+		palette.setQuery(trigger.query);
 	} else {
-		palette.open(query);
+		palette.open(trigger.query);
 	}
 }
 
+/**
+ * Codex P2 on PR #375: clear the `/<query>` token from the textarea
+ * before dispatching the command, so non-clearing commands like `/help`
+ * and `/advance-stage` don't leave the literal slash text behind — the
+ * next Ctrl/Cmd+Enter would otherwise send the command text to the model
+ * as a regular prompt.
+ *
+ * Uses the trigger's own `slashIndex` + `endIndex` (NOT the current
+ * caret) so the replacement stays correct even if the user moved the
+ * caret with ArrowLeft/Right while the dropdown was open.
+ */
+function scrubSlashTrigger(): void {
+	const ta = textareaEl.value;
+	if (ta === null) return;
+	const trigger = detectSlashTrigger(ta.value, ta.selectionStart);
+	if (trigger === null) return;
+	const before = props.modelValue.slice(0, trigger.slashIndex);
+	const after = props.modelValue.slice(trigger.endIndex);
+	const next = `${before}${after}`;
+	emit('update:modelValue', next);
+	void Promise.resolve().then(() => {
+		const el = textareaEl.value;
+		if (el === null) return;
+		const pos = before.length;
+		el.focus();
+		el.setSelectionRange(pos, pos);
+	});
+}
+
 function handleSelectFromPalette(command: SlashCommand): void {
+	scrubSlashTrigger();
 	palette.close();
 	emit('select-command', command);
 	textareaEl.value?.focus();
@@ -112,6 +153,7 @@ function handlePaletteKeydown(event: KeyboardEvent): boolean {
 		const command = palette.select();
 		if (command !== null) {
 			event.preventDefault();
+			scrubSlashTrigger();
 			palette.close();
 			emit('select-command', command);
 			return true;

--- a/src/ui/components/chat/ChatInput.vue
+++ b/src/ui/components/chat/ChatInput.vue
@@ -102,8 +102,20 @@ function scrubSlashTrigger(): void {
 	if (ta === null) return;
 	const trigger = detectSlashTrigger(ta.value, ta.selectionStart);
 	if (trigger === null) return;
+	// Codex P2 (second pass) on PR #375: `detectSlashTrigger` slices to the
+	// CURRENT caret, but the user may have moved the caret left inside the
+	// token (e.g. typed `/help`, ArrowLeft once, Enter). The trigger's
+	// captured `endIndex` is the caret, not the end of the token — that
+	// leaves trailing characters of `/<query>` behind after scrub. Walk
+	// forward from `endIndex` through any non-whitespace characters to find
+	// the true token end. Whitespace acts as the boundary because a
+	// whitespace after `/` would have already aborted trigger detection.
+	let tokenEnd = trigger.endIndex;
+	while (tokenEnd < props.modelValue.length && !/\s/.test(props.modelValue[tokenEnd] ?? '')) {
+		tokenEnd++;
+	}
 	const before = props.modelValue.slice(0, trigger.slashIndex);
-	const after = props.modelValue.slice(trigger.endIndex);
+	const after = props.modelValue.slice(tokenEnd);
 	const next = `${before}${after}`;
 	emit('update:modelValue', next);
 	void Promise.resolve().then(() => {

--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -27,6 +27,7 @@ import {
 } from '@/infrastructure/bridge/ports';
 import type { SessionId } from '@/domain/chat/SessionId';
 import type { ChatThreadRecord } from '@/domain/chat/ChatThreadRecord';
+import type { SlashCommand } from '@/domain/chat/SlashCommand';
 import type {
 	ConfirmModalPort,
 	TranslationPort,
@@ -52,6 +53,10 @@ import SubprocessStartingPill from './SubprocessStartingPill.vue';
 import SessionResumeIndicator from './SessionResumeIndicator.vue';
 import TransportStatusPill from './TransportStatusPill.vue';
 import FileWriteProposalCard from './FileWriteProposalCard.vue';
+
+const emit = defineEmits<{
+	'select-command': [command: SlashCommand];
+}>();
 
 const store = useChatStore();
 const claudeCliPort = useClaudeCliPort();
@@ -1006,18 +1011,11 @@ function handleUserTextUpdate(text: string): void {
 /**
  * Mention-picker selection (PR-ASV-4 / D-ASV-3). `ChatInput` already
  * replaces the `@<query>` text fragment inline; the sidebar's job is to
- * create the matching context-file chip via `store.addContextFile`. The
- * chip stays `isAuto: false` so the user can dismiss it with the chip's
- * remove button — auto chips are reserved for the active editor file.
+ * create the matching context-file chip via `store.addContextFile`.
  */
 function handleAddContextFile(candidate: { path: string; name: string }): void {
-	// Codex P2 on PR #376: `store.addContextFile` is a no-op when the path
-	// already exists. If the user mentions a file that currently lives
-	// ONLY as the auto-context chip, the explicit mention is silently
-	// dropped — then when the active editor file later changes,
-	// `setActiveFile` removes the old auto entry and the user's mention
-	// disappears from context. Promote the auto entry to a manual one so
-	// the explicit mention survives editor rotation.
+	// Codex P2 on PR #376: promote auto entry to manual so explicit mention
+	// survives editor rotation.
 	const existing = store.contextFiles.find((f) => f.path === candidate.path);
 	if (existing?.isAuto === true) {
 		store.removeContextFile(candidate.path);
@@ -1027,6 +1025,14 @@ function handleAddContextFile(candidate: { path: string; name: string }): void {
 		label: candidate.name,
 		isAuto: false,
 	});
+}
+
+/**
+ * Forward the slash-command-palette selection up to `AgentSidepanelRoot`,
+ * which owns the dispatcher (PR-ASV-3, D-ASV-2).
+ */
+function handleSelectCommand(command: SlashCommand): void {
+	emit('select-command', command);
 }
 
 // Determine if API key is missing when unavailable
@@ -1152,6 +1158,7 @@ watch(available, async () => {
 				@update:model-value="handleUserTextUpdate"
 				@send="handleSend"
 				@add-context-file="handleAddContextFile"
+				@select-command="handleSelectCommand"
 			/>
 
 			<hr class="sp-chat__divider" />

--- a/src/ui/components/chat/SlashCommandDropdown.vue
+++ b/src/ui/components/chat/SlashCommandDropdown.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+/**
+ * Floating palette anchored under `ChatInput`'s textarea (PR-ASV-3, D-ASV-2).
+ * Renders the matched `SlashCommand` list with keyboard navigation hooks and
+ * ARIA listbox semantics. The component is purely presentational: it does NOT
+ * own the open/close state nor the trigger detection — those live in
+ * `useSlashPalette` (state) and `ChatInput.vue` (textarea integration).
+ *
+ * Visual reference: Claudian's `SlashCommandDropdown.ts`
+ * (https://github.com/YishenTu/claudian) rendered with Vue 3 SFCs instead of
+ * imperative DOM (ADR-003). No `obsidian` import — composes with the narrow
+ * ports (ADR-008).
+ */
+import type { SlashCommand } from '@/domain/chat/SlashCommand';
+
+const props = defineProps<{
+	/** Matched commands to render. Empty array = "no matches" placeholder. */
+	commands: readonly SlashCommand[];
+	/** Index of the highlighted command. `-1` when empty. */
+	selectedIndex: number;
+}>();
+
+const emit = defineEmits<{
+	/**
+	 * Emitted when the user clicks an entry or hovers over it. The parent is
+	 * expected to dispatch the action AND close the palette (the dropdown does
+	 * not own state — see `useSlashPalette`).
+	 */
+	select: [command: SlashCommand];
+	/** Emitted when the user mouses over an entry; parent updates the highlight. */
+	highlight: [index: number];
+}>();
+
+function handleClick(command: SlashCommand): void {
+	emit('select', command);
+}
+
+function handleMouseEnter(index: number): void {
+	emit('highlight', index);
+}
+
+function isSelected(index: number): boolean {
+	return index === props.selectedIndex;
+}
+</script>
+
+<template>
+	<div
+		class="sp-slash-dropdown"
+		role="listbox"
+		aria-label="Slash commands"
+		data-testid="slash-command-dropdown"
+	>
+		<p
+			v-if="commands.length === 0"
+			class="sp-slash-dropdown__empty"
+			data-testid="slash-command-empty"
+		>
+			No matching commands
+		</p>
+		<ul v-else class="sp-slash-dropdown__list" data-testid="slash-command-list">
+			<li
+				v-for="(command, index) in commands"
+				:key="command.name"
+				class="sp-slash-dropdown__item"
+				:class="{ 'sp-slash-dropdown__item--selected': isSelected(index) }"
+				role="option"
+				:aria-selected="isSelected(index)"
+				:data-testid="`slash-command-item-${command.name}`"
+				@mousedown.prevent="handleClick(command)"
+				@mouseenter="handleMouseEnter(index)"
+			>
+				<span class="sp-slash-dropdown__name" data-testid="slash-command-name">
+					/{{ command.name }}
+				</span>
+				<span class="sp-slash-dropdown__description" data-testid="slash-command-description">
+					{{ command.description }}
+				</span>
+			</li>
+		</ul>
+	</div>
+</template>
+
+<style scoped>
+.sp-slash-dropdown {
+	position: absolute;
+	left: 0;
+	right: 0;
+	bottom: 100%;
+	margin-bottom: 0.25rem;
+	background: var(--background-primary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 6px;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+	max-height: 14rem;
+	overflow-y: auto;
+	z-index: 20;
+}
+
+.sp-slash-dropdown__list {
+	list-style: none;
+	margin: 0;
+	padding: 0.25rem 0;
+}
+
+.sp-slash-dropdown__item {
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+	padding: 0.375rem 0.75rem;
+	cursor: pointer;
+	transition: background-color 0.1s;
+}
+
+.sp-slash-dropdown__item--selected {
+	background: var(--interactive-hover);
+}
+
+.sp-slash-dropdown__name {
+	font-size: 0.875rem;
+	font-weight: 600;
+	color: var(--text-normal);
+}
+
+.sp-slash-dropdown__description {
+	font-size: 0.75rem;
+	color: var(--text-muted);
+}
+
+.sp-slash-dropdown__empty {
+	margin: 0;
+	padding: 0.5rem 0.75rem;
+	font-size: 0.8125rem;
+	color: var(--text-muted);
+	font-style: italic;
+}
+</style>

--- a/src/ui/composables/useSlashPalette.ts
+++ b/src/ui/composables/useSlashPalette.ts
@@ -1,0 +1,147 @@
+import { computed, ref } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+
+import type { SlashCommand } from '@/domain/chat/SlashCommand';
+import { BUILT_IN_SLASH_COMMANDS } from '@/application/chat/builtInSlashCommands';
+
+/**
+ * State machine for the slash-command palette (PR-ASV-3, D-ASV-2). Owns the
+ * filtered command list, the highlighted index, and the open/close gate. The
+ * trigger-detection scan that opens the palette lives in `ChatInput.vue` —
+ * this composable's job is everything that happens *after* the `/` has been
+ * accepted.
+ *
+ * Selection wraps top-to-bottom and bottom-to-top so keyboard navigation is
+ * deterministic regardless of match-count, mirroring Claudian's
+ * `SlashCommandDropdown` behaviour.
+ *
+ * The match algorithm is a case-insensitive substring scan against the
+ * command's `name` and `description`. A bare `/` (empty query) matches every
+ * command — the user gets a full discovery surface. No fuzzy / Levenshtein /
+ * prefix matching today; this stays in sync with the design brief in
+ * `specs/agent-sidepanel-v2/research.md` D-ASV-2.
+ */
+export interface UseSlashPalette {
+	/** True while the dropdown is mounted. */
+	readonly isOpen: ComputedRef<boolean>;
+	/** Current substring query (without the leading `/`). */
+	readonly query: ComputedRef<string>;
+	/** Commands that match `query` against `name`/`description`. */
+	readonly matchedCommands: ComputedRef<readonly SlashCommand[]>;
+	/** Highlighted index into `matchedCommands`. `-1` when empty. */
+	readonly selectedIndex: ComputedRef<number>;
+	/** All commands the palette can surface. Frozen at construction. */
+	readonly commands: readonly SlashCommand[];
+	/** Open the palette with the supplied query. Resets the selection to 0. */
+	open(query: string): void;
+	/** Close the palette and clear state. */
+	close(): void;
+	/** Update the query while the palette is open. Resets the selection to 0. */
+	setQuery(query: string): void;
+	/** Move the selection by `delta` (with wrap-around). No-op when closed. */
+	navigate(delta: number): void;
+	/**
+	 * Return the currently-highlighted command, or `null` when the palette is
+	 * closed / has no matches. The caller is responsible for dispatching the
+	 * action — `useSlashPalette` does not perform side-effects.
+	 */
+	select(): SlashCommand | null;
+}
+
+interface UseSlashPaletteOptions {
+	/**
+	 * Override the registry. Tests inject a controlled list; production callers
+	 * accept the default (`BUILT_IN_SLASH_COMMANDS`).
+	 */
+	readonly commands?: readonly SlashCommand[];
+}
+
+function matchesQuery(command: SlashCommand, query: string): boolean {
+	if (query.length === 0) return true;
+	const needle = query.toLowerCase();
+	return (
+		command.name.toLowerCase().includes(needle) ||
+		command.description.toLowerCase().includes(needle)
+	);
+}
+
+export function useSlashPalette(options?: UseSlashPaletteOptions): UseSlashPalette {
+	const commands: readonly SlashCommand[] = options?.commands ?? BUILT_IN_SLASH_COMMANDS;
+
+	const isOpenRef: Ref<boolean> = ref(false);
+	const queryRef: Ref<string> = ref('');
+	const selectedIndexRef: Ref<number> = ref(-1);
+
+	const matchedCommands = computed<readonly SlashCommand[]>(() => {
+		if (!isOpenRef.value) return [];
+		return commands.filter((c) => matchesQuery(c, queryRef.value));
+	});
+
+	function clampSelection(): void {
+		const count = matchedCommands.value.length;
+		if (count === 0) {
+			selectedIndexRef.value = -1;
+			return;
+		}
+		if (selectedIndexRef.value < 0 || selectedIndexRef.value >= count) {
+			selectedIndexRef.value = 0;
+		}
+	}
+
+	function open(query: string): void {
+		isOpenRef.value = true;
+		queryRef.value = query;
+		selectedIndexRef.value = 0;
+		clampSelection();
+	}
+
+	function close(): void {
+		isOpenRef.value = false;
+		queryRef.value = '';
+		selectedIndexRef.value = -1;
+	}
+
+	function setQuery(query: string): void {
+		if (!isOpenRef.value) return;
+		queryRef.value = query;
+		selectedIndexRef.value = 0;
+		clampSelection();
+	}
+
+	function navigate(delta: number): void {
+		if (!isOpenRef.value) return;
+		const count = matchedCommands.value.length;
+		if (count === 0) {
+			selectedIndexRef.value = -1;
+			return;
+		}
+		// Mod-based wrap so `delta = -1` from index 0 lands on the last entry
+		// (and `delta = +1` from the last entry wraps to 0). JavaScript's `%`
+		// preserves sign for negative numerators, so we offset by `count` before
+		// the mod to stay in `[0, count)`.
+		const next = (((selectedIndexRef.value + delta) % count) + count) % count;
+		selectedIndexRef.value = next;
+	}
+
+	function select(): SlashCommand | null {
+		if (!isOpenRef.value) return null;
+		const list = matchedCommands.value;
+		if (list.length === 0) return null;
+		const idx = selectedIndexRef.value;
+		if (idx < 0 || idx >= list.length) return null;
+		return list[idx] ?? null;
+	}
+
+	return {
+		isOpen: computed(() => isOpenRef.value),
+		query: computed(() => queryRef.value),
+		matchedCommands,
+		selectedIndex: computed(() => selectedIndexRef.value),
+		commands,
+		open,
+		close,
+		setQuery,
+		navigate,
+		select,
+	};
+}

--- a/tests/application/chat/builtInSlashCommands.test.ts
+++ b/tests/application/chat/builtInSlashCommands.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests for the built-in slash command registry (PR-ASV-3, D-ASV-2). Covers
+ * shape invariants — names are unique kebab-case, every action is a known
+ * dispatch id, the array is frozen, and the four expected built-ins are
+ * present.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { BUILT_IN_SLASH_COMMANDS } from '@/application/chat/builtInSlashCommands';
+import type { SlashCommandAction } from '@/domain/chat/SlashCommand';
+
+const KNOWN_ACTIONS: ReadonlySet<SlashCommandAction> = new Set<SlashCommandAction>([
+	'clear-input',
+	'new-conversation',
+	'help',
+	'advance-stage',
+]);
+
+describe('BUILT_IN_SLASH_COMMANDS', () => {
+	it('exposes the four PR-ASV-3 built-ins', () => {
+		const names = BUILT_IN_SLASH_COMMANDS.map((c) => c.name).sort();
+		expect(names).toEqual(['advance-stage', 'clear', 'help', 'new']);
+	});
+
+	it('is frozen so consumers cannot mutate the registry', () => {
+		expect(Object.isFrozen(BUILT_IN_SLASH_COMMANDS)).toBe(true);
+		// Every individual entry is frozen so a caller cannot rewrite an entry
+		// in place either.
+		for (const command of BUILT_IN_SLASH_COMMANDS) {
+			expect(Object.isFrozen(command)).toBe(true);
+		}
+	});
+
+	it('every command declares kind "builtin"', () => {
+		for (const command of BUILT_IN_SLASH_COMMANDS) {
+			expect(command.kind).toBe('builtin');
+		}
+	});
+
+	it('every command action is one of the known dispatch ids', () => {
+		for (const command of BUILT_IN_SLASH_COMMANDS) {
+			expect(KNOWN_ACTIONS.has(command.action)).toBe(true);
+		}
+	});
+
+	it('command names are unique and kebab-case', () => {
+		const names = BUILT_IN_SLASH_COMMANDS.map((c) => c.name);
+		expect(new Set(names).size).toBe(names.length);
+		for (const name of names) {
+			expect(name).toMatch(/^[a-z][a-z0-9-]*$/);
+		}
+	});
+
+	it('every command carries a non-empty description', () => {
+		for (const command of BUILT_IN_SLASH_COMMANDS) {
+			expect(command.description.length).toBeGreaterThan(0);
+		}
+	});
+});

--- a/tests/ui/agent/AgentSidepanelRoot.slashCommands.po.ts
+++ b/tests/ui/agent/AgentSidepanelRoot.slashCommands.po.ts
@@ -1,0 +1,33 @@
+import type { VueWrapper } from '@vue/test-utils';
+
+export class AgentSidepanelRootSlashCommandsPO {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	private byTid(tid: string) {
+		return `[data-testid="${tid}"]`;
+	}
+
+	get root() {
+		return this.wrapper.find(this.byTid('agent-sidepanel'));
+	}
+
+	get helpPanel() {
+		return this.wrapper.find(this.byTid('agent-help-panel'));
+	}
+
+	get helpClose() {
+		return this.wrapper.find(this.byTid('agent-help-close'));
+	}
+
+	helpItemByName(name: string) {
+		return this.wrapper.find(this.byTid(`agent-help-item-${name}`));
+	}
+
+	hasHelpPanel(): boolean {
+		return this.helpPanel.exists();
+	}
+
+	async clickHelpClose(): Promise<void> {
+		await this.helpClose.trigger('click');
+	}
+}

--- a/tests/ui/agent/AgentSidepanelRoot.slashCommands.test.ts
+++ b/tests/ui/agent/AgentSidepanelRoot.slashCommands.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Tests for the slash-command dispatcher in `AgentSidepanelRoot.vue`
+ * (PR-ASV-3, D-ASV-2). The root component owns the switch over
+ * `SlashCommandAction` and wires each id to the matching store mutation,
+ * header flow, inline help, or notification toast.
+ *
+ * The embedded `ChatSidebar` and `MessageList` are stubbed so the dispatch
+ * surface can be exercised in isolation. Stubbing also frees us from wiring
+ * the Claude-CLI / vault / settings ports that `ChatSidebar` would otherwise
+ * require.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { setActivePinia, createPinia } from 'pinia';
+import { defineComponent, h } from 'vue';
+
+import AgentSidepanelRoot from '@/ui/agent/AgentSidepanelRoot.vue';
+import { useChatStore } from '@/ui/stores/chatStore';
+import { useNotificationStore } from '@/ui/stores/notificationStore';
+import { i18n } from '@/ui/i18n';
+import { LOGGER_PORT, NOTIFICATION_PORT } from '@/infrastructure/bridge/ports';
+import type { LoggerPort, NotificationPort } from '@/domain/ports';
+import type { SlashCommand } from '@/domain/chat/SlashCommand';
+import { AgentSidepanelRootSlashCommandsPO } from './AgentSidepanelRoot.slashCommands.po';
+
+const ChatSidebarStub = defineComponent({
+	name: 'ChatSidebarStub',
+	emits: ['select-command'],
+	setup(_, { emit }) {
+		function emitCommand(command: SlashCommand): void {
+			emit('select-command', command);
+		}
+		// expose method for tests via $.exposed isn't reliable across versions;
+		// instead we render a hidden span with the trigger function attached.
+		return () =>
+			h('div', { 'data-testid': 'chat-sidebar-stub' }, [
+				h(
+					'button',
+					{
+						type: 'button',
+						'data-testid': 'stub-emit-clear',
+						onClick: () => {
+							emitCommand({
+								name: 'clear',
+								description: 'Clear the input',
+								kind: 'builtin',
+								action: 'clear-input',
+							});
+						},
+					},
+					'emit clear',
+				),
+				h(
+					'button',
+					{
+						type: 'button',
+						'data-testid': 'stub-emit-new',
+						onClick: () => {
+							emitCommand({
+								name: 'new',
+								description: 'Start a new conversation',
+								kind: 'builtin',
+								action: 'new-conversation',
+							});
+						},
+					},
+					'emit new',
+				),
+				h(
+					'button',
+					{
+						type: 'button',
+						'data-testid': 'stub-emit-help',
+						onClick: () => {
+							emitCommand({
+								name: 'help',
+								description: 'Show available commands',
+								kind: 'builtin',
+								action: 'help',
+							});
+						},
+					},
+					'emit help',
+				),
+				h(
+					'button',
+					{
+						type: 'button',
+						'data-testid': 'stub-emit-advance',
+						onClick: () => {
+							emitCommand({
+								name: 'advance-stage',
+								description: 'Advance the active feature to the next stage (coming soon)',
+								kind: 'builtin',
+								action: 'advance-stage',
+							});
+						},
+					},
+					'emit advance',
+				),
+			]);
+	},
+});
+
+const MessageListStub = defineComponent({
+	name: 'MessageListStub',
+	props: { threadId: { type: String, default: null } },
+	render() {
+		return h('div', { 'data-testid': 'message-list-stub' });
+	},
+});
+
+const AppToastStub = defineComponent({
+	name: 'AppToastStub',
+	render() {
+		return h('div', { 'data-testid': 'app-toast-stub' });
+	},
+});
+
+function makeLoggerStub(): LoggerPort {
+	return {
+		debug: () => undefined,
+		info: () => undefined,
+		warn: () => undefined,
+		error: () => undefined,
+	};
+}
+
+function makeNotificationStub(): NotificationPort {
+	return {
+		showError: () => undefined,
+		showWarning: () => undefined,
+		showSuccess: () => undefined,
+		showInfo: () => undefined,
+	};
+}
+
+function mountRoot() {
+	const pinia = createPinia();
+	setActivePinia(pinia);
+	const wrapper = mount(AgentSidepanelRoot, {
+		global: {
+			plugins: [pinia, i18n],
+			stubs: {
+				ChatSidebar: ChatSidebarStub,
+				MessageList: MessageListStub,
+				AppToast: AppToastStub,
+			},
+			provide: {
+				[LOGGER_PORT as symbol]: makeLoggerStub(),
+				[NOTIFICATION_PORT as symbol]: makeNotificationStub(),
+			},
+		},
+	});
+	const chatStore = useChatStore(pinia);
+	const notificationStore = useNotificationStore(pinia);
+	const po = new AgentSidepanelRootSlashCommandsPO(wrapper);
+	return { wrapper, po, chatStore, notificationStore };
+}
+
+describe('AgentSidepanelRoot — slash command dispatch (PR-ASV-3)', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+	});
+
+	describe('/clear', () => {
+		it('clears userText without sending', async () => {
+			const { wrapper, chatStore } = mountRoot();
+			chatStore.setUserText('hello world');
+			await wrapper.find('[data-testid="stub-emit-clear"]').trigger('click');
+			expect(chatStore.userText).toBe('');
+		});
+	});
+
+	describe('/new', () => {
+		it('clears the active thread when not loading', async () => {
+			const { wrapper, chatStore } = mountRoot();
+			chatStore.upsertThread({
+				threadId: 't1',
+				sessionId: null,
+				feature: null,
+				logPath: '',
+				transport: 'api-key',
+				createdAt: '2026-05-16T00:00:00.000Z',
+				lastUsedAt: '2026-05-16T00:00:00.000Z',
+			});
+			chatStore.setActiveThreadId('t1');
+			chatStore.setUserText('hello');
+			await wrapper.find('[data-testid="stub-emit-new"]').trigger('click');
+			expect(chatStore.activeThreadId).toBeNull();
+			expect(chatStore.userText).toBe('');
+		});
+
+		it('is a no-op when a turn is in flight (Codex P1 mid-flight guard)', async () => {
+			const { wrapper, chatStore } = mountRoot();
+			chatStore.upsertThread({
+				threadId: 't2',
+				sessionId: null,
+				feature: null,
+				logPath: '',
+				transport: 'api-key',
+				createdAt: '2026-05-16T00:00:00.000Z',
+				lastUsedAt: '2026-05-16T00:00:00.000Z',
+			});
+			chatStore.setActiveThreadId('t2');
+			chatStore.beginRequest(); // status = 'loading'
+			await wrapper.find('[data-testid="stub-emit-new"]').trigger('click');
+			expect(chatStore.activeThreadId).toBe('t2');
+		});
+	});
+
+	describe('/help', () => {
+		it('opens the inline help panel listing every built-in command', async () => {
+			const { wrapper, po } = mountRoot();
+			expect(po.hasHelpPanel()).toBe(false);
+			await wrapper.find('[data-testid="stub-emit-help"]').trigger('click');
+			expect(po.hasHelpPanel()).toBe(true);
+			expect(po.helpItemByName('clear').exists()).toBe(true);
+			expect(po.helpItemByName('new').exists()).toBe(true);
+			expect(po.helpItemByName('advance-stage').exists()).toBe(true);
+			expect(po.helpItemByName('help').exists()).toBe(true);
+		});
+
+		it('the help close button hides the panel', async () => {
+			const { wrapper, po } = mountRoot();
+			await wrapper.find('[data-testid="stub-emit-help"]').trigger('click');
+			expect(po.hasHelpPanel()).toBe(true);
+			await po.clickHelpClose();
+			expect(po.hasHelpPanel()).toBe(false);
+		});
+	});
+
+	describe('/advance-stage', () => {
+		it('shows a "Not yet implemented" notice', async () => {
+			const { wrapper, notificationStore } = mountRoot();
+			expect(notificationStore.notices).toHaveLength(0);
+			await wrapper.find('[data-testid="stub-emit-advance"]').trigger('click');
+			expect(notificationStore.notices).toHaveLength(1);
+			expect(notificationStore.notices[0].message.toLowerCase()).toContain('not yet implemented');
+		});
+	});
+});

--- a/tests/ui/components/chat/ChatInput.po.ts
+++ b/tests/ui/components/chat/ChatInput.po.ts
@@ -124,14 +124,6 @@ export class ChatInputPO {
 		await this.textarea.trigger('input')
 	}
 
-	async pressKey(key: string, opts: { ctrl?: boolean; meta?: boolean } = {}): Promise<void> {
-		await this.textarea.trigger('keydown', {
-			key,
-			ctrlKey: opts.ctrl ?? false,
-			metaKey: opts.meta ?? false,
-		})
-	}
-
 	emitted(name: string): unknown {
 		return this.wrapper.emitted(name)
 	}

--- a/tests/ui/components/chat/ChatInput.po.ts
+++ b/tests/ui/components/chat/ChatInput.po.ts
@@ -89,6 +89,49 @@ export class ChatInputPO {
 		await this.sendButton.trigger('click')
 	}
 
+	get dropdown() {
+		return this.wrapper.find(this.byTid('slash-command-dropdown'))
+	}
+
+	get dropdownEmpty() {
+		return this.wrapper.find(this.byTid('slash-command-empty'))
+	}
+
+	hasDropdown(): boolean {
+		return this.dropdown.exists()
+	}
+
+	dropdownItem(name: string) {
+		return this.wrapper.find(this.byTid(`slash-command-item-${name}`))
+	}
+
+	dropdownItems() {
+		return this.wrapper.findAll('[role="option"]')
+	}
+
+	/**
+	 * Simulate typing into the textarea AND set the caret to end-of-string,
+	 * since `setValue` does not synthesise caret position. The component reads
+	 * `selectionStart` to detect the slash trigger, so tests must move the
+	 * caret explicitly.
+	 */
+	async typeAndMoveCaret(value: string, caret?: number): Promise<void> {
+		const el = this.textarea.element as HTMLTextAreaElement
+		el.value = value
+		const pos = caret ?? value.length
+		el.selectionStart = pos
+		el.selectionEnd = pos
+		await this.textarea.trigger('input')
+	}
+
+	async pressKey(key: string, opts: { ctrl?: boolean; meta?: boolean } = {}): Promise<void> {
+		await this.textarea.trigger('keydown', {
+			key,
+			ctrlKey: opts.ctrl ?? false,
+			metaKey: opts.meta ?? false,
+		})
+	}
+
 	emitted(name: string): unknown {
 		return this.wrapper.emitted(name)
 	}

--- a/tests/ui/components/chat/ChatInput.test.ts
+++ b/tests/ui/components/chat/ChatInput.test.ts
@@ -274,4 +274,118 @@ describe('ChatInput', () => {
 			expect(po.emitted('add-context-file')).toBeFalsy()
 		})
 	})
+
+	describe('slash-command palette (PR-ASV-3)', () => {
+		it('does not render the dropdown before any `/` is typed', () => {
+			const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
+			expect(po.hasDropdown()).toBe(false)
+		})
+
+		it('opens the dropdown when `/` is typed at position 0', async () => {
+			const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
+			await po.typeAndMoveCaret('/')
+			expect(po.hasDropdown()).toBe(true)
+		})
+
+		it('opens the dropdown when `/` follows whitespace', async () => {
+			const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
+			await po.typeAndMoveCaret('hello /')
+			expect(po.hasDropdown()).toBe(true)
+		})
+
+		it('does NOT open when `/` follows a non-whitespace character', async () => {
+			const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
+			await po.typeAndMoveCaret('path/to/file')
+			expect(po.hasDropdown()).toBe(false)
+		})
+
+		it('filters items as the user types the query', async () => {
+			const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
+			await po.typeAndMoveCaret('/cle')
+			expect(po.dropdownItem('clear').exists()).toBe(true)
+			expect(po.dropdownItem('help').exists()).toBe(false)
+			expect(po.dropdownItem('new').exists()).toBe(false)
+		})
+
+		it('shows the empty placeholder when no commands match', async () => {
+			const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
+			await po.typeAndMoveCaret('/xyzzy')
+			expect(po.hasDropdown()).toBe(true)
+			expect(po.dropdownEmpty.exists()).toBe(true)
+		})
+
+		it('closes when a whitespace is typed after the trigger', async () => {
+			const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
+			await po.typeAndMoveCaret('/cle')
+			expect(po.hasDropdown()).toBe(true)
+			await po.typeAndMoveCaret('/cle ')
+			expect(po.hasDropdown()).toBe(false)
+		})
+
+		describe('keyboard navigation', () => {
+			it('ArrowDown moves the highlight forward', async () => {
+				const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
+				await po.typeAndMoveCaret('/')
+				// First item is highlighted by default
+				expect(po.dropdownItem('clear').attributes('aria-selected')).toBe('true')
+				await po.pressKey('ArrowDown')
+				expect(po.dropdownItem('clear').attributes('aria-selected')).toBe('false')
+				expect(po.dropdownItem('new').attributes('aria-selected')).toBe('true')
+			})
+
+			it('ArrowUp from index 0 wraps to the last entry', async () => {
+				const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
+				await po.typeAndMoveCaret('/')
+				const items = po.dropdownItems()
+				expect(items.length).toBeGreaterThan(0)
+				await po.pressKey('ArrowUp')
+				// Last item should now be aria-selected
+				expect(items[items.length - 1].attributes('aria-selected')).toBe('true')
+			})
+
+			it('Escape closes the palette', async () => {
+				const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
+				await po.typeAndMoveCaret('/')
+				expect(po.hasDropdown()).toBe(true)
+				await po.pressKey('Escape')
+				expect(po.hasDropdown()).toBe(false)
+			})
+		})
+
+		describe('selection emits', () => {
+			it('Enter on a highlighted entry emits select-command and does NOT emit send', async () => {
+				const po = mountChatInput({ modelValue: '/', disabled: false, loading: false })
+				await po.typeAndMoveCaret('/')
+				await po.pressKey('Enter', { ctrl: true })
+				expect(po.emitted('send')).toBeFalsy()
+				const emitted = po.emitted('select-command') as Array<[{ name: string }]> | undefined
+				expect(emitted).toBeTruthy()
+				expect(emitted?.[0][0].name).toBe('clear')
+			})
+
+			it('Tab selects the highlighted entry', async () => {
+				const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
+				await po.typeAndMoveCaret('/')
+				await po.pressKey('Tab')
+				const emitted = po.emitted('select-command') as Array<[{ name: string }]> | undefined
+				expect(emitted).toBeTruthy()
+				expect(emitted?.[0][0].name).toBe('clear')
+			})
+
+			it('clicking an item emits select-command for that command', async () => {
+				const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
+				await po.typeAndMoveCaret('/')
+				await po.dropdownItem('new').trigger('mousedown')
+				const emitted = po.emitted('select-command') as Array<[{ name: string }]> | undefined
+				expect(emitted).toBeTruthy()
+				expect(emitted?.[0][0].name).toBe('new')
+			})
+
+			it('Ctrl+Enter still fires send when the palette is closed', async () => {
+				const po = mountChatInput({ modelValue: 'hello', disabled: false, loading: false })
+				await po.pressKey('Enter', { ctrl: true })
+				expect(po.emitted('send')).toBeTruthy()
+			})
+		})
+	})
 })

--- a/tests/ui/components/chat/SlashCommandDropdown.po.ts
+++ b/tests/ui/components/chat/SlashCommandDropdown.po.ts
@@ -1,0 +1,69 @@
+import type { DOMWrapper, VueWrapper } from '@vue/test-utils';
+
+export class SlashCommandDropdownPO {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	private byTid(tid: string) {
+		return `[data-testid="${tid}"]`;
+	}
+
+	get root() {
+		return this.wrapper.find(this.byTid('slash-command-dropdown'));
+	}
+
+	get list() {
+		return this.wrapper.find(this.byTid('slash-command-list'));
+	}
+
+	get empty() {
+		return this.wrapper.find(this.byTid('slash-command-empty'));
+	}
+
+	hasList(): boolean {
+		return this.list.exists();
+	}
+
+	hasEmpty(): boolean {
+		return this.empty.exists();
+	}
+
+	emptyText(): string {
+		return this.empty.text();
+	}
+
+	rootRole(): string | undefined {
+		return this.root.attributes('role');
+	}
+
+	items(): DOMWrapper<Element>[] {
+		return this.wrapper.findAll('[role="option"]');
+	}
+
+	itemByName(name: string) {
+		return this.wrapper.find(this.byTid(`slash-command-item-${name}`));
+	}
+
+	itemAriaSelected(name: string): string | undefined {
+		return this.itemByName(name).attributes('aria-selected');
+	}
+
+	itemNameText(name: string): string {
+		return this.itemByName(name).find(this.byTid('slash-command-name')).text();
+	}
+
+	itemDescriptionText(name: string): string {
+		return this.itemByName(name).find(this.byTid('slash-command-description')).text();
+	}
+
+	async clickItem(name: string): Promise<void> {
+		await this.itemByName(name).trigger('mousedown');
+	}
+
+	async hoverItem(name: string): Promise<void> {
+		await this.itemByName(name).trigger('mouseenter');
+	}
+
+	emitted(name: string): unknown {
+		return this.wrapper.emitted(name);
+	}
+}

--- a/tests/ui/components/chat/SlashCommandDropdown.test.ts
+++ b/tests/ui/components/chat/SlashCommandDropdown.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for the slash-command dropdown component (PR-ASV-3, D-ASV-2). Covers
+ * the three match-count branches (0, 1, many), the ARIA semantics
+ * (`role="listbox"` / `role="option"` / `aria-selected`), and the `select`
+ * + `highlight` emits.
+ */
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import SlashCommandDropdown from '@/ui/components/chat/SlashCommandDropdown.vue';
+import type { SlashCommand } from '@/domain/chat/SlashCommand';
+import { SlashCommandDropdownPO } from './SlashCommandDropdown.po';
+
+const CLEAR: SlashCommand = Object.freeze({
+	name: 'clear',
+	description: 'Clear the input',
+	kind: 'builtin',
+	action: 'clear-input',
+});
+
+const NEW: SlashCommand = Object.freeze({
+	name: 'new',
+	description: 'Start a new conversation',
+	kind: 'builtin',
+	action: 'new-conversation',
+});
+
+const HELP: SlashCommand = Object.freeze({
+	name: 'help',
+	description: 'Show available commands',
+	kind: 'builtin',
+	action: 'help',
+});
+
+function mountDropdown(props: { commands: readonly SlashCommand[]; selectedIndex: number }) {
+	const wrapper = mount(SlashCommandDropdown, { props });
+	return { wrapper, po: new SlashCommandDropdownPO(wrapper) };
+}
+
+describe('SlashCommandDropdown', () => {
+	describe('zero matches', () => {
+		it('renders the empty placeholder and no list', () => {
+			const { po } = mountDropdown({ commands: [], selectedIndex: -1 });
+			expect(po.hasEmpty()).toBe(true);
+			expect(po.hasList()).toBe(false);
+			expect(po.emptyText().toLowerCase()).toContain('no matching');
+		});
+	});
+
+	describe('single match', () => {
+		it('renders one option with name and description', () => {
+			const { po } = mountDropdown({ commands: [CLEAR], selectedIndex: 0 });
+			expect(po.hasEmpty()).toBe(false);
+			expect(po.hasList()).toBe(true);
+			expect(po.items()).toHaveLength(1);
+			expect(po.itemNameText('clear')).toContain('clear');
+			expect(po.itemDescriptionText('clear')).toBe('Clear the input');
+		});
+
+		it('marks the only entry as aria-selected when selectedIndex=0', () => {
+			const { po } = mountDropdown({ commands: [CLEAR], selectedIndex: 0 });
+			expect(po.itemAriaSelected('clear')).toBe('true');
+		});
+	});
+
+	describe('many matches', () => {
+		it('renders one option per command in order', () => {
+			const { po } = mountDropdown({
+				commands: [CLEAR, NEW, HELP],
+				selectedIndex: 0,
+			});
+			expect(po.items()).toHaveLength(3);
+			expect(po.itemNameText('clear')).toContain('clear');
+			expect(po.itemNameText('new')).toContain('new');
+			expect(po.itemNameText('help')).toContain('help');
+		});
+
+		it('marks exactly one entry as aria-selected', () => {
+			const { po } = mountDropdown({
+				commands: [CLEAR, NEW, HELP],
+				selectedIndex: 1,
+			});
+			expect(po.itemAriaSelected('clear')).toBe('false');
+			expect(po.itemAriaSelected('new')).toBe('true');
+			expect(po.itemAriaSelected('help')).toBe('false');
+		});
+	});
+
+	describe('ARIA semantics', () => {
+		it('root has role="listbox"', () => {
+			const { po } = mountDropdown({ commands: [CLEAR], selectedIndex: 0 });
+			expect(po.rootRole()).toBe('listbox');
+		});
+
+		it('each item has role="option"', () => {
+			const { po } = mountDropdown({
+				commands: [CLEAR, NEW, HELP],
+				selectedIndex: 0,
+			});
+			for (const item of po.items()) {
+				expect(item.attributes('role')).toBe('option');
+			}
+		});
+	});
+
+	describe('emits', () => {
+		it('emits "select" with the clicked command (mousedown)', async () => {
+			const { wrapper, po } = mountDropdown({
+				commands: [CLEAR, NEW],
+				selectedIndex: 0,
+			});
+			await po.clickItem('new');
+			const emitted = wrapper.emitted('select');
+			expect(emitted).toBeTruthy();
+			const first = (emitted as Array<[SlashCommand]>)[0];
+			expect(first[0].name).toBe('new');
+		});
+
+		it('emits "highlight" with the hovered index', async () => {
+			const { wrapper, po } = mountDropdown({
+				commands: [CLEAR, NEW, HELP],
+				selectedIndex: 0,
+			});
+			await po.hoverItem('help');
+			const emitted = wrapper.emitted('highlight');
+			expect(emitted).toBeTruthy();
+			const first = (emitted as Array<[number]>)[0];
+			expect(first[0]).toBe(2);
+		});
+	});
+});

--- a/tests/ui/composables/useSlashPalette.test.ts
+++ b/tests/ui/composables/useSlashPalette.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for the slash-command palette composable (PR-ASV-3, D-ASV-2). Covers
+ * the state machine: open/close, query updates, matching, navigation
+ * (including wrap-around), and selection.
+ */
+import { describe, it, expect } from 'vitest';
+
+import type { SlashCommand } from '@/domain/chat/SlashCommand';
+import { useSlashPalette } from '@/ui/composables/useSlashPalette';
+
+const FIXTURE_COMMANDS: readonly SlashCommand[] = Object.freeze([
+	Object.freeze({
+		name: 'clear',
+		description: 'Clear the input',
+		kind: 'builtin' as const,
+		action: 'clear-input' as const,
+	}),
+	Object.freeze({
+		name: 'new',
+		description: 'Start a new conversation',
+		kind: 'builtin' as const,
+		action: 'new-conversation' as const,
+	}),
+	Object.freeze({
+		name: 'help',
+		description: 'Show available commands',
+		kind: 'builtin' as const,
+		action: 'help' as const,
+	}),
+]);
+
+describe('useSlashPalette', () => {
+	it('starts closed with no matches and no selection', () => {
+		const palette = useSlashPalette({ commands: FIXTURE_COMMANDS });
+		expect(palette.isOpen.value).toBe(false);
+		expect(palette.query.value).toBe('');
+		expect(palette.matchedCommands.value).toEqual([]);
+		expect(palette.selectedIndex.value).toBe(-1);
+	});
+
+	describe('open()', () => {
+		it('opens the palette and seeds the selection at 0', () => {
+			const palette = useSlashPalette({ commands: FIXTURE_COMMANDS });
+			palette.open('');
+			expect(palette.isOpen.value).toBe(true);
+			expect(palette.query.value).toBe('');
+			expect(palette.selectedIndex.value).toBe(0);
+		});
+
+		it('with an empty query matches every command', () => {
+			const palette = useSlashPalette({ commands: FIXTURE_COMMANDS });
+			palette.open('');
+			expect(palette.matchedCommands.value).toHaveLength(FIXTURE_COMMANDS.length);
+		});
+
+		it('filters by case-insensitive substring on name', () => {
+			const palette = useSlashPalette({ commands: FIXTURE_COMMANDS });
+			palette.open('CLE');
+			expect(palette.matchedCommands.value.map((c) => c.name)).toEqual(['clear']);
+		});
+
+		it('filters by case-insensitive substring on description', () => {
+			const palette = useSlashPalette({ commands: FIXTURE_COMMANDS });
+			palette.open('conversation');
+			expect(palette.matchedCommands.value.map((c) => c.name)).toEqual(['new']);
+		});
+
+		it('clamps selection to -1 when no commands match', () => {
+			const palette = useSlashPalette({ commands: FIXTURE_COMMANDS });
+			palette.open('xyzzy');
+			expect(palette.matchedCommands.value).toEqual([]);
+			expect(palette.selectedIndex.value).toBe(-1);
+		});
+	});
+
+	describe('close()', () => {
+		it('clears query, selection, and isOpen', () => {
+			const palette = useSlashPalette({ commands: FIXTURE_COMMANDS });
+			palette.open('cle');
+			palette.close();
+			expect(palette.isOpen.value).toBe(false);
+			expect(palette.query.value).toBe('');
+			expect(palette.selectedIndex.value).toBe(-1);
+			expect(palette.matchedCommands.value).toEqual([]);
+		});
+	});
+
+	describe('setQuery()', () => {
+		it('updates the filter and resets selection to 0', () => {
+			const palette = useSlashPalette({ commands: FIXTURE_COMMANDS });
+			palette.open('');
+			palette.navigate(2); // move off index 0
+			expect(palette.selectedIndex.value).toBe(2);
+			palette.setQuery('new');
+			expect(palette.matchedCommands.value.map((c) => c.name)).toEqual(['new']);
+			expect(palette.selectedIndex.value).toBe(0);
+		});
+
+		it('is a no-op when the palette is closed', () => {
+			const palette = useSlashPalette({ commands: FIXTURE_COMMANDS });
+			palette.setQuery('help');
+			expect(palette.isOpen.value).toBe(false);
+			expect(palette.query.value).toBe('');
+		});
+	});
+
+	describe('navigate()', () => {
+		it('moves the selection forward by `delta`', () => {
+			const palette = useSlashPalette({ commands: FIXTURE_COMMANDS });
+			palette.open('');
+			palette.navigate(1);
+			expect(palette.selectedIndex.value).toBe(1);
+			palette.navigate(1);
+			expect(palette.selectedIndex.value).toBe(2);
+		});
+
+		it('wraps from the last index back to the first', () => {
+			const palette = useSlashPalette({ commands: FIXTURE_COMMANDS });
+			palette.open('');
+			palette.navigate(FIXTURE_COMMANDS.length - 1); // land on last index
+			expect(palette.selectedIndex.value).toBe(FIXTURE_COMMANDS.length - 1);
+			palette.navigate(1);
+			expect(palette.selectedIndex.value).toBe(0);
+		});
+
+		it('wraps from the first index back to the last on negative delta', () => {
+			const palette = useSlashPalette({ commands: FIXTURE_COMMANDS });
+			palette.open('');
+			expect(palette.selectedIndex.value).toBe(0);
+			palette.navigate(-1);
+			expect(palette.selectedIndex.value).toBe(FIXTURE_COMMANDS.length - 1);
+		});
+
+		it('is a no-op when the palette is closed', () => {
+			const palette = useSlashPalette({ commands: FIXTURE_COMMANDS });
+			palette.navigate(1);
+			expect(palette.selectedIndex.value).toBe(-1);
+		});
+
+		it('is a no-op when there are zero matches', () => {
+			const palette = useSlashPalette({ commands: FIXTURE_COMMANDS });
+			palette.open('xyzzy');
+			palette.navigate(1);
+			expect(palette.selectedIndex.value).toBe(-1);
+		});
+	});
+
+	describe('select()', () => {
+		it('returns the highlighted command', () => {
+			const palette = useSlashPalette({ commands: FIXTURE_COMMANDS });
+			palette.open('');
+			expect(palette.select()?.name).toBe('clear');
+			palette.navigate(1);
+			expect(palette.select()?.name).toBe('new');
+		});
+
+		it('returns null when the palette is closed', () => {
+			const palette = useSlashPalette({ commands: FIXTURE_COMMANDS });
+			expect(palette.select()).toBeNull();
+		});
+
+		it('returns null when there are no matches', () => {
+			const palette = useSlashPalette({ commands: FIXTURE_COMMANDS });
+			palette.open('xyzzy');
+			expect(palette.select()).toBeNull();
+		});
+
+		it('does not perform any side-effects (caller-driven dispatch)', () => {
+			const palette = useSlashPalette({ commands: FIXTURE_COMMANDS });
+			palette.open('');
+			palette.select();
+			// Still open after select() — the caller is expected to close().
+			expect(palette.isOpen.value).toBe(true);
+		});
+	});
+
+	describe('reopen after close', () => {
+		it('re-seeds selection to 0 after close → open', () => {
+			const palette = useSlashPalette({ commands: FIXTURE_COMMANDS });
+			palette.open('');
+			palette.navigate(2);
+			palette.close();
+			palette.open('');
+			expect(palette.selectedIndex.value).toBe(0);
+		});
+	});
+
+	describe('default registry', () => {
+		it('uses BUILT_IN_SLASH_COMMANDS when no override is supplied', () => {
+			const palette = useSlashPalette();
+			palette.open('');
+			const names = palette.matchedCommands.value.map((c) => c.name);
+			expect(names).toContain('clear');
+			expect(names).toContain('new');
+			expect(names).toContain('help');
+			expect(names).toContain('advance-stage');
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Slash-command palette for the agent sidepanel — D-ASV-2 from `specs/agent-sidepanel-v2/research.md`. Inspired by Claudian's `SlashCommandDropdown.ts`.

**Stacked on #372 → #371 → #370 → #369 → develop.**

### Trigger rules

`/` typed at position 0 OR after whitespace. Backward scan from caret. Aborts if whitespace appears after the trigger.

### Built-in commands

| Command | Action |
|---|---|
| `/clear` | clears `chatStore.userText` |
| `/new` | rotates active thread + clears messages (guarded by `store.status !== 'loading'`) |
| `/help` | opens inline help popover listing available commands |
| `/advance-stage` | placeholder toast for Increment 4 |

### Keyboard

- ArrowUp/Down navigate (wrap-around)
- Enter / Tab select
- Esc dismiss
- ARIA: `role="listbox"`, items `role="option"` with `aria-selected`
- Substring match on `name` OR `description`, case-insensitive

### New surfaces

- `src/domain/chat/SlashCommand.ts` — DTO type
- `src/application/chat/builtInSlashCommands.ts` — frozen registry
- `src/ui/composables/useSlashPalette.ts` — trigger detection, navigation, selection state machine
- `src/ui/components/chat/SlashCommandDropdown.vue` — floating listbox UI
- `src/ui/components/chat/ChatInput.vue` — input integration, emits `select-command`
- `src/ui/components/chat/ChatSidebar.vue` — handles `select-command`
- `src/ui/agent/AgentSidepanelRoot.vue` — wires `/new` to the existing `handleNewConversation`

## Test plan

- [x] Composable unit tests (trigger detect, navigation wraparound, selection)
- [x] `SlashCommandDropdown` component tests (mounts under various match counts)
- [x] Integration test: `/clear` clears userText without sending
- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 errors
- [x] `npm run test` — 1523/1523 pass on the slash branch

https://claude.ai/code/session_01VvXsK3aGp2g4jSpT1py7Mh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvXsK3aGp2g4jSpT1py7Mh)_