### PR TITLE
feat(agent): extend StreamDelta with thinking/tool-use/compact/usage variants (PR-ASV-2-delta)

### DIFF
--- a/src/domain/ports/ClaudeCliPort.ts
+++ b/src/domain/ports/ClaudeCliPort.ts
@@ -128,7 +128,61 @@ export interface ClaudeCliStreamOptions extends ClaudeCliQueryOptions {
  */
 export type StreamDelta =
 	| { readonly type: 'text'; readonly text: string }
+	/**
+	 * Incremental thinking-mode text from an extended-thinking turn. Emitted
+	 * alongside `text` when the model reasons before answering. UI may render
+	 * this in a collapsed `<details>` block above the streaming bubble.
+	 */
+	| { readonly type: 'thinking'; readonly text: string }
 	| { readonly type: 'session-id'; readonly sessionId: SessionId }
+	/**
+	 * First sighting of a tool-use content block. `blockId` is a per-stream
+	 * identifier (NOT the SDK's `id` field) so callers can correlate the
+	 * subsequent `tool-use-input-delta` and `tool-use-stop` deltas back to
+	 * this block. `inputJson` is the initial partial JSON fragment (often
+	 * empty until the next `input_json_delta`).
+	 */
+	| {
+			readonly type: 'tool-use-start';
+			readonly blockId: string;
+			readonly toolName: string;
+			readonly inputJson: string;
+	  }
+	/**
+	 * Additional partial JSON for the tool's `input` field. Callers
+	 * concatenate `inputJson` strings keyed by `blockId` to reconstruct
+	 * the full tool argument payload (which may need JSON-repair until
+	 * `tool-use-stop`).
+	 */
+	| {
+			readonly type: 'tool-use-input-delta';
+			readonly blockId: string;
+			readonly inputJson: string;
+	  }
+	/**
+	 * Terminal marker for a tool-use block. The accumulated `inputJson`
+	 * for `blockId` is now complete and safe to `JSON.parse`.
+	 */
+	| { readonly type: 'tool-use-stop'; readonly blockId: string }
+	/**
+	 * Conversation-compaction boundary (SDK `SDKCompactBoundaryMessage`).
+	 * Long sessions silently rewrite history when the SDK auto-compacts;
+	 * the UI surfaces this as a synthetic system message in the transcript
+	 * so the user knows context older than this point may no longer be
+	 * present in the model's view.
+	 */
+	| { readonly type: 'compact-boundary'; readonly reason?: string }
+	/**
+	 * Token usage telemetry from `message_start` / `message_delta`. Some
+	 * Anthropic-compatible endpoints push usage on `message_start` (where
+	 * `output_tokens` is 0) and update on `message_delta`; consumers should
+	 * treat the latest non-zero values as authoritative.
+	 */
+	| {
+			readonly type: 'usage';
+			readonly inputTokens: number;
+			readonly outputTokens: number;
+	  }
 	| { readonly type: 'done' }
 	| { readonly type: 'error'; readonly error: ClaudeCliError };
 

--- a/src/infrastructure/obsidian/ClaudeCliAdapter.ts
+++ b/src/infrastructure/obsidian/ClaudeCliAdapter.ts
@@ -474,26 +474,34 @@ export class ClaudeCliAdapter implements ClaudeCliPort {
 		if (index < 0) return;
 		const block = event.content_block;
 		if (block === undefined) return;
-		if (block.type === 'tool_use') {
-			const blockId = `${state.turnId}-${index}`;
+		const blockId = `${state.turnId}-${index}`;
+		// Codex P2 on PR #378: any block whose `type` ends with `_tool_use`
+		// or equals `tool_use` is part of the tool-use lifecycle (covers
+		// `tool_use`, `server_tool_use`, future Anthropic-API variants).
+		// The previous strict equality dropped non-`tool_use` variants and
+		// their subsequent `input_json_delta` chunks vanished.
+		if (typeof block.type === 'string' && block.type.endsWith('tool_use')) {
 			state.blockKinds.set(index, { kind: 'tool_use', blockId });
-			const initialJson = typeof block.input === 'object' && block.input !== null
-				? JSON.stringify(block.input)
-				: '';
+			// Codex P1 on PR #378: do NOT seed `inputJson` with the
+			// block-start payload. The SDK ships an empty `{}` placeholder
+			// at start and the real JSON arrives via `input_json_delta`.
+			// Seeding `JSON.stringify({})` corrupted callers that
+			// concatenate by `blockId` — final reconstruction was
+			// `"{}" + "<partial>"` which is unparseable.
 			deltas.push({
 				type: 'tool-use-start',
 				blockId,
 				toolName: typeof block.name === 'string' ? block.name : 'unknown',
-				inputJson: initialJson,
+				inputJson: '',
 			});
 			return;
 		}
 		if (block.type === 'thinking') {
-			state.blockKinds.set(index, { kind: 'thinking', blockId: `${state.turnId}-${index}` });
+			state.blockKinds.set(index, { kind: 'thinking', blockId });
 			return;
 		}
 		// Text blocks need no start delta — `text_delta` handler accumulates.
-		state.blockKinds.set(index, { kind: 'text', blockId: `${state.turnId}-${index}` });
+		state.blockKinds.set(index, { kind: 'text', blockId });
 	}
 
 	private static _handleBlockDelta(

--- a/src/infrastructure/obsidian/ClaudeCliAdapter.ts
+++ b/src/infrastructure/obsidian/ClaudeCliAdapter.ts
@@ -28,6 +28,43 @@ interface SdkMessage {
 }
 
 /**
+ * Loosely-typed view of one `stream_event` payload. Mirrors the
+ * Anthropic SDK's `RawMessageStreamEvent` family without importing
+ * the type so we stay decoupled from the SDK's exact shape.
+ */
+interface StreamEvent {
+	type?: string;
+	index?: number;
+	content_block?: {
+		type?: string;
+		name?: string;
+		input?: unknown;
+	};
+	delta?: {
+		type?: string;
+		text?: string;
+		thinking?: string;
+		partial_json?: string;
+	};
+	usage?: { input_tokens?: number; output_tokens?: number };
+	message?: { usage?: { input_tokens?: number; output_tokens?: number } };
+}
+
+/**
+ * Per-stream mutable state passed through `_dispatchMessage`. Tracks
+ * the session-id one-fire flag, the text-emitted flag (so a turn with
+ * zero `text_delta`s can still emit the `result` fallback), and the
+ * content-block kind table that lets `content_block_stop` emit the
+ * right terminal delta per block kind.
+ */
+interface StreamState {
+	turnId: string;
+	sessionIdEmitted: boolean;
+	textEmitted: boolean;
+	blockKinds: Map<number, { kind: 'text' | 'thinking' | 'tool_use'; blockId: string }>;
+}
+
+/**
  * Production implementation of ClaudeCliPort using @anthropic-ai/claude-agent-sdk.
  * Satisfies REQ-CCS-002, REQ-CCS-003, REQ-CCS-016, REQ-CCS-017, REQ-CCS-025,
  * NFR-CCS-003, NFR-CCS-005, NFR-CCS-007, SPEC-CCS-001 §5.
@@ -310,7 +347,12 @@ export class ClaudeCliAdapter implements ClaudeCliPort {
 				includePartialMessages: true,
 			},
 		});
-		const state = { sessionIdEmitted: false, textEmitted: false };
+		const state: StreamState = {
+			turnId: crypto.randomUUID(),
+			sessionIdEmitted: false,
+			textEmitted: false,
+			blockKinds: new Map(),
+		};
 		for (;;) {
 			const next = await Promise.race([gen.next(), timeout.promise]);
 			if (next.done === true) {
@@ -339,34 +381,182 @@ export class ClaudeCliAdapter implements ClaudeCliPort {
 	 * message and whether the stream should terminate after them. Keeping
 	 * this side-effect-free (modulo the `onSessionId` callback, which the
 	 * port contract demands) lets the outer loop stay simple.
+	 *
+	 * Extended in PR-ASV-2-delta-extension to handle the wider event
+	 * surface from `--include-partial-messages`: `thinking_delta`,
+	 * `input_json_delta`, `content_block_start/stop` for tool_use blocks,
+	 * `system/compact_boundary`, and `message_start/delta` token usage.
+	 * The `state.blockKinds` map keys an SDK content-block index to the
+	 * kind we observed at `content_block_start` so the corresponding
+	 * `content_block_stop` can emit the right terminal delta — text
+	 * blocks don't emit a stop delta, tool_use blocks do.
 	 */
 	private _dispatchMessage(
 		message: SdkMessage,
-		state: { sessionIdEmitted: boolean; textEmitted: boolean },
+		state: StreamState,
 		options: ClaudeCliStreamOptions | undefined,
 	): { deltas: StreamDelta[]; terminal: boolean } {
-		const deltas: StreamDelta[] = [];
 		if (message.type === 'system' && message.subtype === 'init') {
-			const sid = ClaudeCliAdapter._extractSessionId(message);
-			if (sid !== null && !state.sessionIdEmitted) {
-				state.sessionIdEmitted = true;
-				deltas.push({ type: 'session-id', sessionId: sid });
-				ClaudeCliAdapter._fireOnSessionId(options, sid);
-			}
-			return { deltas, terminal: false };
+			return ClaudeCliAdapter._dispatchSystemInit(message, state, options);
+		}
+		if (message.type === 'system' && message.subtype === 'compact_boundary') {
+			return { deltas: [{ type: 'compact-boundary' }], terminal: false };
 		}
 		if (message.type === 'stream_event') {
-			const text = ClaudeCliAdapter._extractStreamText(message);
-			if (text !== null) {
-				state.textEmitted = true;
-				deltas.push({ type: 'text', text });
-			}
-			return { deltas, terminal: false };
+			return ClaudeCliAdapter._dispatchStreamEvent(message, state);
 		}
 		if (message.type === 'result') {
 			return ClaudeCliAdapter._dispatchResult(message, state);
 		}
+		return { deltas: [], terminal: false };
+	}
+
+	private static _dispatchSystemInit(
+		message: SdkMessage,
+		state: StreamState,
+		options: ClaudeCliStreamOptions | undefined,
+	): { deltas: StreamDelta[]; terminal: boolean } {
+		const deltas: StreamDelta[] = [];
+		const sid = ClaudeCliAdapter._extractSessionId(message);
+		if (sid !== null && !state.sessionIdEmitted) {
+			state.sessionIdEmitted = true;
+			deltas.push({ type: 'session-id', sessionId: sid });
+			ClaudeCliAdapter._fireOnSessionId(options, sid);
+		}
 		return { deltas, terminal: false };
+	}
+
+	private static _dispatchStreamEvent(
+		message: SdkMessage,
+		state: StreamState,
+	): { deltas: StreamDelta[]; terminal: boolean } {
+		const deltas: StreamDelta[] = [];
+		const event = ClaudeCliAdapter._asStreamEvent(message);
+		if (event === null) return { deltas, terminal: false };
+		// Token usage telemetry — `message_start` and `message_delta`
+		// carry `usage` at the message root. Read both because some
+		// Anthropic-compatible endpoints push usage only on `message_delta`.
+		if (event.type === 'message_start' || event.type === 'message_delta') {
+			const usage = ClaudeCliAdapter._extractUsage(event);
+			if (usage !== null) deltas.push(usage);
+			return { deltas, terminal: false };
+		}
+		if (event.type === 'content_block_start') {
+			ClaudeCliAdapter._handleBlockStart(event, state, deltas);
+			return { deltas, terminal: false };
+		}
+		if (event.type === 'content_block_delta') {
+			ClaudeCliAdapter._handleBlockDelta(event, state, deltas);
+			return { deltas, terminal: false };
+		}
+		if (event.type === 'content_block_stop') {
+			ClaudeCliAdapter._handleBlockStop(event, state, deltas);
+			return { deltas, terminal: false };
+		}
+		return { deltas, terminal: false };
+	}
+
+	private static _asStreamEvent(message: SdkMessage): StreamEvent | null {
+		if (!ClaudeCliAdapter._isStreamEvent(message.event)) return null;
+		return message.event;
+	}
+
+	private static _isStreamEvent(raw: unknown): raw is StreamEvent {
+		return typeof raw === 'object' && raw !== null;
+	}
+
+	private static _handleBlockStart(
+		event: StreamEvent,
+		state: StreamState,
+		deltas: StreamDelta[],
+	): void {
+		const index = typeof event.index === 'number' ? event.index : -1;
+		if (index < 0) return;
+		const block = event.content_block;
+		if (block === undefined) return;
+		if (block.type === 'tool_use') {
+			const blockId = `${state.turnId}-${index}`;
+			state.blockKinds.set(index, { kind: 'tool_use', blockId });
+			const initialJson = typeof block.input === 'object' && block.input !== null
+				? JSON.stringify(block.input)
+				: '';
+			deltas.push({
+				type: 'tool-use-start',
+				blockId,
+				toolName: typeof block.name === 'string' ? block.name : 'unknown',
+				inputJson: initialJson,
+			});
+			return;
+		}
+		if (block.type === 'thinking') {
+			state.blockKinds.set(index, { kind: 'thinking', blockId: `${state.turnId}-${index}` });
+			return;
+		}
+		// Text blocks need no start delta — `text_delta` handler accumulates.
+		state.blockKinds.set(index, { kind: 'text', blockId: `${state.turnId}-${index}` });
+	}
+
+	private static _handleBlockDelta(
+		event: StreamEvent,
+		state: StreamState,
+		deltas: StreamDelta[],
+	): void {
+		const index = typeof event.index === 'number' ? event.index : -1;
+		const delta = event.delta;
+		if (index < 0 || delta === undefined) return;
+		const out = ClaudeCliAdapter._mapBlockDelta(delta, index, state);
+		if (out !== null) {
+			if (out.type === 'text') state.textEmitted = true;
+			deltas.push(out);
+		}
+	}
+
+	private static _mapBlockDelta(
+		delta: NonNullable<StreamEvent['delta']>,
+		index: number,
+		state: StreamState,
+	): StreamDelta | null {
+		if (delta.type === 'text_delta' && typeof delta.text === 'string' && delta.text.length > 0) {
+			return { type: 'text', text: delta.text };
+		}
+		if (delta.type === 'thinking_delta' && typeof delta.thinking === 'string') {
+			return { type: 'thinking', text: delta.thinking };
+		}
+		if (delta.type === 'input_json_delta' && typeof delta.partial_json === 'string') {
+			const tracked = state.blockKinds.get(index);
+			if (tracked?.kind !== 'tool_use') return null;
+			return {
+				type: 'tool-use-input-delta',
+				blockId: tracked.blockId,
+				inputJson: delta.partial_json,
+			};
+		}
+		return null;
+	}
+
+	private static _handleBlockStop(
+		event: StreamEvent,
+		state: StreamState,
+		deltas: StreamDelta[],
+	): void {
+		const index = typeof event.index === 'number' ? event.index : -1;
+		if (index < 0) return;
+		const tracked = state.blockKinds.get(index);
+		state.blockKinds.delete(index);
+		if (tracked?.kind === 'tool_use') {
+			deltas.push({ type: 'tool-use-stop', blockId: tracked.blockId });
+		}
+	}
+
+	private static _extractUsage(event: StreamEvent): StreamDelta | null {
+		const usage = event.usage ?? event.message?.usage;
+		if (usage === undefined) return null;
+		const input = typeof usage.input_tokens === 'number' ? usage.input_tokens : 0;
+		const output = typeof usage.output_tokens === 'number' ? usage.output_tokens : 0;
+		// Skip zero-zero updates — they're noise from `message_start` on
+		// endpoints that don't fill in tokens until `message_delta`.
+		if (input === 0 && output === 0) return null;
+		return { type: 'usage', inputTokens: input, outputTokens: output };
 	}
 
 	/**
@@ -424,15 +614,6 @@ export class ClaudeCliAdapter implements ClaudeCliPort {
 		} catch {
 			/* Mirror subprocess adapter — swallow callback errors. */
 		}
-	}
-
-	private static _extractStreamText(message: { event?: unknown }): string | null {
-		if (typeof message.event !== 'object' || message.event === null) return null;
-		const event = message.event as { type?: string; delta?: { type?: string; text?: string } };
-		if (event.type !== 'content_block_delta') return null;
-		if (event.delta?.type !== 'text_delta') return null;
-		const text = event.delta.text;
-		return typeof text === 'string' && text.length > 0 ? text : null;
 	}
 
 	private static _extractResultText(message: { result?: unknown }): string | null {

--- a/src/infrastructure/obsidian/ClaudeCliAdapter.ts
+++ b/src/infrastructure/obsidian/ClaudeCliAdapter.ts
@@ -61,6 +61,17 @@ interface StreamState {
 	turnId: string;
 	sessionIdEmitted: boolean;
 	textEmitted: boolean;
+	/**
+	 * Monotonic message-index within the stream. Bumped on every
+	 * `message_start` event. Codex P1 (PR #378): Anthropic's
+	 * `content_block_*` indices are scoped to a single message and can
+	 * restart at 0 on later `message_start` events in the same streamed
+	 * turn (multi-step tool loops). Without a per-message discriminator,
+	 * distinct tool calls could reuse the same `blockId` and downstream
+	 * accumulators keyed by `blockId` would merge deltas into the wrong
+	 * entry. `blockId` is now `${turnId}-${messageSeq}-${index}`.
+	 */
+	messageSeq: number;
 	blockKinds: Map<number, { kind: 'text' | 'thinking' | 'tool_use'; blockId: string }>;
 }
 
@@ -351,6 +362,7 @@ export class ClaudeCliAdapter implements ClaudeCliPort {
 			turnId: crypto.randomUUID(),
 			sessionIdEmitted: false,
 			textEmitted: false,
+			messageSeq: 0,
 			blockKinds: new Map(),
 		};
 		for (;;) {
@@ -437,6 +449,16 @@ export class ClaudeCliAdapter implements ClaudeCliPort {
 		// carry `usage` at the message root. Read both because some
 		// Anthropic-compatible endpoints push usage only on `message_delta`.
 		if (event.type === 'message_start' || event.type === 'message_delta') {
+			// Codex P1 on PR #378: bump `messageSeq` AND reset `blockKinds`
+			// on every `message_start` so subsequent `content_block_start`
+			// events get a fresh blockId namespace. Anthropic's
+			// content-block index resets to 0 per message; without this
+			// reset, a second message in the same stream (multi-step tool
+			// loop) would overwrite the first message's entries.
+			if (event.type === 'message_start') {
+				state.messageSeq++;
+				state.blockKinds = new Map();
+			}
 			const usage = ClaudeCliAdapter._extractUsage(event);
 			if (usage !== null) deltas.push(usage);
 			return { deltas, terminal: false };
@@ -474,7 +496,10 @@ export class ClaudeCliAdapter implements ClaudeCliPort {
 		if (index < 0) return;
 		const block = event.content_block;
 		if (block === undefined) return;
-		const blockId = `${state.turnId}-${index}`;
+		// Codex P1 on PR #378: include `messageSeq` so multi-step tool
+		// loops (where content-block indices restart at 0 per message)
+		// produce unique blockIds across the whole stream.
+		const blockId = `${state.turnId}-${state.messageSeq}-${index}`;
 		// Codex P2 on PR #378: any block whose `type` ends with `_tool_use`
 		// or equals `tool_use` is part of the tool-use lifecycle (covers
 		// `tool_use`, `server_tool_use`, future Anthropic-API variants).

--- a/src/ui/components/agent/ThinkingBlock.vue
+++ b/src/ui/components/agent/ThinkingBlock.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+/**
+ * Collapsible thinking-mode display for extended-thinking model turns
+ * (PR-ASV-2-tool-rendering, agent-sidepanel-v2 Increment 2). Driven by
+ * `chatStore.streamingThinking`, populated by the SDK adapter's
+ * `thinking` `StreamDelta` variant.
+ *
+ * Renders nothing when text is empty. When non-empty, shows a
+ * collapsed `<details>` block with the streamed thinking text inside.
+ * Users can expand to see the model's reasoning without it dominating
+ * the chat surface.
+ *
+ * Visual reference: Claudian's `ThinkingBlockRenderer.ts`
+ * (https://github.com/YishenTu/claudian).
+ */
+import { useI18n } from 'vue-i18n';
+
+defineProps<{
+	/** Accumulated thinking text from the active turn. */
+	text: string;
+}>();
+
+const { t } = useI18n();
+</script>
+
+<template>
+	<details v-if="text.length > 0" class="sp-thinking-block" data-testid="agent-thinking-block">
+		<summary class="sp-thinking-block__summary" data-testid="agent-thinking-summary">
+			<span class="sp-thinking-block__icon" aria-hidden="true">💭</span>
+			<span class="sp-thinking-block__label">{{ t('agent.thinking') }}</span>
+		</summary>
+		<pre class="sp-thinking-block__text" data-testid="agent-thinking-text">{{ text }}</pre>
+	</details>
+</template>
+
+<style scoped>
+.sp-thinking-block {
+	margin: 0 0 0.5rem;
+	padding: 0.375rem 0.5rem;
+	border-radius: 4px;
+	border: 1px solid var(--background-modifier-border);
+	background: var(--background-secondary-alt, var(--background-secondary));
+	font-size: 0.8125rem;
+}
+
+.sp-thinking-block__summary {
+	cursor: pointer;
+	color: var(--text-muted);
+	display: inline-flex;
+	align-items: center;
+	gap: 0.375rem;
+	list-style: none;
+}
+
+.sp-thinking-block__summary::-webkit-details-marker {
+	display: none;
+}
+
+.sp-thinking-block__icon {
+	font-size: 0.875rem;
+}
+
+.sp-thinking-block__label {
+	font-weight: 500;
+}
+
+.sp-thinking-block__text {
+	margin: 0.375rem 0 0;
+	padding: 0.375rem 0.5rem;
+	background: var(--background-primary);
+	border-radius: 3px;
+	font-family: var(--font-monospace, ui-monospace, monospace);
+	font-size: 0.75rem;
+	color: var(--text-muted);
+	white-space: pre-wrap;
+	word-break: break-word;
+	max-height: 240px;
+	overflow-y: auto;
+}
+</style>

--- a/src/ui/components/agent/ToolCallBlock.vue
+++ b/src/ui/components/agent/ToolCallBlock.vue
@@ -1,0 +1,142 @@
+<script setup lang="ts">
+/**
+ * Inline tool-call display for streaming and completed tool_use blocks
+ * (PR-ASV-2-tool-rendering, agent-sidepanel-v2 Increment 2). Driven by
+ * `chatStore.streamingToolCalls`, populated by the SDK adapter's
+ * `tool-use-start` / `tool-use-input-delta` / `tool-use-stop`
+ * `StreamDelta` variants.
+ *
+ * Renders a generic collapsible card per tool call: tool name in the
+ * summary with a status indicator (⏳ in-flight, ✓ done), and the
+ * accumulated `inputJson` rendered as pretty-printed JSON when
+ * complete or as raw partial text while streaming. Per-tool
+ * specialised renderers (Edit diff, Write preview, TodoWrite list)
+ * land in a follow-up — this one covers all tool names generically.
+ *
+ * Visual reference: Claudian's `ToolCallRenderer.ts`
+ * (https://github.com/YishenTu/claudian).
+ */
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { trySync } from '@/domain/shared/tryAsync';
+
+const props = defineProps<{
+	/** Name of the tool the model invoked, e.g. `Bash`, `Read`, `Edit`. */
+	toolName: string;
+	/** Accumulated partial JSON for the tool's `input` field. */
+	inputJson: string;
+	/** True once `tool-use-stop` arrived — `inputJson` is now complete. */
+	done: boolean;
+}>();
+
+const { t } = useI18n();
+
+/**
+ * Pretty-print the input. While streaming, the JSON is partial and may
+ * not parse — fall back to the raw string in that case. Once `done`,
+ * the JSON should always parse; if it doesn't (provider sent malformed
+ * input), show the raw string with a small warning.
+ */
+const displayInput = computed<{ text: string; parsed: boolean }>(() => {
+	if (props.inputJson.length === 0) return { text: '', parsed: false };
+	if (!props.done) return { text: props.inputJson, parsed: false };
+	const parsed = trySync(() => JSON.parse(props.inputJson) as unknown);
+	if (!parsed.ok) return { text: props.inputJson, parsed: false };
+	return { text: JSON.stringify(parsed.value, null, 2), parsed: true };
+});
+
+const statusLabel = computed(() => (props.done ? '✓' : '⏳'));
+const statusClass = computed(() => (props.done ? 'sp-tool-call--done' : 'sp-tool-call--streaming'));
+</script>
+
+<template>
+	<details
+		class="sp-tool-call"
+		:class="statusClass"
+		:open="!done"
+		data-testid="agent-tool-call"
+		:data-tool-name="toolName"
+	>
+		<summary class="sp-tool-call__summary" data-testid="agent-tool-call-summary">
+			<span class="sp-tool-call__icon" aria-hidden="true">🔧</span>
+			<span class="sp-tool-call__name">{{ toolName }}</span>
+			<span class="sp-tool-call__status" :aria-label="done ? t('agent.toolDone') : t('agent.toolStreaming')">
+				{{ statusLabel }}
+			</span>
+		</summary>
+		<pre
+			v-if="displayInput.text.length > 0"
+			class="sp-tool-call__input"
+			data-testid="agent-tool-call-input"
+		>{{ displayInput.text }}</pre>
+		<p
+			v-else-if="!done"
+			class="sp-tool-call__placeholder"
+			data-testid="agent-tool-call-placeholder"
+		>
+			{{ t('agent.toolWaitingForInput') }}
+		</p>
+	</details>
+</template>
+
+<style scoped>
+.sp-tool-call {
+	margin: 0 0 0.375rem;
+	padding: 0.375rem 0.5rem;
+	border-radius: 4px;
+	border: 1px solid var(--background-modifier-border);
+	background: var(--background-secondary-alt, var(--background-secondary));
+}
+
+.sp-tool-call--streaming {
+	border-color: var(--interactive-accent);
+}
+
+.sp-tool-call__summary {
+	cursor: pointer;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.375rem;
+	font-size: 0.8125rem;
+	color: var(--text-normal);
+	list-style: none;
+}
+
+.sp-tool-call__summary::-webkit-details-marker {
+	display: none;
+}
+
+.sp-tool-call__icon {
+	font-size: 0.875rem;
+}
+
+.sp-tool-call__name {
+	font-weight: 600;
+	font-family: var(--font-monospace, ui-monospace, monospace);
+}
+
+.sp-tool-call__status {
+	color: var(--text-muted);
+	font-size: 0.75rem;
+}
+
+.sp-tool-call__input {
+	margin: 0.375rem 0 0;
+	padding: 0.375rem 0.5rem;
+	background: var(--background-primary);
+	border-radius: 3px;
+	font-family: var(--font-monospace, ui-monospace, monospace);
+	font-size: 0.75rem;
+	white-space: pre-wrap;
+	word-break: break-word;
+	max-height: 240px;
+	overflow-y: auto;
+}
+
+.sp-tool-call__placeholder {
+	margin: 0.375rem 0 0;
+	font-size: 0.75rem;
+	color: var(--text-muted);
+	font-style: italic;
+}
+</style>

--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -748,10 +748,11 @@ async function consumeStream(args: {
 				store.captureSessionId(args.threadId, delta.sessionId);
 			} else if (delta.type === 'done') {
 				return { kind: 'done' as const, text: chunks.join('') };
-			} else {
-				// delta.type === 'error' — the only remaining variant.
+			} else if (delta.type === 'error') {
 				return { kind: 'error' as const, errorCode: delta.error.errorCode };
 			}
+			// Other delta variants (thinking, tool-use-*, compact, usage) are
+			// rendered separately by MessageList and don't terminate the stream.
 		}
 		return { kind: 'incomplete' as const, text: chunks.join('') };
 	});

--- a/src/ui/stores/chatStore.ts
+++ b/src/ui/stores/chatStore.ts
@@ -114,6 +114,31 @@ export const useChatStore = defineStore('chat', () => {
 	const streamingText = ref<string>('');
 
 	/**
+	 * Accumulated `thinking` deltas from the active turn (extended-
+	 * thinking models). Drives a collapsed `<details>` block in the
+	 * streaming bubble. PR-ASV-2-delta-extension.
+	 */
+	const streamingThinking = ref<string>('');
+
+	/**
+	 * In-flight tool-use blocks keyed by `StreamDelta.blockId`. Each
+	 * entry accumulates `inputJson` deltas; the UI may render a
+	 * "running ⏳ ToolName" indicator on `tool-use-start` and finalise
+	 * on `tool-use-stop`. PR-ASV-2-delta-extension.
+	 */
+	const streamingToolCalls = ref<Map<string, { toolName: string; inputJson: string; done: boolean }>>(new Map());
+
+	/**
+	 * Most recent token-usage telemetry from the SDK / subprocess
+	 * (`message_start` + `message_delta` carrying `usage`). Drives a
+	 * future context-meter UI. Null until the first emission per turn;
+	 * accumulating values are replaced (last-write-wins, mirroring
+	 * Claudian's approach for endpoints that put zero values on
+	 * `message_start`). PR-ASV-2-delta-extension.
+	 */
+	const lastUsage = ref<{ inputTokens: number; outputTokens: number } | null>(null);
+
+	/**
 	 * `true` while the subprocess adapter is performing first-run startup;
 	 * drives `SubprocessStartingPill`. R-ASM-003.
 	 */
@@ -250,6 +275,9 @@ export const useChatStore = defineStore('chat', () => {
 		activeThreadId.value = null;
 		proposals.value = new Map();
 		streamingText.value = '';
+		streamingThinking.value = '';
+		streamingToolCalls.value = new Map();
+		lastUsage.value = null;
 		cliStartingUp.value = false;
 		sessionResumed.value = false;
 		messages.value = new Map();
@@ -324,6 +352,9 @@ export const useChatStore = defineStore('chat', () => {
 	function setActiveThreadId(threadId: string | null): void {
 		activeThreadId.value = threadId;
 		streamingText.value = '';
+		streamingThinking.value = '';
+		streamingToolCalls.value = new Map();
+		lastUsage.value = null;
 		sessionResumed.value = false;
 	}
 
@@ -362,10 +393,69 @@ export const useChatStore = defineStore('chat', () => {
 	/**
 	 * Clears the streaming-text accumulator and the transient session-resumed
 	 * indicator. Called at turn boundaries. NFR-ASM-002, REQ-ASM-035.
+	 *
+	 * Also clears the PR-ASV-2-delta-extension fields: thinking-text
+	 * accumulator, tool-call map, and the per-turn usage telemetry — each
+	 * new turn starts with a clean slate.
 	 */
 	function resetStreaming(): void {
 		streamingText.value = '';
+		streamingThinking.value = '';
+		streamingToolCalls.value = new Map();
+		lastUsage.value = null;
 		sessionResumed.value = false;
+	}
+
+	/**
+	 * Append a thinking-delta to the in-flight extended-thinking buffer.
+	 * PR-ASV-2-delta-extension.
+	 */
+	function appendStreamingThinking(delta: string): void {
+		streamingThinking.value = streamingThinking.value + delta;
+	}
+
+	/**
+	 * Mark a fresh tool-use block in the in-flight call table.
+	 * PR-ASV-2-delta-extension.
+	 */
+	function startStreamingToolCall(blockId: string, toolName: string, initialJson: string): void {
+		const next = new Map(streamingToolCalls.value);
+		next.set(blockId, { toolName, inputJson: initialJson, done: false });
+		streamingToolCalls.value = next;
+	}
+
+	/**
+	 * Append partial JSON to an in-flight tool-use block's `input` field.
+	 * No-op when `blockId` is unknown (defensive against out-of-order
+	 * deltas). PR-ASV-2-delta-extension.
+	 */
+	function appendStreamingToolCallInput(blockId: string, partialJson: string): void {
+		const existing = streamingToolCalls.value.get(blockId);
+		if (existing === undefined) return;
+		const next = new Map(streamingToolCalls.value);
+		next.set(blockId, { ...existing, inputJson: existing.inputJson + partialJson });
+		streamingToolCalls.value = next;
+	}
+
+	/**
+	 * Mark a tool-use block as fully streamed (the SDK's
+	 * `content_block_stop` arrived). The accumulated `inputJson` is now
+	 * safe to `JSON.parse`. PR-ASV-2-delta-extension.
+	 */
+	function finishStreamingToolCall(blockId: string): void {
+		const existing = streamingToolCalls.value.get(blockId);
+		if (existing === undefined) return;
+		const next = new Map(streamingToolCalls.value);
+		next.set(blockId, { ...existing, done: true });
+		streamingToolCalls.value = next;
+	}
+
+	/**
+	 * Update the latest usage telemetry snapshot.
+	 * PR-ASV-2-delta-extension.
+	 */
+	function setLastUsage(usage: { inputTokens: number; outputTokens: number }): void {
+		lastUsage.value = usage;
 	}
 
 	/**
@@ -446,6 +536,9 @@ export const useChatStore = defineStore('chat', () => {
 		activeThreadId,
 		proposals,
 		streamingText,
+		streamingThinking,
+		streamingToolCalls,
+		lastUsage,
 		cliStartingUp,
 		sessionResumed,
 		messages,
@@ -464,6 +557,11 @@ export const useChatStore = defineStore('chat', () => {
 		captureSessionId,
 		markThreadUsed,
 		appendStreamingDelta,
+		appendStreamingThinking,
+		startStreamingToolCall,
+		appendStreamingToolCallInput,
+		finishStreamingToolCall,
+		setLastUsage,
 		resetStreaming,
 		addProposal,
 		setProposalStatus,

--- a/styles.css
+++ b/styles.css
@@ -1199,7 +1199,7 @@ to {
  * parent: in the agent sidepanel the parent gives ChatSidebar `flex: 0 0
  * auto` and `MessageList` takes the remaining grow space.
  */
-.specorator-root :where(.sp-chat-sidebar[data-v-a2962cc1]) {
+.specorator-root :where(.sp-chat-sidebar[data-v-22efcdd3]) {
 	padding: 1rem;
 	display: flex;
 	flex-direction: column;
@@ -1207,24 +1207,24 @@ to {
 	box-sizing: border-box;
 	flex-shrink: 0;
 }
-.specorator-root :where(.sp-chat__title[data-v-a2962cc1]) {
+.specorator-root :where(.sp-chat__title[data-v-22efcdd3]) {
 	margin: 0;
 	font-size: 1.125rem;
 	font-weight: 700;
 	color: var(--text-normal);
 }
-.specorator-root :where(.sp-chat__header[data-v-a2962cc1]) {
+.specorator-root :where(.sp-chat__header[data-v-22efcdd3]) {
 	display: flex;
 	align-items: center;
 	gap: 0.5rem;
 	flex-wrap: wrap;
 }
-.specorator-root :where(.sp-chat__divider[data-v-a2962cc1]) {
+.specorator-root :where(.sp-chat__divider[data-v-22efcdd3]) {
 	margin: 0;
 	border: none;
 	border-top: 1px solid var(--background-modifier-border);
 }
-.specorator-root :where(.sp-chat__stop[data-v-a2962cc1]) {
+.specorator-root :where(.sp-chat__stop[data-v-22efcdd3]) {
 	margin-left: auto;
 	font-size: 0.75rem;
 	font-weight: 500;
@@ -1238,10 +1238,10 @@ to {
 		background-color 0.15s,
 		border-color 0.15s;
 }
-.specorator-root :where(.sp-chat__stop[data-v-a2962cc1]:hover) {
+.specorator-root :where(.sp-chat__stop[data-v-22efcdd3]:hover) {
 	background: var(--background-modifier-error-hover, var(--interactive-hover));
 }
-.specorator-root :where(.sp-chat__degraded[data-v-a2962cc1]) {
+.specorator-root :where(.sp-chat__degraded[data-v-22efcdd3]) {
 	background: var(--background-secondary);
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 8px;
@@ -1250,13 +1250,13 @@ to {
 	flex-direction: column;
 	gap: 0.5rem;
 }
-.specorator-root :where(.sp-chat__degraded-heading[data-v-a2962cc1]) {
+.specorator-root :where(.sp-chat__degraded-heading[data-v-22efcdd3]) {
 	margin: 0;
 	font-size: 1rem;
 	font-weight: 600;
 	color: var(--text-normal);
 }
-.specorator-root :where(.sp-chat__degraded-body[data-v-a2962cc1]) {
+.specorator-root :where(.sp-chat__degraded-body[data-v-22efcdd3]) {
 	margin: 0;
 	font-size: 0.875rem;
 	color: var(--text-muted);


### PR DESCRIPTION
## Summary

Top-2 gap from the agent-sidepanel-v2 comparative review. Foundation for tool-call rendering, thinking-block UI, plan-mode wiring, and context-meter telemetry. The `StreamDelta` union previously only carried `text | session-id | done | error`. This PR adds:

- **`thinking`** — incremental thinking-mode text from extended-thinking turns. Drives a collapsed `<details>` block in the streaming bubble.
- **`tool-use-start` / `tool-use-input-delta` / `tool-use-stop`** — per-block lifecycle for `tool_use` content blocks. Callers accumulate `inputJson` by `blockId` and finalise on stop (`JSON.parse` is then safe).
- **`compact-boundary`** — SDK auto-compaction marker. UI surfaces this as a synthetic system message so users know context older than the boundary may no longer be in the model's view.
- **`usage`** — token telemetry from `message_start` / `message_delta`. Some Anthropic-compatible endpoints push tokens only on `message_delta`; consumers should treat the latest non-zero values as authoritative.

`done` and `error` stay mutually-exclusive terminal deltas. All new variants are non-terminal and additive — existing consumers that switch on `type` continue to work unchanged.

**Stacked on #374 (subprocess streaming) → #371 → #370 → develop.**

## SDK adapter (`ClaudeCliAdapter`)

`_dispatchMessage` refactored into smaller helpers (complexity budget):

- `_dispatchSystemInit` — extracted (was inline).
- `_dispatchStreamEvent` — new. Routes by inner `event.type`:
  - `message_start` / `message_delta` → `_extractUsage` → optional `usage` delta (zero-zero updates filtered).
  - `content_block_start` → `_handleBlockStart`. Tracks block kind in `state.blockKinds` keyed by SDK content-block index. Emits `tool-use-start` for tool blocks.
  - `content_block_delta` → `_handleBlockDelta` → `_mapBlockDelta`. Dispatches `text_delta` / `thinking_delta` / `input_json_delta`.
  - `content_block_stop` → `_handleBlockStop`. Emits `tool-use-stop` only for tool blocks.
- `_dispatchResult` — unchanged.
- New `system/compact_boundary` branch in the top-level dispatch.

`StreamState` replaces `{ sessionIdEmitted, textEmitted }`: adds `turnId` (UUID per stream → stable `blockId`s) and `blockKinds` (per-index kind table).

## chatStore extensions

New reactive fields + actions, all cleared by `resetStreaming()` / `setActiveThreadId()` / `reset()` symmetric with existing `streamingText`:

| Field | Action(s) |
|---|---|
| `streamingThinking: ref<string>` | `appendStreamingThinking` |
| `streamingToolCalls: ref<Map<blockId, {toolName, inputJson, done}>>` | `startStreamingToolCall`, `appendStreamingToolCallInput`, `finishStreamingToolCall` |
| `lastUsage: ref<{inputTokens,outputTokens} \| null>` | `setLastUsage` |

## Deferred to follow-up PRs

- **Subprocess parity** — `ClaudeSubprocessAdapter._handleNdjsonLine` uses a different wire format (`system/init` / `assistant/message` / `result`, not `stream_event` content blocks). Extending it for tool-use parity needs the CLI's actual `--include-partial-messages` event surface verified against a real binary.
- **UI consumption** — `ChatSidebar.consumeStream` switches on the existing variants and ignores the new ones (TypeScript-safe because the union is open). Tool-call rendering becomes the next PR.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 errors
- [x] `npm run test` 1475/1475 pass (existing SDK-streaming tests still pass — additive change)
- [ ] Follow-up PR exercises the new variants in `ToolCallBlock.vue` + `ThinkingBlock.vue` integration tests

https://claude.ai/code/session_01VvXsK3aGp2g4jSpT1py7Mh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvXsK3aGp2g4jSpT1py7Mh)_