### PR TITLE
feat(agent): ToolCallBlock + ThinkingBlock renderers (PR-ASV-2-tool-rendering)

### DIFF
--- a/specs/agent-sidepanel-v2/workflow-state.md
+++ b/specs/agent-sidepanel-v2/workflow-state.md
@@ -3,20 +3,20 @@ id: d7e8f9a0-1234-4b56-9c78-d9e0f1a2b3c4
 feature: 'Agent Sidepanel v2'
 area: ASV
 slug: agent-sidepanel-v2
-current_stage: idea
+current_stage: implementation
 status: active
 last_updated: 2026-05-16
-last_agent: pm
+last_agent: dev
 createdAt: 2026-05-16T00:00:00+02:00
 updatedAt: 2026-05-16T00:00:00+02:00
 artifacts:
   idea: complete
-  research: pending
-  requirements: pending
-  design: pending
-  spec: pending
-  tasks: pending
-  implementation-log: pending
+  research: complete
+  requirements: complete
+  design: complete
+  spec: complete
+  tasks: complete
+  implementation-log: in-progress
   test-plan: pending
   test-report: pending
   review: pending
@@ -26,19 +26,39 @@ artifacts:
 
 ## Stage progress
 
-| Stage              | Status   | Artifact  | Notes                                                                                   |
-| ------------------ | -------- | --------- | --------------------------------------------------------------------------------------- |
-| 1 — Idea           | complete | `idea.md` | IDEA-ASV-001 — Lift chat into its own dedicated sidepanel + adopt Claudian-inspired UX. |
-| 2 — Research       | pending  | —         |                                                                                         |
-| 3 — Requirements   | pending  | —         |                                                                                         |
-| 4 — Design         | pending  | —         |                                                                                         |
-| 5 — Specification  | pending  | —         |                                                                                         |
-| 6 — Tasks          | pending  | —         |                                                                                         |
-| 7 — Implementation | pending  | —         | PR-ASV-1 (structural lift) will land first on `claude/refactor-agent-sidepanel-2CDgl`.  |
-| 8 — Testing        | pending  | —         |                                                                                         |
-| 9 — Review         | pending  | —         |                                                                                         |
-| 10 — Release       | pending  | —         |                                                                                         |
-| 11 — Retrospective | pending  | —         |                                                                                         |
+| Stage              | Status      | Artifact                                                                                                            | Notes                                                                                                                                                                                                                                |
+| ------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1 — Idea           | complete    | `idea.md`                                                                                                           | IDEA-ASV-001 — Dedicated sidepanel + Claudian-inspired UX.                                                                                                                                                                           |
+| 2 — Research       | complete    | inline in `workflow-state.md` ("Increment 2+ research wave")                                                        | Two research subagents: Claudian-issue mining + Specorator-vs-Claudian gap analysis. Five reviewer subagents (UX, a11y, security, performance pending, architecture) on the v2 PR stack.                                            |
+| 3 — Requirements   | complete    | implicit — derived from Claudian feature-set scoped to Claude                                                       | Captured in tracking issue #385 (parity checklist). Explicit non-goals documented.                                                                                                                                                  |
+| 4 — Design         | complete    | inline PR descriptions across the 14 PRs                                                                            | Narrow-port discipline (ADR-008) for every new surface (`MarkdownRenderPort`, `ApprovalPort`, `SecretStorePort`). `StreamDelta` discriminated union (ADR-0034 candidate — see OQ-ASV-4).                                            |
+| 5 — Specification  | complete    | per-PR commit messages + spec entries                                                                               | Each PR carries a complete spec section in its body.                                                                                                                                                                                  |
+| 6 — Tasks          | complete    | implicit — 14 PRs                                                                                                   | Subagent-driven decomposition; each PR is a single mergeable unit.                                                                                                                                                                  |
+| 7 — Implementation | in-progress | PRs #369, #370, #371, #372, #373, #374, #375, #376, #377, #378, #379, #380, #381, #386, #387                          | 15 PRs in flight (see "PR stack" below). Codex review threads on most; ~25 P1/P2 findings addressed since the stack opened. Three follow-up issues open (#382 secret-storage → addressed by #387, #383 subprocess parity, #384 plan-mode wiring). |
+| 8 — Testing        | pending     | per-PR test coverage                                                                                                | Each PR is gated on `npm run test` + typecheck + lint before push. Cross-PR integration testing happens once the stack lands.                                                                                                       |
+| 9 — Review         | pending     | Codex P1/P2 reviews per-PR                                                                                          | Reviewer subagent reports (UX / a11y / security / architecture / perf) being synthesized into a final polish wave.                                                                                                                  |
+| 10 — Release       | pending     | —                                                                                                                   | After the stack squash-merges onto `develop`.                                                                                                                                                                                       |
+| 11 — Retrospective | pending     | —                                                                                                                   | After demo / main promotion.                                                                                                                                                                                                        |
+
+## PR stack (Increment 1 + Increment 2)
+
+| #     | Branch                                                          | Scope                                                          | Status                |
+| ----- | --------------------------------------------------------------- | -------------------------------------------------------------- | --------------------- |
+| #369  | `claude/refactor-agent-sidepanel-2CDgl`                         | Sidepanel lift + multi-turn message list                       | Open, multiple Codex fixes |
+| #370  | `claude/agent-sidepanel-v2-streaming-port`                      | `queryStream` port shape + `streamFromQuery` helper             | Open                  |
+| #371  | `claude/agent-sidepanel-v2-streaming-sdk`                       | SDK real streaming + P1 abort race + P1 exhaustion              | Open                  |
+| #372  | `claude/agent-sidepanel-v2-streaming-ui`                        | UI consume + Stop button + P2 buffer reset                      | Open                  |
+| #373  | `claude/agent-sidepanel-v2-markdown`                            | Hand-rolled markdown + P2 link-parens                           | Open                  |
+| #374  | `claude/agent-sidepanel-v2-streaming-subproc-v2`                | Subprocess real streaming                                       | Open                  |
+| #375  | `claude/agent-sidepanel-v2-slash-palette`                       | Slash palette + P2 ×3 (clear-on-select / token-bounds / selEnd) | Open                  |
+| #376  | `claude/agent-sidepanel-v2-mention-picker`                      | `@`-mention picker + IME guard + P2 ×5                          | Open                  |
+| #377  | `claude/agent-sidepanel-v2-obsidian-markdown`                   | Obsidian `MarkdownRenderer` port + P1 render race               | Open                  |
+| #378  | `claude/agent-sidepanel-v2-stream-delta-extension`              | `StreamDelta` extension (SDK only — superseded by #386)         | Superseded            |
+| #379  | `claude/agent-sidepanel-v2-tool-rendering`                      | `ToolCallBlock` + `ThinkingBlock`                               | Open                  |
+| #380  | `claude/agent-sidepanel-v2-plan-mode`                           | `InlinePlanApprovalCard` + `ApprovalPort`                       | Open                  |
+| #381  | `claude/agent-sidepanel-v2-folder-mentions`                     | Folder rows in `@`-picker                                       | Open                  |
+| #386  | `claude/agent-sidepanel-v2-stream-delta-extension-v2`           | `StreamDelta` ext (SDK + subprocess) + P1 toolJson + P2 usage   | Open — closes #383    |
+| #387  | `claude/agent-sidepanel-v2-secret-storage-v2-retry`             | `SecretStorePort` migration                                     | Open — closes #382    |
 
 ## Blocks
 
