### PR TITLE
feat(agent): @-file mention picker (PR-ASV-4)

### DIFF
--- a/src/application/chat/vaultFileSearch.ts
+++ b/src/application/chat/vaultFileSearch.ts
@@ -1,0 +1,132 @@
+/**
+ * Pure search helpers for the `@`-file mention picker (PR-ASV-4 /
+ * IDEA-ASV-001 D-ASV-3). Inspired by Claudian's `VaultMentionDataProvider`
+ * but scoped to vault *files* only (no folders, no agents, no MCP, no
+ * external dirs — see `specs/agent-sidepanel-v2/research.md` D-ASV-3).
+ *
+ * Application-layer only — depends on `VaultPort` and primitive types. No
+ * Vue, no Obsidian imports.
+ */
+import type { VaultPort } from '@/domain/ports'
+
+/**
+ * Hard cap on returned candidates. Matches the per-PR cap in the research
+ * notes ("Cap results to 50 entries"). Higher caps quickly drown the
+ * dropdown UI; 50 is the practical floor.
+ */
+export const MENTION_RESULT_CAP = 50
+
+/**
+ * A single search candidate. `path` is vault-relative (e.g.
+ * `specs/foo/idea.md`); `name` is the basename ("idea.md").
+ */
+export interface MentionCandidate {
+	readonly path: string
+	readonly name: string
+}
+
+/**
+ * Pre-computed search row. `pathLower` / `nameLower` cache the lowercase
+ * forms so the per-keystroke `matchAndRank` loop avoids repeated
+ * `.toLowerCase()` allocations.
+ */
+export interface RankedCandidate {
+	readonly path: string
+	readonly name: string
+	readonly pathLower: string
+	readonly nameLower: string
+}
+
+/**
+ * Recursively collect every file under `root` via `VaultPort`. Uses the
+ * non-recursive `listFiles` + `listFolders` primitives so it works against
+ * all three bridges without extending the port surface.
+ *
+ * The empty-string root listing the entire vault is intentional — it
+ * matches Claudian's `MentionDataProvider.scanVault('')` and the brief
+ * (`VaultPort.listFiles('')`). Tests inject smaller MockBridge
+ * fixtures.
+ */
+export async function collectVaultFiles(vault: VaultPort, root = ''): Promise<string[]> {
+	const [files, subfolders] = await Promise.all([
+		vault.listFiles(root),
+		vault.listFolders(root),
+	])
+	const nested = await Promise.all(
+		subfolders.map((sub) => collectVaultFiles(vault, joinPath(root, sub))),
+	)
+	return [...files, ...nested.flat()]
+}
+
+/**
+ * Vault-path join that tolerates an empty parent (top-level scan).
+ */
+function joinPath(parent: string, child: string): string {
+	const p = parent.replace(/\/+$/, '')
+	return p ? `${p}/${child}` : child
+}
+
+/**
+ * Extract the basename ("foo.md") from a vault-relative path. Pure helper
+ * so callers can keep paths normalised on the way in.
+ */
+export function basenameOf(path: string): string {
+	const idx = path.lastIndexOf('/')
+	return idx === -1 ? path : path.slice(idx + 1)
+}
+
+/**
+ * Pre-compute the lowercase search keys for every candidate. Done once per
+ * dropdown open (the composable invalidates the cache on each `@` trigger
+ * open), not on every keystroke.
+ */
+export function prepareCandidates(paths: readonly string[]): RankedCandidate[] {
+	const out: RankedCandidate[] = []
+	for (const path of paths) {
+		const name = basenameOf(path)
+		out.push({
+			path,
+			name,
+			pathLower: path.toLowerCase(),
+			nameLower: name.toLowerCase(),
+		})
+	}
+	return out
+}
+
+/**
+ * Substring-match a candidate set against a query, sort by
+ * 1) filename prefix-match wins (true > false),
+ * 2) path lexicographic ascending,
+ * and cap at {@link MENTION_RESULT_CAP}.
+ *
+ * Empty query short-circuits to the lexicographically-first
+ * {@link MENTION_RESULT_CAP} candidates so the dropdown is never empty
+ * immediately after a bare `@` keystroke.
+ */
+export function matchAndRank(
+	candidates: readonly RankedCandidate[],
+	query: string,
+): MentionCandidate[] {
+	const q = query.toLowerCase()
+	const matches: RankedCandidate[] = []
+	if (q === '') {
+		matches.push(...candidates)
+	} else {
+		for (const c of candidates) {
+			if (c.nameLower.includes(q) || c.pathLower.includes(q)) {
+				matches.push(c)
+			}
+		}
+	}
+	matches.sort((a, b) => {
+		const aPrefix = q !== '' && a.nameLower.startsWith(q)
+		const bPrefix = q !== '' && b.nameLower.startsWith(q)
+		if (aPrefix !== bPrefix) return aPrefix ? -1 : 1
+		if (a.pathLower < b.pathLower) return -1
+		if (a.pathLower > b.pathLower) return 1
+		return 0
+	})
+	const limited = matches.slice(0, MENTION_RESULT_CAP)
+	return limited.map(({ path, name }) => ({ path, name }))
+}

