### PR TITLE
feat(agent): MarkdownRenderPort backed by Obsidian native renderer (PR-ASV-7-obsidian)

### DIFF
--- a/src/domain/ports/MarkdownRenderPort.ts
+++ b/src/domain/ports/MarkdownRenderPort.ts
@@ -1,0 +1,37 @@
+/**
+ * Narrow port for native markdown rendering (top-1 gap from the
+ * agent-sidepanel-v2 comparative review). When provided by the host, the
+ * Vue `MarkdownBlock` component delegates rendering to the port —
+ * unlocking GFM tables, syntax-highlighted code blocks, math, wikilinks,
+ * image embeds, and mermaid. When NOT provided (tests, GitHub Pages
+ * demo), the component falls back to a hand-rolled VNode parser that
+ * covers the markdown subset Claudian's plain blocks need.
+ *
+ * The Obsidian implementation wraps `MarkdownRenderer.render`. It
+ * requires an Obsidian `Component` instance per render call to scope
+ * the renderer's internal disposables; the Vue component owns that
+ * lifecycle. Domain layer purposely stays free of `obsidian` imports —
+ * the adapter lives in `src/infrastructure/obsidian/`.
+ */
+export interface MarkdownRenderPort {
+	/**
+	 * Render `markdown` into `container`. Implementations must clear any
+	 * prior content and append fresh DOM. Output is XSS-safe by
+	 * construction (Obsidian's renderer escapes user input).
+	 *
+	 * `sourcePath` is the vault path the content is "anchored at" — used
+	 * by Obsidian's link resolver for relative wikilink targets.
+	 * Implementations that don't resolve links may ignore it.
+	 *
+	 * Returns a disposer that the caller invokes when the rendered DOM
+	 * leaves the document (component unmount, content replace). The
+	 * disposer cleans up any lifecycle hooks the renderer attached to
+	 * the container's children — load-bearing for Obsidian's
+	 * `MarkdownRenderer.render`, which registers child `Component`s.
+	 */
+	render(args: {
+		markdown: string;
+		container: HTMLElement;
+		sourcePath?: string;
+	}): Promise<() => void>;
+}

--- a/src/infrastructure/bridge/ports.ts
+++ b/src/infrastructure/bridge/ports.ts
@@ -11,6 +11,7 @@ import type {
 	ClaudeCliPort,
 	ConfirmModalPort,
 } from '@/domain/ports'
+import type { MarkdownRenderPort } from '@/domain/ports/MarkdownRenderPort'
 import type { TransportKind } from '@/domain/chat/TransportKind'
 
 export const SETTINGS_PORT: InjectionKey<SettingsPort> = Symbol('SettingsPort')
@@ -23,6 +24,14 @@ export const CANVAS_PORT: InjectionKey<CanvasPort> = Symbol('CanvasPort')
 export const COMMUNITY_PLUGIN_PORT: InjectionKey<CommunityPluginPort> = Symbol('CommunityPluginPort')
 export const CLAUDE_CLI_PORT: InjectionKey<ClaudeCliPort> = Symbol('ClaudeCliPort')
 export const CONFIRM_MODAL_PORT: InjectionKey<ConfirmModalPort> = Symbol('ConfirmModalPort')
