### PR TITLE
feat(agent): folder rows in @-mention picker (PR-ASV-4-folders)

### DIFF
--- a/src/application/chat/vaultFileSearch.ts
+++ b/src/application/chat/vaultFileSearch.ts
@@ -1,8 +1,9 @@
 /**
  * Pure search helpers for the `@`-file mention picker (PR-ASV-4 /
  * IDEA-ASV-001 D-ASV-3). Inspired by Claudian's `VaultMentionDataProvider`
- * but scoped to vault *files* only (no folders, no agents, no MCP, no
- * external dirs — see `specs/agent-sidepanel-v2/research.md` D-ASV-3).
+ * but scoped to vault *files and folders* (PR-ASV-4-folders extension —
+ * folders surface alongside files but never become context chips; see
+ * `specs/agent-sidepanel-v2/research.md` D-ASV-3).
  *
  * Application-layer only — depends on `VaultPort` and primitive types. No
  * Vue, no Obsidian imports.
@@ -17,24 +18,37 @@ import type { VaultPort } from '@/domain/ports'
 export const MENTION_RESULT_CAP = 50
 
 /**
+ * Discriminator for a candidate. Files commit as `@<name> ` and emit
+ * `add-context-file`; folders commit as `@<name>/` and do NOT emit (the
+ * user is meant to keep typing to narrow into a child). PR-ASV-4-folders.
+ */
+export type MentionCandidateKind = 'file' | 'folder'
+
+/**
  * A single search candidate. `path` is vault-relative (e.g.
- * `specs/foo/idea.md`); `name` is the basename ("idea.md").
+ * `specs/foo/idea.md` for a file, `specs/foo` for a folder); `name` is
+ * the basename ("idea.md" / "foo"). `kind` discriminates files from
+ * folders so the dropdown / commit handlers can branch.
  */
 export interface MentionCandidate {
 	readonly path: string
 	readonly name: string
+	readonly mtime?: number
+	readonly kind: 'file' | 'folder'
 }
 
 /**
  * Pre-computed search row. `pathLower` / `nameLower` cache the lowercase
  * forms so the per-keystroke `matchAndRank` loop avoids repeated
- * `.toLowerCase()` allocations.
+ * `.toLowerCase()` allocations. `kind` rides along so the ranking
+ * comparator can break ties with files before folders.
  */
 export interface RankedCandidate {
 	readonly path: string
 	readonly name: string
 	readonly pathLower: string
 	readonly nameLower: string
+	readonly kind: MentionCandidateKind
 }
 
 /**
@@ -59,6 +73,27 @@ export async function collectVaultFiles(vault: VaultPort, root = ''): Promise<st
 }
 
 /**
+ * Recursively collect every folder under `root` via `VaultPort`. Mirror of
+ * {@link collectVaultFiles} but emits folder paths (the parent path joined
+ * with the child folder name) rather than file paths. PR-ASV-4-folders.
+ *
+ * The root itself is intentionally NOT included — only its descendants —
+ * matching the dropdown's mental model that `@` opens a picker for the
+ * vault's *contents*.
+ */
+export async function collectVaultFolders(
+	vault: VaultPort,
+	root = '',
+): Promise<readonly string[]> {
+	const subfolders = await vault.listFolders(root)
+	const direct = subfolders.map((sub) => joinPath(root, sub))
+	const nested = await Promise.all(
+		subfolders.map((sub) => collectVaultFolders(vault, joinPath(root, sub))),
+	)
+	return [...direct, ...nested.flat()]
+}
+
+/**
  * Vault-path join that tolerates an empty parent (top-level scan).
  */
 function joinPath(parent: string, child: string): string {
@@ -76,28 +111,50 @@ export function basenameOf(path: string): string {
 }
 
 /**
- * Pre-compute the lowercase search keys for every candidate. Done once per
- * dropdown open (the composable invalidates the cache on each `@` trigger
- * open), not on every keystroke.
+ * Pre-compute the lowercase search keys for every candidate.
+ *
+ * Accepts either a plain string-array of file paths (legacy call sites
+ * pre-PR-ASV-4-folders) or a structured `{ files, folders }` shape so
+ * folders can ride along with the `kind: 'folder'` tag. The legacy
+ * string-array form defaults to `kind: 'file'` for every entry.
+ *
+ * Done once per dropdown open (the composable invalidates the cache on
+ * each `@` trigger open), not on every keystroke.
  */
-export function prepareCandidates(paths: readonly string[]): RankedCandidate[] {
+export function prepareCandidates(
+	input: readonly string[] | { files: readonly string[]; folders: readonly string[] },
+): RankedCandidate[] {
 	const out: RankedCandidate[] = []
-	for (const path of paths) {
-		const name = basenameOf(path)
-		out.push({
-			path,
-			name,
-			pathLower: path.toLowerCase(),
-			nameLower: name.toLowerCase(),
-		})
-	}
+	const { files, folders } = isStructuredInput(input)
+		? input
+		: { files: input, folders: [] as readonly string[] }
+	for (const path of files) out.push(makeRanked(path, 'file'))
+	for (const path of folders) out.push(makeRanked(path, 'folder'))
 	return out
+}
+
+function isStructuredInput(
+	value: readonly string[] | { files: readonly string[]; folders: readonly string[] },
+): value is { files: readonly string[]; folders: readonly string[] } {
+	return !Array.isArray(value)
+}
+
+function makeRanked(path: string, kind: MentionCandidateKind): RankedCandidate {
+	const name = basenameOf(path)
+	return {
+		path,
+		name,
+		pathLower: path.toLowerCase(),
+		nameLower: name.toLowerCase(),
+		kind,
+	}
 }
 
 /**
  * Substring-match a candidate set against a query, sort by
  * 1) filename prefix-match wins (true > false),
- * 2) path lexicographic ascending,
+ * 2) files before folders on tie,
+ * 3) path lexicographic ascending,
  * and cap at {@link MENTION_RESULT_CAP}.
  *
  * Empty query short-circuits to the lexicographically-first
@@ -123,10 +180,14 @@ export function matchAndRank(
 		const aPrefix = q !== '' && a.nameLower.startsWith(q)
 		const bPrefix = q !== '' && b.nameLower.startsWith(q)
 		if (aPrefix !== bPrefix) return aPrefix ? -1 : 1
+		// PR-ASV-4-folders: files outrank folders on tie. A file and a
+		// folder with the same basename (e.g. `notes.md` next to
+		// `notes/`) keeps the file at the top of the dropdown.
+		if (a.kind !== b.kind) return a.kind === 'file' ? -1 : 1
 		if (a.pathLower < b.pathLower) return -1
 		if (a.pathLower > b.pathLower) return 1
 		return 0
 	})
 	const limited = matches.slice(0, MENTION_RESULT_CAP)
-	return limited.map(({ path, name }) => ({ path, name }))
+	return limited.map(({ path, name, kind }) => ({ path, name, kind }))
 }

--- a/src/ui/components/chat/ChatInput.vue
+++ b/src/ui/components/chat/ChatInput.vue
@@ -131,10 +131,20 @@ function commitMention(candidate: MentionCandidate): void {
   const queryEnd = at + 1 + picker.query.value.length
   const before = props.modelValue.slice(0, at)
   const after = props.modelValue.slice(queryEnd)
-  const token = `@${basenameOf(candidate.path)} `
+  // PR-ASV-4-folders: folders commit as `@<name>/` (no trailing space,
+  // user keeps typing into the folder) and do NOT emit
+  // `add-context-file` — folders aren't context chips, only files are.
+  // Files keep the original `@<filename> ` shape (trailing space) and
+  // still emit the chip-creation event.
+  const token =
+    candidate.kind === 'folder'
+      ? `@${basenameOf(candidate.path)}/`
+      : `@${basenameOf(candidate.path)} `
   const next = `${before}${token}${after}`
   emit('update:modelValue', next)
-  emit('add-context-file', candidate)
+  if (candidate.kind === 'file') {
+    emit('add-context-file', candidate)
+  }
   picker.close()
   // Restore caret after the inserted token. Wrapped in a microtask
   // because the textarea value updates after the parent re-renders.

--- a/src/ui/components/chat/MentionDropdown.vue
+++ b/src/ui/components/chat/MentionDropdown.vue
@@ -33,16 +33,24 @@ const emit = defineEmits<{
 	>
 		<li
 			v-for="(candidate, index) in results"
-			:key="candidate.path"
+			:key="`${candidate.kind}:${candidate.path}`"
 			class="sp-mention-dropdown__item"
 			:class="{ 'sp-mention-dropdown__item--selected': index === selectedIndex }"
 			role="option"
 			:aria-selected="index === selectedIndex"
 			:data-testid="`mention-option-${index}`"
+			:data-kind="candidate.kind"
 			@mousedown.prevent="emit('select', candidate)"
 			@mouseenter="emit('hover', index)"
 		>
-			<span class="sp-mention-dropdown__name">{{ candidate.name }}</span>
+			<span class="sp-mention-dropdown__name">
+				<span v-if="candidate.kind === 'folder'" aria-hidden="true">📁 </span>
+				<!-- PR-ASV-4-folders: folders render with a trailing slash so the
+					user can distinguish e.g. `notes.md` (file) from `notes/`
+					(folder) at a glance, mirroring the inline-token suffix
+					inserted by `ChatInput.commitMention`. -->
+				{{ candidate.kind === 'folder' ? `${candidate.name}/` : candidate.name }}
+			</span>
 			<span class="sp-mention-dropdown__path">{{ candidate.path }}</span>
 		</li>
 	</ul>

--- a/src/ui/composables/useMentionPicker.ts
+++ b/src/ui/composables/useMentionPicker.ts
@@ -22,6 +22,7 @@ import { ref, computed, type Ref } from 'vue'
 import type { VaultPort } from '@/domain/ports'
 import {
 	collectVaultFiles,
+	collectVaultFolders,
 	matchAndRank,
 	prepareCandidates,
 	type MentionCandidate,
@@ -138,8 +139,14 @@ export function useMentionPicker(vault: VaultPort): UseMentionPicker {
 	 * keystroke re-enter the `cached === null` branch and start a second
 	 * concurrent recursive walk. Reused across all searches in the open
 	 * session; cleared on close alongside `cached`.
+	 *
+	 * PR-ASV-4-folders: the shared scan now resolves to BOTH files and
+	 * folders so a single recursive walk feeds the kind-aware dropdown.
 	 */
-	let inFlightScan: Promise<readonly string[]> | null = null
+	let inFlightScan: Promise<{
+		files: readonly string[]
+		folders: readonly string[]
+	}> | null = null
 
 	function clearDebounce(): void {
 		if (debounceTimer !== null) {
@@ -170,17 +177,28 @@ export function useMentionPicker(vault: VaultPort): UseMentionPicker {
 			// — every later keystroke awaited the same rejection and the
 			// picker rendered empty results until close/reopen instead of
 			// retrying on the next debounced call.
-			inFlightScan ??= collectVaultFiles(vault, '').catch((err: unknown) => {
-				inFlightScan = null
-				throw err
-			})
-			const paths = await inFlightScan
+			//
+			// PR-ASV-4-folders: parallelise the file + folder walks so the
+			// dropdown shows both kinds after a single debounced tick.
+			// `Promise.all` short-circuits to the rejection branch on
+			// either failure, preserving the retry-on-next-keystroke
+			// behaviour established for the file-only scan.
+			inFlightScan ??= Promise.all([
+				collectVaultFiles(vault, ''),
+				collectVaultFolders(vault, ''),
+			])
+				.then(([files, folders]) => ({ files, folders }))
+				.catch((err: unknown) => {
+					inFlightScan = null
+					throw err
+				})
+			const { files, folders } = await inFlightScan
 			// Drop the result if the user has typed past this open session
 			// (e.g. escape + new `@`) — `searchSeq` was bumped past `seq`.
 			if (seq !== searchSeq) return
 			// Only the first awaiter populates `cached`; subsequent
 			// awaiters see the populated cache and skip the assignment.
-			cached ??= prepareCandidates(paths)
+			cached ??= prepareCandidates({ files, folders })
 		}
 		if (seq !== searchSeq) return
 		const ranked = matchAndRank(cached, q)

--- a/styles.css
+++ b/styles.css
@@ -970,7 +970,7 @@ to {
   color: var(--text-muted);
 }
 
-.specorator-root :where(.sp-mention-dropdown[data-v-ace43c9f]) {
+.specorator-root :where(.sp-mention-dropdown[data-v-b7654c6a]) {
 	list-style: none;
 	margin: 0;
 	padding: 0.25rem 0;
@@ -983,7 +983,7 @@ to {
 	font-family: var(--font-text);
 	font-size: 0.8125rem;
 }
-.specorator-root :where(.sp-mention-dropdown__item[data-v-ace43c9f]) {
+.specorator-root :where(.sp-mention-dropdown__item[data-v-b7654c6a]) {
 	display: flex;
 	flex-direction: column;
 	gap: 0.125rem;
@@ -991,14 +991,14 @@ to {
 	cursor: pointer;
 	color: var(--text-normal);
 }
-.specorator-root :where(.sp-mention-dropdown__item--selected[data-v-ace43c9f]),
-.specorator-root :where(.sp-mention-dropdown__item[data-v-ace43c9f]:hover) {
+.specorator-root :where(.sp-mention-dropdown__item--selected[data-v-b7654c6a]),
+.specorator-root :where(.sp-mention-dropdown__item[data-v-b7654c6a]:hover) {
 	background: var(--background-modifier-hover);
 }
-.specorator-root :where(.sp-mention-dropdown__name[data-v-ace43c9f]) {
+.specorator-root :where(.sp-mention-dropdown__name[data-v-b7654c6a]) {
 	font-weight: 600;
 }
-.specorator-root :where(.sp-mention-dropdown__path[data-v-ace43c9f]) {
+.specorator-root :where(.sp-mention-dropdown__path[data-v-b7654c6a]) {
 	color: var(--text-muted);
 	font-size: 0.75rem;
 	overflow: hidden;
@@ -1006,13 +1006,13 @@ to {
 	white-space: nowrap;
 }
 
-.specorator-root :where(.sp-chat__input-area[data-v-950e70df]) {
+.specorator-root :where(.sp-chat__input-area[data-v-65cc6585]) {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
   position: relative;
 }
-.specorator-root :where(.sp-chat__textarea[data-v-950e70df]) {
+.specorator-root :where(.sp-chat__textarea[data-v-65cc6585]) {
   width: 100%;
   min-height: 4.5rem;
   max-height: 8rem;
@@ -1027,11 +1027,11 @@ to {
   font-size: 0.875rem;
   box-sizing: border-box;
 }
-.specorator-root :where(.sp-chat__textarea[data-v-950e70df]:focus) {
+.specorator-root :where(.sp-chat__textarea[data-v-65cc6585]:focus) {
   outline: none;
   border-color: var(--interactive-accent);
 }
-.specorator-root :where(.sp-chat__input-actions[data-v-950e70df]) {
+.specorator-root :where(.sp-chat__input-actions[data-v-65cc6585]) {
   display: flex;
   justify-content: flex-end;
 }

--- a/tests/application/chat/vaultFileSearch.test.ts
+++ b/tests/application/chat/vaultFileSearch.test.ts
@@ -9,6 +9,7 @@ import {
 	MENTION_RESULT_CAP,
 	basenameOf,
 	collectVaultFiles,
+	collectVaultFolders,
 	matchAndRank,
 	prepareCandidates,
 } from '@/application/chat/vaultFileSearch'
@@ -119,5 +120,79 @@ describe('vaultFileSearch.matchAndRank', () => {
 	it('non-matching query returns empty array', () => {
 		const out = matchAndRank(candidates, 'zzzzz-not-present')
 		expect(out).toEqual([])
+	})
+})
+
+/**
+ * PR-ASV-4-folders — folder rows alongside files.
+ *
+ * These tests cover the kind-aware extensions: a `collectVaultFolders`
+ * recursive walk mirroring `collectVaultFiles`, the structured
+ * `prepareCandidates({ files, folders })` shape, file-beats-folder tie
+ * ordering, the `kind` tag riding through `matchAndRank`, and the cap
+ * applied to mixed file+folder result sets.
+ */
+describe('vaultFileSearch.collectVaultFolders', () => {
+	it('walks nested folders recursively and emits folder paths', async () => {
+		const bridge = new MockBridge({
+			'README.md': '',
+			'specs/foo/idea.md': '',
+			'specs/foo/requirements.md': '',
+			'specs/bar/idea.md': '',
+		})
+		const out = await collectVaultFolders(bridge, '')
+		expect([...out].sort()).toEqual(['specs', 'specs/bar', 'specs/foo'])
+	})
+})
+
+describe('vaultFileSearch.matchAndRank — folders', () => {
+	it('ranks files-and-folders together; query matches both kinds', () => {
+		const candidates = prepareCandidates({
+			files: ['notes/sketch.md'],
+			folders: ['notes', 'sketches'],
+		})
+		const out = matchAndRank(candidates, 'sketch')
+		// Prefix match on `sketches` (folder) AND `sketch.md` (file).
+		// File wins on the same-prefix tie.
+		expect(out.map((c) => ({ path: c.path, kind: c.kind }))).toEqual([
+			{ path: 'notes/sketch.md', kind: 'file' },
+			{ path: 'sketches', kind: 'folder' },
+		])
+	})
+
+	it('files beat folders on tie (same basename, same path order)', () => {
+		// A `notes.md` file and a `notes/` folder both prefix-match `notes`.
+		// The file must come first so users selecting Enter immediately get
+		// the file (chip), not the folder (no-op navigation).
+		const candidates = prepareCandidates({
+			files: ['notes.md'],
+			folders: ['notes'],
+		})
+		const out = matchAndRank(candidates, 'notes')
+		expect(out.map((c) => c.kind)).toEqual(['file', 'folder'])
+	})
+
+	it('preserves the `kind` discriminator on every returned candidate', () => {
+		const candidates = prepareCandidates({
+			files: ['a/x.md'],
+			folders: ['a'],
+		})
+		const out = matchAndRank(candidates, '')
+		const kinds = new Set(out.map((c) => c.kind))
+		expect(kinds.has('file')).toBe(true)
+		expect(kinds.has('folder')).toBe(true)
+	})
+
+	it('caps mixed file+folder results at MENTION_RESULT_CAP', () => {
+		const files = Array.from(
+			{ length: 100 },
+			(_, i) => `notes/${i.toString().padStart(4, '0')}.md`,
+		)
+		const folders = Array.from(
+			{ length: 100 },
+			(_, i) => `dirs/${i.toString().padStart(4, '0')}`,
+		)
+		const out = matchAndRank(prepareCandidates({ files, folders }), '')
+		expect(out.length).toBe(MENTION_RESULT_CAP)
 	})
 })

--- a/tests/ui/components/chat/ChatInput.test.ts
+++ b/tests/ui/components/chat/ChatInput.test.ts
@@ -200,6 +200,7 @@ describe('ChatInput', () => {
 			expect(added[0][0]).toEqual({
 				path: 'specs/bar/requirements.md',
 				name: 'requirements.md',
+				kind: 'file',
 			})
 		})
 
@@ -243,6 +244,33 @@ describe('ChatInput', () => {
 			await po.pressKey('Enter', { ctrl: true })
 
 			expect(po.emitted('send')).toBeTruthy()
+			expect(po.emitted('add-context-file')).toBeFalsy()
+		})
+
+		/**
+		 * PR-ASV-4-folders — selecting a folder commits as `@<name>/`
+		 * (trailing slash, no trailing space — user keeps typing to narrow)
+		 * and must NOT emit `add-context-file`. Folders aren't context
+		 * chips; only files are.
+		 */
+		it('selecting a folder rewrites to `@<name>/` and skips add-context-file', async () => {
+			const po = mountChatInput(
+				{ modelValue: '', disabled: false, loading: false },
+				FILES,
+			)
+			await po.typeAndMoveCaretToEnd('@spec')
+			await vi.advanceTimersByTimeAsync(MENTION_DEBOUNCE_MS + 1)
+			await flushPromises()
+			expect(po.mentionDropdownExists()).toBe(true)
+			// The first row is the `specs` folder (prefix-matches `spec`;
+			// files don't prefix-match the basename here).
+			const firstLabel = po.wrapper.find('[data-testid="mention-option-0"]').text()
+			expect(firstLabel).toContain('specs/')
+			await po.pressKey('Enter')
+
+			const updates = po.emitted('update:modelValue') as string[][]
+			const lastValue = updates[updates.length - 1][0]
+			expect(lastValue).toBe('@specs/')
 			expect(po.emitted('add-context-file')).toBeFalsy()
 		})
 	})

--- a/tests/ui/components/chat/MentionDropdown.po.ts
+++ b/tests/ui/components/chat/MentionDropdown.po.ts
@@ -28,6 +28,14 @@ export class MentionDropdownPO {
 		return this.optionAt(index).attributes('aria-selected') === 'true'
 	}
 
+	optionKind(index: number): string | undefined {
+		return this.optionAt(index).attributes('data-kind')
+	}
+
+	optionLabel(index: number): string {
+		return this.optionAt(index).text()
+	}
+
 	async clickOption(index: number): Promise<void> {
 		await this.optionAt(index).trigger('mousedown')
 	}

--- a/tests/ui/components/chat/MentionDropdown.test.ts
+++ b/tests/ui/components/chat/MentionDropdown.test.ts
@@ -13,9 +13,9 @@ import type { MentionCandidate } from '@/application/chat/vaultFileSearch'
 import { MentionDropdownPO } from './MentionDropdown.po'
 
 const candidates: MentionCandidate[] = [
-	{ path: 'specs/foo/idea.md', name: 'idea.md' },
-	{ path: 'specs/foo/requirements.md', name: 'requirements.md' },
-	{ path: 'specs/bar/idea.md', name: 'idea.md' },
+	{ path: 'specs/foo/idea.md', name: 'idea.md', kind: 'file' },
+	{ path: 'specs/foo/requirements.md', name: 'requirements.md', kind: 'file' },
+	{ path: 'specs/bar/idea.md', name: 'idea.md', kind: 'file' },
 ]
 
 function mountDropdown(props: {
@@ -63,5 +63,38 @@ describe('MentionDropdown', () => {
 		const emitted = po.emitted('hover') as number[][]
 		expect(emitted).toBeTruthy()
 		expect(emitted[0][0]).toBe(1)
+	})
+
+	/**
+	 * PR-ASV-4-folders — folder rows render with a trailing slash and a
+	 * `data-kind="folder"` discriminator so the consumer (`ChatInput`) can
+	 * branch in `commitMention`. Files keep their bare basename rendering.
+	 */
+	describe('folder rows', () => {
+		it('renders a folder row with a trailing slash suffix', () => {
+			const po = mountDropdown({
+				results: [{ path: 'specs', name: 'specs', kind: 'folder' }],
+				selectedIndex: 0,
+			})
+			expect(po.optionCount()).toBe(1)
+			expect(po.optionLabel(0)).toContain('specs/')
+			expect(po.optionKind(0)).toBe('folder')
+		})
+
+		it('mixes files and folders in the provided order', () => {
+			const mixed: MentionCandidate[] = [
+				{ path: 'specs/foo/idea.md', name: 'idea.md', kind: 'file' },
+				{ path: 'specs', name: 'specs', kind: 'folder' },
+				{ path: 'specs/foo', name: 'foo', kind: 'folder' },
+			]
+			const po = mountDropdown({ results: mixed, selectedIndex: 0 })
+			expect(po.optionCount()).toBe(3)
+			expect(po.optionKind(0)).toBe('file')
+			expect(po.optionKind(1)).toBe('folder')
+			expect(po.optionKind(2)).toBe('folder')
+			expect(po.optionLabel(0)).toContain('idea.md')
+			expect(po.optionLabel(1)).toContain('specs/')
+			expect(po.optionLabel(2)).toContain('foo/')
+		})
 	})
 })

--- a/tests/ui/composables/useMentionPicker.test.ts
+++ b/tests/ui/composables/useMentionPicker.test.ts
@@ -102,9 +102,10 @@ describe('useMentionPicker', () => {
 	})
 
 	it('arrow-down + arrow-up wrap selection', async () => {
-		const picker = useMentionPicker(
-			makeBridge(['notes/a.md', 'notes/b.md', 'notes/c.md']),
-		)
+		// Root-level files only — keeps `collectVaultFolders` empty so the
+		// result count is exactly 3 (PR-ASV-4-folders no longer surfaces
+		// `notes/` alongside the three notes files).
+		const picker = useMentionPicker(makeBridge(['a.md', 'b.md', 'c.md']))
 		picker.handleInput('@', 1)
 		await vi.advanceTimersByTimeAsync(MENTION_DEBOUNCE_MS + 1)
 		expect(picker.selectedIndex.value).toBe(0)


### PR DESCRIPTION
## Summary

Top-4 finalization from the agent-sidepanel-v2 comparative review. The IME composition guard for CJK input already shipped on the parent branch; this PR closes the other half — folders surface alongside files in the `@`-mention picker.

**Stacked on #376 (mention picker) → #369 → develop.**

### Behaviour

- Typing `@` triggers the picker; `@spec` now matches both `specs/foo/idea.md` (file) and `specs/` (folder).
- Files render as `<filename>`; folders render as `<name>/` with a 📁 glyph.
- Selecting a **file** inserts `@<filename> ` (trailing space) and emits `add-context-file` → chip lands in the context list.
- Selecting a **folder** inserts `@<foldername>/` (no trailing space, no emit) so the user can keep typing to narrow into children.
- Sort: filename-prefix match > files-before-folders on tie > path lexicographic, capped at 50.

### Files touched (9)

- `src/application/chat/vaultFileSearch.ts` — `MentionCandidateKind`, `kind` on candidates, `collectVaultFolders()`, kind-aware `prepareCandidates`, file-beats-folder tiebreaker.
- `src/ui/composables/useMentionPicker.ts` — `inFlightScan` now resolves to `{files, folders}` via parallel walks.
- `src/ui/components/chat/MentionDropdown.vue` — kind-aware row rendering with `data-kind` attribute.
- `src/ui/components/chat/ChatInput.vue` — `commitMention` branches on candidate kind.
- Tests: +5 vaultFileSearch · +2 MentionDropdown · +1 ChatInput integration. PageObject extended with `optionKind()` / `optionLabel()` getters.

## Test plan

- [x] +8 new tests
- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 errors
- [x] `npm run test` 1518/1518 pass

https://claude.ai/code/session_01VvXsK3aGp2g4jSpT1py7Mh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvXsK3aGp2g4jSpT1py7Mh)_