--- a/src/infrastructure/localstorage/LocalStorageBridge.ts
+++ b/src/infrastructure/localstorage/LocalStorageBridge.ts
@@ -46,13 +46,22 @@ export class LocalStorageBridge
 	}
 
 	async listFiles(folder: string): Promise<string[]> {
-		const prefix = FILE_PREFIX + (folder.endsWith('/') ? folder : folder + '/');
+		// Codex P1 on PR #376: empty-string root must enumerate top-level
+		// files. The previous prefix `FILE_PREFIX + '/'` matched none of the
+		// stored `specorator:file:<path>` keys (they have no leading slash),
+		// breaking the `@`-mention picker in standalone/web mode where it
+		// kicked off a recursive vault walk from `''`.
+		const isRoot = folder === '';
+		const prefix = isRoot
+			? FILE_PREFIX
+			: FILE_PREFIX + (folder.endsWith('/') ? folder : folder + '/');
+		const stripLength = isRoot ? 0 : folder.endsWith('/') ? folder.length : folder.length + 1;
 		const results: string[] = [];
 		for (let i = 0; i < localStorage.length; i++) {
 			const key = localStorage.key(i);
 			if (key?.startsWith(prefix) === true) {
 				const filePath = key.slice(FILE_PREFIX.length);
-				const relative = filePath.slice(folder.endsWith('/') ? folder.length : folder.length + 1);
+				const relative = filePath.slice(stripLength);
 				if (!relative.includes('/')) results.push(filePath);
 			}
 		}
@@ -60,13 +69,18 @@ export class LocalStorageBridge
 	}
 
 	async listFolders(parent: string): Promise<string[]> {
-		const prefix = FILE_PREFIX + (parent.endsWith('/') ? parent : parent + '/');
+		// Codex P1 on PR #376: symmetric fix for the empty-root case.
+		const isRoot = parent === '';
+		const prefix = isRoot
+			? FILE_PREFIX
+			: FILE_PREFIX + (parent.endsWith('/') ? parent : parent + '/');
+		const stripLength = isRoot ? 0 : parent.endsWith('/') ? parent.length : parent.length + 1;
 		const folders = new Set<string>();
 		for (let i = 0; i < localStorage.length; i++) {
 			const key = localStorage.key(i);
 			if (key?.startsWith(prefix) === true) {
 				const filePath = key.slice(FILE_PREFIX.length);
-				const relative = filePath.slice(parent.endsWith('/') ? parent.length : parent.length + 1);
+				const relative = filePath.slice(stripLength);
 				const slash = relative.indexOf('/');
 				if (slash !== -1) {
 					folders.add(relative.slice(0, slash));

--- a/src/infrastructure/mock/MockBridge.ts
+++ b/src/infrastructure/mock/MockBridge.ts
@@ -81,6 +81,12 @@ export class MockBridge
 	}
 
 	async listFiles(folder: string): Promise<string[]> {
+		// Root listing: top-level files have no `/` in their path. Honours
+		// `listFiles('')` symmetry with Obsidian's `vault.getAbstractFileByPath('/')`
+		// (PR-ASV-4, recursive walker for the @-mention picker).
+		if (folder === '') {
+			return [...this.files.keys()].filter((p) => !p.includes('/'));
+		}
 		const prefix = folder.endsWith('/') ? folder : `${folder}/`;
 		return [...this.files.keys()].filter((p) => {
 			if (!p.startsWith(prefix)) return false;

--- a/src/ui/components/chat/ChatInput.vue
+++ b/src/ui/components/chat/ChatInput.vue
@@ -57,7 +57,19 @@ function tryCommitFromKey(event: KeyboardEvent): boolean {
  * complexity budget.
  */
 function handlePickerKey(event: KeyboardEvent): boolean {
-  if (!picker.open.value || !picker.hasResults.value) return false
+  // Codex P2 on PR #376: Escape must dismiss the picker even when the
+  // result list is empty (zero matches OR a scan error cleared results).
+  // The previous guard required BOTH `open` and `hasResults`, so users
+  // were stranded with no keyboard way to leave mention mode until
+  // blur or further text changes.
+  if (!picker.open.value) return false
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    picker.close()
+    return true
+  }
+  // Navigation and commit keys still require results to be useful.
+  if (!picker.hasResults.value) return false
   if (event.key === 'ArrowDown') {
     event.preventDefault()
     picker.moveSelectionDown()
@@ -66,11 +78,6 @@ function handlePickerKey(event: KeyboardEvent): boolean {
   if (event.key === 'ArrowUp') {
     event.preventDefault()
     picker.moveSelectionUp()
-    return true
-  }
-  if (event.key === 'Escape') {
-    event.preventDefault()
-    picker.close()
     return true
   }
   if (event.key === 'Tab' || event.key === 'Enter') {

--- a/src/ui/components/chat/ChatInput.vue
+++ b/src/ui/components/chat/ChatInput.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, onBeforeUnmount } from 'vue'
+import { useVaultPort } from '@/ui/composables/useVaultPort'
+import { useMentionPicker } from '@/ui/composables/useMentionPicker'
+import type { MentionCandidate } from '@/application/chat/vaultFileSearch'
+import { basenameOf } from '@/application/chat/vaultFileSearch'
+import MentionDropdown from './MentionDropdown.vue'
 
 const props = defineProps<{
   modelValue: string
@@ -10,13 +15,72 @@ const props = defineProps<{
 const emit = defineEmits<{
   'update:modelValue': [value: string]
   send: []
+  /**
+   * Emitted alongside `update:modelValue` when the user accepts a mention
+   * candidate. The consumer is responsible for invoking
+   * `chatStore.addContextFile` so a context-file chip is created
+   * (PR-ASV-4 / D-ASV-3 — the inline token and the chip travel together).
+   */
+  'add-context-file': [candidate: MentionCandidate]
 }>()
 
 const textareaEl = ref<HTMLTextAreaElement | null>(null)
+const vaultPort = useVaultPort()
+const picker = useMentionPicker(vaultPort)
 
 defineExpose({ textareaEl })
 
+onBeforeUnmount(() => {
+  // Cancel any pending debounce / discard in-flight scans so timer
+  // callbacks do not fire against an unmounted reactive ref.
+  picker.close()
+})
+
+/**
+ * Tab / non-modifier Enter handler for the open picker — consume to
+ * commit; otherwise let the caller treat the event normally. Split out
+ * to keep `handlePickerKey` under the project's complexity budget.
+ */
+function tryCommitFromKey(event: KeyboardEvent): boolean {
+  if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) return false
+  const selection = picker.currentSelection()
+  if (selection === null) return false
+  event.preventDefault()
+  commitMention(selection)
+  return true
+}
+
+/**
+ * Picker keyboard handler. Returns `true` if the event was consumed —
+ * the caller skips its own send handling in that case. Kept as a
+ * separate function so `handleKeydown` stays within the project's
+ * complexity budget.
+ */
+function handlePickerKey(event: KeyboardEvent): boolean {
+  if (!picker.open.value || !picker.hasResults.value) return false
+  if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    picker.moveSelectionDown()
+    return true
+  }
+  if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    picker.moveSelectionUp()
+    return true
+  }
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    picker.close()
+    return true
+  }
+  if (event.key === 'Tab' || event.key === 'Enter') {
+    return tryCommitFromKey(event)
+  }
+  return false
+}
+
 function handleKeydown(event: KeyboardEvent): void {
+  if (handlePickerKey(event)) return
   if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
     if (!props.disabled && !props.loading) {
       event.preventDefault()
@@ -26,7 +90,47 @@ function handleKeydown(event: KeyboardEvent): void {
 }
 
 function handleInput(event: Event): void {
-  emit('update:modelValue', (event.target as HTMLTextAreaElement).value)
+  const ta = event.target as HTMLTextAreaElement
+  emit('update:modelValue', ta.value)
+  picker.handleInput(ta.value, ta.selectionStart)
+}
+
+function commitMention(candidate: MentionCandidate): void {
+  const ta = textareaEl.value
+  // Replace the `@<query>` fragment with `@<filename> ` (with trailing
+  // space) in the textarea value. We compute the new value from the
+  // current `modelValue` + the trigger's `atIndex` so the replacement is
+  // deterministic regardless of where the picker was opened.
+  const at = picker.atIndex.value
+  if (at < 0) {
+    picker.close()
+    return
+  }
+  const before = props.modelValue.slice(0, at)
+  const caret = ta?.selectionStart ?? props.modelValue.length
+  const after = props.modelValue.slice(caret)
+  const token = `@${basenameOf(candidate.path)} `
+  const next = `${before}${token}${after}`
+  emit('update:modelValue', next)
+  emit('add-context-file', candidate)
+  picker.close()
+  // Restore caret after the inserted token. Wrapped in a microtask
+  // because the textarea value updates after the parent re-renders.
+  void Promise.resolve().then(() => {
+    const el = textareaEl.value
+    if (el === null) return
+    const pos = before.length + token.length
+    el.focus()
+    el.setSelectionRange(pos, pos)
+  })
+}
+
+function onDropdownSelect(candidate: MentionCandidate): void {
+  commitMention(candidate)
+}
+
+function onDropdownHover(index: number): void {
+  picker.setSelectedIndex(index)
 }
 </script>
 
@@ -39,11 +143,23 @@ function handleInput(event: Event): void {
       :readonly="disabled"
       :aria-label="'Message'"
       aria-multiline="true"
+      :aria-expanded="picker.open.value"
+      aria-autocomplete="list"
+      :aria-controls="picker.open.value ? 'mention-dropdown' : undefined"
       placeholder="Ask anything about your work…"
       rows="3"
       data-testid="chat-input-textarea"
       @input="handleInput"
       @keydown="handleKeydown"
+      @blur="picker.close()"
+    />
+    <MentionDropdown
+      v-if="picker.open.value"
+      id="mention-dropdown"
+      :results="picker.results.value"
+      :selected-index="picker.selectedIndex.value"
+      @select="onDropdownSelect"
+      @hover="onDropdownHover"
     />
     <div class="sp-chat__input-actions">
       <button
@@ -66,6 +182,7 @@ function handleInput(event: Event): void {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  position: relative;
 }
 
 .sp-chat__textarea {

--- a/src/ui/components/chat/ChatInput.vue
+++ b/src/ui/components/chat/ChatInput.vue
@@ -91,6 +91,13 @@ function handleKeydown(event: KeyboardEvent): void {
   if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
     if (!props.disabled && !props.loading) {
       event.preventDefault()
+      // Codex P2 on PR #376: close the mention picker before the send.
+      // Without this, the dropdown stays mounted on a now-readonly
+      // textarea during loading, and a subsequent Enter/Tab can commit
+      // a mention mid-request and mutate `modelValue` / `contextFiles`
+      // while the send is in flight — breaking the disabled-input
+      // contract and leaving stale UI behind after submit.
+      if (picker.open.value) picker.close()
       emit('send')
     }
   }

--- a/src/ui/components/chat/ChatInput.vue
+++ b/src/ui/components/chat/ChatInput.vue
@@ -96,19 +96,21 @@ function handleInput(event: Event): void {
 }
 
 function commitMention(candidate: MentionCandidate): void {
-  const ta = textareaEl.value
-  // Replace the `@<query>` fragment with `@<filename> ` (with trailing
-  // space) in the textarea value. We compute the new value from the
-  // current `modelValue` + the trigger's `atIndex` so the replacement is
-  // deterministic regardless of where the picker was opened.
+  // Codex P2 on PR #376: replace the `@<query>` span using trigger
+  // bounds, NOT the current caret. The picker may stay open while the
+  // user moves the caret with ArrowLeft/ArrowRight; using
+  // `ta.selectionStart` would slice the wrong suffix and leak the old
+  // query (or unrelated text) into the prompt. `picker.atIndex` is the
+  // `@`, and `picker.atIndex + 1 + picker.query.length` is the end of
+  // the detected token at the time the picker last opened/updated.
   const at = picker.atIndex.value
   if (at < 0) {
     picker.close()
     return
   }
+  const queryEnd = at + 1 + picker.query.value.length
   const before = props.modelValue.slice(0, at)
-  const caret = ta?.selectionStart ?? props.modelValue.length
-  const after = props.modelValue.slice(caret)
+  const after = props.modelValue.slice(queryEnd)
   const token = `@${basenameOf(candidate.path)} `
   const next = `${before}${token}${after}`
   emit('update:modelValue', next)

--- a/src/ui/components/chat/ChatInput.vue
+++ b/src/ui/components/chat/ChatInput.vue
@@ -87,6 +87,12 @@ function handlePickerKey(event: KeyboardEvent): boolean {
 }
 
 function handleKeydown(event: KeyboardEvent): void {
+  // IME-composition guard (top-4 from comparative review). `isComposing`
+  // is `true` while a Japanese/Chinese/Korean IME is mid-composition;
+  // pressing Enter to commit the composition must NOT trigger send /
+  // commit-mention / dismiss-picker. `keyCode === 229` is the legacy IME
+  // indicator for older browsers — defence in depth.
+  if (event.isComposing || event.keyCode === 229) return
   if (handlePickerKey(event)) return
   if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
     if (!props.disabled && !props.loading) {

--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -951,6 +951,21 @@ function handleUserTextUpdate(text: string): void {
 	store.setUserText(text);
 }
 
+/**
+ * Mention-picker selection (PR-ASV-4 / D-ASV-3). `ChatInput` already
+ * replaces the `@<query>` text fragment inline; the sidebar's job is to
+ * create the matching context-file chip via `store.addContextFile`. The
+ * chip stays `isAuto: false` so the user can dismiss it with the chip's
+ * remove button — auto chips are reserved for the active editor file.
+ */
+function handleAddContextFile(candidate: { path: string; name: string }): void {
+	store.addContextFile({
+		path: candidate.path,
+		label: candidate.name,
+		isAuto: false,
+	});
+}
+
 // Determine if API key is missing when unavailable
 async function isApiKeyMissing(): Promise<boolean> {
 	const settings = await settingsPort.getSettings();
@@ -1073,6 +1088,7 @@ watch(available, async () => {
 				:loading="store.status === 'loading'"
 				@update:model-value="handleUserTextUpdate"
 				@send="handleSend"
+				@add-context-file="handleAddContextFile"
 			/>
 
 			<hr class="sp-chat__divider" />

--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -959,6 +959,17 @@ function handleUserTextUpdate(text: string): void {
  * remove button — auto chips are reserved for the active editor file.
  */
 function handleAddContextFile(candidate: { path: string; name: string }): void {
+	// Codex P2 on PR #376: `store.addContextFile` is a no-op when the path
+	// already exists. If the user mentions a file that currently lives
+	// ONLY as the auto-context chip, the explicit mention is silently
+	// dropped — then when the active editor file later changes,
+	// `setActiveFile` removes the old auto entry and the user's mention
+	// disappears from context. Promote the auto entry to a manual one so
+	// the explicit mention survives editor rotation.
+	const existing = store.contextFiles.find((f) => f.path === candidate.path);
+	if (existing?.isAuto === true) {
+		store.removeContextFile(candidate.path);
+	}
 	store.addContextFile({
 		path: candidate.path,
 		label: candidate.name,

--- a/src/ui/components/chat/MentionDropdown.vue
+++ b/src/ui/components/chat/MentionDropdown.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+/**
+ * Floating listbox that surfaces the `@`-mention search results beneath
+ * `ChatInput`'s textarea (PR-ASV-4 / D-ASV-3). Stateless — receives the
+ * candidate array and selected index from `useMentionPicker`; emits
+ * `select` (mouse) and `hover` (mouse-over) back to the consumer. Keyboard
+ * navigation is handled by `ChatInput.handleKeydown` because the textarea
+ * keeps focus while the dropdown is open.
+ *
+ * ARIA: `role="listbox"` on the container, `role="option"` + `aria-
+ * selected` per entry, matching the WAI-ARIA combobox pattern.
+ */
+import type { MentionCandidate } from '@/application/chat/vaultFileSearch'
+
+defineProps<{
+	results: readonly MentionCandidate[]
+	selectedIndex: number
+}>()
+
+const emit = defineEmits<{
+	select: [candidate: MentionCandidate]
+	hover: [index: number]
+}>()
+</script>
+
+<template>
+	<ul
+		v-if="results.length > 0"
+		class="sp-mention-dropdown"
+		role="listbox"
+		aria-label="File mentions"
+		data-testid="mention-dropdown"
+	>
+		<li
+			v-for="(candidate, index) in results"
+			:key="candidate.path"
+			class="sp-mention-dropdown__item"
+			:class="{ 'sp-mention-dropdown__item--selected': index === selectedIndex }"
+			role="option"
+			:aria-selected="index === selectedIndex"
+			:data-testid="`mention-option-${index}`"
+			@mousedown.prevent="emit('select', candidate)"
+			@mouseenter="emit('hover', index)"
+		>
+			<span class="sp-mention-dropdown__name">{{ candidate.name }}</span>
+			<span class="sp-mention-dropdown__path">{{ candidate.path }}</span>
+		</li>
+	</ul>
+</template>
+
+<style scoped>
+.sp-mention-dropdown {
+	list-style: none;
+	margin: 0;
+	padding: 0.25rem 0;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 6px;
+	background: var(--background-primary);
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+	max-height: 16rem;
+	overflow-y: auto;
+	font-family: var(--font-text);
+	font-size: 0.8125rem;
+}
+
+.sp-mention-dropdown__item {
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+	padding: 0.3rem 0.75rem;
+	cursor: pointer;
+	color: var(--text-normal);
+}
+
+.sp-mention-dropdown__item--selected,
+.sp-mention-dropdown__item:hover {
+	background: var(--background-modifier-hover);
+}
+
+.sp-mention-dropdown__name {
+	font-weight: 600;
+}
+
+.sp-mention-dropdown__path {
+	color: var(--text-muted);
+	font-size: 0.75rem;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+</style>

--- a/src/ui/composables/useMentionPicker.ts
+++ b/src/ui/composables/useMentionPicker.ts
@@ -132,6 +132,14 @@ export function useMentionPicker(vault: VaultPort): UseMentionPicker {
 	 * and overwrite the fresher results.
 	 */
 	let searchSeq = 0
+	/**
+	 * Shared in-flight vault-scan promise (Codex P2 on PR #376). Without
+	 * this, a slow `collectVaultFiles` could let a second debounced
+	 * keystroke re-enter the `cached === null` branch and start a second
+	 * concurrent recursive walk. Reused across all searches in the open
+	 * session; cleared on close alongside `cached`.
+	 */
+	let inFlightScan: Promise<readonly string[]> | null = null
 
 	function clearDebounce(): void {
 		if (debounceTimer !== null) {
@@ -149,11 +157,20 @@ export function useMentionPicker(vault: VaultPort): UseMentionPicker {
 
 	async function runSearch(seq: number, q: string): Promise<void> {
 		if (cached === null) {
-			const paths = await collectVaultFiles(vault, '')
+			// Codex P2 on PR #376: share a single in-flight scan promise.
+			// `collectVaultFiles` is a recursive walk and the user can
+			// type faster than the scan resolves. The previous
+			// implementation kicked off a fresh walk on every debounced
+			// search until the first one populated `cached`, leading to
+			// N concurrent root scans on a large vault.
+			inFlightScan ??= collectVaultFiles(vault, '')
+			const paths = await inFlightScan
 			// Drop the result if the user has typed past this open session
 			// (e.g. escape + new `@`) — `searchSeq` was bumped past `seq`.
 			if (seq !== searchSeq) return
-			cached = prepareCandidates(paths)
+			// Only the first awaiter populates `cached`; subsequent
+			// awaiters see the populated cache and skip the assignment.
+			cached ??= prepareCandidates(paths)
 		}
 		if (seq !== searchSeq) return
 		const ranked = matchAndRank(cached, q)
@@ -180,7 +197,10 @@ export function useMentionPicker(vault: VaultPort): UseMentionPicker {
 		query.value = trigger.query
 		// Invalidate the candidate cache on each fresh open — picks up
 		// vault writes that landed between picker sessions (per the brief).
-		if (!wasOpen) cached = null
+		if (!wasOpen) {
+			cached = null
+			inFlightScan = null
+		}
 		scheduleSearch(trigger.query)
 	}
 
@@ -191,6 +211,7 @@ export function useMentionPicker(vault: VaultPort): UseMentionPicker {
 		selectedIndex.value = 0
 		atIndex.value = -1
 		cached = null
+		inFlightScan = null
 		clearDebounce()
 		// Bump the sequence so any in-flight scan promise is discarded.
 		searchSeq++

--- a/src/ui/composables/useMentionPicker.ts
+++ b/src/ui/composables/useMentionPicker.ts
@@ -163,7 +163,17 @@ export function useMentionPicker(vault: VaultPort): UseMentionPicker {
 			// implementation kicked off a fresh walk on every debounced
 			// search until the first one populated `cached`, leading to
 			// N concurrent root scans on a large vault.
-			inFlightScan ??= collectVaultFiles(vault, '')
+			//
+			// Codex P2 (second pass) on PR #376: chain a `.catch` that
+			// resets `inFlightScan` on rejection. Otherwise one transient
+			// `collectVaultFiles` failure left the rejected promise stuck
+			// — every later keystroke awaited the same rejection and the
+			// picker rendered empty results until close/reopen instead of
+			// retrying on the next debounced call.
+			inFlightScan ??= collectVaultFiles(vault, '').catch((err: unknown) => {
+				inFlightScan = null
+				throw err
+			})
 			const paths = await inFlightScan
 			// Drop the result if the user has typed past this open session
 			// (e.g. escape + new `@`) — `searchSeq` was bumped past `seq`.

--- a/src/ui/composables/useMentionPicker.ts
+++ b/src/ui/composables/useMentionPicker.ts
@@ -1,0 +1,251 @@
+/**
+ * `@`-file mention picker composable (PR-ASV-4 / IDEA-ASV-001 D-ASV-3).
+ *
+ * Encapsulates trigger detection, debounced search, and keyboard navigation
+ * for the inline `@`-mention dropdown shown beneath `ChatInput`'s
+ * textarea. Composable-only — owns no DOM. The `MentionDropdown` component
+ * reads `state` and dispatches `commit` on selection; `ChatInput` calls
+ * `handleInput` on every keystroke and `handleKey` for navigation keys.
+ *
+ * The composable is intentionally bridge-agnostic: it accepts a `VaultPort`
+ * (injected by the consumer via `useVaultPort()`) so the same code paths
+ * exercise MockBridge in unit tests, LocalStorageBridge on GitHub Pages,
+ * and ObsidianBridge in production.
+ *
+ * Debouncing uses raw `setTimeout` rather than `obsidianmd/prefer-active-
+ * window-timers` (the rule is disabled for `src/ui/**` — see
+ * `eslint.config.js:444`) so the composable works in jsdom unit tests as
+ * well as inside Obsidian's popout windows. The 200 ms delay matches
+ * Claudian's `MentionDropdownController`.
+ */
+import { ref, computed, type Ref } from 'vue'
+import type { VaultPort } from '@/domain/ports'
+import {
+	collectVaultFiles,
+	matchAndRank,
+	prepareCandidates,
+	type MentionCandidate,
+	type RankedCandidate,
+} from '@/application/chat/vaultFileSearch'
+
+/**
+ * Debounce window for the search query (Claudian pattern). 200 ms keeps
+ * the dropdown responsive without re-scanning the vault on every
+ * keystroke.
+ */
+export const MENTION_DEBOUNCE_MS = 200
+
+/**
+ * Outcome of `detectTrigger`. Returned for every `handleInput` call so
+ * the composable can decide whether to open, close, or update the
+ * dropdown.
+ */
+export interface MentionTrigger {
+	/** Index of the `@` character in the textarea value. */
+	readonly atIndex: number
+	/** The substring between `@` and the caret (excluding both). */
+	readonly query: string
+}
+
+/**
+ * Backward-scan from `caret` to find the most recent `@` that qualifies
+ * as a mention trigger:
+ *   - at position 0, OR
+ *   - immediately preceded by whitespace.
+ *
+ * The trigger is aborted if any whitespace appears between `@` and the
+ * caret — typing a space dismisses the picker (matching Claudian's
+ * `MentionTextProcessor.detectTrigger`).
+ *
+ * Pure function so the composable can reuse it after debounce ticks
+ * without paying a Vue reactivity tax.
+ */
+export function detectTrigger(value: string, caret: number): MentionTrigger | null {
+	for (let i = caret - 1; i >= 0; i--) {
+		const ch = value[i]
+		if (ch === '@') {
+			if (i === 0 || /\s/.test(value[i - 1] ?? '')) {
+				const query = value.slice(i + 1, caret)
+				return { atIndex: i, query }
+			}
+			return null
+		}
+		if (/\s/.test(ch)) return null
+	}
+	return null
+}
+
+/**
+ * Public composable surface. `state` is reactive; the rest are
+ * imperative handlers driven by `ChatInput` keyboard / input events.
+ */
+export interface UseMentionPicker {
+	readonly open: Readonly<Ref<boolean>>
+	readonly query: Readonly<Ref<string>>
+	readonly results: Readonly<Ref<readonly MentionCandidate[]>>
+	readonly selectedIndex: Readonly<Ref<number>>
+	readonly atIndex: Readonly<Ref<number>>
+	readonly hasResults: Readonly<Ref<boolean>>
+	/**
+	 * Called on every textarea `input` event. Detects (or dismisses) the
+	 * trigger; schedules a debounced search if open.
+	 */
+	handleInput(value: string, caret: number): void
+	/**
+	 * Force-close the picker. Used by `ChatInput` on Escape, on blur, and
+	 * on commit.
+	 */
+	close(): void
+	/** Move selection up by one (wraps to the last entry). */
+	moveSelectionUp(): void
+	/** Move selection down by one (wraps to the first entry). */
+	moveSelectionDown(): void
+	/** Set the highlighted index (used by mouse hover). */
+	setSelectedIndex(index: number): void
+	/** Return the currently-highlighted candidate, or null. */
+	currentSelection(): MentionCandidate | null
+}
+
+/**
+ * Construct a picker bound to `vault`. The caller owns the lifecycle:
+ * `close()` should be invoked from the consumer's `onBeforeUnmount` to
+ * cancel any pending debounce.
+ */
+export function useMentionPicker(vault: VaultPort): UseMentionPicker {
+	const open = ref(false)
+	const query = ref('')
+	const results = ref<readonly MentionCandidate[]>([])
+	const selectedIndex = ref(0)
+	const atIndex = ref(-1)
+
+	/**
+	 * Cached candidate list for the *current* open session. Re-scanned on
+	 * every dropdown open to honor late vault writes; cleared on close.
+	 * Pre-lowered for cheaper per-keystroke matching.
+	 */
+	let cached: RankedCandidate[] | null = null
+	let debounceTimer: ReturnType<typeof setTimeout> | null = null
+	/**
+	 * Monotonic id of the most recent `triggerSearch` invocation. Used to
+	 * discard out-of-order scan results — without this guard, a slow
+	 * `collectVaultFiles` promise from search #1 can land after search #2
+	 * and overwrite the fresher results.
+	 */
+	let searchSeq = 0
+
+	function clearDebounce(): void {
+		if (debounceTimer !== null) {
+			clearTimeout(debounceTimer)
+			debounceTimer = null
+		}
+	}
+
+	function applyResults(next: readonly MentionCandidate[]): void {
+		results.value = next
+		// Clamp selection to the new bounds; default to the first entry on
+		// every query change so Enter/Tab targets the top match.
+		selectedIndex.value = 0
+	}
+
+	async function runSearch(seq: number, q: string): Promise<void> {
+		if (cached === null) {
+			const paths = await collectVaultFiles(vault, '')
+			// Drop the result if the user has typed past this open session
+			// (e.g. escape + new `@`) — `searchSeq` was bumped past `seq`.
+			if (seq !== searchSeq) return
+			cached = prepareCandidates(paths)
+		}
+		if (seq !== searchSeq) return
+		const ranked = matchAndRank(cached, q)
+		applyResults(ranked)
+	}
+
+	function scheduleSearch(q: string): void {
+		clearDebounce()
+		const seq = ++searchSeq
+		debounceTimer = setTimeout(() => {
+			debounceTimer = null
+			// Fire-and-forget: vault scan failures should not crash the
+			// textarea. The picker simply renders no results.
+			void runSearch(seq, q).catch(() => {
+				if (seq === searchSeq) applyResults([])
+			})
+		}, MENTION_DEBOUNCE_MS)
+	}
+
+	function openWithTrigger(trigger: MentionTrigger): void {
+		const wasOpen = open.value
+		open.value = true
+		atIndex.value = trigger.atIndex
+		query.value = trigger.query
+		// Invalidate the candidate cache on each fresh open — picks up
+		// vault writes that landed between picker sessions (per the brief).
+		if (!wasOpen) cached = null
+		scheduleSearch(trigger.query)
+	}
+
+	function close(): void {
+		open.value = false
+		query.value = ''
+		results.value = []
+		selectedIndex.value = 0
+		atIndex.value = -1
+		cached = null
+		clearDebounce()
+		// Bump the sequence so any in-flight scan promise is discarded.
+		searchSeq++
+	}
+
+	function handleInput(value: string, caret: number): void {
+		const trigger = detectTrigger(value, caret)
+		if (trigger === null) {
+			if (open.value) close()
+			return
+		}
+		openWithTrigger(trigger)
+	}
+
+	function moveSelectionUp(): void {
+		const len = results.value.length
+		if (len === 0) return
+		selectedIndex.value = (selectedIndex.value - 1 + len) % len
+	}
+
+	function moveSelectionDown(): void {
+		const len = results.value.length
+		if (len === 0) return
+		selectedIndex.value = (selectedIndex.value + 1) % len
+	}
+
+	function setSelectedIndex(index: number): void {
+		const len = results.value.length
+		if (len === 0) return
+		if (index < 0 || index >= len) return
+		selectedIndex.value = index
+	}
+
+	function currentSelection(): MentionCandidate | null {
+		const list = results.value
+		if (list.length === 0) return null
+		const idx = selectedIndex.value
+		if (idx < 0 || idx >= list.length) return null
+		return list[idx]
+	}
+
+	const hasResults = computed(() => results.value.length > 0)
+
+	return {
+		open,
+		query,
+		results,
+		selectedIndex,
+		atIndex,
+		hasResults,
+		handleInput,
+		close,
+		moveSelectionUp,
+		moveSelectionDown,
+		setSelectedIndex,
+		currentSelection,
+	}
+}

--- a/styles.css
+++ b/styles.css
@@ -970,12 +970,49 @@ to {
   color: var(--text-muted);
 }
 
-.specorator-root :where(.sp-chat__input-area[data-v-e70d8df8]) {
+.specorator-root :where(.sp-mention-dropdown[data-v-ace43c9f]) {
+	list-style: none;
+	margin: 0;
+	padding: 0.25rem 0;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 6px;
+	background: var(--background-primary);
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+	max-height: 16rem;
+	overflow-y: auto;
+	font-family: var(--font-text);
+	font-size: 0.8125rem;
+}
+.specorator-root :where(.sp-mention-dropdown__item[data-v-ace43c9f]) {
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+	padding: 0.3rem 0.75rem;
+	cursor: pointer;
+	color: var(--text-normal);
+}
+.specorator-root :where(.sp-mention-dropdown__item--selected[data-v-ace43c9f]),
+.specorator-root :where(.sp-mention-dropdown__item[data-v-ace43c9f]:hover) {
+	background: var(--background-modifier-hover);
+}
+.specorator-root :where(.sp-mention-dropdown__name[data-v-ace43c9f]) {
+	font-weight: 600;
+}
+.specorator-root :where(.sp-mention-dropdown__path[data-v-ace43c9f]) {
+	color: var(--text-muted);
+	font-size: 0.75rem;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.specorator-root :where(.sp-chat__input-area[data-v-950e70df]) {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  position: relative;
 }
-.specorator-root :where(.sp-chat__textarea[data-v-e70d8df8]) {
+.specorator-root :where(.sp-chat__textarea[data-v-950e70df]) {
   width: 100%;
   min-height: 4.5rem;
   max-height: 8rem;
@@ -990,11 +1027,11 @@ to {
   font-size: 0.875rem;
   box-sizing: border-box;
 }
-.specorator-root :where(.sp-chat__textarea[data-v-e70d8df8]:focus) {
+.specorator-root :where(.sp-chat__textarea[data-v-950e70df]:focus) {
   outline: none;
   border-color: var(--interactive-accent);
 }
-.specorator-root :where(.sp-chat__input-actions[data-v-e70d8df8]) {
+.specorator-root :where(.sp-chat__input-actions[data-v-950e70df]) {
   display: flex;
   justify-content: flex-end;
 }
@@ -1162,7 +1199,7 @@ to {
  * parent: in the agent sidepanel the parent gives ChatSidebar `flex: 0 0
  * auto` and `MessageList` takes the remaining grow space.
  */
-.specorator-root :where(.sp-chat-sidebar[data-v-bc55d886]) {
+.specorator-root :where(.sp-chat-sidebar[data-v-a2962cc1]) {
 	padding: 1rem;
 	display: flex;
 	flex-direction: column;
@@ -1170,24 +1207,24 @@ to {
 	box-sizing: border-box;
 	flex-shrink: 0;
 }
-.specorator-root :where(.sp-chat__title[data-v-bc55d886]) {
+.specorator-root :where(.sp-chat__title[data-v-a2962cc1]) {
 	margin: 0;
 	font-size: 1.125rem;
 	font-weight: 700;
 	color: var(--text-normal);
 }
-.specorator-root :where(.sp-chat__header[data-v-bc55d886]) {
+.specorator-root :where(.sp-chat__header[data-v-a2962cc1]) {
 	display: flex;
 	align-items: center;
 	gap: 0.5rem;
 	flex-wrap: wrap;
 }
-.specorator-root :where(.sp-chat__divider[data-v-bc55d886]) {
+.specorator-root :where(.sp-chat__divider[data-v-a2962cc1]) {
 	margin: 0;
 	border: none;
 	border-top: 1px solid var(--background-modifier-border);
 }
-.specorator-root :where(.sp-chat__stop[data-v-bc55d886]) {
+.specorator-root :where(.sp-chat__stop[data-v-a2962cc1]) {
 	margin-left: auto;
 	font-size: 0.75rem;
 	font-weight: 500;
@@ -1201,10 +1238,10 @@ to {
 		background-color 0.15s,
 		border-color 0.15s;
 }
-.specorator-root :where(.sp-chat__stop[data-v-bc55d886]:hover) {
+.specorator-root :where(.sp-chat__stop[data-v-a2962cc1]:hover) {
 	background: var(--background-modifier-error-hover, var(--interactive-hover));
 }
-.specorator-root :where(.sp-chat__degraded[data-v-bc55d886]) {
+.specorator-root :where(.sp-chat__degraded[data-v-a2962cc1]) {
 	background: var(--background-secondary);
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 8px;
@@ -1213,13 +1250,13 @@ to {
 	flex-direction: column;
 	gap: 0.5rem;
 }
-.specorator-root :where(.sp-chat__degraded-heading[data-v-bc55d886]) {
+.specorator-root :where(.sp-chat__degraded-heading[data-v-a2962cc1]) {
 	margin: 0;
 	font-size: 1rem;
 	font-weight: 600;
 	color: var(--text-normal);
 }
-.specorator-root :where(.sp-chat__degraded-body[data-v-bc55d886]) {
+.specorator-root :where(.sp-chat__degraded-body[data-v-a2962cc1]) {
 	margin: 0;
 	font-size: 0.875rem;
 	color: var(--text-muted);

--- a/tests/application/chat/vaultFileSearch.test.ts
+++ b/tests/application/chat/vaultFileSearch.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for the pure `vaultFileSearch` helpers backing the `@`-file
+ * mention picker (PR-ASV-4 / D-ASV-3). Pure-function tests — no Vue, no
+ * timers, no port mocks beyond a `VaultPort`-shaped fixture for the
+ * recursive walk.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+	MENTION_RESULT_CAP,
+	basenameOf,
+	collectVaultFiles,
+	matchAndRank,
+	prepareCandidates,
+} from '@/application/chat/vaultFileSearch'
+import { MockBridge } from '@/infrastructure/mock/MockBridge'
+
+describe('vaultFileSearch.basenameOf', () => {
+	it('returns the last path segment', () => {
+		expect(basenameOf('specs/foo/idea.md')).toBe('idea.md')
+	})
+
+	it('handles top-level paths', () => {
+		expect(basenameOf('README.md')).toBe('README.md')
+	})
+
+	it('handles empty strings', () => {
+		expect(basenameOf('')).toBe('')
+	})
+})
+
+describe('vaultFileSearch.collectVaultFiles', () => {
+	it('walks nested folders recursively', async () => {
+		const bridge = new MockBridge({
+			'README.md': '',
+			'specs/foo/idea.md': '',
+			'specs/foo/requirements.md': '',
+			'specs/bar/idea.md': '',
+		})
+		const out = await collectVaultFiles(bridge, '')
+		expect(out.sort()).toEqual([
+			'README.md',
+			'specs/bar/idea.md',
+			'specs/foo/idea.md',
+			'specs/foo/requirements.md',
+		])
+	})
+
+	it('returns an empty array for an empty vault', async () => {
+		const bridge = new MockBridge({})
+		expect(await collectVaultFiles(bridge, '')).toEqual([])
+	})
+
+	it('honours non-empty root parameter', async () => {
+		const bridge = new MockBridge({
+			'a/x.md': '',
+			'b/y.md': '',
+		})
+		const out = await collectVaultFiles(bridge, 'a')
+		expect(out).toEqual(['a/x.md'])
+	})
+})
+
+describe('vaultFileSearch.matchAndRank', () => {
+	const paths = [
+		'README.md',
+		'specs/foo/idea.md',
+		'specs/foo/requirements.md',
+		'specs/bar/requirements.md',
+		'specs/zzz/requirements-extras.md',
+	]
+	const candidates = prepareCandidates(paths)
+
+	it('substring-matches on the basename', () => {
+		const out = matchAndRank(candidates, 'idea')
+		expect(out.map((c) => c.path)).toEqual(['specs/foo/idea.md'])
+	})
+
+	it('substring-matches on the full path', () => {
+		const out = matchAndRank(candidates, 'bar')
+		expect(out.map((c) => c.path)).toEqual(['specs/bar/requirements.md'])
+	})
+
+	it('is case-insensitive', () => {
+		const out = matchAndRank(candidates, 'IDEA')
+		expect(out.map((c) => c.path)).toEqual(['specs/foo/idea.md'])
+	})
+
+	it('sorts filename-prefix matches before contains-only matches', () => {
+		// "requirements" prefix-matches `requirements.md` and
+		// `requirements-extras.md`; the other entries only contain it
+		// elsewhere in the path. The two prefix matches come first; ties
+		// among them break on path lexicographic order.
+		const out = matchAndRank(candidates, 'requirements')
+		expect(out.map((c) => c.path)).toEqual([
+			'specs/bar/requirements.md',
+			'specs/foo/requirements.md',
+			'specs/zzz/requirements-extras.md',
+		])
+	})
+
+	it('further ties broken by path ascending lexicographic order', () => {
+		const out = matchAndRank(prepareCandidates(['a/z.md', 'a/a.md', 'b/m.md']), '.md')
+		expect(out.map((c) => c.path)).toEqual(['a/a.md', 'a/z.md', 'b/m.md'])
+	})
+
+	it('caps results at MENTION_RESULT_CAP', () => {
+		const many = Array.from({ length: 200 }, (_, i) => `notes/${i.toString().padStart(4, '0')}.md`)
+		const out = matchAndRank(prepareCandidates(many), '.md')
+		expect(out.length).toBe(MENTION_RESULT_CAP)
+		expect(out[0].path).toBe('notes/0000.md')
+	})
+
+	it('empty query returns capped-prefix slice of vault', () => {
+		const out = matchAndRank(candidates, '')
+		expect(out.length).toBeGreaterThan(0)
+		expect(out.length).toBeLessThanOrEqual(MENTION_RESULT_CAP)
+	})
+
+	it('non-matching query returns empty array', () => {
+		const out = matchAndRank(candidates, 'zzzzz-not-present')
+		expect(out).toEqual([])
+	})
+})

--- a/tests/ui/components/chat/ChatInput.po.ts
+++ b/tests/ui/components/chat/ChatInput.po.ts
@@ -1,10 +1,40 @@
 import type { VueWrapper } from '@vue/test-utils'
 
 export class ChatInputPO {
-	constructor(private readonly wrapper: VueWrapper) {}
+	constructor(public readonly wrapper: VueWrapper) {}
 
 	private byTid(tid: string) {
 		return `[data-testid="${tid}"]`
+	}
+
+	mentionDropdownExists(): boolean {
+		return this.wrapper.find(this.byTid('mention-dropdown')).exists()
+	}
+
+	mentionOptionAt(index: number) {
+		return this.wrapper.find(this.byTid(`mention-option-${index}`))
+	}
+
+	mentionOptionPaths(): string[] {
+		return this.wrapper.findAll('[role="option"]').map((el) => {
+			const path = el.find('[data-testid^="mention-option-"] > :last-child')
+			return path.exists() ? path.text() : ''
+		})
+	}
+
+	async typeAndMoveCaretToEnd(value: string): Promise<void> {
+		const el = this.textarea.element as HTMLTextAreaElement
+		el.value = value
+		el.setSelectionRange(value.length, value.length)
+		await this.textarea.trigger('input')
+	}
+
+	async pressKey(key: string, modifiers: { ctrl?: boolean; meta?: boolean } = {}): Promise<void> {
+		await this.textarea.trigger('keydown', {
+			key,
+			ctrlKey: modifiers.ctrl ?? false,
+			metaKey: modifiers.meta ?? false,
+		})
 	}
 
 	get textarea() {

--- a/tests/ui/components/chat/ChatInput.test.ts
+++ b/tests/ui/components/chat/ChatInput.test.ts
@@ -1,14 +1,31 @@
 /**
  * T-CCS-022 — Tests: ChatInput — v-model, disabled state, send via Ctrl+Enter, button states.
  * Satisfies REQ-CCS-013, REQ-CCS-014, REQ-CCS-015, NFR-CCS-009, SPEC-CCS-001 §7.5.
+ *
+ * Mention-picker tests (PR-ASV-4 / D-ASV-3) live in the
+ * `describe('mention picker', ...)` block at the bottom.
  */
-import { describe, it, expect } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
 import ChatInput from '@/ui/components/chat/ChatInput.vue'
+import { MockBridge } from '@/infrastructure/mock/MockBridge'
+import { VAULT_PORT } from '@/infrastructure/bridge/ports'
+import { MENTION_DEBOUNCE_MS } from '@/ui/composables/useMentionPicker'
 import { ChatInputPO } from './ChatInput.po'
 
-function mountChatInput(props: { modelValue: string; disabled: boolean; loading: boolean }) {
-	const wrapper = mount(ChatInput, { props })
+function mountChatInput(
+	props: { modelValue: string; disabled: boolean; loading: boolean },
+	files: Record<string, string> = {},
+) {
+	const bridge = new MockBridge(files)
+	const wrapper = mount(ChatInput, {
+		props,
+		global: {
+			provide: {
+				[VAULT_PORT as symbol]: bridge,
+			},
+		},
+	})
 	return new ChatInputPO(wrapper)
 }
 
@@ -96,6 +113,121 @@ describe('ChatInput', () => {
 		it('when loading=true, button shows "Asking…" label', () => {
 			const po = mountChatInput({ modelValue: '', disabled: false, loading: true })
 			expect(po.sendButtonText()).toContain('Asking')
+		})
+	})
+
+	/**
+	 * PR-ASV-4 / D-ASV-3 — `@`-file mention picker integration tests.
+	 *
+	 * Cover the end-to-end keystroke flow: type `@req`, see a
+	 * `requirements.md` candidate, press Enter, expect the inline text
+	 * replacement AND the `add-context-file` event emitted (which
+	 * `ChatSidebar.handleAddContextFile` then routes to
+	 * `chatStore.addContextFile`).
+	 */
+	describe('mention picker', () => {
+		const FILES = {
+			'specs/foo/idea.md': '',
+			'specs/foo/requirements.md': '',
+			'specs/bar/requirements.md': '',
+		}
+
+		beforeEach(() => {
+			vi.useFakeTimers()
+		})
+
+		afterEach(() => {
+			vi.useRealTimers()
+		})
+
+		it('opens the mention dropdown when the user types `@`', async () => {
+			const po = mountChatInput(
+				{ modelValue: '', disabled: false, loading: false },
+				FILES,
+			)
+			await po.typeAndMoveCaretToEnd('@')
+			expect(po.mentionDropdownExists()).toBe(false)
+			await vi.advanceTimersByTimeAsync(MENTION_DEBOUNCE_MS + 1)
+			await flushPromises()
+			expect(po.mentionDropdownExists()).toBe(true)
+		})
+
+		it('typing `@req` surfaces a requirements.md candidate', async () => {
+			const po = mountChatInput(
+				{ modelValue: '', disabled: false, loading: false },
+				FILES,
+			)
+			await po.typeAndMoveCaretToEnd('@req')
+			await vi.advanceTimersByTimeAsync(MENTION_DEBOUNCE_MS + 1)
+			await flushPromises()
+			expect(po.mentionDropdownExists()).toBe(true)
+			const text = po.wrapper.find('[data-testid="mention-option-0"]').text()
+			expect(text).toContain('requirements.md')
+		})
+
+		it('Enter commits the selection: replaces `@req` and emits `add-context-file`', async () => {
+			const po = mountChatInput(
+				{ modelValue: '', disabled: false, loading: false },
+				FILES,
+			)
+			await po.typeAndMoveCaretToEnd('@req')
+			await vi.advanceTimersByTimeAsync(MENTION_DEBOUNCE_MS + 1)
+			await flushPromises()
+			await po.pressKey('Enter')
+
+			const updates = po.emitted('update:modelValue') as string[][]
+			const lastValue = updates[updates.length - 1][0]
+			expect(lastValue).toBe('@requirements.md ')
+
+			const added = po.emitted('add-context-file') as Array<[{ path: string; name: string }]>
+			expect(added).toBeTruthy()
+			expect(added[0][0]).toEqual({
+				path: 'specs/bar/requirements.md',
+				name: 'requirements.md',
+			})
+		})
+
+		it('Escape closes the dropdown without committing', async () => {
+			const po = mountChatInput(
+				{ modelValue: '', disabled: false, loading: false },
+				FILES,
+			)
+			await po.typeAndMoveCaretToEnd('@req')
+			await vi.advanceTimersByTimeAsync(MENTION_DEBOUNCE_MS + 1)
+			await flushPromises()
+			await po.pressKey('Escape')
+			expect(po.mentionDropdownExists()).toBe(false)
+			expect(po.emitted('add-context-file')).toBeFalsy()
+		})
+
+		it('ArrowDown moves selection and Enter commits the new highlight', async () => {
+			const po = mountChatInput(
+				{ modelValue: '', disabled: false, loading: false },
+				FILES,
+			)
+			await po.typeAndMoveCaretToEnd('@req')
+			await vi.advanceTimersByTimeAsync(MENTION_DEBOUNCE_MS + 1)
+			await flushPromises()
+			await po.pressKey('ArrowDown')
+			await po.pressKey('Enter')
+
+			const added = po.emitted('add-context-file') as Array<[{ path: string; name: string }]>
+			expect(added).toBeTruthy()
+			expect(added[0][0].path).toBe('specs/foo/requirements.md')
+		})
+
+		it('Ctrl+Enter still emits `send` instead of committing the mention', async () => {
+			const po = mountChatInput(
+				{ modelValue: '', disabled: false, loading: false },
+				FILES,
+			)
+			await po.typeAndMoveCaretToEnd('@req')
+			await vi.advanceTimersByTimeAsync(MENTION_DEBOUNCE_MS + 1)
+			await flushPromises()
+			await po.pressKey('Enter', { ctrl: true })
+
+			expect(po.emitted('send')).toBeTruthy()
+			expect(po.emitted('add-context-file')).toBeFalsy()
 		})
 	})
 })

--- a/tests/ui/components/chat/ChatInput.test.ts
+++ b/tests/ui/components/chat/ChatInput.test.ts
@@ -85,6 +85,22 @@ describe('ChatInput', () => {
 			await po.triggerSendKey(true)
 			expect(po.emitted('send')).toBeFalsy()
 		})
+
+		// IME-composition guard (top-4 from comparative review): Enter
+		// committed by a Japanese/Chinese/Korean IME must NOT trigger send.
+		it('Ctrl+Enter does not emit send while an IME is composing', async () => {
+			const po = mountChatInput({ modelValue: 'こんにち', disabled: false, loading: false })
+			const ta = po.textarea
+			await ta.trigger('keydown', { key: 'Enter', ctrlKey: true, isComposing: true })
+			expect(po.emitted('send')).toBeFalsy()
+		})
+
+		it('Ctrl+Enter does not emit send when legacy keyCode === 229 fires', async () => {
+			const po = mountChatInput({ modelValue: '中文', disabled: false, loading: false })
+			const ta = po.textarea
+			await ta.trigger('keydown', { key: 'Enter', ctrlKey: true, keyCode: 229 })
+			expect(po.emitted('send')).toBeFalsy()
+		})
 	})
 
 	describe('disabled state', () => {

--- a/tests/ui/components/chat/MentionDropdown.po.ts
+++ b/tests/ui/components/chat/MentionDropdown.po.ts
@@ -1,0 +1,42 @@
+import type { VueWrapper } from '@vue/test-utils'
+
+export class MentionDropdownPO {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	private byTid(tid: string) {
+		return `[data-testid="${tid}"]`
+	}
+
+	dropdownExists(): boolean {
+		return this.wrapper.find(this.byTid('mention-dropdown')).exists()
+	}
+
+	hasRoleListbox(): boolean {
+		const el = this.wrapper.find(this.byTid('mention-dropdown'))
+		return el.exists() && el.attributes('role') === 'listbox'
+	}
+
+	optionAt(index: number) {
+		return this.wrapper.find(this.byTid(`mention-option-${index}`))
+	}
+
+	optionCount(): number {
+		return this.wrapper.findAll('[role="option"]').length
+	}
+
+	optionIsSelected(index: number): boolean {
+		return this.optionAt(index).attributes('aria-selected') === 'true'
+	}
+
+	async clickOption(index: number): Promise<void> {
+		await this.optionAt(index).trigger('mousedown')
+	}
+
+	async hoverOption(index: number): Promise<void> {
+		await this.optionAt(index).trigger('mouseenter')
+	}
+
+	emitted(name: string): unknown {
+		return this.wrapper.emitted(name)
+	}
+}

--- a/tests/ui/components/chat/MentionDropdown.test.ts
+++ b/tests/ui/components/chat/MentionDropdown.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for the `MentionDropdown` listbox component (PR-ASV-4 / D-ASV-3).
+ *
+ * Verifies the ARIA contract (`role=listbox`, `role=option`,
+ * `aria-selected`), keyboard-agnostic selection (mousedown emits
+ * `select`), and hover-emits-index so the consumer can sync
+ * `useMentionPicker.setSelectedIndex`.
+ */
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import MentionDropdown from '@/ui/components/chat/MentionDropdown.vue'
+import type { MentionCandidate } from '@/application/chat/vaultFileSearch'
+import { MentionDropdownPO } from './MentionDropdown.po'
+
+const candidates: MentionCandidate[] = [
+	{ path: 'specs/foo/idea.md', name: 'idea.md' },
+	{ path: 'specs/foo/requirements.md', name: 'requirements.md' },
+	{ path: 'specs/bar/idea.md', name: 'idea.md' },
+]
+
+function mountDropdown(props: {
+	results: MentionCandidate[]
+	selectedIndex: number
+}): MentionDropdownPO {
+	return new MentionDropdownPO(mount(MentionDropdown, { props }))
+}
+
+describe('MentionDropdown', () => {
+	it('renders nothing when results array is empty', () => {
+		const po = mountDropdown({ results: [], selectedIndex: 0 })
+		expect(po.dropdownExists()).toBe(false)
+	})
+
+	it('renders one option per result with role="option"', () => {
+		const po = mountDropdown({ results: candidates, selectedIndex: 0 })
+		expect(po.dropdownExists()).toBe(true)
+		expect(po.optionCount()).toBe(3)
+	})
+
+	it('container has role="listbox"', () => {
+		const po = mountDropdown({ results: candidates, selectedIndex: 0 })
+		expect(po.hasRoleListbox()).toBe(true)
+	})
+
+	it('marks the selected index with aria-selected="true"', () => {
+		const po = mountDropdown({ results: candidates, selectedIndex: 1 })
+		expect(po.optionIsSelected(0)).toBe(false)
+		expect(po.optionIsSelected(1)).toBe(true)
+		expect(po.optionIsSelected(2)).toBe(false)
+	})
+
+	it('mousedown on an option emits `select` with the candidate', async () => {
+		const po = mountDropdown({ results: candidates, selectedIndex: 0 })
+		await po.clickOption(2)
+		const emitted = po.emitted('select') as MentionCandidate[][]
+		expect(emitted).toBeTruthy()
+		expect(emitted[0][0]).toEqual(candidates[2])
+	})
+
+	it('mouseenter on an option emits `hover` with the index', async () => {
+		const po = mountDropdown({ results: candidates, selectedIndex: 0 })
+		await po.hoverOption(1)
+		const emitted = po.emitted('hover') as number[][]
+		expect(emitted).toBeTruthy()
+		expect(emitted[0][0]).toBe(1)
+	})
+})

--- a/tests/ui/composables/useMentionPicker.test.ts
+++ b/tests/ui/composables/useMentionPicker.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for the `useMentionPicker` composable (PR-ASV-4 / D-ASV-3).
+ *
+ * Covers trigger detection edges, 200 ms debounce, navigation wrapping,
+ * and stale-search discard. Uses `vi.useFakeTimers()` so the 200 ms
+ * debounce window is observable without sleeping the runner.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+	useMentionPicker,
+	detectTrigger,
+	MENTION_DEBOUNCE_MS,
+} from '@/ui/composables/useMentionPicker'
+import { MockBridge } from '@/infrastructure/mock/MockBridge'
+
+describe('detectTrigger', () => {
+	it('detects `@` at position 0', () => {
+		const t = detectTrigger('@foo', 4)
+		expect(t).toEqual({ atIndex: 0, query: 'foo' })
+	})
+
+	it('detects `@` preceded by whitespace', () => {
+		const t = detectTrigger('hi @bar', 7)
+		expect(t).toEqual({ atIndex: 3, query: 'bar' })
+	})
+
+	it('returns null when `@` is preceded by a non-whitespace char', () => {
+		// e.g. an email-like context — no mention picker.
+		expect(detectTrigger('a@bar', 5)).toBeNull()
+	})
+
+	it('returns null when a whitespace appears after the `@`', () => {
+		expect(detectTrigger('@foo bar', 8)).toBeNull()
+	})
+
+	it('returns null when there is no `@` to the left of the caret', () => {
+		expect(detectTrigger('hello world', 5)).toBeNull()
+	})
+
+	it('returns empty query for a bare `@` at the caret', () => {
+		const t = detectTrigger('@', 1)
+		expect(t).toEqual({ atIndex: 0, query: '' })
+	})
+})
+
+describe('useMentionPicker', () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	function makeBridge(files: string[] = ['specs/foo/idea.md', 'specs/foo/requirements.md']) {
+		const seed: Record<string, string> = {}
+		for (const f of files) seed[f] = ''
+		return new MockBridge(seed)
+	}
+
+	it('opens the picker when an `@` trigger is detected', () => {
+		const picker = useMentionPicker(makeBridge())
+		picker.handleInput('@', 1)
+		expect(picker.open.value).toBe(true)
+		expect(picker.atIndex.value).toBe(0)
+		expect(picker.query.value).toBe('')
+	})
+
+	it('closes the picker when the trigger is invalidated', () => {
+		const picker = useMentionPicker(makeBridge())
+		picker.handleInput('@x', 2)
+		expect(picker.open.value).toBe(true)
+		picker.handleInput('@x y', 4)
+		expect(picker.open.value).toBe(false)
+	})
+
+	it('debounces the search by 200 ms (Claudian pattern)', async () => {
+		const picker = useMentionPicker(makeBridge())
+		picker.handleInput('@req', 4)
+		// Before the debounce fires no search has run.
+		expect(picker.results.value).toEqual([])
+		await vi.advanceTimersByTimeAsync(MENTION_DEBOUNCE_MS - 1)
+		expect(picker.results.value).toEqual([])
+		await vi.advanceTimersByTimeAsync(2)
+		expect(picker.results.value.length).toBe(1)
+		expect(picker.results.value[0].path).toBe('specs/foo/requirements.md')
+	})
+
+	it('caps results and orders prefix-match before contains-only', async () => {
+		const bridge = makeBridge([
+			'specs/foo/requirements.md',
+			'specs/bar/idea.md',
+			'specs/zzz/requirements-extras.md',
+		])
+		const picker = useMentionPicker(bridge)
+		picker.handleInput('@requirements', 13)
+		await vi.advanceTimersByTimeAsync(MENTION_DEBOUNCE_MS + 1)
+		expect(picker.results.value.map((c) => c.path)).toEqual([
+			'specs/foo/requirements.md',
+			'specs/zzz/requirements-extras.md',
+		])
+	})
+
+	it('arrow-down + arrow-up wrap selection', async () => {
+		const picker = useMentionPicker(
+			makeBridge(['notes/a.md', 'notes/b.md', 'notes/c.md']),
+		)
+		picker.handleInput('@', 1)
+		await vi.advanceTimersByTimeAsync(MENTION_DEBOUNCE_MS + 1)
+		expect(picker.selectedIndex.value).toBe(0)
+		picker.moveSelectionDown()
+		expect(picker.selectedIndex.value).toBe(1)
+		picker.moveSelectionDown()
+		picker.moveSelectionDown()
+		// wraps back to 0
+		expect(picker.selectedIndex.value).toBe(0)
+		picker.moveSelectionUp()
+		// wraps to last
+		expect(picker.selectedIndex.value).toBe(2)
+	})
+
+	it('close() clears state and discards a pending debounced scan', async () => {
+		const picker = useMentionPicker(makeBridge())
+		picker.handleInput('@req', 4)
+		picker.close()
+		await vi.advanceTimersByTimeAsync(MENTION_DEBOUNCE_MS + 5)
+		expect(picker.open.value).toBe(false)
+		expect(picker.results.value).toEqual([])
+		expect(picker.atIndex.value).toBe(-1)
+	})
+
+	it('currentSelection() returns the highlighted candidate', async () => {
+		const picker = useMentionPicker(makeBridge(['notes/a.md', 'notes/b.md']))
+		picker.handleInput('@', 1)
+		await vi.advanceTimersByTimeAsync(MENTION_DEBOUNCE_MS + 1)
+		expect(picker.currentSelection()?.path).toBe('notes/a.md')
+		picker.moveSelectionDown()
+		expect(picker.currentSelection()?.path).toBe('notes/b.md')
+	})
+
+	it('setSelectedIndex clamps and ignores out-of-range indices', async () => {
+		const picker = useMentionPicker(makeBridge(['x/a.md', 'x/b.md']))
+		picker.handleInput('@', 1)
+		await vi.advanceTimersByTimeAsync(MENTION_DEBOUNCE_MS + 1)
+		picker.setSelectedIndex(1)
+		expect(picker.selectedIndex.value).toBe(1)
+		picker.setSelectedIndex(99)
+		expect(picker.selectedIndex.value).toBe(1)
+		picker.setSelectedIndex(-1)
+		expect(picker.selectedIndex.value).toBe(1)
+	})
+})


### PR DESCRIPTION
## Summary

`@`-file mention picker for the agent sidepanel — D-ASV-3 from `specs/agent-sidepanel-v2/research.md`. Inspired by Claudian's `MentionDropdownController`.

**Stacked on #372 → #371 → #370 → #369 → develop.**

### Trigger rules

`@` typed at position 0 OR after whitespace. Backward scan from caret. Aborts if whitespace appears after the `@`.

### Behaviour

- **200 ms debounce** on input changes.
- **Search source:** recursive vault walk via `VaultPort.listFiles` + `listFolders` — no new port.
- **Match:** case-insensitive substring on `path` OR `filename`.
- **Sort:** filename-prefix-match wins, then by path lexicographic.
- **Cap:** 50 results.
- **Selection:**
  - Replaces the `@<query>` fragment with `@<filename> ` (trailing space)
  - Emits `add-context-file` → `ChatSidebar.handleAddContextFile` calls `chatStore.addContextFile({ path, label: name, isAuto: false })` so a chip appears alongside the inline token.
- **Keyboard:** ArrowUp/Down navigate, Enter/Tab select, Esc dismiss. `Ctrl/Cmd+Enter` still sends (mention key handler explicitly ignores).
- ARIA: `role="listbox"`, `role="option"`, `aria-selected`.

### New surfaces

- `src/application/chat/vaultFileSearch.ts` — pure helpers (`collectVaultFiles`, `prepareCandidates`, `matchAndRank`). 100% unit-test coverage.
- `src/ui/composables/useMentionPicker.ts` — trigger detection, debounce, candidate caching with monotonic search-sequence (discards out-of-order scans), navigation state with wrap-around.
- `src/ui/components/chat/MentionDropdown.vue` — floating listbox.
- `src/ui/components/chat/ChatInput.vue` — input + keydown + blur handlers, inline-replace + caret restore, emits `add-context-file`.
- `src/ui/components/chat/ChatSidebar.vue` — `handleAddContextFile` adds the chip via store.
- `src/infrastructure/mock/MockBridge.ts` — bugfix: `listFiles('')` now lists top-level files (prefix logic mis-handled the empty folder, broke recursive vault walk).

### Key decisions

1. **No new port.** Existing `VaultPort` is sufficient.
2. **Application-layer pure helpers separate from composable.** Reactivity-free, 100% covered.
3. **`@` emits an event, not a store mutation.** `ChatInput` stays Pinia-agnostic — reusable for Storybook later.
4. **Mention chip is `isAuto: false`.** Users can dismiss via the existing chip remove button.
5. **`Ctrl/Cmd+Enter` still sends.** Picker key handler explicitly defers to the existing send shortcut.
6. **200 ms debounce + per-open caching.** Cache invalidates on each fresh `@` trigger so vault writes between sessions are picked up.

## Test plan

- [x] **+40 new tests** across 4 new test files + extended ChatInput tests (1508/1508 passing on the mention branch)
- [x] `vaultFileSearch.test.ts` (14): list collection, match-and-rank correctness, sort order, cap
- [x] `useMentionPicker.test.ts` (14, uses `vi.useFakeTimers`): trigger detect, debounce, navigation
- [x] `MentionDropdown.test.ts` + PO (6): rendering, accessibility, selection emit
- [x] Extended `ChatInput.test.ts` (+6): integration covers brief's scenario — type `@req`, see `requirements.md`, press Enter, expect inline replacement AND `add-context-file` event
- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 errors
- [x] `npm run build:web` succeeds

https://claude.ai/code/session_01VvXsK3aGp2g4jSpT1py7Mh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvXsK3aGp2g4jSpT1py7Mh)_