+/**
+ * Optional `MarkdownRenderPort` provided by the Obsidian view. When
+ * present, `MarkdownBlock.vue` delegates rendering to Obsidian's native
+ * `MarkdownRenderer.render` (GFM tables, code highlighting, math,
+ * wikilinks, mermaid). When absent (tests / standalone web demo),
+ * `MarkdownBlock` falls back to the hand-rolled VNode parser.
+ */
+export const MARKDOWN_RENDER_PORT: InjectionKey<MarkdownRenderPort> = Symbol('MarkdownRenderPort')
 /**
  * Reactive transport kind provided by `SpecoratorView` (SPEC-ASM-001 §10.1).
  * Consumed by `ChatSidebar` to drive `TransportStatusPill` and the

--- a/src/infrastructure/obsidian/ObsidianMarkdownRenderAdapter.ts
+++ b/src/infrastructure/obsidian/ObsidianMarkdownRenderAdapter.ts
@@ -9,13 +9,17 @@ import type { MarkdownRenderPort } from '@/domain/ports/MarkdownRenderPort';
  * math (`$...$` / `$$...$$`), wikilinks, image embeds, and mermaid for
  * free — anything Obsidian itself renders.
  *
- * Lifecycle: every `render()` call creates a fresh Obsidian `Component`
- * and registers it as the rendering scope. The returned disposer
- * `unload()`s that component, releasing any sub-renderers (mermaid
- * diagrams, code blocks with copy-buttons, dataview widgets, etc).
- * The Vue caller MUST invoke the disposer on `onBeforeUnmount` and
- * before re-rendering on prop change, otherwise long-lived listeners
- * accumulate per turn.
+ * Render isolation (Codex P1 on PR #377): each `render()` call appends
+ * its own private child div ("scratch") into the caller's container
+ * after evicting any existing scratch children. The disposer removes
+ * ONLY this render's scratch div (not the whole container) and unloads
+ * its component. With this contract, a stale render's late-arriving
+ * disposer cannot blank a newer render's already-painted output.
+ *
+ * Component cleanup on failure (Codex P2 on PR #377): if
+ * `MarkdownRenderer.render` rejects, the catch branch unloads the
+ * component AND removes the scratch div before re-throwing, so failed
+ * renders don't leak post-processor listeners.
  */
 export class ObsidianMarkdownRenderAdapter implements MarkdownRenderPort {
 	constructor(private readonly app: App) {}
@@ -25,19 +29,45 @@ export class ObsidianMarkdownRenderAdapter implements MarkdownRenderPort {
 		container: HTMLElement;
 		sourcePath?: string;
 	}): Promise<() => void> {
-		args.container.empty();
+		// Evict any prior scratch children so successive renders don't
+		// stack. We tag scratch divs with a dataset attribute so unrelated
+		// children (none today) survive a render-cycle reset.
+		// Duck-typed `HTMLElement` check (the Obsidian lint rule blocks
+		// `instanceof HTMLElement` because it isn't cross-window safe):
+		// every relevant child here is created by `createDiv()` and so is
+		// guaranteed to be an `HTMLElement`; the dataset check below is
+		// the actual identification.
+		for (const prior of Array.from(args.container.children)) {
+			const el = prior as HTMLElement;
+			if (el.dataset.specoratorMarkdownScratch === '1') {
+				el.remove();
+			}
+		}
+		const scratch = args.container.createDiv({
+			cls: 'sp-markdown-scratch',
+		});
+		scratch.dataset.specoratorMarkdownScratch = '1';
 		const component = new Component();
 		component.load();
-		await MarkdownRenderer.render(
-			this.app,
-			args.markdown,
-			args.container,
-			args.sourcePath ?? '',
-			component,
-		);
+		try {
+			await MarkdownRenderer.render(
+				this.app,
+				args.markdown,
+				scratch,
+				args.sourcePath ?? '',
+				component,
+			);
+		} catch (err: unknown) {
+			component.unload();
+			scratch.remove();
+			throw err;
+		}
 		return () => {
 			component.unload();
-			args.container.empty();
+			// Disposer removes ONLY this render's scratch div, leaving any
+			// newer render's scratch untouched. `remove()` is a no-op if
+			// the node was already detached (defence in depth).
+			scratch.remove();
 		};
 	}
 }

--- a/src/infrastructure/obsidian/ObsidianMarkdownRenderAdapter.ts
+++ b/src/infrastructure/obsidian/ObsidianMarkdownRenderAdapter.ts
@@ -1,0 +1,43 @@
+import { Component, MarkdownRenderer, type App } from 'obsidian';
+import type { MarkdownRenderPort } from '@/domain/ports/MarkdownRenderPort';
+
+/**
+ * Obsidian-backed `MarkdownRenderPort` implementation (top-1 gap from
+ * the agent-sidepanel-v2 comparative review). Delegates to Obsidian's
+ * native `MarkdownRenderer.render(app, markdown, container, sourcePath,
+ * component)`, which gives us GFM tables, code syntax highlighting,
+ * math (`$...$` / `$$...$$`), wikilinks, image embeds, and mermaid for
+ * free — anything Obsidian itself renders.
+ *
+ * Lifecycle: every `render()` call creates a fresh Obsidian `Component`
+ * and registers it as the rendering scope. The returned disposer
+ * `unload()`s that component, releasing any sub-renderers (mermaid
+ * diagrams, code blocks with copy-buttons, dataview widgets, etc).
+ * The Vue caller MUST invoke the disposer on `onBeforeUnmount` and
+ * before re-rendering on prop change, otherwise long-lived listeners
+ * accumulate per turn.
+ */
+export class ObsidianMarkdownRenderAdapter implements MarkdownRenderPort {
+	constructor(private readonly app: App) {}
+
+	async render(args: {
+		markdown: string;
+		container: HTMLElement;
+		sourcePath?: string;
+	}): Promise<() => void> {
+		args.container.empty();
+		const component = new Component();
+		component.load();
+		await MarkdownRenderer.render(
+			this.app,
+			args.markdown,
+			args.container,
+			args.sourcePath ?? '',
+			component,
+		);
+		return () => {
+			component.unload();
+			args.container.empty();
+		};
+	}
+}