@@ -51,6 +71,7 @@ None.
 | 2026-05-16 | pm   | dev | Spec entry created on `claude/refactor-agent-sidepanel-2CDgl` to track the agent-sidepanel v2 work. Increment 1 of v2 is a pure structural lift: extract chat into its own `ItemView` (`VIEW_TYPE = 'specorator-agent'`), remove `/chat` from `MainLayout` tab nav, preserve every existing REQ-CCS / REQ-ASM behaviour. Claudian-style UX features (multi-turn message list, streaming, slash-command palette, @file mentions) land as Increment 2+.                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | 2026-05-16 | dev  | qa  | PR-ASV-1 landed structural lift + multi-turn message list. New surfaces: `AgentSidepanelView` (`VIEW_TYPE_AGENT = 'specorator-agent'`), `AgentSidepanelRoot.vue`, `AgentSidepanelHeader.vue`, `MessageList.vue`, `ChatMessage` DTO + `appendMessage`/`clearThreadMessages` store actions. Removed: `/chat` route, `ChatSidebarView.vue`, `nav.chat` i18n key. URI handler reroutes `open-chat`/`focus-chat` to the new sidepanel. 1445 tests pass (34 new), typecheck clean, plugin build and standalone web build pass. Streaming, slash palette, `@`-mentions, stop-button still deferred to Increment 2.                                                                                                                                                                                                                                                                                                |
 | 2026-05-16 | dev  | dev | PR-ASV-1 post-open polish: Codex P2 (clear prior thread's message bucket on "New conversation") fixed by `handleNewConversation` calling `clearThreadMessages(prev)` before rotating `activeThreadId`. Internal-review P1 #2 closed by `tests/plugin/main.uri-handler.test.ts` covering all action branches (`open-chat`, `focus-chat`, `open-agent`, deferred, unknown, core short-circuit). Internal-review P2 #5 (MessageList scroll watcher will miss streaming deltas) documented inline as a forward-looking comment. Deferred: P1 #1 / P2 #6 (`SpecoratorView` retains a now-vestigial chat-thread hydration + status watcher — harmless dead code in production but load-bearing in `tests/plugin/SpecoratorView.test.ts`; clean up in a follow-up refactor PR before Increment 2). P3 polish (i18n unused keys, hard-coded `getDisplayText`, single timestamp for user+assistant turns) deferred. |
+| 2026-05-16 | dev  | dev | Increment 2 wave landed across 11 PRs (streaming port → tool rendering → plan-mode card → folder mentions → SecretStorage). Five reviewer subagents (UX / a11y / security / performance / architecture) dispatched in parallel. Findings consolidated for a polish-wave dispatch — see "Reviewer findings" below.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 
 ## Open clarifications
 

--- a/src/ui/components/agent/MessageList.vue
+++ b/src/ui/components/agent/MessageList.vue
@@ -13,6 +13,8 @@ import { computed, nextTick, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useChatStore } from '@/ui/stores/chatStore';
 import MarkdownBlock from '@/ui/components/agent/MarkdownBlock.vue';
+import ThinkingBlock from './ThinkingBlock.vue';
+import ToolCallBlock from './ToolCallBlock.vue';
 
 const props = defineProps<{
 	/** Active thread id, or `null` when no thread is selected. */
@@ -35,22 +37,33 @@ const messages = computed(() => {
  * it is replaced by the real `appendMessage` once the stream resolves.
  */
 const streamingText = computed<string>(() => store.streamingText);
+const streamingThinking = computed<string>(() => store.streamingThinking);
+const streamingToolCalls = computed(() => Array.from(store.streamingToolCalls.entries()));
 const isStreaming = computed<boolean>(
-	() => store.status === 'loading' && streamingText.value.length > 0,
+	() =>
+		store.status === 'loading' &&
+		(streamingText.value.length > 0 ||
+			streamingThinking.value.length > 0 ||
+			streamingToolCalls.value.length > 0),
 );
 
 const scrollContainer = ref<HTMLElement | null>(null);
 
-// Track BOTH the message-array length AND the streaming-text length so the
-// scroll position follows live deltas during a streaming turn. Without the
-// second observed value, the scroll watcher only fires at turn boundaries
-// (appendMessage) and the user has to scroll manually as Claude streams.
-watch([() => messages.value.length, () => streamingText.value.length], async () => {
-	await nextTick();
-	const el = scrollContainer.value;
-	if (el === null) return;
-	el.scrollTop = el.scrollHeight;
-});
+// Track message-array length and streaming text/thinking/tool-call lengths.
+watch(
+	[
+		() => messages.value.length,
+		() => streamingText.value.length,
+		() => streamingThinking.value.length,
+		() => streamingToolCalls.value.length,
+	],
+	async () => {
+		await nextTick();
+		const el = scrollContainer.value;
+		if (el === null) return;
+		el.scrollTop = el.scrollHeight;
+	},
+);
 </script>
 
 <template>
@@ -100,7 +113,19 @@ watch([() => messages.value.length, () => streamingText.value.length], async () 
 				{{ t('agent.roleAssistant') }}
 			</header>
 			<div class="sp-agent-message__body">
-				<MarkdownBlock class="sp-agent-message__text" :text="streamingText" />
+				<ThinkingBlock :text="streamingThinking" />
+				<ToolCallBlock
+					v-for="[blockId, call] in streamingToolCalls"
+					:key="blockId"
+					:tool-name="call.toolName"
+					:input-json="call.inputJson"
+					:done="call.done"
+				/>
+				<MarkdownBlock
+					v-if="streamingText.length > 0"
+					class="sp-agent-message__text"
+					:text="streamingText"
+				/>
 				<span
 					class="sp-agent-message__cursor"
 					aria-hidden="true"

--- a/src/ui/components/agent/MessageList.vue
+++ b/src/ui/components/agent/MessageList.vue
@@ -49,13 +49,23 @@ const isStreaming = computed<boolean>(
 
 const scrollContainer = ref<HTMLElement | null>(null);
 
-// Track message-array length and streaming text/thinking/tool-call lengths.
+// Track message length, streaming text/thinking lengths, and tool-call inputJson byte-length
+// (Codex P2 PR #379: observing only `streamingToolCalls.length` missed deltas to existing blocks).
+const streamingToolCallsLength = computed(() => {
+	let total = streamingToolCalls.value.length;
+	for (const [, call] of streamingToolCalls.value) {
+		total += call.inputJson.length;
+	}
+	return total;
+});
+
+
 watch(
 	[
 		() => messages.value.length,
 		() => streamingText.value.length,
 		() => streamingThinking.value.length,
-		() => streamingToolCalls.value.length,
+		streamingToolCallsLength,
 	],
 	async () => {
 		await nextTick();

--- a/src/ui/components/agent/MessageList.vue
+++ b/src/ui/components/agent/MessageList.vue
@@ -11,10 +11,21 @@
  */
 import { computed, nextTick, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useChatStore } from '@/ui/stores/chatStore';
+import { useChatStore, type CompactBoundaryNoticeDto } from '@/ui/stores/chatStore';
+import type { ChatMessage } from '@/domain/chat/ChatMessage';
 import MarkdownBlock from '@/ui/components/agent/MarkdownBlock.vue';
 import ThinkingBlock from './ThinkingBlock.vue';
 import ToolCallBlock from './ToolCallBlock.vue';
+
+/**
+ * Discriminated union for the interleaved transcript: either a real
+ * `ChatMessage` turn or a synthetic `compact-boundary` notice (Codex P2 on
+ * PR #379). Ordered by `createdAt` so the divider appears at the point where
+ * the SDK auto-compacted history.
+ */
+type TranscriptEntry =
+	| { readonly kind: 'message'; readonly message: ChatMessage }
+	| { readonly kind: 'compact-boundary'; readonly notice: CompactBoundaryNoticeDto };
 
 const props = defineProps<{
 	/** Active thread id, or `null` when no thread is selected. */
@@ -28,6 +39,37 @@ const messages = computed(() => {
 	if (props.threadId === null) return [];
 	return store.messages.get(props.threadId) ?? [];
 });
+
+/**
+ * Per-thread `compact-boundary` notices for the active thread (Codex P2 on
+ * PR #379). Empty when no compaction has occurred or no thread is selected.
+ */
+const compactBoundaries = computed<readonly CompactBoundaryNoticeDto[]>(() => {
+	if (props.threadId === null) return [];
+	return store.compactBoundaries.get(props.threadId) ?? [];
+});
+
+/**
+ * Merged, time-ordered transcript of real messages and synthetic
+ * compact-boundary notices. `createdAt` is the ordering key — notices fall
+ * naturally between the turn that triggered them and the next turn.
+ */
+const transcript = computed<readonly TranscriptEntry[]>(() => {
+	const entries: TranscriptEntry[] = [];
+	for (const m of messages.value) entries.push({ kind: 'message', message: m });
+	for (const n of compactBoundaries.value)
+		entries.push({ kind: 'compact-boundary', notice: n });
+	entries.sort((a, b) => {
+		const aAt = a.kind === 'message' ? a.message.createdAt : a.notice.createdAt;
+		const bAt = b.kind === 'message' ? b.message.createdAt : b.notice.createdAt;
+		return aAt < bAt ? -1 : aAt > bAt ? 1 : 0;
+	});
+	return entries;
+});
+
+const hasContent = computed<boolean>(
+	() => messages.value.length > 0 || compactBoundaries.value.length > 0,
+);
 
 /**
  * Streaming in-flight indicator. While `chatStore.status === 'loading'` and
@@ -63,6 +105,7 @@ const streamingToolCallsLength = computed(() => {
 watch(
 	[
 		() => messages.value.length,
+		() => compactBoundaries.value.length,
 		() => streamingText.value.length,
 		() => streamingThinking.value.length,
 		streamingToolCallsLength,
@@ -78,7 +121,7 @@ watch(
 
 <template>
 	<div
-		v-if="messages.length > 0 || isStreaming"
+		v-if="hasContent || isStreaming"
 		ref="scrollContainer"
 		class="sp-agent-messages"
 		data-testid="agent-message-list"
@@ -86,34 +129,49 @@ watch(
 		:aria-label="t('agent.messageListAriaLabel')"
 		aria-live="polite"
 	>
-		<article
-			v-for="message in messages"
-			:key="message.id"
-			class="sp-agent-message"
-			:class="`sp-agent-message--${message.role}`"
-			:data-testid="`agent-message-${message.role}`"
-		>
-			<header class="sp-agent-message__role" data-testid="agent-message-role">
-				{{ message.role === 'user' ? t('agent.roleUser') : t('agent.roleAssistant') }}
-			</header>
-			<div class="sp-agent-message__body" data-testid="agent-message-body">
-				<MarkdownBlock
-					v-if="message.text.length > 0"
-					class="sp-agent-message__text"
-					:text="message.text"
-				/>
-				<p v-else class="sp-agent-message__empty" data-testid="agent-message-empty">
-					{{ t('agent.assistantEmpty') }}
-				</p>
-				<p
-					v-if="message.truncated === true"
-					class="sp-agent-message__trim-note"
-					data-testid="agent-message-trim-note"
-				>
-					{{ t('agent.contextTrimmed') }}
-				</p>
+		<template v-for="entry in transcript">
+			<article
+				v-if="entry.kind === 'message'"
+				:key="entry.message.id"
+				class="sp-agent-message"
+				:class="`sp-agent-message--${entry.message.role}`"
+				:data-testid="`agent-message-${entry.message.role}`"
+			>
+				<header class="sp-agent-message__role" data-testid="agent-message-role">
+					{{ entry.message.role === 'user' ? t('agent.roleUser') : t('agent.roleAssistant') }}
+				</header>
+				<div class="sp-agent-message__body" data-testid="agent-message-body">
+					<MarkdownBlock
+						v-if="entry.message.text.length > 0"
+						class="sp-agent-message__text"
+						:text="entry.message.text"
+					/>
+					<p v-else class="sp-agent-message__empty" data-testid="agent-message-empty">
+						{{ t('agent.assistantEmpty') }}
+					</p>
+					<p
+						v-if="entry.message.truncated === true"
+						class="sp-agent-message__trim-note"
+						data-testid="agent-message-trim-note"
+					>
+						{{ t('agent.contextTrimmed') }}
+					</p>
+				</div>
+			</article>
+			<div
+				v-else
+				:key="entry.notice.id"
+				class="sp-agent-compact-boundary"
+				data-testid="compact-boundary-notice"
+				role="status"
+			>
+				<span class="sp-agent-compact-boundary__line" aria-hidden="true"></span>
+				<span class="sp-agent-compact-boundary__label">
+					{{ t('chat.compactBoundary.notice') }}
+				</span>
+				<span class="sp-agent-compact-boundary__line" aria-hidden="true"></span>
 			</div>
-		</article>
+		</template>
 		<article
 			v-if="isStreaming"
 			class="sp-agent-message sp-agent-message--assistant sp-agent-message--streaming"
@@ -228,6 +286,27 @@ watch(
 
 .sp-agent-message--streaming {
 	opacity: 0.95;
+}
+
+.sp-agent-compact-boundary {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	margin: 0.25rem 0;
+	color: var(--text-faint);
+	font-size: 0.75rem;
+	font-style: italic;
+	text-align: center;
+}
+
+.sp-agent-compact-boundary__line {
+	flex: 1 1 auto;
+	height: 1px;
+	background: var(--background-modifier-border);
+}
+
+.sp-agent-compact-boundary__label {
+	flex: 0 0 auto;
 }
 
 .sp-agent-message__cursor {

--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -725,6 +725,64 @@ async function handleSend(): Promise<void> {
 	focusTextarea();
 }
 
+type DrainOutcome =
+	| { kind: 'done'; text: string }
+	| { kind: 'error'; errorCode: ClaudeCliErrorCode };
+
+/**
+ * Dispatch one delta to the store and return a terminal outcome when the
+ * stream is over. Extracted from `consumeStream` to keep the async-iterator
+ * loop under the project's complexity budget.
+ */
+function applyStreamDelta(
+	delta: StreamDelta,
+	chunks: string[],
+	threadId: string,
+): DrainOutcome | null {
+	if (delta.type === 'done') return { kind: 'done', text: chunks.join('') };
+	if (delta.type === 'error') return { kind: 'error', errorCode: delta.error.errorCode };
+	applyNonTerminalDelta(delta, chunks, threadId);
+	return null;
+}
+
+function applyNonTerminalDelta(
+	delta: Exclude<StreamDelta, { type: 'done' } | { type: 'error' }>,
+	chunks: string[],
+	threadId: string,
+): void {
+	switch (delta.type) {
+		case 'text':
+			chunks.push(delta.text);
+			store.appendStreamingDelta(delta.text);
+			return;
+		case 'session-id':
+			store.captureSessionId(threadId, delta.sessionId);
+			return;
+		case 'thinking':
+			store.appendStreamingThinking(delta.text);
+			return;
+		case 'tool-use-start':
+			store.startStreamingToolCall(delta.blockId, delta.toolName, delta.inputJson);
+			return;
+		case 'tool-use-input-delta':
+			store.appendStreamingToolCallInput(delta.blockId, delta.inputJson);
+			return;
+		case 'tool-use-stop':
+			store.finishStreamingToolCall(delta.blockId);
+			return;
+		case 'usage':
+			store.setLastUsage({
+				inputTokens: delta.inputTokens,
+				outputTokens: delta.outputTokens,
+			});
+			return;
+		case 'compact-boundary':
+			// Surfaced as a synthetic system entry by `MessageList.vue`;
+			// no in-flight store mutation needed.
+			return;
+	}
+}
+
 /**
  * Drain `queryStream` to a terminal delta. Accumulates `text` deltas into
  * `store.streamingText` so `MessageList.vue` can render the in-flight
@@ -739,30 +797,20 @@ async function consumeStream(args: {
 	threadId: string;
 }): Promise<{ kind: 'success'; text: string } | { kind: 'error'; errorCode: ClaudeCliErrorCode }> {
 	const chunks: string[] = [];
-	const drained = await tryAsync(async () => {
+	const drained = await tryAsync(async (): Promise<DrainOutcome | null> => {
 		for await (const delta of args.stream) {
-			if (delta.type === 'text') {
-				chunks.push(delta.text);
-				store.appendStreamingDelta(delta.text);
-			} else if (delta.type === 'session-id') {
-				store.captureSessionId(args.threadId, delta.sessionId);
-			} else if (delta.type === 'done') {
-				return { kind: 'done' as const, text: chunks.join('') };
-			} else if (delta.type === 'error') {
-				return { kind: 'error' as const, errorCode: delta.error.errorCode };
-			}
-			// Other delta variants (thinking, tool-use-*, compact, usage) are
-			// rendered separately by MessageList and don't terminate the stream.
+			const terminal = applyStreamDelta(delta, chunks, args.threadId);
+			if (terminal !== null) return terminal;
 		}
-		return { kind: 'incomplete' as const, text: chunks.join('') };
+		return null;
 	});
 	if (!drained.ok) {
 		return { kind: 'error', errorCode: 'QUERY_FAILED' };
 	}
 	const outcome = drained.value;
+	if (outcome === null) return { kind: 'error', errorCode: 'QUERY_FAILED' };
 	if (outcome.kind === 'done') return { kind: 'success', text: outcome.text };
-	if (outcome.kind === 'error') return { kind: 'error', errorCode: outcome.errorCode };
-	return { kind: 'error', errorCode: 'QUERY_FAILED' };
+	return { kind: 'error', errorCode: outcome.errorCode };
 }
 
 /**

--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -777,8 +777,11 @@ function applyNonTerminalDelta(
 			});
 			return;
 		case 'compact-boundary':
-			// Surfaced as a synthetic system entry by `MessageList.vue`;
-			// no in-flight store mutation needed.
+			// Push a synthetic notice into the per-thread compact-boundary
+			// log so `MessageList.vue` can render an inline divider. Without
+			// this the auto-compaction event was invisible — hiding a
+			// critical history-rewrite transition (Codex P2 on PR #379).
+			store.appendCompactBoundaryNotice(threadId, { reason: delta.reason });
 			return;
 	}
 }

--- a/src/ui/i18n/locales/de.ts
+++ b/src/ui/i18n/locales/de.ts
@@ -139,6 +139,9 @@ export default {
     response: {
       structuredFail: 'Der Assistent hat eine unerwartete Antwort zurückgegeben. Bitte versuche es erneut.',
     },
+    compactBoundary: {
+      notice: 'Frühere Konversation wurde zusammengefasst, um Platz zu sparen.',
+    },
   },
   agent: {
     title: 'Specorator Agent',

--- a/src/ui/i18n/locales/de.ts
+++ b/src/ui/i18n/locales/de.ts
@@ -154,5 +154,10 @@ export default {
     contextTrimmed: 'Ein Teil des Kontexts wurde gekürzt, damit die Nachricht im Größenlimit bleibt.',
     assistantEmpty: '(Kein Text — siehe Vorschlagskarte unten.)',
     emptyHistory: 'Frag Claude etwas — dein Gespräch erscheint hier.',
+    thinking: 'Denkt nach',
+    toolDone: 'Werkzeug abgeschlossen',
+    toolStreaming: 'Werkzeug läuft',
+    toolWaitingForInput: 'Warte auf Werkzeug-Eingabe…',
+    streamingResponse: 'Assistent antwortet…',
   },
 } as const

--- a/src/ui/i18n/locales/en.ts
+++ b/src/ui/i18n/locales/en.ts
@@ -139,6 +139,9 @@ export default {
     response: {
       structuredFail: 'Assistant returned an unexpected response. Please try again.',
     },
+    compactBoundary: {
+      notice: 'Earlier conversation was summarised to save space.',
+    },
   },
   agent: {
     title: 'Specorator agent',

--- a/src/ui/i18n/locales/en.ts
+++ b/src/ui/i18n/locales/en.ts
@@ -154,5 +154,10 @@ export default {
     contextTrimmed: 'Some context was trimmed to keep the message within size limits.',
     assistantEmpty: '(No text — see the proposal card below.)',
     emptyHistory: "Ask Claude anything — your conversation will appear here.",
+    thinking: 'Thinking',
+    toolDone: 'Tool finished',
+    toolStreaming: 'Tool running',
+    toolWaitingForInput: 'Waiting for tool input…',
+    streamingResponse: 'Assistant is replying…',
   },
 } as const

--- a/src/ui/stores/chatStore.ts
+++ b/src/ui/stores/chatStore.ts
@@ -4,6 +4,32 @@ import { computed, ref } from 'vue';
 import type { ChatThreadRecord } from '@/domain/chat/ChatThreadRecord';
 import type { ChatMessage } from '@/domain/chat/ChatMessage';
 import type { SessionId } from '@/domain/chat/SessionId';
+
+/**
+ * Plain DTO for a `compact-boundary` synthetic notice rendered inline in the
+ * thread's message log. Emitted by the SDK / subprocess transport via
+ * `StreamDelta { type: 'compact-boundary' }` when the underlying agent
+ * auto-compacted prior context; surfaces a visible "history was rewritten"
+ * marker so the user can tell that messages above the divider may no longer
+ * be in the model's working set. Codex P2 on PR #379.
+ *
+ * Lives in a per-thread map separate from `ChatMessage` so the existing
+ * `role: 'user' | 'assistant'` discriminator stays untouched.
+ */
+export interface CompactBoundaryNoticeDto {
+	/** Stable id used as `:key` in lists. UUID v4 from `crypto.randomUUID()`. */
+	readonly id: string;
+	/** Thread the boundary belongs to. */
+	readonly threadId: string;
+	/** ISO 8601 UTC timestamp recorded when the delta was received. */
+	readonly createdAt: string;
+	/**
+	 * Optional reason string forwarded from the SDK
+	 * (`SDKCompactBoundaryMessage`). May be undefined; the UI falls back to
+	 * the generic i18n notice when missing.
+	 */
+	readonly reason?: string;
+}
 import type {
 	FileWriteProposal,
 	FileWriteProposalStatus,
@@ -160,6 +186,17 @@ export const useChatStore = defineStore('chat', () => {
 	const messages = ref<Map<string, ChatMessage[]>>(new Map());
 
 	/**
+	 * Per-thread synthetic `compact-boundary` notices, keyed by `threadId`.
+	 * Each entry marks the point where the SDK auto-compacted prior context
+	 * (StreamDelta `compact-boundary`). Rendered inline by `MessageList.vue`
+	 * so users see when conversation history may have been rewritten.
+	 * Memory-only — boundaries are not persisted across restarts because the
+	 * vault session log already captures the underlying SDK event.
+	 * Codex P2 on PR #379.
+	 */
+	const compactBoundaries = ref<Map<string, CompactBoundaryNoticeDto[]>>(new Map());
+
+	/**
 	 * Structured-output parse-failure flag (REQ-ASM-025). Set by `ChatSidebar`
 	 * when `queryStructured()` returns an `EnvelopeParseError`; surfaced via
 	 * `ChatResponse` state `'structured-fail'`. Lives in the store (not in
@@ -281,6 +318,7 @@ export const useChatStore = defineStore('chat', () => {
 		cliStartingUp.value = false;
 		sessionResumed.value = false;
 		messages.value = new Map();
+		compactBoundaries.value = new Map();
 		structuredFail.value = false;
 	}
 
@@ -305,10 +343,43 @@ export const useChatStore = defineStore('chat', () => {
 	 * (transport + session_id continuity) but starts the visible log fresh.
 	 */
 	function clearThreadMessages(threadId: string): void {
-		if (!messages.value.has(threadId)) return;
-		const next = new Map(messages.value);
-		next.delete(threadId);
-		messages.value = next;
+		if (messages.value.has(threadId)) {
+			const next = new Map(messages.value);
+			next.delete(threadId);
+			messages.value = next;
+		}
+		if (compactBoundaries.value.has(threadId)) {
+			const next = new Map(compactBoundaries.value);
+			next.delete(threadId);
+			compactBoundaries.value = next;
+		}
+	}
+
+	/**
+	 * Append a `compact-boundary` notice to the active thread's notice log.
+	 * Idempotent on `id` collision. Creates the bucket lazily for unseen
+	 * thread ids. Used by `ChatSidebar.applyNonTerminalDelta` when the
+	 * transport emits a `StreamDelta { type: 'compact-boundary' }` so that
+	 * `MessageList.vue` can render the divider inline with the conversation.
+	 * Codex P2 on PR #379.
+	 */
+	function appendCompactBoundaryNotice(
+		threadId: string,
+		payload: { reason?: string },
+	): void {
+		const bucket = compactBoundaries.value.get(threadId) ?? [];
+		const entry: CompactBoundaryNoticeDto = {
+			id:
+				typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+					? crypto.randomUUID()
+					: `cb-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+			threadId,
+			createdAt: new Date().toISOString(),
+			reason: payload.reason,
+		};
+		const next = new Map(compactBoundaries.value);
+		next.set(threadId, [...bucket, entry]);
+		compactBoundaries.value = next;
 	}
 
 	/**
@@ -542,6 +613,7 @@ export const useChatStore = defineStore('chat', () => {
 		cliStartingUp,
 		sessionResumed,
 		messages,
+		compactBoundaries,
 		structuredFail,
 		addContextFile,
 		removeContextFile,
@@ -570,6 +642,7 @@ export const useChatStore = defineStore('chat', () => {
 		appendMessage,
 		clearThreadMessages,
 		clearThreadProposals,
+		appendCompactBoundaryNotice,
 		setStructuredFail,
 	};
 });

--- a/styles.css
+++ b/styles.css
@@ -811,7 +811,98 @@ to   { opacity: 1; transform: translateY(0);
 	text-decoration: underline;
 }
 
-.specorator-root :where(.sp-agent-messages[data-v-25c3bb88]) {
+.specorator-root :where(.sp-thinking-block[data-v-85062e16]) {
+	margin: 0 0 0.5rem;
+	padding: 0.375rem 0.5rem;
+	border-radius: 4px;
+	border: 1px solid var(--background-modifier-border);
+	background: var(--background-secondary-alt, var(--background-secondary));
+	font-size: 0.8125rem;
+}
+.specorator-root :where(.sp-thinking-block__summary[data-v-85062e16]) {
+	cursor: pointer;
+	color: var(--text-muted);
+	display: inline-flex;
+	align-items: center;
+	gap: 0.375rem;
+	list-style: none;
+}
+.specorator-root :where(.sp-thinking-block__summary[data-v-85062e16]::-webkit-details-marker) {
+	display: none;
+}
+.specorator-root :where(.sp-thinking-block__icon[data-v-85062e16]) {
+	font-size: 0.875rem;
+}
+.specorator-root :where(.sp-thinking-block__label[data-v-85062e16]) {
+	font-weight: 500;
+}
+.specorator-root :where(.sp-thinking-block__text[data-v-85062e16]) {
+	margin: 0.375rem 0 0;
+	padding: 0.375rem 0.5rem;
+	background: var(--background-primary);
+	border-radius: 3px;
+	font-family: var(--font-monospace, ui-monospace, monospace);
+	font-size: 0.75rem;
+	color: var(--text-muted);
+	white-space: pre-wrap;
+	word-break: break-word;
+	max-height: 240px;
+	overflow-y: auto;
+}
+
+.specorator-root :where(.sp-tool-call[data-v-9154ac7e]) {
+	margin: 0 0 0.375rem;
+	padding: 0.375rem 0.5rem;
+	border-radius: 4px;
+	border: 1px solid var(--background-modifier-border);
+	background: var(--background-secondary-alt, var(--background-secondary));
+}
+.specorator-root :where(.sp-tool-call--streaming[data-v-9154ac7e]) {
+	border-color: var(--interactive-accent);
+}
+.specorator-root :where(.sp-tool-call__summary[data-v-9154ac7e]) {
+	cursor: pointer;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.375rem;
+	font-size: 0.8125rem;
+	color: var(--text-normal);
+	list-style: none;
+}
+.specorator-root :where(.sp-tool-call__summary[data-v-9154ac7e]::-webkit-details-marker) {
+	display: none;
+}
+.specorator-root :where(.sp-tool-call__icon[data-v-9154ac7e]) {
+	font-size: 0.875rem;
+}
+.specorator-root :where(.sp-tool-call__name[data-v-9154ac7e]) {
+	font-weight: 600;
+	font-family: var(--font-monospace, ui-monospace, monospace);
+}
+.specorator-root :where(.sp-tool-call__status[data-v-9154ac7e]) {
+	color: var(--text-muted);
+	font-size: 0.75rem;
+}
+.specorator-root :where(.sp-tool-call__input[data-v-9154ac7e]) {
+	margin: 0.375rem 0 0;
+	padding: 0.375rem 0.5rem;
+	background: var(--background-primary);
+	border-radius: 3px;
+	font-family: var(--font-monospace, ui-monospace, monospace);
+	font-size: 0.75rem;
+	white-space: pre-wrap;
+	word-break: break-word;
+	max-height: 240px;
+	overflow-y: auto;
+}
+.specorator-root :where(.sp-tool-call__placeholder[data-v-9154ac7e]) {
+	margin: 0.375rem 0 0;
+	font-size: 0.75rem;
+	color: var(--text-muted);
+	font-style: italic;
+}
+
+.specorator-root :where(.sp-agent-messages[data-v-79fec309]) {
 	flex: 1 1 auto;
 	min-height: 0;
 	overflow-y: auto;
@@ -820,21 +911,21 @@ to   { opacity: 1; transform: translateY(0);
 	flex-direction: column;
 	gap: 0.75rem;
 }
-.specorator-root :where(.sp-agent-messages--empty[data-v-25c3bb88]) {
+.specorator-root :where(.sp-agent-messages--empty[data-v-79fec309]) {
 	flex: 0 0 auto;
 	padding: 1.25rem 1rem 0;
 	display: flex;
 	align-items: center;
 	justify-content: center;
 }
-.specorator-root :where(.sp-agent-messages__empty-body[data-v-25c3bb88]) {
+.specorator-root :where(.sp-agent-messages__empty-body[data-v-79fec309]) {
 	margin: 0;
 	font-size: 0.8125rem;
 	color: var(--text-muted);
 	text-align: center;
 	font-style: italic;
 }
-.specorator-root :where(.sp-agent-message[data-v-25c3bb88]) {
+.specorator-root :where(.sp-agent-message[data-v-79fec309]) {
 	display: flex;
 	flex-direction: column;
 	gap: 0.25rem;
@@ -843,49 +934,67 @@ to   { opacity: 1; transform: translateY(0);
 	background: var(--background-secondary);
 	border: 1px solid var(--background-modifier-border);
 }
-.specorator-root :where(.sp-agent-message--user[data-v-25c3bb88]) {
+.specorator-root :where(.sp-agent-message--user[data-v-79fec309]) {
 	background: var(--background-secondary-alt, var(--background-secondary));
 }
-.specorator-root :where(.sp-agent-message__role[data-v-25c3bb88]) {
+.specorator-root :where(.sp-agent-message__role[data-v-79fec309]) {
 	font-size: 0.6875rem;
 	font-weight: 600;
 	text-transform: uppercase;
 	letter-spacing: 0.04em;
 	color: var(--text-muted);
 }
-.specorator-root :where(.sp-agent-message__body[data-v-25c3bb88]) {
+.specorator-root :where(.sp-agent-message__body[data-v-79fec309]) {
 	display: flex;
 	flex-direction: column;
 	gap: 0.25rem;
 }
-.specorator-root :where(.sp-agent-message__text[data-v-25c3bb88]) {
+.specorator-root :where(.sp-agent-message__text[data-v-79fec309]) {
 	margin: 0;
 	font-family: inherit;
 	font-size: 0.875rem;
 	color: var(--text-normal);
 	word-break: break-word;
 }
-.specorator-root :where(.sp-agent-message__empty[data-v-25c3bb88]) {
+.specorator-root :where(.sp-agent-message__empty[data-v-79fec309]) {
 	margin: 0;
 	font-size: 0.8125rem;
 	color: var(--text-muted);
 	font-style: italic;
 }
-.specorator-root :where(.sp-agent-message__trim-note[data-v-25c3bb88]) {
+.specorator-root :where(.sp-agent-message__trim-note[data-v-79fec309]) {
 	margin: 0;
 	font-size: 0.75rem;
 	color: var(--text-faint);
 }
-.specorator-root :where(.sp-agent-message--streaming[data-v-25c3bb88]) {
+.specorator-root :where(.sp-agent-message--streaming[data-v-79fec309]) {
 	opacity: 0.95;
 }
-.specorator-root :where(.sp-agent-message__cursor[data-v-25c3bb88]) {
+.specorator-root :where(.sp-agent-compact-boundary[data-v-79fec309]) {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	margin: 0.25rem 0;
+	color: var(--text-faint);
+	font-size: 0.75rem;
+	font-style: italic;
+	text-align: center;
+}
+.specorator-root :where(.sp-agent-compact-boundary__line[data-v-79fec309]) {
+	flex: 1 1 auto;
+	height: 1px;
+	background: var(--background-modifier-border);
+}
+.specorator-root :where(.sp-agent-compact-boundary__label[data-v-79fec309]) {
+	flex: 0 0 auto;
+}
+.specorator-root :where(.sp-agent-message__cursor[data-v-79fec309]) {
 	display: inline-block;
 	font-size: 0.875rem;
 	color: var(--text-accent);
-	animation: sp-agent-message__blink-25c3bb88 1s steps(2, start) infinite;
+	animation: sp-agent-message__blink-79fec309 1s steps(2, start) infinite;
 }
-@keyframes sp-agent-message__blink-25c3bb88 {
+@keyframes sp-agent-message__blink-79fec309 {
 to {
 		visibility: hidden;
 }
@@ -1199,7 +1308,7 @@ to {
  * parent: in the agent sidepanel the parent gives ChatSidebar `flex: 0 0
  * auto` and `MessageList` takes the remaining grow space.
  */
-.specorator-root :where(.sp-chat-sidebar[data-v-22efcdd3]) {
+.specorator-root :where(.sp-chat-sidebar[data-v-0fc8a7b8]) {
 	padding: 1rem;
 	display: flex;
 	flex-direction: column;
@@ -1207,24 +1316,24 @@ to {
 	box-sizing: border-box;
 	flex-shrink: 0;
 }
-.specorator-root :where(.sp-chat__title[data-v-22efcdd3]) {
+.specorator-root :where(.sp-chat__title[data-v-0fc8a7b8]) {
 	margin: 0;
 	font-size: 1.125rem;
 	font-weight: 700;
 	color: var(--text-normal);
 }
-.specorator-root :where(.sp-chat__header[data-v-22efcdd3]) {
+.specorator-root :where(.sp-chat__header[data-v-0fc8a7b8]) {
 	display: flex;
 	align-items: center;
 	gap: 0.5rem;
 	flex-wrap: wrap;
 }
-.specorator-root :where(.sp-chat__divider[data-v-22efcdd3]) {
+.specorator-root :where(.sp-chat__divider[data-v-0fc8a7b8]) {
 	margin: 0;
 	border: none;
 	border-top: 1px solid var(--background-modifier-border);
 }
-.specorator-root :where(.sp-chat__stop[data-v-22efcdd3]) {
+.specorator-root :where(.sp-chat__stop[data-v-0fc8a7b8]) {
 	margin-left: auto;
 	font-size: 0.75rem;
 	font-weight: 500;
@@ -1238,10 +1347,10 @@ to {
 		background-color 0.15s,
 		border-color 0.15s;
 }
-.specorator-root :where(.sp-chat__stop[data-v-22efcdd3]:hover) {
+.specorator-root :where(.sp-chat__stop[data-v-0fc8a7b8]:hover) {
 	background: var(--background-modifier-error-hover, var(--interactive-hover));
 }
-.specorator-root :where(.sp-chat__degraded[data-v-22efcdd3]) {
+.specorator-root :where(.sp-chat__degraded[data-v-0fc8a7b8]) {
 	background: var(--background-secondary);
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 8px;
@@ -1250,13 +1359,13 @@ to {
 	flex-direction: column;
 	gap: 0.5rem;
 }
-.specorator-root :where(.sp-chat__degraded-heading[data-v-22efcdd3]) {
+.specorator-root :where(.sp-chat__degraded-heading[data-v-0fc8a7b8]) {
 	margin: 0;
 	font-size: 1rem;
 	font-weight: 600;
 	color: var(--text-normal);
 }
-.specorator-root :where(.sp-chat__degraded-body[data-v-22efcdd3]) {
+.specorator-root :where(.sp-chat__degraded-body[data-v-0fc8a7b8]) {
 	margin: 0;
 	font-size: 0.875rem;
 	color: var(--text-muted);

--- a/tests/ui/components/agent/MessageList.compactBoundary.po.ts
+++ b/tests/ui/components/agent/MessageList.compactBoundary.po.ts
@@ -1,0 +1,33 @@
+import type { VueWrapper } from '@vue/test-utils';
+
+/**
+ * PageObject for `MessageList.vue`'s compact-boundary notice rendering
+ * (Codex P2 on PR #379). Queries by `data-testid` only — ADR-009.
+ */
+export class MessageListCompactBoundaryPO {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	private byTid(tid: string) {
+		return `[data-testid="${tid}"]`;
+	}
+
+	get root() {
+		return this.wrapper.find(this.byTid('agent-message-list'));
+	}
+
+	notices() {
+		return this.wrapper.findAll(this.byTid('compact-boundary-notice'));
+	}
+
+	firstNotice() {
+		return this.notices()[0];
+	}
+
+	userMessages() {
+		return this.wrapper.findAll(this.byTid('agent-message-user'));
+	}
+
+	assistantMessages() {
+		return this.wrapper.findAll(this.byTid('agent-message-assistant'));
+	}
+}

--- a/tests/ui/components/agent/MessageList.compactBoundary.test.ts
+++ b/tests/ui/components/agent/MessageList.compactBoundary.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for the `compact-boundary` notice rendering in `MessageList.vue`
+ * (Codex P2 on PR #379 — `agent-sidepanel-v2-tool-rendering`). Confirms the
+ * divider renders only when a notice exists, lives in the same `role="log"`
+ * aria-live region as messages, surfaces the i18n copy, carries
+ * `role="status"`, and interleaves between messages by `createdAt`.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import MessageList from '@/ui/components/agent/MessageList.vue';
+import { i18n } from '@/ui/i18n';
+import { useChatStore } from '@/ui/stores/chatStore';
+import type { ChatMessage } from '@/domain/chat/ChatMessage';
+import { MessageListCompactBoundaryPO } from './MessageList.compactBoundary.po';
+
+function mountList(threadId: string | null) {
+	const wrapper = mount(MessageList, {
+		global: { plugins: [i18n] },
+		props: { threadId },
+	});
+	return { wrapper, po: new MessageListCompactBoundaryPO(wrapper) };
+}
+
+function msg(
+	threadId: string,
+	role: 'user' | 'assistant',
+	overrides: { id?: string; text?: string; createdAt?: string } = {},
+): ChatMessage {
+	return {
+		id: overrides.id ?? `m-${role}-${Math.random().toString(36).slice(2)}`,
+		threadId,
+		role,
+		text: overrides.text ?? `${role} text`,
+		createdAt: overrides.createdAt ?? new Date().toISOString(),
+	};
+}
+
+describe('MessageList — compact-boundary notice', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+	});
+
+	it('does not render a notice when no boundary has been recorded', () => {
+		const store = useChatStore();
+		const tid = 'thread-noisy';
+		store.appendMessage(msg(tid, 'user'));
+		const { po } = mountList(tid);
+		expect(po.notices()).toHaveLength(0);
+	});
+
+	it('renders a notice inside the message list when a boundary exists', () => {
+		const store = useChatStore();
+		const tid = 'thread-compact';
+		store.appendMessage(msg(tid, 'user', { createdAt: '2026-05-16T00:00:00Z' }));
+		store.appendCompactBoundaryNotice(tid, { reason: 'auto-compact' });
+		const { po } = mountList(tid);
+		expect(po.root.exists()).toBe(true);
+		expect(po.notices()).toHaveLength(1);
+		// Notice is inside the same aria-live="polite" log region.
+		expect(po.root.attributes('aria-live')).toBe('polite');
+		expect(po.root.attributes('role')).toBe('log');
+	});
+
+	it('carries role="status" on the notice element', () => {
+		const store = useChatStore();
+		const tid = 'thread-role';
+		store.appendCompactBoundaryNotice(tid, {});
+		const { po } = mountList(tid);
+		const all = po.notices();
+		expect(all).toHaveLength(1);
+		expect(all[0].attributes('role')).toBe('status');
+	});
+
+	it('surfaces the i18n notice copy (chat.compactBoundary.notice)', () => {
+		const store = useChatStore();
+		const tid = 'thread-i18n';
+		store.appendCompactBoundaryNotice(tid, {});
+		const { po } = mountList(tid);
+		const all = po.notices();
+		expect(all).toHaveLength(1);
+		expect(all[0].text()).toContain('Earlier conversation was summarised');
+	});
+
+	it('renders the empty list when threadId is null even if a boundary exists for another thread', () => {
+		const store = useChatStore();
+		store.appendCompactBoundaryNotice('other-thread', {});
+		const { po } = mountList(null);
+		expect(po.notices()).toHaveLength(0);
+	});
+
+	it('isolates notices by threadId', () => {
+		const store = useChatStore();
+		store.appendCompactBoundaryNotice('thread-a', {});
+		store.appendCompactBoundaryNotice('thread-b', {});
+		const { po } = mountList('thread-b');
+		expect(po.notices()).toHaveLength(1);
+	});
+
+	it('interleaves the notice with messages by createdAt', () => {
+		const store = useChatStore();
+		const tid = 'thread-interleave';
+		store.appendMessage(msg(tid, 'user', { text: 'first', createdAt: '2026-05-16T00:00:00Z' }));
+		store.appendMessage(msg(tid, 'assistant', { text: 'second', createdAt: '2026-05-16T00:00:01Z' }));
+		// Manually-shaped notice via store mutation; createdAt is generated as
+		// "now" so it sorts after the messages above (which are dated 2026-05-16).
+		store.appendCompactBoundaryNotice(tid, {});
+		store.appendMessage(msg(tid, 'user', { text: 'third', createdAt: '2099-01-01T00:00:00Z' }));
+
+		const { po, wrapper } = mountList(tid);
+		const html = wrapper.html();
+		const noticeIdx = html.indexOf('compact-boundary-notice');
+		const thirdIdx = html.indexOf('third');
+		const secondIdx = html.indexOf('second');
+		expect(po.notices()).toHaveLength(1);
+		expect(noticeIdx).toBeGreaterThan(secondIdx);
+		expect(thirdIdx).toBeGreaterThan(noticeIdx);
+	});
+});

--- a/tests/ui/components/agent/MessageList.po.ts
+++ b/tests/ui/components/agent/MessageList.po.ts
@@ -31,12 +31,11 @@ export class MessageListPO {
 		return this.wrapper.findAll(this.byTid('agent-message-empty'));
 	}
 
-	/**
-	 * Returns the rendered HTML of all markdown bodies in the active thread.
-	 * Used to assert markdown features (bold, code, code blocks) and to verify
-	 * that potentially unsafe input was escaped.
-	 */
 	markdownBlocks() {
 		return this.wrapper.findAll(this.byTid('agent-markdown-block'));
+	}
+
+	compactBoundaryNotices() {
+		return this.wrapper.findAll(this.byTid('compact-boundary-notice'));
 	}
 }

--- a/tests/ui/components/agent/ThinkingBlock.test.ts
+++ b/tests/ui/components/agent/ThinkingBlock.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Tests for `ThinkingBlock.vue` — collapsible extended-thinking display.
+ * PR-ASV-2-tool-rendering, agent-sidepanel-v2 Increment 2.
+ */
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import ThinkingBlock from '@/ui/components/agent/ThinkingBlock.vue';
+import { i18n } from '@/ui/i18n';
+
+function mountBlock(text: string) {
+	const wrapper = mount(ThinkingBlock, {
+		global: { plugins: [i18n] },
+		props: { text },
+	});
+	return wrapper;
+}
+
+describe('ThinkingBlock', () => {
+	it('renders nothing when text is empty', () => {
+		const w = mountBlock('');
+		expect(w.find('[data-testid="agent-thinking-block"]').exists()).toBe(false);
+	});
+
+	it('renders a collapsible details block when text is non-empty', () => {
+		const w = mountBlock('I should consider…');
+		expect(w.find('[data-testid="agent-thinking-block"]').exists()).toBe(true);
+		expect(w.find('[data-testid="agent-thinking-summary"]').exists()).toBe(true);
+		expect(w.find('[data-testid="agent-thinking-text"]').text()).toBe('I should consider…');
+	});
+
+	it('shows the localised label in the summary', () => {
+		const w = mountBlock('reason');
+		expect(w.find('[data-testid="agent-thinking-summary"]').text()).toContain('Thinking');
+	});
+
+	it('updates the rendered text when the prop changes', async () => {
+		const w = mountBlock('first');
+		expect(w.find('[data-testid="agent-thinking-text"]').text()).toBe('first');
+		await w.setProps({ text: 'first and second' });
+		expect(w.find('[data-testid="agent-thinking-text"]').text()).toBe('first and second');
+	});
+});

--- a/tests/ui/components/agent/ToolCallBlock.test.ts
+++ b/tests/ui/components/agent/ToolCallBlock.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for `ToolCallBlock.vue` — inline tool-call display.
+ * PR-ASV-2-tool-rendering, agent-sidepanel-v2 Increment 2.
+ */
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import ToolCallBlock from '@/ui/components/agent/ToolCallBlock.vue';
+import { i18n } from '@/ui/i18n';
+
+function mountBlock(props: { toolName: string; inputJson: string; done: boolean }) {
+	const wrapper = mount(ToolCallBlock, {
+		global: { plugins: [i18n] },
+		props,
+	});
+	return wrapper;
+}
+
+describe('ToolCallBlock', () => {
+	it('renders the tool name in the summary', () => {
+		const w = mountBlock({ toolName: 'Bash', inputJson: '', done: false });
+		expect(w.find('[data-testid="agent-tool-call-summary"]').text()).toContain('Bash');
+	});
+
+	it('shows the streaming indicator while not done', () => {
+		const w = mountBlock({ toolName: 'Read', inputJson: '', done: false });
+		const summary = w.find('[data-testid="agent-tool-call-summary"]');
+		expect(summary.text()).toContain('⏳');
+		expect(summary.text()).not.toContain('✓');
+	});
+
+	it('shows the done indicator once the call finishes', () => {
+		const w = mountBlock({ toolName: 'Read', inputJson: '{"path":"foo.md"}', done: true });
+		const summary = w.find('[data-testid="agent-tool-call-summary"]');
+		expect(summary.text()).toContain('✓');
+		expect(summary.text()).not.toContain('⏳');
+	});
+
+	it('renders the partial JSON verbatim while streaming', () => {
+		const w = mountBlock({ toolName: 'Edit', inputJson: '{"path":"f', done: false });
+		expect(w.find('[data-testid="agent-tool-call-input"]').text()).toBe('{"path":"f');
+	});
+
+	it('renders pretty-printed JSON once the call finishes', () => {
+		const w = mountBlock({
+			toolName: 'Write',
+			inputJson: '{"path":"a.md","content":"hi"}',
+			done: true,
+		});
+		const text = w.find('[data-testid="agent-tool-call-input"]').text();
+		expect(text).toContain('"path"');
+		expect(text).toContain('a.md');
+		// Pretty-print inserts a newline between the two top-level keys.
+		expect(text).toContain('\n');
+	});
+
+	it('falls back to raw text if the completed input is malformed JSON', () => {
+		const w = mountBlock({ toolName: 'Bash', inputJson: '{not-valid}', done: true });
+		expect(w.find('[data-testid="agent-tool-call-input"]').text()).toBe('{not-valid}');
+	});
+
+	it('shows the waiting placeholder when input is still empty mid-stream', () => {
+		const w = mountBlock({ toolName: 'Bash', inputJson: '', done: false });
+		expect(w.find('[data-testid="agent-tool-call-placeholder"]').exists()).toBe(true);
+		expect(w.find('[data-testid="agent-tool-call-input"]').exists()).toBe(false);
+	});
+
+	it('exposes the tool name as data-tool-name for selector-based queries', () => {
+		const w = mountBlock({ toolName: 'TodoWrite', inputJson: '', done: false });
+		expect(w.find('[data-testid="agent-tool-call"]').attributes('data-tool-name')).toBe(
+			'TodoWrite',
+		);
+	});
+});

--- a/tests/ui/stores/chatStore.compactBoundary.test.ts
+++ b/tests/ui/stores/chatStore.compactBoundary.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for the per-thread compact-boundary notice log on `useChatStore()`
+ * (Codex P2 on PR #379 — `agent-sidepanel-v2-tool-rendering`).
+ *
+ * Validates that `appendCompactBoundaryNotice(threadId, payload)` pushes a
+ * `CompactBoundaryNoticeDto` into the per-thread bucket, that the bucket is
+ * isolated across threads, that `reset()` clears it, and that
+ * `clearThreadMessages(threadId)` drops the boundary log alongside the
+ * matching message bucket.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useChatStore, type CompactBoundaryNoticeDto } from '@/ui/stores/chatStore';
+
+function lastNoticeFor(
+	store: ReturnType<typeof useChatStore>,
+	threadId: string,
+): CompactBoundaryNoticeDto | undefined {
+	const bucket = store.compactBoundaries.get(threadId) ?? [];
+	return bucket[bucket.length - 1];
+}
+
+describe('useChatStore() — compact-boundary notices', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+	});
+
+	it('initial state has an empty compactBoundaries Map', () => {
+		const store = useChatStore();
+		expect(store.compactBoundaries.size).toBe(0);
+	});
+
+	it('appendCompactBoundaryNotice creates a fresh bucket for a new thread', () => {
+		const store = useChatStore();
+		store.appendCompactBoundaryNotice('t-A', { reason: 'auto-compact' });
+		expect(store.compactBoundaries.get('t-A')).toHaveLength(1);
+		const notice = lastNoticeFor(store, 't-A');
+		expect(notice?.threadId).toBe('t-A');
+		expect(notice?.reason).toBe('auto-compact');
+		expect(typeof notice?.id).toBe('string');
+		expect(notice?.id.length ?? 0).toBeGreaterThan(0);
+		expect(typeof notice?.createdAt).toBe('string');
+	});
+
+	it('appendCompactBoundaryNotice accepts an absent reason', () => {
+		const store = useChatStore();
+		store.appendCompactBoundaryNotice('t-A', {});
+		const notice = lastNoticeFor(store, 't-A');
+		expect(notice?.reason).toBeUndefined();
+	});
+
+	it('appendCompactBoundaryNotice appends multiple entries in insertion order', () => {
+		const store = useChatStore();
+		store.appendCompactBoundaryNotice('t-A', { reason: 'r1' });
+		store.appendCompactBoundaryNotice('t-A', { reason: 'r2' });
+		const bucket = store.compactBoundaries.get('t-A') ?? [];
+		expect(bucket.map((n) => n.reason)).toEqual(['r1', 'r2']);
+	});
+
+	it('appendCompactBoundaryNotice isolates buckets per threadId', () => {
+		const store = useChatStore();
+		store.appendCompactBoundaryNotice('t-A', { reason: 'r-A' });
+		store.appendCompactBoundaryNotice('t-B', { reason: 'r-B' });
+		expect(store.compactBoundaries.get('t-A')).toHaveLength(1);
+		expect(store.compactBoundaries.get('t-B')).toHaveLength(1);
+		expect(lastNoticeFor(store, 't-A')?.reason).toBe('r-A');
+		expect(lastNoticeFor(store, 't-B')?.reason).toBe('r-B');
+	});
+
+	it('generates a unique id per notice', () => {
+		const store = useChatStore();
+		store.appendCompactBoundaryNotice('t-A', {});
+		store.appendCompactBoundaryNotice('t-A', {});
+		const bucket = store.compactBoundaries.get('t-A') ?? [];
+		expect(bucket).toHaveLength(2);
+		expect(bucket[0]?.id).not.toBe(bucket[1]?.id);
+	});
+
+	it('clearThreadMessages drops the matching compact-boundary bucket only', () => {
+		const store = useChatStore();
+		store.appendCompactBoundaryNotice('t-A', { reason: 'r-A' });
+		store.appendCompactBoundaryNotice('t-B', { reason: 'r-B' });
+		store.clearThreadMessages('t-A');
+		expect(store.compactBoundaries.has('t-A')).toBe(false);
+		expect(store.compactBoundaries.get('t-B')).toHaveLength(1);
+	});
+
+	it('reset() clears all compact-boundary notices', () => {
+		const store = useChatStore();
+		store.appendCompactBoundaryNotice('t-A', { reason: 'r' });
+		store.appendCompactBoundaryNotice('t-B', { reason: 'r' });
+		store.reset();
+		expect(store.compactBoundaries.size).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary

Top-3 from the agent-sidepanel-v2 comparative review. Consumes the new `StreamDelta` variants from #378 to render extended-thinking and tool-use content as the model streams them. Together with the existing `streamingText` bubble, this brings parity with Claudian's inline rendering of tool-use turns.

**Stacked on #378 (StreamDelta extension) → #374 → #371 → #370 → develop.**

## New components

### `src/ui/components/agent/ThinkingBlock.vue`
- Collapsible `<details>` block driven by `chatStore.streamingThinking`.
- Renders nothing while empty.
- Expands by default so the user sees the model's reasoning; collapse after reading.

### `src/ui/components/agent/ToolCallBlock.vue`
- Generic per-tool card driven by entries in `chatStore.streamingToolCalls`.
- Header: tool name + status (⏳ streaming / ✓ done).
- Body: partial JSON verbatim while streaming; pretty-printed JSON once `tool-use-stop` lands; raw text fallback when finished but malformed.
- Per-tool specialised renderers (Edit diff, Write preview, TodoWrite list) land in follow-ups; this generic block covers all tool names today.

## Wiring

### `MessageList.vue`
- Imports `ThinkingBlock` + `ToolCallBlock`.
- Streaming bubble now renders thinking → tool calls → text, in that order, mirroring the model's typical block order.
- `isStreaming` now triggers on any of thinking / tool-calls / streaming-text being non-empty (was just text).
- Scroll watcher observes lengths of all four (messages, text, thinking, tool-calls) so the user's view follows live deltas.

### `ChatSidebar.consumeStream`
- Refactored into `applyStreamDelta` + `applyNonTerminalDelta` helpers (complexity cap).
- Routes the new delta variants (`thinking`, `tool-use-*`, `usage`, `compact-boundary`) into the matching store actions.
- Terminal variants (`done`, `error`) still drive the existing success/error outcome.

## i18n

Five new strings under `agent.*` for the new UI surfaces:

- `thinking` → "Thinking" / "Denkt nach"
- `toolDone` → "Tool finished" / "Werkzeug abgeschlossen"
- `toolStreaming` → "Tool running" / "Werkzeug läuft"
- `toolWaitingForInput` → "Waiting for tool input…" / "Warte auf Werkzeug-Eingabe…"
- `streamingResponse` → "Assistant is replying…" / "Assistent antwortet…"

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 errors
- [x] `npm run test` 1487/1487 pass — 12 new tests:
  - `ThinkingBlock.test.ts` (4): empty / non-empty / localised label / reactive prop
  - `ToolCallBlock.test.ts` (8): summary text, streaming/done indicators, partial JSON, pretty-printed JSON, malformed-JSON fallback, waiting placeholder, `data-tool-name` selector hook

## Deferred to follow-up PRs

- **Per-tool specialised renderers** — diff for Edit, syntax-highlighted preview for Write, checkbox list for TodoWrite, output preview for Bash. The generic `ToolCallBlock` works for all tools today; specialised renderers are pure UX polish.
- **Subprocess parity** — the subprocess adapter emits a different wire format (no `content_block_*` events visible in `assistant/message`). When its streaming surface grows to match the SDK's, these renderers will pick up tool-use events from both transports without changes.

https://claude.ai/code/session_01VvXsK3aGp2g4jSpT1py7Mh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvXsK3aGp2g4jSpT1py7Mh)_