--- a/src/plugin/AgentSidepanelView.ts
+++ b/src/plugin/AgentSidepanelView.ts
@@ -12,11 +12,13 @@ import {
 	CLAUDE_CLI_PORT,
 	COMMUNITY_PLUGIN_PORT,
 	CONFIRM_MODAL_PORT,
+	MARKDOWN_RENDER_PORT,
 	IS_MOBILE_KEY,
 	SETTINGS_VERSION_KEY,
 	TRANSPORT_KIND_KEY,
 	OPEN_PLUGIN_SETTINGS_KEY,
 } from '@/infrastructure/bridge/ports';
+import { ObsidianMarkdownRenderAdapter } from '@/infrastructure/obsidian/ObsidianMarkdownRenderAdapter';
 import type { ClaudeCliPort, ConfirmModalPort } from '@/domain/ports';
 import type { PluginSettings } from '@/domain/settings/PluginSettings';
 import type { TransportKind } from '@/domain/chat/TransportKind';
@@ -167,6 +169,15 @@ export class AgentSidepanelView extends ItemView {
 		if (this._options?.confirmModalAdapter !== undefined) {
 			this.vueApp.provide(CONFIRM_MODAL_PORT, this._options.confirmModalAdapter);
 		}
+		// Top-1 gap from the comparative review: hand markdown rendering to
+		// Obsidian's native `MarkdownRenderer` so messages get GFM tables,
+		// syntax-highlighted code blocks, math, wikilinks, image embeds,
+		// and mermaid. `MarkdownBlock.vue` falls back to a hand-rolled
+		// parser when this port is absent (tests / standalone web demo).
+		this.vueApp.provide(
+			MARKDOWN_RENDER_PORT,
+			new ObsidianMarkdownRenderAdapter(this.plugin.app),
+		);
 		this.vueApp.provide(TRANSPORT_KIND_KEY, this._activeTransportKind);
 		this.vueApp.provide(IS_MOBILE_KEY, Platform.isMobile);
 		this.vueApp.provide(SETTINGS_VERSION_KEY, this._settingsVersion);

--- a/src/ui/components/agent/MarkdownBlock.vue
+++ b/src/ui/components/agent/MarkdownBlock.vue
@@ -348,16 +348,36 @@ const blocks = computed<Block[]>(() => parseBlocks(props.text));
 const renderPort = inject<MarkdownRenderPort | undefined>(MARKDOWN_RENDER_PORT, undefined);
 const nativeContainer = ref<HTMLElement | null>(null);
 let nativeDisposer: (() => void) | null = null;
+/**
+ * Monotonic render sequence (Codex P1 on PR #377). `renderPort.render`
+ * is async, so rapid `text` updates (e.g. streaming assistant tokens
+ * during PR-ASV-2-ui) could land out of order: an older render
+ * resolving after a newer one would repaint stale markdown AND
+ * overwrite `nativeDisposer`, leaking the newer Obsidian Component's
+ * listeners + child widgets. Each render captures `seq` on dispatch
+ * and discards itself on resolve if `latestSeq` has moved past it.
+ */
+let latestSeq = 0;
 
 async function rerenderNative(): Promise<void> {
 	if (renderPort === undefined) return;
 	const el = nativeContainer.value;
 	if (el === null) return;
+	const seq = ++latestSeq;
+	// Dispose the prior render synchronously so its DOM + listeners are
+	// gone before the next render starts writing into the container.
 	if (nativeDisposer !== null) {
 		nativeDisposer();
 		nativeDisposer = null;
 	}
-	nativeDisposer = await renderPort.render({ markdown: props.text, container: el });
+	const disposer = await renderPort.render({ markdown: props.text, container: el });
+	// If a newer render started while this one was awaiting, drop this
+	// result: dispose its DOM and leave `nativeDisposer` untouched.
+	if (seq !== latestSeq) {
+		disposer();
+		return;
+	}
+	nativeDisposer = disposer;
 }
 
 watch(
@@ -369,6 +389,10 @@ watch(
 );
 
 onBeforeUnmount(() => {
+	// Bump latestSeq so any in-flight render's tail recognises it lost
+	// the race and disposes itself rather than touching the freed
+	// container.
+	latestSeq++;
 	if (nativeDisposer !== null) {
 		nativeDisposer();
 		nativeDisposer = null;

--- a/src/ui/components/agent/MarkdownBlock.vue
+++ b/src/ui/components/agent/MarkdownBlock.vue
@@ -27,7 +27,9 @@
  *     emitted without an `href` attribute so they cannot smuggle
  *     `javascript:` URIs.
  */
-import { computed, h, type VNode } from 'vue';
+import { computed, h, inject, onBeforeUnmount, ref, watch, type VNode } from 'vue';
+import { MARKDOWN_RENDER_PORT } from '@/infrastructure/bridge/ports';
+import type { MarkdownRenderPort } from '@/domain/ports/MarkdownRenderPort';
 
 const props = defineProps<{
 	/** Raw markdown source to render. May be empty. */
@@ -334,10 +336,54 @@ function renderBlock(block: Block): VNode {
 }
 
 const blocks = computed<Block[]>(() => parseBlocks(props.text));
+
+/**
+ * Optional `MarkdownRenderPort` (top-1 gap from comparative review).
+ * Provided only by the Obsidian view (`AgentSidepanelView.onOpen`); when
+ * present we hand `text` off to `MarkdownRenderer.render` for full GFM
+ * tables, code syntax highlighting, math, wikilinks, image embeds,
+ * mermaid. When absent (tests, GitHub Pages standalone), we fall back
+ * to the hand-rolled VNode tree below.
+ */
+const renderPort = inject<MarkdownRenderPort | undefined>(MARKDOWN_RENDER_PORT, undefined);
+const nativeContainer = ref<HTMLElement | null>(null);
+let nativeDisposer: (() => void) | null = null;
+
+async function rerenderNative(): Promise<void> {
+	if (renderPort === undefined) return;
+	const el = nativeContainer.value;
+	if (el === null) return;
+	if (nativeDisposer !== null) {
+		nativeDisposer();
+		nativeDisposer = null;
+	}
+	nativeDisposer = await renderPort.render({ markdown: props.text, container: el });
+}
+
+watch(
+	() => props.text,
+	() => {
+		void rerenderNative();
+	},
+	{ immediate: true, flush: 'post' },
+);
+
+onBeforeUnmount(() => {
+	if (nativeDisposer !== null) {
+		nativeDisposer();
+		nativeDisposer = null;
+	}
+});
 </script>
 
 <template>
-	<div class="sp-markdown" data-testid="agent-markdown-block">
+	<div
+		v-if="renderPort !== undefined"
+		ref="nativeContainer"
+		class="sp-markdown sp-markdown--native"
+		data-testid="agent-markdown-block"
+	/>
+	<div v-else class="sp-markdown" data-testid="agent-markdown-block">
 		<component :is="renderBlock(block)" v-for="(block, index) in blocks" :key="index" />
 	</div>
 </template>

--- a/styles.css
+++ b/styles.css
@@ -760,19 +760,19 @@ to   { opacity: 1; transform: translateY(0);
 	font-style: italic;
 }
 
-.specorator-root :where(.sp-markdown[data-v-b1397c03]) {
+.specorator-root :where(.sp-markdown[data-v-7f656229]) {
 	font-size: 0.875rem;
 	color: var(--text-normal);
 	word-break: break-word;
 }
-.specorator-root :where(.sp-markdown[data-v-b1397c03] .sp-markdown__p) {
+.specorator-root :where(.sp-markdown[data-v-7f656229] .sp-markdown__p) {
 	margin: 0 0 0.5rem;
 	white-space: pre-wrap;
 }
-.specorator-root :where(.sp-markdown[data-v-b1397c03] .sp-markdown__p:last-child) {
+.specorator-root :where(.sp-markdown[data-v-7f656229] .sp-markdown__p:last-child) {
 	margin-bottom: 0;
 }
-.specorator-root :where(.sp-markdown[data-v-b1397c03] .sp-markdown__pre) {
+.specorator-root :where(.sp-markdown[data-v-7f656229] .sp-markdown__pre) {
 	margin: 0 0 0.5rem;
 	padding: 0.5rem 0.625rem;
 	border-radius: 4px;
@@ -781,32 +781,32 @@ to   { opacity: 1; transform: translateY(0);
 	overflow-x: auto;
 	font-size: 0.8125rem;
 }
-.specorator-root :where(.sp-markdown[data-v-b1397c03] .sp-markdown__pre-code) {
+.specorator-root :where(.sp-markdown[data-v-7f656229] .sp-markdown__pre-code) {
 	font-family: var(--font-monospace, ui-monospace, monospace);
 	white-space: pre;
 }
-.specorator-root :where(.sp-markdown[data-v-b1397c03] .sp-markdown__code) {
+.specorator-root :where(.sp-markdown[data-v-7f656229] .sp-markdown__code) {
 	padding: 0.05rem 0.25rem;
 	border-radius: 3px;
 	background: var(--background-modifier-border);
 	font-family: var(--font-monospace, ui-monospace, monospace);
 	font-size: 0.85em;
 }
-.specorator-root :where(.sp-markdown[data-v-b1397c03] .sp-markdown__blockquote) {
+.specorator-root :where(.sp-markdown[data-v-7f656229] .sp-markdown__blockquote) {
 	margin: 0 0 0.5rem;
 	padding: 0.25rem 0.625rem;
 	border-left: 3px solid var(--background-modifier-border);
 	color: var(--text-muted);
 	white-space: pre-wrap;
 }
-.specorator-root :where(.sp-markdown[data-v-b1397c03] .sp-markdown__list) {
+.specorator-root :where(.sp-markdown[data-v-7f656229] .sp-markdown__list) {
 	margin: 0 0 0.5rem;
 	padding-left: 1.25rem;
 }
-.specorator-root :where(.sp-markdown[data-v-b1397c03] .sp-markdown__li) {
+.specorator-root :where(.sp-markdown[data-v-7f656229] .sp-markdown__li) {
 	margin: 0 0 0.125rem;
 }
-.specorator-root :where(.sp-markdown[data-v-b1397c03] .sp-markdown__link) {
+.specorator-root :where(.sp-markdown[data-v-7f656229] .sp-markdown__link) {
 	color: var(--text-accent);
 	text-decoration: underline;
 }


### PR DESCRIPTION
## Summary

Top-1 gap from the agent-sidepanel-v2 comparative review. The hand-rolled `MarkdownBlock.vue` parser missed GFM tables, code syntax highlighting, math (`$...$` / `$$...$$`), wikilinks, image embeds, and mermaid. This PR adds an optional `MarkdownRenderPort` (narrow port per ADR-008) and an `ObsidianMarkdownRenderAdapter` that wraps Obsidian's native `MarkdownRenderer.render` — unlocking everything Obsidian itself can render.

**Stacked on #373 (markdown) → #372 (UI) → #371 (SDK) → #370 (port) → #369 → develop.**

### Pattern

- `src/domain/ports/MarkdownRenderPort.ts` — the port. Domain layer, no `obsidian` imports.
- `src/infrastructure/obsidian/ObsidianMarkdownRenderAdapter.ts` — Obsidian-only adapter. Manages an `Obsidian.Component` per render call so the renderer's internal disposables (mermaid widgets, code-block copy buttons, dataview cells) get unloaded cleanly. Returns a disposer the caller invokes on unmount / re-render.
- `src/infrastructure/bridge/ports.ts` — `MARKDOWN_RENDER_PORT` InjectionKey.
- `src/plugin/AgentSidepanelView.ts` — provides the Obsidian adapter to the Vue tree at mount.
- `src/ui/components/agent/MarkdownBlock.vue` — injects the port; when present, renders into a `<div ref>` via `port.render({...})` and tracks the disposer for unmount + text-change cleanup. When absent (tests, standalone web), falls back to the existing hand-rolled VNode tree so all existing tests still pass.

### What this unlocks

- **GFM tables** in assistant replies (today renders as plain text).
- **Syntax highlighting** in code blocks (today renders as monospaced plain text).
- **Math** (`$inline$` / `$$display$$`).
- **Wikilinks** that resolve against the vault.
- **Image embeds** (`[[image.png]]`).
- **Mermaid diagrams**, dataview blocks, any other Obsidian renderer plugin.

### Lifecycle

Each `render()` call:
1. Empties the container.
2. Creates a fresh Obsidian `Component`, calls `.load()`.
3. Awaits `MarkdownRenderer.render(app, markdown, container, sourcePath, component)`.
4. Returns a disposer that `.unload()`s the component + empties the container.

The Vue caller invokes the disposer on `onBeforeUnmount` AND before re-rendering when `text` changes — so long-running renderers (mermaid, plugins that register child components) get cleaned up between turns.

## Test plan

- [x] 1491/1491 unit tests pass on the new branch (no fallback test regressions — the hand-rolled parser path still runs in jsdom).
- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 errors
- [ ] Manual: open Obsidian, send a turn that produces a GFM table → table renders with `<table>`/`<tr>`/`<td>`.
- [ ] Manual: send a turn with a ```typescript fenced block → syntax highlighting appears.
- [ ] Manual: send `[[wikilink]]` → resolves to a vault link.

Native-renderer behaviour will get its own integration test once the Obsidian test harness mocks `MarkdownRenderer.render`.

https://claude.ai/code/session_01VvXsK3aGp2g4jSpT1py7Mh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvXsK3aGp2g4jSpT1py7Mh)_