### PR TITLE
feat(secret-storage): move Anthropic API key to Obsidian secretStorage

### DIFF
--- a/src/core/core-settings.ts
+++ b/src/core/core-settings.ts
@@ -79,7 +79,6 @@ export const coreSettingsModule = defineModule<PluginSettings>({
       mcpServerEnabled: coerceBoolean(r.mcpServerEnabled, DEFAULT_SETTINGS.mcpServerEnabled),
       userPersona: coercePassthroughString(r.userPersona, DEFAULT_SETTINGS.userPersona),
       onboardingComplete: coerceBoolean(r.onboardingComplete, DEFAULT_SETTINGS.onboardingComplete),
-      anthropicApiKey: coercePassthroughString(r.anthropicApiKey, DEFAULT_SETTINGS.anthropicApiKey),
       claudeCliPath: coerceTrimmedString(r.claudeCliPath, DEFAULT_SETTINGS.claudeCliPath),
       transportKind: coerceEnum(r.transportKind, VALID_TRANSPORT_KINDS, DEFAULT_SETTINGS.transportKind),
     }

--- a/src/domain/ports/SecretStorePort.ts
+++ b/src/domain/ports/SecretStorePort.ts
@@ -1,0 +1,44 @@
+/**
+ * Narrow port for OS-level secret storage (ADR-008).
+ *
+ * Production implementation wraps Obsidian's `App.secretStorage` (available
+ * since desktop 1.11.4, 2026-01-07) which persists secrets in the OS keychain
+ * and explicitly OPTS OUT of Obsidian Sync. This is the only correct home for
+ * the Anthropic API key — `PluginSettings` ships with Obsidian Sync, leaking
+ * the key across the user's devices.
+ *
+ * `available` is `false` on mobile (where `app.secretStorage` is `undefined`)
+ * and on desktop builds older than 1.11.4. Consumers must check this flag and
+ * fall back to a "key not stored on this device" state rather than throwing.
+ */
+export interface SecretStorePort {
+	/**
+	 * `true` when the underlying secret-storage backend is reachable. Mobile
+	 * Obsidian and pre-1.11.4 desktop builds return `false`; the localstorage
+	 * (GitHub Pages) bridge also returns `false`.
+	 */
+	readonly available: boolean
+
+	/**
+	 * Retrieve a previously-stored secret by id. Returns `null` when the secret
+	 * is unset or the backend is unavailable.
+	 */
+	getSecret(id: string): Promise<string | null>
+
+	/**
+	 * Persist a secret under the given id. No-op when `available === false`.
+	 * Implementations MUST NOT throw on the unavailable path.
+	 */
+	setSecret(id: string, secret: string): Promise<void>
+}
+
+/**
+ * Canonical identifier for the Anthropic API key. Keep all consumers using
+ * this constant so a future rename is a one-edit change.
+ *
+ * Obsidian's `App.secretStorage` validates IDs to lowercase alphanumeric
+ * with optional dashes — the previous dot-delimited / camelCase form was
+ * rejected at `setSecret()` time, so settings writes never persisted on
+ * desktop builds where secret storage was available.
+ */
+export const SECRET_ID_ANTHROPIC = 'specorator-anthropic-apikey'

--- a/src/domain/ports/index.ts
+++ b/src/domain/ports/index.ts
@@ -27,3 +27,5 @@ export type {
 } from './ClaudeCliPort';
 export { ClaudeCliError, streamFromQuery } from './ClaudeCliPort';
 export type { ConfirmModalPort, ConfirmModalRequest } from './ConfirmModalPort';
+export type { SecretStorePort } from './SecretStorePort';
+export { SECRET_ID_ANTHROPIC } from './SecretStorePort';

--- a/src/domain/settings/PluginSettings.ts
+++ b/src/domain/settings/PluginSettings.ts
@@ -23,17 +23,6 @@ export interface PluginSettings {
 	readonly userPersona: string
 	readonly onboardingComplete: boolean
 	/**
-	 * Anthropic API key. Written to process.env.ANTHROPIC_API_KEY at plugin load time
-	 * and used solely to initialise ClaudeCliAdapter. Never written to any vault file.
-	 * Never logged. Stored in the plugin data blob (Obsidian's this.saveData()).
-	 *
-	 * Security note: Obsidian Sync will include this key if the user has Sync enabled.
-	 * A notice in the settings tab informs users of this (REQ-CCS-001, C.7).
-	 *
-	 * Satisfies REQ-CCS-001, REQ-CCS-002, NFR-CCS-005, NFR-CCS-006.
-	 */
-	readonly anthropicApiKey: string
-	/**
 	 * Absolute filesystem path to the user's `claude` binary. Empty string = unset
 	 * (auto-detect at runtime). Per SPEC-ASM-001 §2.12, REQ-ASM-004.
 	 */
@@ -58,7 +47,6 @@ export const DEFAULT_SETTINGS: PluginSettings = {
 	mcpServerEnabled: false,
 	userPersona: '',
 	onboardingComplete: false,
-	anthropicApiKey: '',
 	claudeCliPath: '',
 	transportKind: 'auto',
 }

--- a/src/infrastructure/bridge/ports.ts
+++ b/src/infrastructure/bridge/ports.ts
@@ -10,6 +10,7 @@ import type {
 	CommunityPluginPort,
 	ClaudeCliPort,
 	ConfirmModalPort,
+	SecretStorePort,
 } from '@/domain/ports'
 import type { MarkdownRenderPort } from '@/domain/ports/MarkdownRenderPort'
 import type { TransportKind } from '@/domain/chat/TransportKind'
@@ -24,6 +25,13 @@ export const CANVAS_PORT: InjectionKey<CanvasPort> = Symbol('CanvasPort')
 export const COMMUNITY_PLUGIN_PORT: InjectionKey<CommunityPluginPort> = Symbol('CommunityPluginPort')
 export const CLAUDE_CLI_PORT: InjectionKey<ClaudeCliPort> = Symbol('ClaudeCliPort')
 export const CONFIRM_MODAL_PORT: InjectionKey<ConfirmModalPort> = Symbol('ConfirmModalPort')
+/**
+ * OS-keychain-backed secret store (ADR-008). Production wraps Obsidian's
+ * `App.secretStorage` (desktop ≥1.11.4); `available === false` on mobile and
+ * older desktop builds. Used by `ChatSidebar` to detect the missing-API-key
+ * branch without reading the synced `PluginSettings` blob.
+ */
+export const SECRET_STORE_PORT: InjectionKey<SecretStorePort> = Symbol('SecretStorePort')
 /**
  * Optional `MarkdownRenderPort` provided by the Obsidian view. When
  * present, `MarkdownBlock.vue` delegates rendering to Obsidian's native

--- a/src/infrastructure/localstorage/LocalStorageSecretStore.ts
+++ b/src/infrastructure/localstorage/LocalStorageSecretStore.ts
@@ -1,0 +1,20 @@
+import type { SecretStorePort } from '@/domain/ports/SecretStorePort'
+
+/**
+ * Browser-only {@link SecretStorePort} for the GitHub Pages demo. There is no
+ * OS keychain in the browser, so `available` is `false` and both operations
+ * are no-ops. The chat-degraded "key not stored on this device" branch fires
+ * unconditionally on the demo.
+ */
+export class LocalStorageSecretStore implements SecretStorePort {
+	public readonly available = false
+
+	async getSecret(_id: string): Promise<string | null> {
+		return null
+	}
+
+	async setSecret(_id: string, _secret: string): Promise<void> {
+		// No-op: persisting a key in localStorage would be insecure (XSS-readable)
+		// and the GitHub Pages demo intentionally cannot make real API calls.
+	}
+}

--- a/src/infrastructure/mock/MockSecretStore.ts
+++ b/src/infrastructure/mock/MockSecretStore.ts
@@ -1,0 +1,39 @@
+import type { SecretStorePort } from '@/domain/ports/SecretStorePort'
+
+/**
+ * In-memory {@link SecretStorePort} for unit tests and the standalone
+ * browser dev mode. Mirrors the production keychain semantics: secrets are
+ * keyed by string id, and `setSecret` overwrites prior values.
+ *
+ * `available` is `true` so tests exercise the same branch as production
+ * desktop. Tests that specifically need the unavailable branch can construct
+ * with `{ available: false }`.
+ */
+export class MockSecretStore implements SecretStorePort {
+	private readonly _secrets = new Map<string, string>()
+	public readonly available: boolean
+
+	constructor(opts: { available?: boolean; initial?: Record<string, string> } = {}) {
+		this.available = opts.available ?? true
+		if (opts.initial !== undefined) {
+			for (const [id, value] of Object.entries(opts.initial)) {
+				this._secrets.set(id, value)
+			}
+		}
+	}
+
+	async getSecret(id: string): Promise<string | null> {
+		if (!this.available) return null
+		return this._secrets.has(id) ? (this._secrets.get(id) ?? null) : null
+	}
+
+	async setSecret(id: string, secret: string): Promise<void> {
+		if (!this.available) return
+		this._secrets.set(id, secret)
+	}
+
+	/** Test helper: inspect every secret currently held. */
+	snapshot(): Record<string, string> {
+		return Object.fromEntries(this._secrets.entries())
+	}
+}

--- a/src/infrastructure/obsidian/ClaudeCliAdapter.ts
+++ b/src/infrastructure/obsidian/ClaudeCliAdapter.ts
@@ -11,7 +11,6 @@ import type { Result } from '@/domain/shared/Result';
 import { ok, err } from '@/domain/shared/Result';
 import { asSessionId, type SessionId } from '@/domain/chat/SessionId';
 import type { LoggerPort } from '@/domain/ports';
-import type { PluginSettings } from '@/domain/settings/PluginSettings';
 
 /**
  * Loosely-typed view of the SDK message union. Only the fields actually
@@ -85,19 +84,25 @@ export class ClaudeCliAdapter implements ClaudeCliPort {
 	private _available = false;
 	/** Indicates whether SDK has been initialized. */
 	private _sdkReady = false;
-	/** Getter for current plugin settings. Injected; never stored as a snapshot. */
-	private readonly _getSettings: () => PluginSettings;
+	/**
+	 * Sync accessor for the Anthropic API key. Injected by the plugin layer so
+	 * `_apiKeyCache` (hydrated from `SecretStorePort` at `loadSettings()` time)
+	 * stays the single source of truth — the SDK call sites must remain
+	 * synchronous, so we cannot call the async `secretStorage.getSecret()` on
+	 * each request.
+	 */
+	private readonly _getApiKey: () => string;
 	/** Logger for internal diagnostics. Never logs the API key value. */
 	private readonly _logger: LoggerPort;
 	/** Binary resolver — injectable for testability (defaults to require.resolve). */
 	private readonly _resolveCliPath: () => string;
 
 	constructor(
-		getSettings: () => PluginSettings,
+		getApiKey: () => string,
 		logger: LoggerPort,
 		resolveCliPath?: () => string,
 	) {
-		this._getSettings = getSettings;
+		this._getApiKey = getApiKey;
 		this._logger = logger;
 		this._resolveCliPath =
 			resolveCliPath ??
@@ -116,12 +121,12 @@ export class ClaudeCliAdapter implements ClaudeCliPort {
 		// Idempotency guard: shutdown() resets _sdkReady, so a post-shutdown re-start is allowed.
 		if (this._sdkReady) return;
 
-		const key = this._getSettings().anthropicApiKey.trim();
+		const key = this._getApiKey().trim();
 
 		// Step 1: Check for empty/whitespace key.
 		if (!key) {
 			this._logger.warn(
-				'ClaudeCliAdapter.startup(): anthropicApiKey is empty — adapter will not start',
+				'ClaudeCliAdapter.startup(): Anthropic API key is empty — adapter will not start',
 			);
 			this._available = false;
 			return;
@@ -193,7 +198,7 @@ export class ClaudeCliAdapter implements ClaudeCliPort {
 	 * Satisfies REQ-CCS-018, REQ-CCS-019, REQ-CCS-022, SPEC-CCS-001 §5.4.
 	 */
 	async isAvailable(): Promise<boolean> {
-		return this._available && this._getSettings().anthropicApiKey.trim() !== '';
+		return this._available && this._getApiKey().trim() !== '';
 	}
 
 	/**
@@ -258,7 +263,7 @@ export class ClaudeCliAdapter implements ClaudeCliPort {
 				error: new ClaudeCliError(this._unavailableCode(), 'ClaudeCliAdapter is not available'),
 			};
 		}
-		const currentKey = this._getSettings().anthropicApiKey.trim();
+		const currentKey = this._getApiKey().trim();
 		if (currentKey === '') {
 			return { type: 'error', error: new ClaudeCliError('API_KEY_MISSING', 'API key is missing') };
 		}
@@ -659,7 +664,7 @@ export class ClaudeCliAdapter implements ClaudeCliPort {
 	// ── Private helpers ───────────────────────────────────────────────────────
 
 	private _unavailableCode(): 'API_KEY_MISSING' | 'NOT_INSTALLED' {
-		return this._getSettings().anthropicApiKey.trim() === '' ? 'API_KEY_MISSING' : 'NOT_INSTALLED';
+		return this._getApiKey().trim() === '' ? 'API_KEY_MISSING' : 'NOT_INSTALLED';
 	}
 
 	private _clampTimeout(raw?: number): number {

--- a/src/infrastructure/obsidian/ObsidianSecretStoreAdapter.ts
+++ b/src/infrastructure/obsidian/ObsidianSecretStoreAdapter.ts
@@ -1,0 +1,46 @@
+import type { App } from 'obsidian'
+import type { SecretStorePort } from '@/domain/ports/SecretStorePort'
+
+/**
+ * Production implementation of {@link SecretStorePort} backed by Obsidian's
+ * `App.secretStorage` (available since Obsidian desktop 1.11.4, 2026-01-07).
+ *
+ * Why this exists: `PluginSettings` is mirrored by Obsidian Sync across the
+ * user's devices, which is the wrong place for an Anthropic API key. The
+ * native `secretStorage` API persists in the OS keychain and is explicitly
+ * NOT synced.
+ *
+ * Mobile + pre-1.11.4 desktop: `app.secretStorage` is `undefined`, so
+ * {@link available} is `false`. `getSecret` returns `null` and `setSecret`
+ * is a no-op on those builds — consumers must check `available` and surface
+ * the missing-key fallback instead of failing hard.
+ */
+interface SecretStorageLike {
+	getSecret(id: string): Promise<string | null>
+	setSecret(id: string, secret: string): Promise<void>
+	listSecrets?(): Promise<string[]>
+}
+
+type AppWithSecretStorage = App & { secretStorage?: SecretStorageLike }
+
+export class ObsidianSecretStoreAdapter implements SecretStorePort {
+	private readonly _secretStorage: SecretStorageLike | undefined
+
+	constructor(app: App) {
+		this._secretStorage = (app as AppWithSecretStorage).secretStorage
+	}
+
+	get available(): boolean {
+		return typeof this._secretStorage?.getSecret === 'function'
+	}
+
+	async getSecret(id: string): Promise<string | null> {
+		if (this._secretStorage === undefined) return null
+		return this._secretStorage.getSecret(id)
+	}
+
+	async setSecret(id: string, secret: string): Promise<void> {
+		if (this._secretStorage === undefined) return
+		await this._secretStorage.setSecret(id, secret)
+	}
+}

--- a/src/plugin/AgentSidepanelView.ts
+++ b/src/plugin/AgentSidepanelView.ts
@@ -13,6 +13,7 @@ import {
 	COMMUNITY_PLUGIN_PORT,
 	CONFIRM_MODAL_PORT,
 	MARKDOWN_RENDER_PORT,
+	SECRET_STORE_PORT,
 	IS_MOBILE_KEY,
 	SETTINGS_VERSION_KEY,
 	TRANSPORT_KIND_KEY,
@@ -166,6 +167,9 @@ export class AgentSidepanelView extends ItemView {
 		});
 		this.vueApp.provide(CLAUDE_CLI_PORT, reactivePort);
 		this.vueApp.provide(COMMUNITY_PLUGIN_PORT, bridge);
+		if (this.plugin.secretStore !== null) {
+			this.vueApp.provide(SECRET_STORE_PORT, this.plugin.secretStore);
+		}
 		if (this._options?.confirmModalAdapter !== undefined) {
 			this.vueApp.provide(CONFIRM_MODAL_PORT, this._options.confirmModalAdapter);
 		}

--- a/src/plugin/SpecoratorView.ts
+++ b/src/plugin/SpecoratorView.ts
@@ -14,6 +14,7 @@ import {
   CLAUDE_CLI_PORT,
   COMMUNITY_PLUGIN_PORT,
   CONFIRM_MODAL_PORT,
+  SECRET_STORE_PORT,
   IS_MOBILE_KEY,
   SETTINGS_VERSION_KEY,
   TRANSPORT_KIND_KEY,
@@ -214,6 +215,9 @@ export class SpecoratorView extends ItemView {
     })
     this.vueApp.provide(CLAUDE_CLI_PORT, reactivePort)
     this.vueApp.provide(COMMUNITY_PLUGIN_PORT, bridge)
+    if (this.plugin.secretStore !== null) {
+      this.vueApp.provide(SECRET_STORE_PORT, this.plugin.secretStore)
+    }
     // REQ-ASM-044 / SPEC-ASM-001 §9.5 — production-grade confirmation modal
     // for proposal-flow accepts. `ChatSidebar` injects this via
     // `useConfirmModalPort()` (PR-ASM-4 batch 7). The provide is

--- a/src/plugin/loadSettings-migrate.ts
+++ b/src/plugin/loadSettings-migrate.ts
@@ -20,7 +20,6 @@ export const PLUGIN_SETTINGS_KEYS: ReadonlyArray<keyof PluginSettings> = [
   'mcpServerEnabled',
   'userPersona',
   'onboardingComplete',
-  'anthropicApiKey',
   'claudeCliPath',
   'transportKind',
 ]

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -22,6 +22,7 @@ import { ObsidianConfirmModalAdapter } from '@/infrastructure/obsidian/ObsidianC
 import { ObsidianMcpServerAdapter } from '@/infrastructure/obsidian/ObsidianMcpServerAdapter'
 import { ObsidianMetadataCacheAdapter } from '@/infrastructure/obsidian/ObsidianMetadataCacheAdapter'
 import { ObsidianCanvasAdapter } from '@/infrastructure/obsidian/ObsidianCanvasAdapter'
+import { ObsidianSecretStoreAdapter } from '@/infrastructure/obsidian/ObsidianSecretStoreAdapter'
 import { ClaudeCliAdapter } from '@/infrastructure/obsidian/ClaudeCliAdapter'
 import { ClaudeSubprocessAdapter, type SpawnFn } from '@/infrastructure/obsidian/ClaudeSubprocessAdapter'
 import { ClaudeBinaryResolver, type SpawnFn as ResolverSpawnFn } from '@/infrastructure/obsidian/ClaudeBinaryResolver'
@@ -31,13 +32,32 @@ import { FeedbackService } from '@/application/shared/FeedbackService'
 import { PluginCore } from '@/core/plugin-core'
 import { ALL_MODULES, type ModuleDescriptor } from '@/modules'
 import { i18nMerge, i18nTranslate, setLocale, type SupportedLocale } from '@/ui/i18n'
-import type { TranslationPort } from '@/domain/ports'
+import type { SecretStorePort, TranslationPort } from '@/domain/ports'
+import { SECRET_ID_ANTHROPIC } from '@/domain/ports'
 import { useChatStore } from '@/ui/stores/chatStore'
 
 export default class SpecoratorPlugin extends Plugin {
   settings: PluginSettings = { ...DEFAULT_SETTINGS }
   core: PluginCore | null = null
   bridge: ObsidianBridge | null = null
+  /**
+   * Secret-store adapter wrapping `App.secretStorage` (desktop ≥1.11.4).
+   * `available === false` on mobile and older desktop builds; consumers
+   * fall through to the degraded transport via the empty `_apiKeyCache`.
+   * Constructed in `loadSettings()` before any consumer needs the key.
+   */
+  secretStore: SecretStorePort | null = null
+  /**
+   * Synchronous Anthropic-API-key cache hydrated from `secretStore` at
+   * `loadSettings()` time. `ClaudeCliAdapter` and the `selectTransport`
+   * closure close over the `_apiKeyCache.trim() !== ''` projection so the
+   * SPEC-ASM-001 §3.1 synchronous purity invariant holds — the async
+   * `secretStorage.getSecret()` is never called on a chat hot path.
+   *
+   * Refreshed by `refreshApiKeyCache()` after the settings tab persists a
+   * new value (T-CCS-037).
+   */
+  private _apiKeyCache = ''
 
   /** Full stored data blob: specorator sub-key + per-module sub-keys + _moduleVersions. */
   private _storedData: Record<string, unknown> = {}
@@ -140,9 +160,12 @@ export default class SpecoratorPlugin extends Plugin {
     await this.saveData(this._storedData)
 
     // T-CCS-032: Instantiate ClaudeCliAdapter. startup() is deferred to onLayoutReady
-    // so it does not hold up the critical onload() path.
+    // so it does not hold up the critical onload() path. The Anthropic API
+    // key is sourced from `_apiKeyCache` (hydrated from `SecretStorePort` in
+    // `loadSettings()`); the sync accessor keeps the SDK call sites off the
+    // async keychain path.
     this._claudeCliAdapter = new ClaudeCliAdapter(
-      () => this.settings,
+      () => this._apiKeyCache,
       this.bridge,
     )
     this.register(() => { this._claudeCliAdapter?.shutdown() })
@@ -196,6 +219,10 @@ export default class SpecoratorPlugin extends Plugin {
             // ClaudeSubprocessAdapter.isAvailableSync(). Evaluated at every
             // selector call so post-startup() availability is honoured.
             cliResolved: this._subscriptionAdapter!.isAvailableSync(),
+            // Synchronous projection of `SecretStorePort.getSecret(...)`
+            // captured in `_apiKeyCache`. Re-read on every selector call so
+            // a key saved mid-session is honoured.
+            apiKeyPresent: this._apiKeyCache.trim() !== '',
           }),
       })
       this._specoratorView = view
@@ -216,6 +243,7 @@ export default class SpecoratorPlugin extends Plugin {
             subscriptionAdapter: this._subscriptionAdapter!,
             degradedPort: degradedClaudeCliPort,
             cliResolved: this._subscriptionAdapter!.isAvailableSync(),
+            apiKeyPresent: this._apiKeyCache.trim() !== '',
           }),
       })
       this._agentSidepanelView = view
@@ -400,6 +428,8 @@ export default class SpecoratorPlugin extends Plugin {
       ...((this._storedData.specorator ?? {}) as Partial<PluginSettings>),
     }
 
+    await this._initializeSecretStore()
+
     // SPEC-ASM-001 §9.3 — read the `chatThreads` blob alongside settings so
     // `SpecoratorView.onOpen()` can hydrate the chat store after the view
     // mounts. Decoding uses the plugin bridge logger when present (typed once
@@ -413,6 +443,45 @@ export default class SpecoratorPlugin extends Plugin {
       warn: (msg, ctx) => { console.warn(msg, ctx ?? {}) },
       error: (msg, ctx) => { console.error(msg, ctx ?? {}) },
     })
+  }
+
+  /**
+   * Construct the secret-store adapter and hydrate `_apiKeyCache` from it.
+   * On desktop ≥1.11.4 `app.secretStorage` is present and any previously
+   * stored Anthropic key is loaded into the cache. On mobile / older
+   * desktop builds `available === false` and the cache stays empty — chat
+   * falls back to degraded mode (see settings tab).
+   */
+  private async _initializeSecretStore(): Promise<void> {
+    this.secretStore = new ObsidianSecretStoreAdapter(this.app)
+    this._apiKeyCache = this.secretStore.available
+      ? ((await this.secretStore.getSecret(SECRET_ID_ANTHROPIC)) ?? '')
+      : ''
+  }
+
+  /**
+   * Read-only accessor exposing the cached Anthropic API key for callers
+   * that need a sync value (settings UI test hooks, transport selector
+   * closures). Returns `''` when no key is configured or when running on a
+   * build without `App.secretStorage`.
+   */
+  getApiKeyCache(): string {
+    return this._apiKeyCache
+  }
+
+  /**
+   * Re-read the Anthropic API key from {@link secretStore} after the settings
+   * tab persists a new value, and bump the in-view settings version so
+   * `ChatSidebar` re-checks adapter availability. Safe to call when the views
+   * are closed (the bump is a no-op).
+   */
+  async refreshApiKeyCache(): Promise<void> {
+    if (this.secretStore === null) return
+    this._apiKeyCache = this.secretStore.available
+      ? ((await this.secretStore.getSecret(SECRET_ID_ANTHROPIC)) ?? '')
+      : ''
+    this._specoratorView?.bumpSettingsVersion()
+    this._agentSidepanelView?.bumpSettingsVersion()
   }
 
   /**

--- a/src/plugin/settings.ts
+++ b/src/plugin/settings.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path'
 import { spawn, spawnSync } from 'node:child_process'
 import { ClaudeBinaryResolver, type ResolverPlatform } from '@/infrastructure/obsidian/ClaudeBinaryResolver'
 import { tryAsync, trySync } from '@/domain/shared/tryAsync'
+import { SECRET_ID_ANTHROPIC } from '@/domain/ports'
 import type { ModuleDescriptor, SettingsFieldDescriptor } from '@/modules/module'
 import { VIEW_TYPE, SpecoratorView } from './SpecoratorView'
 import { VIEW_TYPE_AGENT, AgentSidepanelView } from './AgentSidepanelView'
@@ -159,30 +160,47 @@ export class SpecoratorSettingTab extends PluginSettingTab {
    * Renders the Anthropic API key password field outside the module-driven settings loop.
    * Satisfies REQ-CCS-001, NFR-CCS-006, SPEC-CCS-001 §8.3.
    *
-   * The key is stored in the plugin data blob (not in any vault file).
+   * The key is stored in Obsidian's `App.secretStorage` (desktop ≥1.11.4) via
+   * `SecretStorePort`, NOT in the synced `PluginSettings` blob — the latter is
+   * mirrored by Obsidian Sync and would leak the key across devices.
    * `inputEl.type = 'password'` masks the value (NFR-CCS-006).
    * `autocomplete = 'off'` prevents browser/OS autofill.
    * onChange handler trims whitespace before saving.
    */
   private renderAnthropicKeyField(): void {
+    const secretStore = this.plugin.secretStore
+    const writable = secretStore?.available ?? false
+    const desc = writable
+      ? "Required to use the AI assistant. Stored in this device's OS keychain (not synced)."
+      : "Required to use the AI assistant. This Obsidian build does not expose the OS keychain, so the field is read-only here."
+
     new Setting(this.containerEl)
       .setName('Anthropic key')
-      .setDesc(
-        "Required to use the AI assistant. Stored in this device's plugin settings. " +
-          'If you use Obsidian Sync, your key will be included in the sync — use a key scoped to your personal devices.',
-      )
+      .setDesc(desc)
       .addText((text) => {
         text.inputEl.type = 'password'
         text.inputEl.autocomplete = 'off'
         text.inputEl.setAttribute('data-testid', 'settings-anthropic-key')
+        if (!writable) {
+          text.inputEl.disabled = true
+        }
         text
           // eslint-disable-next-line obsidianmd/ui/sentence-case
           .setPlaceholder('sk-ant-…')
-          .setValue(this.plugin.settings.anthropicApiKey)
+          .setValue(this.plugin.getApiKeyCache())
           .onChange(async (value) => {
-            await this.plugin.updateSettings({ anthropicApiKey: value.trim() })
-            // T-CCS-037: signal ChatSidebar to re-check adapter availability.
-            this._bumpAllViews()
+            const store = secretStore
+            if (store === null) return
+            if (!store.available) return
+            // Codex P2: persisting via the OS keychain can fail (locked
+            // keychain, OS denial). Surface as a no-op rather than throwing
+            // out of the onChange handler — the input keeps the user's
+            // typed value but `_apiKeyCache` is unchanged on error.
+            const outcome = await tryAsync(() =>
+              store.setSecret(SECRET_ID_ANTHROPIC, value.trim()),
+            )
+            if (!outcome.ok) return
+            await this.plugin.refreshApiKeyCache()
           })
       })
   }

--- a/src/plugin/transport/TransportSelector.ts
+++ b/src/plugin/transport/TransportSelector.ts
@@ -10,10 +10,10 @@
  *
  * Purity invariants (SPEC-ASM-001 §3.1):
  *   - Synchronous (returns `TransportSelection`, never `Promise`).
- *   - No I/O. `deps.cliResolved` is consumed as a plain boolean — the selector
- *     must NOT call `.isAvailable()` (or any other method) on the candidate
- *     ports at selection time.
- *   - Whitespace-only `anthropicApiKey` is treated as empty (trim semantics).
+ *   - No I/O. `deps.cliResolved` and `deps.apiKeyPresent` are consumed as
+ *     plain booleans — the selector must NOT call `.isAvailable()` (or any
+ *     other method) on the candidate ports at selection time, and must NOT
+ *     read the API key from `SecretStorePort` (which is async).
  *
  * ADR-008: this file lives in the plugin layer but imports only domain types.
  * It must not import from `obsidian`, `child_process`, or any infrastructure
@@ -40,47 +40,43 @@ export interface TransportSelection {
  * `subscriptionAdapter.isAvailable()`, evaluated once at plugin-wiring time
  * (see SPEC-ASM-001 §3.1 closing note). The selector never calls
  * `.isAvailable()` itself.
+ *
+ * `apiKeyPresent` is the synchronous projection of the
+ * `SecretStorePort.getSecret(SECRET_ID_ANTHROPIC)` value cached at
+ * `loadSettings()` time. Evaluated by the plugin layer per call so a key
+ * saved mid-session is honoured without re-reading the keychain on the
+ * selector hot path.
  */
 export interface TransportSelectorDeps {
   readonly sdkAdapter: ClaudeCliPort
   readonly subscriptionAdapter: ClaudeCliPort
   readonly degradedPort: ClaudeCliPort
   readonly cliResolved: boolean
-}
-
-/**
- * The settings shape consumed by `selectTransport`. Until T-ASM-014 extends
- * `PluginSettings` with `transportKind`, callers pass a structural intersection
- * — this avoids coupling the selector's compile-time contract to the
- * not-yet-landed settings field.
- */
-type TransportSelectorSettings = PluginSettings & {
-  readonly transportKind: TransportKind
+  readonly apiKeyPresent: boolean
 }
 
 export type TransportSelectorFn = (
-  settings: TransportSelectorSettings,
+  settings: PluginSettings,
   deps: TransportSelectorDeps,
 ) => TransportSelection
 
 /**
  * SPEC-ASM-001 §3.1 truth table (8 rows, first-match-wins).
  *
- * | Row | transportKind   | apiKey.trim() !== '' | cliResolved | Result                              |
- * |-----|-----------------|----------------------|-------------|-------------------------------------|
- * | R1  | 'degraded'      | *                    | *           | { degradedPort,        'degraded'  }|
- * | R2  | 'api-key'       | true                 | *           | { sdkAdapter,          'api-key'   }|
- * | R3  | 'api-key'       | false                | *           | { degradedPort,        'degraded'  }|
- * | R4  | 'subscription'  | *                    | true        | { subscriptionAdapter, 'subscription'}|
- * | R5  | 'subscription'  | *                    | false       | { degradedPort,        'degraded'  }|
- * | R6  | 'auto'          | true                 | *           | { sdkAdapter,          'api-key'   }|
- * | R7  | 'auto'          | false                | true        | { subscriptionAdapter, 'subscription'}|
- * | R8  | 'auto'          | false                | false       | { degradedPort,        'degraded'  }|
+ * | Row | transportKind   | apiKeyPresent | cliResolved | Result                              |
+ * |-----|-----------------|---------------|-------------|-------------------------------------|
+ * | R1  | 'degraded'      | *             | *           | { degradedPort,        'degraded'  }|
+ * | R2  | 'api-key'       | true          | *           | { sdkAdapter,          'api-key'   }|
+ * | R3  | 'api-key'       | false         | *           | { degradedPort,        'degraded'  }|
+ * | R4  | 'subscription'  | *             | true        | { subscriptionAdapter, 'subscription'}|
+ * | R5  | 'subscription'  | *             | false       | { degradedPort,        'degraded'  }|
+ * | R6  | 'auto'          | true          | *           | { sdkAdapter,          'api-key'   }|
+ * | R7  | 'auto'          | false         | true        | { subscriptionAdapter, 'subscription'}|
+ * | R8  | 'auto'          | false         | false       | { degradedPort,        'degraded'  }|
  */
 export const selectTransport: TransportSelectorFn = (settings, deps) => {
   const { transportKind } = settings
-  const apiKeyPresent = settings.anthropicApiKey.trim() !== ''
-  const { sdkAdapter, subscriptionAdapter, degradedPort, cliResolved } = deps
+  const { sdkAdapter, subscriptionAdapter, degradedPort, cliResolved, apiKeyPresent } = deps
 
   // R1 — explicit 'degraded' overrides everything.
   if (transportKind === 'degraded') {

--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -9,6 +9,8 @@ import { usePlatform } from '@/ui/composables/usePlatform';
 import { useVaultPort } from '@/ui/composables/useVaultPort';
 import { useWorkspacePort } from '@/ui/composables/useWorkspacePort';
 import { useSettingsPort } from '@/ui/composables/useSettingsPort';
+import { useSecretStorePort } from '@/ui/composables/useSecretStorePort';
+import { SECRET_ID_ANTHROPIC } from '@/domain/ports';
 import { useLoggerPort } from '@/ui/composables/useLoggerPort';
 import { useSessionLogWriter } from '@/ui/composables/useSessionLogWriter';
 import { buildPrompt } from '@/application/chat/buildPrompt';
@@ -64,6 +66,7 @@ const { isMobile } = usePlatform();
 const vaultPort = useVaultPort();
 const workspacePort = useWorkspacePort();
 const settingsPort = useSettingsPort();
+const secretStorePort = useSecretStorePort();
 const loggerPort = useLoggerPort();
 const sessionLogWriterFactory = useSessionLogWriter();
 
@@ -1035,11 +1038,16 @@ function handleSelectCommand(command: SlashCommand): void {
 	emit('select-command', command);
 }
 
-// Determine if API key is missing when unavailable
+// Determine if API key is missing when unavailable. Reads from
+// `SecretStorePort` (OS keychain) since the Anthropic key no longer lives in
+// the synced `PluginSettings` blob. Codex P2: wrap in `tryAsync` so a
+// transient keychain error degrades to "missing" (the same fallback the
+// `available === false` branch produces) instead of bubbling up.
 async function isApiKeyMissing(): Promise<boolean> {
-	const settings = await settingsPort.getSettings();
-	// Cast to string|undefined: legacy stored settings may lack this field at runtime.
-	return ((settings.anthropicApiKey as string | undefined) ?? '').trim() === '';
+	if (!secretStorePort.available) return true;
+	const outcome = await tryAsync(() => secretStorePort.getSecret(SECRET_ID_ANTHROPIC));
+	if (!outcome.ok) return true;
+	return (outcome.value ?? '').trim() === '';
 }
 
 const apiKeyMissing = ref(false);

--- a/src/ui/composables/useSecretStorePort.ts
+++ b/src/ui/composables/useSecretStorePort.ts
@@ -1,0 +1,20 @@
+import { inject } from 'vue'
+import type { SecretStorePort } from '@/domain/ports'
+import { SECRET_STORE_PORT } from '@/infrastructure/bridge/ports'
+
+/**
+ * Stub used when no `SecretStorePort` was provided — the consumer is running
+ * outside an Obsidian context (e.g. a UI unit test without explicit wiring).
+ * Mirrors the unavailable-backend semantics: `getSecret` returns `null` and
+ * `setSecret` is a no-op, so consumers fall through to the degraded branch
+ * instead of throwing.
+ */
+const UNAVAILABLE_STUB: SecretStorePort = {
+	available: false,
+	getSecret: () => Promise.resolve(null),
+	setSecret: () => Promise.resolve(),
+}
+
+export function useSecretStorePort(): SecretStorePort {
+	return inject(SECRET_STORE_PORT, UNAVAILABLE_STUB)
+}

--- a/src/ui/main.ts
+++ b/src/ui/main.ts
@@ -19,10 +19,13 @@ import {
   LOGGER_PORT,
   CLAUDE_CLI_PORT,
   COMMUNITY_PLUGIN_PORT,
+  SECRET_STORE_PORT,
   OPEN_PLUGIN_SETTINGS_KEY,
 } from '@/infrastructure/bridge/ports'
 import { LocalStorageBridge } from '@/infrastructure/localstorage/LocalStorageBridge'
+import { LocalStorageSecretStore } from '@/infrastructure/localstorage/LocalStorageSecretStore'
 import { MockBridge } from '@/infrastructure/mock/MockBridge'
+import { MockSecretStore } from '@/infrastructure/mock/MockSecretStore'
 import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
 import { FeatureService } from '@/application/feature/FeatureService'
 import { FeedbackService } from '@/application/shared/FeedbackService'
@@ -34,6 +37,7 @@ import { ALL_MODULES, type ModuleDescriptor, type ModulePorts } from '@/modules'
 import type { TranslationPort } from '@/domain/ports'
 
 const bridge = import.meta.env.PROD ? new LocalStorageBridge() : new MockBridge(DEV_FIXTURES)
+const secretStore = import.meta.env.PROD ? new LocalStorageSecretStore() : new MockSecretStore()
 const mountPoint = document.querySelector('#app')
 
 mountPoint?.classList.add('specorator-root')
@@ -69,6 +73,7 @@ void bridge.getSettings()
     app.provide(LOGGER_PORT, bridge)
     app.provide(CLAUDE_CLI_PORT, bridge)
     app.provide(COMMUNITY_PLUGIN_PORT, bridge)
+    app.provide(SECRET_STORE_PORT, secretStore)
     // The Obsidian build provides this via `SpecoratorView.onOpen()` and
     // opens the real plugin settings tab. In the standalone browser UI
     // there is no Obsidian `App`, so route to the in-app Vue `/settings`

--- a/styles.css
+++ b/styles.css
@@ -1367,7 +1367,7 @@ to {
  * parent: in the agent sidepanel the parent gives ChatSidebar `flex: 0 0
  * auto` and `MessageList` takes the remaining grow space.
  */
-.specorator-root :where(.sp-chat-sidebar[data-v-16cae3a6]) {
+.specorator-root :where(.sp-chat-sidebar[data-v-a32f38e8]) {
 	padding: 1rem;
 	display: flex;
 	flex-direction: column;
@@ -1375,24 +1375,24 @@ to {
 	box-sizing: border-box;
 	flex-shrink: 0;
 }
-.specorator-root :where(.sp-chat__title[data-v-16cae3a6]) {
+.specorator-root :where(.sp-chat__title[data-v-a32f38e8]) {
 	margin: 0;
 	font-size: 1.125rem;
 	font-weight: 700;
 	color: var(--text-normal);
 }
-.specorator-root :where(.sp-chat__header[data-v-16cae3a6]) {
+.specorator-root :where(.sp-chat__header[data-v-a32f38e8]) {
 	display: flex;
 	align-items: center;
 	gap: 0.5rem;
 	flex-wrap: wrap;
 }
-.specorator-root :where(.sp-chat__divider[data-v-16cae3a6]) {
+.specorator-root :where(.sp-chat__divider[data-v-a32f38e8]) {
 	margin: 0;
 	border: none;
 	border-top: 1px solid var(--background-modifier-border);
 }
-.specorator-root :where(.sp-chat__stop[data-v-16cae3a6]) {
+.specorator-root :where(.sp-chat__stop[data-v-a32f38e8]) {
 	margin-left: auto;
 	font-size: 0.75rem;
 	font-weight: 500;
@@ -1406,10 +1406,10 @@ to {
 		background-color 0.15s,
 		border-color 0.15s;
 }
-.specorator-root :where(.sp-chat__stop[data-v-16cae3a6]:hover) {
+.specorator-root :where(.sp-chat__stop[data-v-a32f38e8]:hover) {
 	background: var(--background-modifier-error-hover, var(--interactive-hover));
 }
-.specorator-root :where(.sp-chat__degraded[data-v-16cae3a6]) {
+.specorator-root :where(.sp-chat__degraded[data-v-a32f38e8]) {
 	background: var(--background-secondary);
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 8px;
@@ -1418,13 +1418,13 @@ to {
 	flex-direction: column;
 	gap: 0.5rem;
 }
-.specorator-root :where(.sp-chat__degraded-heading[data-v-16cae3a6]) {
+.specorator-root :where(.sp-chat__degraded-heading[data-v-a32f38e8]) {
 	margin: 0;
 	font-size: 1rem;
 	font-weight: 600;
 	color: var(--text-normal);
 }
-.specorator-root :where(.sp-chat__degraded-body[data-v-16cae3a6]) {
+.specorator-root :where(.sp-chat__degraded-body[data-v-a32f38e8]) {
 	margin: 0;
 	font-size: 0.875rem;
 	color: var(--text-muted);

--- a/tests/core/core-settings.test.ts
+++ b/tests/core/core-settings.test.ts
@@ -265,13 +265,12 @@ describe('coreSettingsModule.validateSettings', () => {
 
 describe('coreSettingsModule.settingsSchema', () => {
   it('exposes a field descriptor for every module-driven PluginSettings key', () => {
-    // `anthropicApiKey` is rendered outside the module loop (SPEC-CCS-001 §8.3, D-CCS-002).
     // `claudeCliPath` is rendered by the custom ClaudeCliPathField.vue component
     // (SPEC-ASM-001 §7.5, T-ASM-016) and `transportKind` is not a user-facing
     // settings field (its value is driven by transport-selection logic).
-    // All three are intentionally absent from settingsSchema.fields.
+    // The Anthropic key is no longer on PluginSettings — it lives in
+    // `SecretStorePort` and is rendered outside the module loop.
     const manuallyRenderedKeys: ReadonlyArray<keyof PluginSettings> = [
-      'anthropicApiKey',
       'claudeCliPath',
       'transportKind',
     ]

--- a/tests/infrastructure/obsidian/ClaudeCliAdapter.test.ts
+++ b/tests/infrastructure/obsidian/ClaudeCliAdapter.test.ts
@@ -6,8 +6,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { MockBridge } from '@/infrastructure/mock/MockBridge'
 import { ClaudeCliError } from '@/domain/ports/ClaudeCliPort'
-import type { PluginSettings } from '@/domain/settings/PluginSettings'
-import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
 
 // We mock the SDK module so no real subprocess is spawned in unit tests.
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
@@ -16,10 +14,6 @@ vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
 
 // Import after mocks are set up
 const { ClaudeCliAdapter } = await import('@/infrastructure/obsidian/ClaudeCliAdapter')
-
-function makeSettings(overrides: Partial<PluginSettings> = {}): PluginSettings {
-  return { ...DEFAULT_SETTINGS, ...overrides }
-}
 
 /** Returns an async generator that yields one SDKResultSuccess message. */
 async function* makeSuccessGen(resultText: string) {
@@ -41,11 +35,11 @@ async function* makeHangingGen() {
 
 describe('REQ-CCS-002, REQ-CCS-003, REQ-CCS-016, REQ-CCS-017: ClaudeCliAdapter', () => {
   let bridge: MockBridge
-  let getSettings: () => PluginSettings
+  let getApiKey: () => string
 
   beforeEach(() => {
     bridge = new MockBridge()
-    getSettings = () => makeSettings()
+    getApiKey = () => ''
     vi.clearAllMocks()
   })
 
@@ -54,27 +48,26 @@ describe('REQ-CCS-002, REQ-CCS-003, REQ-CCS-016, REQ-CCS-017: ClaudeCliAdapter',
   })
 
   describe('startup()', () => {
-    // (a) startup() with empty key: sets _available=false, returns without throwing
-    it('with empty anthropicApiKey: _available=false, does not throw', async () => {
-      getSettings = () => makeSettings({ anthropicApiKey: '' })
-      const adapter = new ClaudeCliAdapter(getSettings, bridge)
+    it('with empty key: _available=false, does not throw', async () => {
+      getApiKey = () => ''
+      const adapter = new ClaudeCliAdapter(getApiKey, bridge)
       await expect(adapter.startup()).resolves.toBeUndefined()
       expect(await adapter.isAvailable()).toBe(false)
     })
 
     it('with empty key: logs a warn and does not proceed', async () => {
-      getSettings = () => makeSettings({ anthropicApiKey: '' })
-      const adapter = new ClaudeCliAdapter(getSettings, bridge)
+      getApiKey = () => ''
+      const adapter = new ClaudeCliAdapter(getApiKey, bridge)
       await adapter.startup()
       const warnLogs = bridge.logEntries.filter((e) => e.level === 'warn')
       expect(warnLogs.length).toBeGreaterThan(0)
-      expect(warnLogs[0].message).toContain('anthropicApiKey is empty')
+      expect(warnLogs[0].message).toContain('Anthropic API key is empty')
     })
 
     // (b) startup() with key but resolver throws: _available=false, does not throw — TEST-CCS-025
     it('with key but resolver throws: _available=false, does not throw', async () => {
-      getSettings = () => makeSettings({ anthropicApiKey: 'sk-ant-test' })
-      const adapter = new ClaudeCliAdapter(getSettings, bridge, () => {
+      getApiKey = () => 'sk-ant-test'
+      const adapter = new ClaudeCliAdapter(getApiKey, bridge, () => {
         throw new Error('MODULE_NOT_FOUND')
       })
       await expect(adapter.startup()).resolves.toBeUndefined()
@@ -83,10 +76,9 @@ describe('REQ-CCS-002, REQ-CCS-003, REQ-CCS-016, REQ-CCS-017: ClaudeCliAdapter',
       expect(warnLogs.some((e) => e.message.includes('binary not found'))).toBe(true)
     })
 
-    // (c) startup() success: _available=true
     it('with key and valid resolver: _available=true after startup', async () => {
-      getSettings = () => makeSettings({ anthropicApiKey: 'sk-ant-test' })
-      const adapter = new ClaudeCliAdapter(getSettings, bridge, () => '/fake/claude')
+      getApiKey = () => 'sk-ant-test'
+      const adapter = new ClaudeCliAdapter(getApiKey, bridge, () => '/fake/claude')
       await adapter.startup()
       expect(await adapter.isAvailable()).toBe(true)
     })
@@ -94,9 +86,9 @@ describe('REQ-CCS-002, REQ-CCS-003, REQ-CCS-016, REQ-CCS-017: ClaudeCliAdapter',
     // TEST-CCS-002: env key set before SDK usage
     it('sets process.env.ANTHROPIC_API_KEY before binary resolution — TEST-CCS-002', async () => {
       const apiKey = 'sk-ant-env-test'
-      getSettings = () => makeSettings({ anthropicApiKey: apiKey })
+      getApiKey = () => apiKey
       let capturedEnv: string | undefined
-      const adapter = new ClaudeCliAdapter(getSettings, bridge, () => {
+      const adapter = new ClaudeCliAdapter(getApiKey, bridge, () => {
         capturedEnv = process.env.ANTHROPIC_API_KEY
         return '/fake/claude'
       })
@@ -105,27 +97,25 @@ describe('REQ-CCS-002, REQ-CCS-003, REQ-CCS-016, REQ-CCS-017: ClaudeCliAdapter',
     })
   })
 
-  // (d) isAvailable() returns this._available
   describe('isAvailable()', () => {
     it('returns false before startup', async () => {
-      getSettings = () => makeSettings({ anthropicApiKey: 'sk-ant-test' })
-      const adapter = new ClaudeCliAdapter(getSettings, bridge, () => '/fake/claude')
+      getApiKey = () => 'sk-ant-test'
+      const adapter = new ClaudeCliAdapter(getApiKey, bridge, () => '/fake/claude')
       expect(await adapter.isAvailable()).toBe(false)
     })
 
     it('returns true after successful startup', async () => {
-      getSettings = () => makeSettings({ anthropicApiKey: 'sk-ant-test' })
-      const adapter = new ClaudeCliAdapter(getSettings, bridge, () => '/fake/claude')
+      getApiKey = () => 'sk-ant-test'
+      const adapter = new ClaudeCliAdapter(getApiKey, bridge, () => '/fake/claude')
       await adapter.startup()
       expect(await adapter.isAvailable()).toBe(true)
     })
   })
 
-  // (e) query() when unavailable + empty key returns err(API_KEY_MISSING)
   describe('query() when not available', () => {
     it('with empty key returns err(API_KEY_MISSING)', async () => {
-      getSettings = () => makeSettings({ anthropicApiKey: '' })
-      const adapter = new ClaudeCliAdapter(getSettings, bridge)
+      getApiKey = () => ''
+      const adapter = new ClaudeCliAdapter(getApiKey, bridge)
       const result = await adapter.query('test prompt')
       expect(result.ok).toBe(false)
       if (result.ok) return
@@ -133,10 +123,9 @@ describe('REQ-CCS-002, REQ-CCS-003, REQ-CCS-016, REQ-CCS-017: ClaudeCliAdapter',
       expect(result.error.errorCode).toBe('API_KEY_MISSING')
     })
 
-    // (f) query() when unavailable + non-empty key returns err(NOT_INSTALLED)
     it('with non-empty key but not started returns err(NOT_INSTALLED)', async () => {
-      getSettings = () => makeSettings({ anthropicApiKey: 'sk-ant-test' })
-      const adapter = new ClaudeCliAdapter(getSettings, bridge)
+      getApiKey = () => 'sk-ant-test'
+      const adapter = new ClaudeCliAdapter(getApiKey, bridge)
       const result = await adapter.query('test prompt')
       expect(result.ok).toBe(false)
       if (result.ok) return
@@ -145,11 +134,10 @@ describe('REQ-CCS-002, REQ-CCS-003, REQ-CCS-016, REQ-CCS-017: ClaudeCliAdapter',
     })
   })
 
-  // (g) query() success path
   describe('query() success path', () => {
     it('returns ok(responseText) from SDK result message', async () => {
-      getSettings = () => makeSettings({ anthropicApiKey: 'sk-ant-test' })
-      const adapter = new ClaudeCliAdapter(getSettings, bridge, () => '/fake/claude')
+      getApiKey = () => 'sk-ant-test'
+      const adapter = new ClaudeCliAdapter(getApiKey, bridge, () => '/fake/claude')
       await adapter.startup()
 
       const sdkModule = await import('@anthropic-ai/claude-agent-sdk')
@@ -164,12 +152,11 @@ describe('REQ-CCS-002, REQ-CCS-003, REQ-CCS-016, REQ-CCS-017: ClaudeCliAdapter',
     })
   })
 
-  // (g) query() timeout race — TEST-CCS-016
   describe('query() timeout', () => {
     it('returns err(TIMEOUT) when query exceeds timeoutMs', async () => {
       vi.useFakeTimers()
-      getSettings = () => makeSettings({ anthropicApiKey: 'sk-ant-test' })
-      const adapter = new ClaudeCliAdapter(getSettings, bridge, () => '/fake/claude')
+      getApiKey = () => 'sk-ant-test'
+      const adapter = new ClaudeCliAdapter(getApiKey, bridge, () => '/fake/claude')
       await adapter.startup()
 
       const sdkModule = await import('@anthropic-ai/claude-agent-sdk')
@@ -187,11 +174,10 @@ describe('REQ-CCS-002, REQ-CCS-003, REQ-CCS-016, REQ-CCS-017: ClaudeCliAdapter',
     })
   })
 
-  // (h) query() SDK error mapped to QUERY_FAILED
   describe('query() SDK error mapping', () => {
     it('maps generic SDK error to QUERY_FAILED', async () => {
-      getSettings = () => makeSettings({ anthropicApiKey: 'sk-ant-test' })
-      const adapter = new ClaudeCliAdapter(getSettings, bridge, () => '/fake/claude')
+      getApiKey = () => 'sk-ant-test'
+      const adapter = new ClaudeCliAdapter(getApiKey, bridge, () => '/fake/claude')
       await adapter.startup()
 
       const sdkModule = await import('@anthropic-ai/claude-agent-sdk')
@@ -206,8 +192,8 @@ describe('REQ-CCS-002, REQ-CCS-003, REQ-CCS-016, REQ-CCS-017: ClaudeCliAdapter',
     })
 
     it('maps authentication error to API_KEY_MISSING', async () => {
-      getSettings = () => makeSettings({ anthropicApiKey: 'sk-ant-test' })
-      const adapter = new ClaudeCliAdapter(getSettings, bridge, () => '/fake/claude')
+      getApiKey = () => 'sk-ant-test'
+      const adapter = new ClaudeCliAdapter(getApiKey, bridge, () => '/fake/claude')
       await adapter.startup()
 
       const sdkModule = await import('@anthropic-ai/claude-agent-sdk')
@@ -224,11 +210,10 @@ describe('REQ-CCS-002, REQ-CCS-003, REQ-CCS-016, REQ-CCS-017: ClaudeCliAdapter',
     })
   })
 
-  // (i) shutdown() — TEST-CCS-017
   describe('shutdown()', () => {
     it('sets _available=false after shutdown', async () => {
-      getSettings = () => makeSettings({ anthropicApiKey: 'sk-ant-test' })
-      const adapter = new ClaudeCliAdapter(getSettings, bridge, () => '/fake/claude')
+      getApiKey = () => 'sk-ant-test'
+      const adapter = new ClaudeCliAdapter(getApiKey, bridge, () => '/fake/claude')
       await adapter.startup()
       expect(await adapter.isAvailable()).toBe(true)
       adapter.shutdown()
@@ -236,13 +221,13 @@ describe('REQ-CCS-002, REQ-CCS-003, REQ-CCS-016, REQ-CCS-017: ClaudeCliAdapter',
     })
 
     it('does not throw when called before startup', () => {
-      const adapter = new ClaudeCliAdapter(getSettings, bridge)
+      const adapter = new ClaudeCliAdapter(getApiKey, bridge)
       expect(() => { adapter.shutdown() }).not.toThrow()
     })
 
     it('logs at debug level when adapter was active', async () => {
-      getSettings = () => makeSettings({ anthropicApiKey: 'sk-ant-test' })
-      const adapter = new ClaudeCliAdapter(getSettings, bridge, () => '/fake/claude')
+      getApiKey = () => 'sk-ant-test'
+      const adapter = new ClaudeCliAdapter(getApiKey, bridge, () => '/fake/claude')
       await adapter.startup()
       bridge.logEntries.length = 0
       adapter.shutdown()

--- a/tests/plugin/AgentSidepanelView.test.ts
+++ b/tests/plugin/AgentSidepanelView.test.ts
@@ -70,6 +70,7 @@ interface Fixture {
 	readonly plugin: { settings: PluginSettings };
 	readonly options: AgentSidepanelViewOptions;
 	readonly cliResolvedRef: { value: boolean };
+	readonly apiKeyPresentRef: { value: boolean };
 	readonly confirmModalAdapter: ConfirmModalPort;
 }
 
@@ -77,11 +78,18 @@ function makeConfirmModalAdapter(): ConfirmModalPort {
 	return { show: vi.fn(async () => true) };
 }
 
-function makeFixture(initialSettings: Partial<PluginSettings>, cliResolved = false): Fixture {
+interface FixtureOptions {
+	readonly transportKind?: PluginSettings['transportKind'];
+	readonly apiKeyPresent?: boolean;
+	readonly cliResolved?: boolean;
+}
+
+function makeFixture(opts: FixtureOptions = {}): Fixture {
 	const sdkAdapter = makePort('sdk');
 	const subscriptionAdapter = makePort('subscription');
 	const degradedPort = degradedClaudeCliPort;
-	const cliResolvedRef = { value: cliResolved };
+	const cliResolvedRef = { value: opts.cliResolved ?? false };
+	const apiKeyPresentRef = { value: opts.apiKeyPresent ?? false };
 	const confirmModalAdapter = makeConfirmModalAdapter();
 
 	const selectTransportSpy = vi.fn((settings: PluginSettings): TransportSelection => {
@@ -90,11 +98,14 @@ function makeFixture(initialSettings: Partial<PluginSettings>, cliResolved = fal
 			subscriptionAdapter,
 			degradedPort,
 			cliResolved: cliResolvedRef.value,
+			apiKeyPresent: apiKeyPresentRef.value,
 		};
 		return selectTransport(settings, deps);
 	});
 
-	const plugin = { settings: makeSettings(initialSettings) };
+	const plugin = {
+		settings: makeSettings(opts.transportKind !== undefined ? { transportKind: opts.transportKind } : {}),
+	};
 
 	const options: AgentSidepanelViewOptions = {
 		subscriptionAdapter,
@@ -110,6 +121,7 @@ function makeFixture(initialSettings: Partial<PluginSettings>, cliResolved = fal
 		plugin,
 		options,
 		cliResolvedRef,
+		apiKeyPresentRef,
 		confirmModalAdapter,
 	};
 }
@@ -162,37 +174,33 @@ describe('AgentSidepanelView transport wiring', () => {
 	});
 
 	it('passes plugin.settings to the selector at construction time', () => {
-		const fixture = makeFixture({ transportKind: 'auto', anthropicApiKey: 'sk-live-abc' }, false);
+		const fixture = makeFixture({ transportKind: 'auto', apiKeyPresent: true, cliResolved: false });
 		makeView(fixture);
 		expect(fixture.selectTransportSpy).toHaveBeenCalledTimes(1);
 		const callArg = fixture.selectTransportSpy.mock.calls[0][0] as PluginSettings;
-		expect(callArg.anthropicApiKey).toBe('sk-live-abc');
 		expect(callArg.transportKind).toBe('auto');
 	});
 
 	it('transportKind="api-key" + key present → resolves to sdkAdapter', () => {
-		const fixture = makeFixture(
-			{ transportKind: 'api-key', anthropicApiKey: 'sk-test-key' },
-			false,
-		);
+		const fixture = makeFixture({ transportKind: 'api-key', apiKeyPresent: true, cliResolved: false });
 		const view = makeView(fixture);
 		expect(activePort(view)).toBe(fixture.sdkAdapter);
 	});
 
 	it('transportKind="subscription" + cliResolved=true → resolves to subscriptionAdapter', () => {
-		const fixture = makeFixture({ transportKind: 'subscription', anthropicApiKey: '' }, true);
+		const fixture = makeFixture({ transportKind: 'subscription', apiKeyPresent: false, cliResolved: true });
 		const view = makeView(fixture);
 		expect(activePort(view)).toBe(fixture.subscriptionAdapter);
 	});
 
 	it('fully degraded (auto + empty key + cliResolved=false) → resolves to degradedPort', () => {
-		const fixture = makeFixture({ transportKind: 'auto', anthropicApiKey: '' }, false);
+		const fixture = makeFixture({ transportKind: 'auto', apiKeyPresent: false, cliResolved: false });
 		const view = makeView(fixture);
 		expect(activePort(view)).toBe(fixture.degradedPort);
 	});
 
 	it('getActiveTransportKind() mirrors the selector verdict', () => {
-		const fixture = makeFixture({ transportKind: 'api-key', anthropicApiKey: 'sk' }, false);
+		const fixture = makeFixture({ transportKind: 'api-key', apiKeyPresent: true, cliResolved: false });
 		const view = makeView(fixture);
 		expect(view.getActiveTransportKind()).toBe('api-key');
 	});
@@ -204,7 +212,7 @@ describe('AgentSidepanelView.bumpSettingsVersion()', () => {
 	});
 
 	it('re-runs the selector when called', () => {
-		const fixture = makeFixture({ transportKind: 'api-key', anthropicApiKey: 'sk' }, false);
+		const fixture = makeFixture({ transportKind: 'api-key', apiKeyPresent: true, cliResolved: false });
 		const view = makeView(fixture);
 		expect(fixture.selectTransportSpy).toHaveBeenCalledTimes(1);
 		view.bumpSettingsVersion();
@@ -214,7 +222,7 @@ describe('AgentSidepanelView.bumpSettingsVersion()', () => {
 	});
 
 	it('reflects a transport change made between two bumpSettingsVersion calls', () => {
-		const fixture = makeFixture({ transportKind: 'subscription', anthropicApiKey: '' }, false);
+		const fixture = makeFixture({ transportKind: 'subscription', apiKeyPresent: false, cliResolved: false });
 		const view = makeView(fixture);
 		// At construction cliResolved=false → degraded
 		expect(activePort(view)).toBe(fixture.degradedPort);

--- a/tests/plugin/SpecoratorView.test.ts
+++ b/tests/plugin/SpecoratorView.test.ts
@@ -83,6 +83,7 @@ interface Fixture {
   readonly plugin: { settings: PluginSettings }
   readonly options: SpecoratorViewOptions
   readonly cliResolvedRef: { value: boolean }
+  readonly apiKeyPresentRef: { value: boolean }
   readonly confirmModalAdapter: ConfirmModalPort
 }
 
@@ -104,11 +105,18 @@ function makeSettings(overrides: Partial<PluginSettings>): PluginSettings {
  * fly so the `bumpSettingsVersion` re-run test can change the world between
  * calls without rebuilding everything.
  */
-function makeFixture(initialSettings: Partial<PluginSettings>, cliResolved = false): Fixture {
+interface FixtureOptions {
+  readonly transportKind?: PluginSettings['transportKind']
+  readonly apiKeyPresent?: boolean
+  readonly cliResolved?: boolean
+}
+
+function makeFixture(opts: FixtureOptions = {}): Fixture {
   const sdkAdapter = makePort('sdk')
   const subscriptionAdapter = makePort('subscription')
   const degradedPort = degradedClaudeCliPort
-  const cliResolvedRef = { value: cliResolved }
+  const cliResolvedRef = { value: opts.cliResolved ?? false }
+  const apiKeyPresentRef = { value: opts.apiKeyPresent ?? false }
   const confirmModalAdapter = makeConfirmModalAdapter()
 
   const selectTransportSpy = vi.fn(
@@ -118,12 +126,15 @@ function makeFixture(initialSettings: Partial<PluginSettings>, cliResolved = fal
         subscriptionAdapter,
         degradedPort,
         cliResolved: cliResolvedRef.value,
+        apiKeyPresent: apiKeyPresentRef.value,
       }
       return selectTransport(settings, deps)
     },
   )
 
-  const plugin = { settings: makeSettings(initialSettings) }
+  const plugin = {
+    settings: makeSettings(opts.transportKind !== undefined ? { transportKind: opts.transportKind } : {}),
+  }
 
   const options: SpecoratorViewOptions = {
     subscriptionAdapter,
@@ -139,6 +150,7 @@ function makeFixture(initialSettings: Partial<PluginSettings>, cliResolved = fal
     plugin,
     options,
     cliResolvedRef,
+    apiKeyPresentRef,
     confirmModalAdapter,
   }
 }
@@ -183,28 +195,22 @@ describe('SpecoratorView wiring — selectTransport receives the correct deps (T
     setActivePinia(createPinia())
   })
 
-  it('passes the api-key + cliResolved snapshot to the selector at construction time', () => {
-    const fixture = makeFixture(
-      { transportKind: 'auto', anthropicApiKey: 'sk-live-abc' },
-      /* cliResolved */ false,
-    )
+  it('passes the transport-kind setting + cliResolved + apiKeyPresent snapshot to the selector at construction time', () => {
+    const fixture = makeFixture({ transportKind: 'auto', apiKeyPresent: true, cliResolved: false })
 
     makeView(fixture)
 
     expect(fixture.selectTransportSpy).toHaveBeenCalledTimes(1)
-    // The view passes `plugin.settings` directly; the selector closure injects
-    // the four port deps. We assert via the verdict (covered below) plus the
-    // settings argument shape here.
+    // The view passes `plugin.settings` directly (the API key now lives in
+    // `SecretStorePort`, not on `PluginSettings`); the selector closure
+    // injects the four port deps plus `apiKeyPresent` derived from the
+    // plugin's `_apiKeyCache`. Verify the settings arg carries `transportKind`.
     const callArg = fixture.selectTransportSpy.mock.calls[0][0] as PluginSettings
-    expect(callArg.anthropicApiKey).toBe('sk-live-abc')
     expect(callArg.transportKind).toBe('auto')
   })
 
   it('R2 wiring — transportKind="api-key" + key present → getActiveClaudeCliPort returns sdkAdapter', () => {
-    const fixture = makeFixture(
-      { transportKind: 'api-key', anthropicApiKey: 'sk-test-key' },
-      /* cliResolved */ false,
-    )
+    const fixture = makeFixture({ transportKind: 'api-key', apiKeyPresent: true, cliResolved: false })
 
     const view = makeView(fixture)
 
@@ -212,10 +218,7 @@ describe('SpecoratorView wiring — selectTransport receives the correct deps (T
   })
 
   it('R4 wiring — transportKind="subscription" + cliResolved=true → returns subscriptionAdapter', () => {
-    const fixture = makeFixture(
-      { transportKind: 'subscription', anthropicApiKey: '' },
-      /* cliResolved */ true,
-    )
+    const fixture = makeFixture({ transportKind: 'subscription', apiKeyPresent: false, cliResolved: true })
 
     const view = makeView(fixture)
 
@@ -223,10 +226,7 @@ describe('SpecoratorView wiring — selectTransport receives the correct deps (T
   })
 
   it('R7 wiring — transportKind="auto" + empty key + cliResolved=true → returns subscriptionAdapter', () => {
-    const fixture = makeFixture(
-      { transportKind: 'auto', anthropicApiKey: '' },
-      /* cliResolved */ true,
-    )
+    const fixture = makeFixture({ transportKind: 'auto', apiKeyPresent: false, cliResolved: true })
 
     const view = makeView(fixture)
 
@@ -234,10 +234,7 @@ describe('SpecoratorView wiring — selectTransport receives the correct deps (T
   })
 
   it('R8 wiring — fully degraded conditions (auto + empty key + cliResolved=false) → returns degradedPort', () => {
-    const fixture = makeFixture(
-      { transportKind: 'auto', anthropicApiKey: '' },
-      /* cliResolved */ false,
-    )
+    const fixture = makeFixture({ transportKind: 'auto', apiKeyPresent: false, cliResolved: false })
 
     const view = makeView(fixture)
 
@@ -245,10 +242,7 @@ describe('SpecoratorView wiring — selectTransport receives the correct deps (T
   })
 
   it('R6 wiring — transportKind="auto" + key present + cliResolved=true → api-key beats subscription (sdkAdapter)', () => {
-    const fixture = makeFixture(
-      { transportKind: 'auto', anthropicApiKey: 'sk-prefers-api' },
-      /* cliResolved */ true,
-    )
+    const fixture = makeFixture({ transportKind: 'auto', apiKeyPresent: true, cliResolved: true })
 
     const view = makeView(fixture)
 
@@ -262,10 +256,7 @@ describe('SpecoratorView.bumpSettingsVersion() re-runs the selector (REQ-ASM-002
   })
 
   it('re-invokes selectTransport when settings change between bumps', () => {
-    const fixture = makeFixture(
-      { transportKind: 'auto', anthropicApiKey: '' },
-      /* cliResolved */ false,
-    )
+    const fixture = makeFixture({ transportKind: 'auto', apiKeyPresent: false, cliResolved: false })
 
     const view = makeView(fixture)
     // Initial: degraded (auto + no key + no cli).
@@ -273,23 +264,19 @@ describe('SpecoratorView.bumpSettingsVersion() re-runs the selector (REQ-ASM-002
     expect(fixture.selectTransportSpy).toHaveBeenCalledTimes(1)
 
     // Mutate the underlying settings object (this is how main.ts persists —
-    // see `updateSettings()` which assigns to `this.settings`).
-    fixture.plugin.settings = makeSettings({
-      transportKind: 'auto',
-      anthropicApiKey: 'sk-just-saved',
-    })
+    // see `updateSettings()` which assigns to `this.settings`). The API key
+    // now lives in `SecretStorePort`, so flip `apiKeyPresentRef` instead of
+    // mutating `plugin.settings.anthropicApiKey`.
+    fixture.apiKeyPresentRef.value = true
     view.bumpSettingsVersion()
 
     expect(fixture.selectTransportSpy).toHaveBeenCalledTimes(2)
-    // New verdict reflects the updated settings.
+    // New verdict reflects the updated key cache.
     expect(activePort(view)).toBe(fixture.sdkAdapter)
   })
 
   it('reflects an `isAvailableSync()` flip (cliResolved toggled true) on the next bump', () => {
-    const fixture = makeFixture(
-      { transportKind: 'subscription', anthropicApiKey: '' },
-      /* cliResolved */ false,
-    )
+    const fixture = makeFixture({ transportKind: 'subscription', apiKeyPresent: false, cliResolved: false })
 
     const view = makeView(fixture)
     // Subscription forced but CLI not resolved → degraded (R5).
@@ -303,17 +290,12 @@ describe('SpecoratorView.bumpSettingsVersion() re-runs the selector (REQ-ASM-002
   })
 
   it('also re-runs startup() on the api-key (SDK) adapter so first-time key setup activates in-session (Codex P1, PR #350)', () => {
-    const fixture = makeFixture(
-      { transportKind: 'api-key', anthropicApiKey: '' },
-      /* cliResolved */ false,
-    )
+    const fixture = makeFixture({ transportKind: 'api-key', apiKeyPresent: false, cliResolved: false })
     const view = makeView(fixture)
 
-    // Save the API key in-session, then bump.
-    fixture.plugin.settings = makeSettings({
-      transportKind: 'api-key',
-      anthropicApiKey: 'sk-just-saved',
-    })
+    // Save the API key in-session, then bump. Reflects `refreshApiKeyCache()`
+    // having repopulated `_apiKeyCache` from the keychain.
+    fixture.apiKeyPresentRef.value = true
     view.bumpSettingsVersion()
 
     // Before the fix, only the subscription adapter's startup() ran. Both
@@ -333,10 +315,7 @@ describe('SpecoratorView.bumpSettingsVersion() mid-turn guard (REQ-ASM-003)', ()
   })
 
   it('does NOT swap the active port while chatStore.status === "loading"', () => {
-    const fixture = makeFixture(
-      { transportKind: 'auto', anthropicApiKey: '' },
-      /* cliResolved */ false,
-    )
+    const fixture = makeFixture({ transportKind: 'auto', apiKeyPresent: false, cliResolved: false })
 
     const view = makeView(fixture)
     // Inject the same pinia the test owns so `_isChatLoading()` reads our store.
@@ -350,10 +329,7 @@ describe('SpecoratorView.bumpSettingsVersion() mid-turn guard (REQ-ASM-003)', ()
     expect(store.status).toBe('loading')
 
     // Settings change that WOULD swap to sdkAdapter under normal conditions.
-    fixture.plugin.settings = makeSettings({
-      transportKind: 'auto',
-      anthropicApiKey: 'sk-in-flight',
-    })
+    fixture.apiKeyPresentRef.value = true
 
     const callsBefore = fixture.selectTransportSpy.mock.calls.length
     view.bumpSettingsVersion()
@@ -366,10 +342,7 @@ describe('SpecoratorView.bumpSettingsVersion() mid-turn guard (REQ-ASM-003)', ()
   })
 
   it('auto-applies the deferred refresh when the turn ends (no manual second bump required) — Codex P1, PR #350', async () => {
-    const fixture = makeFixture(
-      { transportKind: 'auto', anthropicApiKey: '' },
-      /* cliResolved */ false,
-    )
+    const fixture = makeFixture({ transportKind: 'auto', apiKeyPresent: false, cliResolved: false })
 
     const view = makeView(fixture)
     view.pinia = pinia
@@ -379,10 +352,7 @@ describe('SpecoratorView.bumpSettingsVersion() mid-turn guard (REQ-ASM-003)', ()
     const store = useChatStore(pinia)
     // Mid-turn settings change.
     store.beginRequest()
-    fixture.plugin.settings = makeSettings({
-      transportKind: 'auto',
-      anthropicApiKey: 'sk-mid-turn',
-    })
+    fixture.apiKeyPresentRef.value = true
     view.bumpSettingsVersion()
     expect(activePort(view)).toBe(fixture.degradedPort)
 
@@ -397,10 +367,7 @@ describe('SpecoratorView.bumpSettingsVersion() mid-turn guard (REQ-ASM-003)', ()
   })
 
   it('picks up the deferred change on the NEXT bump after the turn settles', () => {
-    const fixture = makeFixture(
-      { transportKind: 'auto', anthropicApiKey: '' },
-      /* cliResolved */ false,
-    )
+    const fixture = makeFixture({ transportKind: 'auto', apiKeyPresent: false, cliResolved: false })
 
     const view = makeView(fixture)
     view.pinia = pinia
@@ -408,10 +375,7 @@ describe('SpecoratorView.bumpSettingsVersion() mid-turn guard (REQ-ASM-003)', ()
 
     // Mid-turn: bump is a no-op for the selector.
     store.beginRequest()
-    fixture.plugin.settings = makeSettings({
-      transportKind: 'auto',
-      anthropicApiKey: 'sk-queued',
-    })
+    fixture.apiKeyPresentRef.value = true
     view.bumpSettingsVersion()
     expect(activePort(view)).toBe(fixture.degradedPort)
 
@@ -424,10 +388,7 @@ describe('SpecoratorView.bumpSettingsVersion() mid-turn guard (REQ-ASM-003)', ()
   })
 
   it('clears `pinia` on close so plugin workspace handlers stop mutating the unmounted store — Codex P2, PR #350', async () => {
-    const fixture = makeFixture(
-      { transportKind: 'auto', anthropicApiKey: '' },
-      /* cliResolved */ false,
-    )
+    const fixture = makeFixture({ transportKind: 'auto', apiKeyPresent: false, cliResolved: false })
 
     const view = makeView(fixture)
     view.pinia = pinia
@@ -460,10 +421,7 @@ describe('SpecoratorView accepts ConfirmModalPort via options bag (T-ASM-075, RE
   })
 
   it('stores the confirmModalAdapter passed through SpecoratorViewOptions', () => {
-    const fixture = makeFixture(
-      { transportKind: 'auto', anthropicApiKey: '' },
-      /* cliResolved */ false,
-    )
+    const fixture = makeFixture({ transportKind: 'auto', apiKeyPresent: false, cliResolved: false })
 
     const view = makeView(fixture)
 
@@ -478,14 +436,12 @@ describe('SpecoratorView accepts ConfirmModalPort via options bag (T-ASM-075, RE
   })
 
   it('accepts construction without a confirmModalAdapter (optional field)', () => {
-    const fixture = makeFixture(
-      { transportKind: 'auto', anthropicApiKey: '' },
-      /* cliResolved */ false,
-    )
+    const fixture = makeFixture({ transportKind: 'auto', apiKeyPresent: false, cliResolved: false })
     const sdkAdapter = fixture.sdkAdapter
     const subscriptionAdapter = fixture.subscriptionAdapter
     const degradedPort = fixture.degradedPort
     const cliResolvedRef = fixture.cliResolvedRef
+    const apiKeyPresentRef = fixture.apiKeyPresentRef
     const optionsNoModal: SpecoratorViewOptions = {
       subscriptionAdapter,
       selectTransport: (settings: PluginSettings): TransportSelection =>
@@ -494,6 +450,7 @@ describe('SpecoratorView accepts ConfirmModalPort via options bag (T-ASM-075, RE
           subscriptionAdapter,
           degradedPort,
           cliResolved: cliResolvedRef.value,
+          apiKeyPresent: apiKeyPresentRef.value,
         }),
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -516,10 +473,7 @@ describe('SpecoratorView.getActiveTransportKind() mirrors selectTransport().kind
   })
 
   it('reflects "api-key" when settings resolve to the SDK adapter', () => {
-    const fixture = makeFixture(
-      { transportKind: 'api-key', anthropicApiKey: 'sk-test' },
-      /* cliResolved */ false,
-    )
+    const fixture = makeFixture({ transportKind: 'api-key', apiKeyPresent: true, cliResolved: false })
 
     const view = makeView(fixture)
 
@@ -527,10 +481,7 @@ describe('SpecoratorView.getActiveTransportKind() mirrors selectTransport().kind
   })
 
   it('reflects "subscription" when settings resolve to the subscription adapter', () => {
-    const fixture = makeFixture(
-      { transportKind: 'subscription', anthropicApiKey: '' },
-      /* cliResolved */ true,
-    )
+    const fixture = makeFixture({ transportKind: 'subscription', apiKeyPresent: false, cliResolved: true })
 
     const view = makeView(fixture)
 
@@ -538,10 +489,7 @@ describe('SpecoratorView.getActiveTransportKind() mirrors selectTransport().kind
   })
 
   it('reflects "degraded" when no transport is available', () => {
-    const fixture = makeFixture(
-      { transportKind: 'auto', anthropicApiKey: '' },
-      /* cliResolved */ false,
-    )
+    const fixture = makeFixture({ transportKind: 'auto', apiKeyPresent: false, cliResolved: false })
 
     const view = makeView(fixture)
 
@@ -549,29 +497,21 @@ describe('SpecoratorView.getActiveTransportKind() mirrors selectTransport().kind
   })
 
   it('updates reactively on bumpSettingsVersion() when settings change', () => {
-    const fixture = makeFixture(
-      { transportKind: 'auto', anthropicApiKey: '' },
-      /* cliResolved */ false,
-    )
+    const fixture = makeFixture({ transportKind: 'auto', apiKeyPresent: false, cliResolved: false })
 
     const view = makeView(fixture)
     expect(view.getActiveTransportKind()).toBe('degraded')
 
-    // Settings change to api-key with a key present.
-    fixture.plugin.settings = makeSettings({
-      transportKind: 'auto',
-      anthropicApiKey: 'sk-newly-set',
-    })
+    // A new API key was persisted to the OS keychain; `_apiKeyCache` was
+    // refreshed and `apiKeyPresent` now reads `true`.
+    fixture.apiKeyPresentRef.value = true
     view.bumpSettingsVersion()
 
     expect(view.getActiveTransportKind()).toBe('api-key')
   })
 
   it('preserves the kind across bumps while a chat turn is in flight (REQ-ASM-003)', () => {
-    const fixture = makeFixture(
-      { transportKind: 'auto', anthropicApiKey: '' },
-      /* cliResolved */ false,
-    )
+    const fixture = makeFixture({ transportKind: 'auto', apiKeyPresent: false, cliResolved: false })
 
     const pinia = createPinia()
     setActivePinia(pinia)
@@ -585,10 +525,7 @@ describe('SpecoratorView.getActiveTransportKind() mirrors selectTransport().kind
     expect(store.status).toBe('loading')
 
     // Settings change that WOULD switch the kind under normal conditions.
-    fixture.plugin.settings = makeSettings({
-      transportKind: 'auto',
-      anthropicApiKey: 'sk-mid-turn',
-    })
+    fixture.apiKeyPresentRef.value = true
     view.bumpSettingsVersion()
 
     // Kind unchanged — selector not re-run mid-turn (REQ-ASM-003).

--- a/tests/plugin/chatThreadsPersistence.test.ts
+++ b/tests/plugin/chatThreadsPersistence.test.ts
@@ -353,7 +353,6 @@ describe('settings + chatThreads coexistence (T-ASM-053 / SPEC §9.3)', () => {
       specorator: {
         locale: 'en',
         specsFolder: 'specs',
-        anthropicApiKey: 'sk-test',
         claudeCliPath: '/usr/local/bin/claude',
         transportKind: 'auto',
       },
@@ -377,7 +376,6 @@ describe('settings + chatThreads coexistence (T-ASM-053 / SPEC §9.3)', () => {
     // PluginSettings keys preserved.
     expect((nextStored.specorator as Record<string, unknown>).locale).toBe('en')
     expect((nextStored.specorator as Record<string, unknown>).specsFolder).toBe('specs')
-    expect((nextStored.specorator as Record<string, unknown>).anthropicApiKey).toBe('sk-test')
     expect((nextStored.specorator as Record<string, unknown>).claudeCliPath).toBe('/usr/local/bin/claude')
     // chatThreads attached as sibling key under specorator.
     expect((nextStored.specorator as Record<string, unknown>).chatThreads).toEqual({

--- a/tests/plugin/loadSettings-migrate.test.ts
+++ b/tests/plugin/loadSettings-migrate.test.ts
@@ -108,7 +108,6 @@ describe('promoteLegacyFlatSettings', () => {
       'mcpServerEnabled',
       'userPersona',
       'onboardingComplete',
-      'anthropicApiKey',
       'claudeCliPath',
       'transportKind',
     ])

--- a/tests/plugin/main.chat-threads-flush.test.ts
+++ b/tests/plugin/main.chat-threads-flush.test.ts
@@ -159,7 +159,7 @@ describe('scheduleChatThreadsPersistence — debounced flush (T-ASM-054)', () =>
 
   it('writes a single blob after the 1 s debounce window expires', async () => {
     const { plugin, state } = makePlugin({
-      specorator: { locale: 'en', specsFolder: 'specs', anthropicApiKey: '' },
+      specorator: { locale: 'en', specsFolder: 'specs' },
     })
     const map = new Map<string, ChatThreadRecord>([['t1', makeRecord({ threadId: 't1' })]])
 
@@ -203,7 +203,6 @@ describe('scheduleChatThreadsPersistence — debounced flush (T-ASM-054)', () =>
       specorator: {
         locale: 'en',
         specsFolder: 'specs',
-        anthropicApiKey: 'sk-test',
         claudeCliPath: '/usr/local/bin/claude',
         transportKind: 'auto',
       },
@@ -216,7 +215,6 @@ describe('scheduleChatThreadsPersistence — debounced flush (T-ASM-054)', () =>
     const specorator = state.blob?.specorator as Record<string, unknown>
     expect(specorator.locale).toBe('en')
     expect(specorator.specsFolder).toBe('specs')
-    expect(specorator.anthropicApiKey).toBe('sk-test')
     expect(specorator.claudeCliPath).toBe('/usr/local/bin/claude')
     expect(specorator.transportKind).toBe('auto')
     // Sibling top-level keys outside `specorator` survive too.
@@ -427,7 +425,6 @@ describe('updateSettings preserves sibling keys under specorator (Codex P1, PR #
       specorator: {
         locale: 'en',
         specsFolder: 'specs',
-        anthropicApiKey: '',
         claudeCliPath: '',
         transportKind: 'auto',
         chatThreads: {
@@ -471,7 +468,6 @@ describe('updateSettings preserves sibling keys under specorator (Codex P1, PR #
       specorator: {
         locale: 'en',
         specsFolder: 'specs',
-        anthropicApiKey: 'old-key',
         claudeCliPath: '',
         transportKind: 'auto',
       },
@@ -483,12 +479,11 @@ describe('updateSettings preserves sibling keys under specorator (Codex P1, PR #
       ...(initialData.specorator as Record<string, unknown>),
     } as unknown as typeof plugin.settings
 
-    await plugin.updateSettings({ anthropicApiKey: 'new-key' })
+    await plugin.updateSettings({ specsFolder: 'notes' })
 
     const saved = state.blob as { specorator?: Record<string, unknown> }
-    expect(saved.specorator?.anthropicApiKey).toBe('new-key')
+    expect(saved.specorator?.specsFolder).toBe('notes')
     // Other settings keys preserved.
     expect(saved.specorator?.locale).toBe('en')
-    expect(saved.specorator?.specsFolder).toBe('specs')
   })
 })

--- a/tests/plugin/settings.test.ts
+++ b/tests/plugin/settings.test.ts
@@ -11,13 +11,9 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
 
-describe('REQ-CCS-001, NFR-CCS-005: PluginSettings anthropicApiKey field', () => {
-  it('DEFAULT_SETTINGS has anthropicApiKey as empty string', () => {
-    expect(DEFAULT_SETTINGS.anthropicApiKey).toBe('')
-  })
-
-  it('DEFAULT_SETTINGS.anthropicApiKey is a string type', () => {
-    expect(typeof DEFAULT_SETTINGS.anthropicApiKey).toBe('string')
+describe('REQ-CCS-001, NFR-CCS-005: Anthropic API key storage', () => {
+  it('PluginSettings does not declare anthropicApiKey (key now lives in SecretStorePort)', () => {
+    expect((DEFAULT_SETTINGS as unknown as Record<string, unknown>).anthropicApiKey).toBeUndefined()
   })
 })
 
@@ -29,7 +25,7 @@ describe('NFR-CCS-006: Settings tab API key field security contract', () => {
     expect(trimmed).toBe('sk-ant-test')
   })
 
-  it('empty string after trim disables adapter (anthropicApiKey = "")', () => {
+  it('empty string after trim disables adapter', () => {
     const rawValue = '   '
     const trimmed = rawValue.trim()
     expect(trimmed).toBe('')

--- a/tests/plugin/transport/TransportSelector.test.ts
+++ b/tests/plugin/transport/TransportSelector.test.ts
@@ -6,23 +6,21 @@
  *
  * SPEC-ASM-001 §3.1 defines the deterministic decision table (first match wins):
  *
- *   | Row | transportKind   | apiKey.trim() !== '' | cliResolved | Result                                             |
- *   |-----|-----------------|----------------------|-------------|----------------------------------------------------|
- *   | R1  | 'degraded'      | *                    | *           | { port: degradedPort,        kind: 'degraded'    } |
- *   | R2  | 'api-key'       | true                 | *           | { port: sdkAdapter,          kind: 'api-key'     } |
- *   | R3  | 'api-key'       | false                | *           | { port: degradedPort,        kind: 'degraded'    } |
- *   | R4  | 'subscription'  | *                    | true        | { port: subscriptionAdapter, kind: 'subscription'} |
- *   | R5  | 'subscription'  | *                    | false       | { port: degradedPort,        kind: 'degraded'    } |
- *   | R6  | 'auto'          | true                 | *           | { port: sdkAdapter,          kind: 'api-key'     } |
- *   | R7  | 'auto'          | false                | true        | { port: subscriptionAdapter, kind: 'subscription'} |
- *   | R8  | 'auto'          | false                | false       | { port: degradedPort,        kind: 'degraded'    } |
+ *   | Row | transportKind   | apiKeyPresent | cliResolved | Result                                             |
+ *   |-----|-----------------|---------------|-------------|----------------------------------------------------|
+ *   | R1  | 'degraded'      | *             | *           | { port: degradedPort,        kind: 'degraded'    } |
+ *   | R2  | 'api-key'       | true          | *           | { port: sdkAdapter,          kind: 'api-key'     } |
+ *   | R3  | 'api-key'       | false         | *           | { port: degradedPort,        kind: 'degraded'    } |
+ *   | R4  | 'subscription'  | *             | true        | { port: subscriptionAdapter, kind: 'subscription'} |
+ *   | R5  | 'subscription'  | *             | false       | { port: degradedPort,        kind: 'degraded'    } |
+ *   | R6  | 'auto'          | true          | *           | { port: sdkAdapter,          kind: 'api-key'     } |
+ *   | R7  | 'auto'          | false         | true        | { port: subscriptionAdapter, kind: 'subscription'} |
+ *   | R8  | 'auto'          | false         | false       | { port: degradedPort,        kind: 'degraded'    } |
  *
- * Per spec §3.1, the selector is synchronous and performs no I/O — `cliResolved`
- * is consumed as a plain boolean (no method call on `deps.subscriptionAdapter`).
- *
- * These tests target the not-yet-implemented module
- * `src/plugin/transport/TransportSelector.ts` (T-ASM-005). They MUST fail until
- * that implementation lands.
+ * Per spec §3.1, the selector is synchronous and performs no I/O. Both
+ * `cliResolved` AND `apiKeyPresent` are consumed as plain booleans — the
+ * selector does not call `.isAvailable()` on `deps.subscriptionAdapter`,
+ * and does not reach into `SecretStorePort` (which is async).
  */
 import { describe, it, expect } from 'vitest'
 
@@ -32,8 +30,6 @@ import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
 import type { PluginSettings } from '@/domain/settings/PluginSettings'
 import type { TransportKind } from '@/domain/chat/TransportKind'
 
-// Module-under-test (will be created in T-ASM-005). Tests fail with
-// "Cannot find module '@/plugin/transport/TransportSelector'" until then.
 import {
   selectTransport,
   type TransportSelection,
@@ -44,14 +40,7 @@ import {
 // Fixtures
 // -----------------------------------------------------------------------------
 
-/**
- * The selector consumes `settings.transportKind` (SPEC-ASM-001 §3.1). The field
- * is being added to `PluginSettings` as part of the ASM work; until that lands
- * we cast through `Partial` here so the test file compiles ahead of T-ASM-005.
- */
-type AsmPluginSettings = PluginSettings & { readonly transportKind: TransportKind }
-
-function makeSettings(overrides: Partial<AsmPluginSettings>): AsmPluginSettings {
+function makeSettings(overrides: Partial<PluginSettings>): PluginSettings {
   return {
     ...DEFAULT_SETTINGS,
     transportKind: 'auto',
@@ -95,6 +84,7 @@ function makeDeps(overrides?: Partial<TransportSelectorDeps>): TransportSelector
     subscriptionAdapter,
     degradedPort: degradedClaudeCliPort,
     cliResolved: false,
+    apiKeyPresent: false,
     ...overrides,
   }
 }
@@ -105,8 +95,8 @@ function makeDeps(overrides?: Partial<TransportSelectorDeps>): TransportSelector
 
 describe('REQ-ASM-002 / REQ-ASM-003: selectTransport() — SPEC-ASM-001 §3.1 truth table', () => {
   it("R1 — transportKind='degraded' (api-key empty, cli unresolved) → degraded", () => {
-    const settings = makeSettings({ transportKind: 'degraded', anthropicApiKey: '' })
-    const deps = makeDeps({ cliResolved: false })
+    const settings = makeSettings({ transportKind: 'degraded' })
+    const deps = makeDeps({ cliResolved: false, apiKeyPresent: false })
 
     const selection: TransportSelection = selectTransport(settings, deps)
 
@@ -115,8 +105,8 @@ describe('REQ-ASM-002 / REQ-ASM-003: selectTransport() — SPEC-ASM-001 §3.1 tr
   })
 
   it("R1 — transportKind='degraded' wins regardless of api-key/cliResolved values", () => {
-    const settings = makeSettings({ transportKind: 'degraded', anthropicApiKey: 'sk-live' })
-    const deps = makeDeps({ cliResolved: true })
+    const settings = makeSettings({ transportKind: 'degraded' })
+    const deps = makeDeps({ cliResolved: true, apiKeyPresent: true })
 
     const selection = selectTransport(settings, deps)
 
@@ -125,8 +115,8 @@ describe('REQ-ASM-002 / REQ-ASM-003: selectTransport() — SPEC-ASM-001 §3.1 tr
   })
 
   it("R2 — transportKind='api-key' + api-key present → api-key (sdkAdapter)", () => {
-    const settings = makeSettings({ transportKind: 'api-key', anthropicApiKey: 'sk-abc123' })
-    const deps = makeDeps({ cliResolved: false })
+    const settings = makeSettings({ transportKind: 'api-key' })
+    const deps = makeDeps({ cliResolved: false, apiKeyPresent: true })
 
     const selection = selectTransport(settings, deps)
 
@@ -136,8 +126,8 @@ describe('REQ-ASM-002 / REQ-ASM-003: selectTransport() — SPEC-ASM-001 §3.1 tr
   })
 
   it("R2 — transportKind='api-key' + api-key present is independent of cliResolved", () => {
-    const settings = makeSettings({ transportKind: 'api-key', anthropicApiKey: 'sk-abc123' })
-    const deps = makeDeps({ cliResolved: true })
+    const settings = makeSettings({ transportKind: 'api-key' })
+    const deps = makeDeps({ cliResolved: true, apiKeyPresent: true })
 
     const selection = selectTransport(settings, deps)
 
@@ -146,8 +136,8 @@ describe('REQ-ASM-002 / REQ-ASM-003: selectTransport() — SPEC-ASM-001 §3.1 tr
   })
 
   it("R3 — transportKind='api-key' + empty api-key → degraded", () => {
-    const settings = makeSettings({ transportKind: 'api-key', anthropicApiKey: '' })
-    const deps = makeDeps({ cliResolved: false })
+    const settings = makeSettings({ transportKind: 'api-key' })
+    const deps = makeDeps({ cliResolved: false, apiKeyPresent: false })
 
     const selection = selectTransport(settings, deps)
 
@@ -155,9 +145,9 @@ describe('REQ-ASM-002 / REQ-ASM-003: selectTransport() — SPEC-ASM-001 §3.1 tr
     expect(selection.port).toBe(deps.degradedPort)
   })
 
-  it("R3 — transportKind='api-key' + whitespace-only api-key → degraded (trim semantics, spec §3.1 col 3)", () => {
-    const settings = makeSettings({ transportKind: 'api-key', anthropicApiKey: '   \t\n  ' })
-    const deps = makeDeps({ cliResolved: true })
+  it("R3 — transportKind='api-key' + apiKeyPresent=false → degraded even with cliResolved=true", () => {
+    const settings = makeSettings({ transportKind: 'api-key' })
+    const deps = makeDeps({ cliResolved: true, apiKeyPresent: false })
 
     const selection = selectTransport(settings, deps)
 
@@ -166,8 +156,8 @@ describe('REQ-ASM-002 / REQ-ASM-003: selectTransport() — SPEC-ASM-001 §3.1 tr
   })
 
   it("R4 — transportKind='subscription' + cliResolved=true → subscription (subscriptionAdapter)", () => {
-    const settings = makeSettings({ transportKind: 'subscription', anthropicApiKey: '' })
-    const deps = makeDeps({ cliResolved: true })
+    const settings = makeSettings({ transportKind: 'subscription' })
+    const deps = makeDeps({ cliResolved: true, apiKeyPresent: false })
 
     const selection = selectTransport(settings, deps)
 
@@ -177,11 +167,8 @@ describe('REQ-ASM-002 / REQ-ASM-003: selectTransport() — SPEC-ASM-001 §3.1 tr
   })
 
   it("R4 — transportKind='subscription' + cliResolved=true is independent of api-key presence", () => {
-    const settings = makeSettings({
-      transportKind: 'subscription',
-      anthropicApiKey: 'sk-live-key',
-    })
-    const deps = makeDeps({ cliResolved: true })
+    const settings = makeSettings({ transportKind: 'subscription' })
+    const deps = makeDeps({ cliResolved: true, apiKeyPresent: true })
 
     const selection = selectTransport(settings, deps)
 
@@ -190,8 +177,8 @@ describe('REQ-ASM-002 / REQ-ASM-003: selectTransport() — SPEC-ASM-001 §3.1 tr
   })
 
   it("R5 — transportKind='subscription' + cliResolved=false → degraded", () => {
-    const settings = makeSettings({ transportKind: 'subscription', anthropicApiKey: '' })
-    const deps = makeDeps({ cliResolved: false })
+    const settings = makeSettings({ transportKind: 'subscription' })
+    const deps = makeDeps({ cliResolved: false, apiKeyPresent: false })
 
     const selection = selectTransport(settings, deps)
 
@@ -200,11 +187,8 @@ describe('REQ-ASM-002 / REQ-ASM-003: selectTransport() — SPEC-ASM-001 §3.1 tr
   })
 
   it("R5 — transportKind='subscription' + cliResolved=false ignores a present api-key", () => {
-    const settings = makeSettings({
-      transportKind: 'subscription',
-      anthropicApiKey: 'sk-live-key',
-    })
-    const deps = makeDeps({ cliResolved: false })
+    const settings = makeSettings({ transportKind: 'subscription' })
+    const deps = makeDeps({ cliResolved: false, apiKeyPresent: true })
 
     const selection = selectTransport(settings, deps)
 
@@ -213,8 +197,8 @@ describe('REQ-ASM-002 / REQ-ASM-003: selectTransport() — SPEC-ASM-001 §3.1 tr
   })
 
   it("R6 — transportKind='auto' + api-key present → api-key (sdkAdapter) — TEST-ASM-001", () => {
-    const settings = makeSettings({ transportKind: 'auto', anthropicApiKey: 'sk-...' })
-    const deps = makeDeps({ cliResolved: false })
+    const settings = makeSettings({ transportKind: 'auto' })
+    const deps = makeDeps({ cliResolved: false, apiKeyPresent: true })
 
     const selection = selectTransport(settings, deps)
 
@@ -224,8 +208,8 @@ describe('REQ-ASM-002 / REQ-ASM-003: selectTransport() — SPEC-ASM-001 §3.1 tr
   })
 
   it("R6 — transportKind='auto' + api-key present beats cliResolved=true (api-key precedes subscription in auto)", () => {
-    const settings = makeSettings({ transportKind: 'auto', anthropicApiKey: 'sk-...' })
-    const deps = makeDeps({ cliResolved: true })
+    const settings = makeSettings({ transportKind: 'auto' })
+    const deps = makeDeps({ cliResolved: true, apiKeyPresent: true })
 
     const selection = selectTransport(settings, deps)
 
@@ -234,8 +218,8 @@ describe('REQ-ASM-002 / REQ-ASM-003: selectTransport() — SPEC-ASM-001 §3.1 tr
   })
 
   it("R7 — transportKind='auto' + empty api-key + cliResolved=true → subscription — TEST-ASM-002", () => {
-    const settings = makeSettings({ transportKind: 'auto', anthropicApiKey: '' })
-    const deps = makeDeps({ cliResolved: true })
+    const settings = makeSettings({ transportKind: 'auto' })
+    const deps = makeDeps({ cliResolved: true, apiKeyPresent: false })
 
     const selection = selectTransport(settings, deps)
 
@@ -244,29 +228,9 @@ describe('REQ-ASM-002 / REQ-ASM-003: selectTransport() — SPEC-ASM-001 §3.1 tr
     )
   })
 
-  it("R7 — transportKind='auto' + whitespace-only api-key + cliResolved=true → subscription (trim semantics)", () => {
-    const settings = makeSettings({ transportKind: 'auto', anthropicApiKey: '  \n' })
-    const deps = makeDeps({ cliResolved: true })
-
-    const selection = selectTransport(settings, deps)
-
-    expect(selection.kind).toBe('subscription')
-    expect(selection.port).toBe(deps.subscriptionAdapter)
-  })
-
   it("R8 — transportKind='auto' + empty api-key + cliResolved=false → degraded — TEST-ASM-003", () => {
-    const settings = makeSettings({ transportKind: 'auto', anthropicApiKey: '' })
-    const deps = makeDeps({ cliResolved: false })
-
-    const selection = selectTransport(settings, deps)
-
-    expect(selection.kind).toBe('degraded')
-    expect(selection.port).toBe(deps.degradedPort)
-  })
-
-  it('R8 — auto + whitespace api-key + cliResolved=false → degraded (trim semantics)', () => {
-    const settings = makeSettings({ transportKind: 'auto', anthropicApiKey: '\t\t ' })
-    const deps = makeDeps({ cliResolved: false })
+    const settings = makeSettings({ transportKind: 'auto' })
+    const deps = makeDeps({ cliResolved: false, apiKeyPresent: false })
 
     const selection = selectTransport(settings, deps)
 
@@ -287,35 +251,33 @@ describe('selectTransport() purity invariants (SPEC-ASM-001 §3.1)', () => {
     // `.startup()` / `.shutdown()` the assertion fails.
     const cases: ReadonlyArray<{
       transportKind: TransportKind
-      anthropicApiKey: string
+      apiKeyPresent: boolean
       cliResolved: boolean
     }> = [
-      { transportKind: 'degraded', anthropicApiKey: 'sk', cliResolved: true },
-      { transportKind: 'api-key', anthropicApiKey: 'sk', cliResolved: true },
-      { transportKind: 'api-key', anthropicApiKey: '', cliResolved: false },
-      { transportKind: 'subscription', anthropicApiKey: '', cliResolved: true },
-      { transportKind: 'subscription', anthropicApiKey: '', cliResolved: false },
-      { transportKind: 'auto', anthropicApiKey: 'sk', cliResolved: false },
-      { transportKind: 'auto', anthropicApiKey: '', cliResolved: true },
-      { transportKind: 'auto', anthropicApiKey: '', cliResolved: false },
+      { transportKind: 'degraded', apiKeyPresent: true, cliResolved: true },
+      { transportKind: 'api-key', apiKeyPresent: true, cliResolved: true },
+      { transportKind: 'api-key', apiKeyPresent: false, cliResolved: false },
+      { transportKind: 'subscription', apiKeyPresent: false, cliResolved: true },
+      { transportKind: 'subscription', apiKeyPresent: false, cliResolved: false },
+      { transportKind: 'auto', apiKeyPresent: true, cliResolved: false },
+      { transportKind: 'auto', apiKeyPresent: false, cliResolved: true },
+      { transportKind: 'auto', apiKeyPresent: false, cliResolved: false },
     ]
 
     for (const c of cases) {
-      const settings = makeSettings({
-        transportKind: c.transportKind,
-        anthropicApiKey: c.anthropicApiKey,
-      })
-      const deps = makeDeps({ cliResolved: c.cliResolved })
+      const settings = makeSettings({ transportKind: c.transportKind })
+      const deps = makeDeps({ cliResolved: c.cliResolved, apiKeyPresent: c.apiKeyPresent })
 
       // The mocks throw on any port-method call; reaching this point at all
-      // means the selector consumed `cliResolved` as a plain boolean.
+      // means the selector consumed `cliResolved` and `apiKeyPresent` as
+      // plain booleans.
       expect(() => selectTransport(settings, deps)).not.toThrow()
     }
   })
 
   it('returns a kind that is never literally "auto" (TransportSelection.kind excludes "auto")', () => {
-    const settings = makeSettings({ transportKind: 'auto', anthropicApiKey: '' })
-    const deps = makeDeps({ cliResolved: true })
+    const settings = makeSettings({ transportKind: 'auto' })
+    const deps = makeDeps({ cliResolved: true, apiKeyPresent: false })
 
     const selection = selectTransport(settings, deps)
 
@@ -323,8 +285,8 @@ describe('selectTransport() purity invariants (SPEC-ASM-001 §3.1)', () => {
   })
 
   it('is referentially stable across repeated calls with identical inputs (deterministic)', () => {
-    const settings = makeSettings({ transportKind: 'auto', anthropicApiKey: 'sk-foo' })
-    const deps = makeDeps({ cliResolved: true })
+    const settings = makeSettings({ transportKind: 'auto' })
+    const deps = makeDeps({ cliResolved: true, apiKeyPresent: true })
 
     const first = selectTransport(settings, deps)
     const second = selectTransport(settings, deps)

--- a/tests/ui/components/chat/ChatSidebar.proposalFlow.test.ts
+++ b/tests/ui/components/chat/ChatSidebar.proposalFlow.test.ts
@@ -31,7 +31,9 @@ import ChatSidebar from '@/ui/components/chat/ChatSidebar.vue'
 import { MockClaudeSubprocessAdapter } from '@/infrastructure/mock/MockClaudeSubprocessAdapter'
 import { MockBridge } from '@/infrastructure/mock/MockBridge'
 import { MockConfirmModalPort } from '@/infrastructure/mock/MockConfirmModalPort'
+import { MockSecretStore } from '@/infrastructure/mock/MockSecretStore'
 import { asSessionId } from '@/domain/chat/SessionId'
+import { SECRET_ID_ANTHROPIC } from '@/domain/ports'
 import {
 	CLAUDE_CLI_PORT,
 	IS_MOBILE_KEY,
@@ -41,6 +43,7 @@ import {
 	LOGGER_PORT,
 	CONFIRM_MODAL_PORT,
 	TRANSPORT_KIND_KEY,
+	SECRET_STORE_PORT,
 } from '@/infrastructure/bridge/ports'
 import { useChatStore } from '@/ui/stores/chatStore'
 import { ChatSidebarPO } from './ChatSidebar.po'
@@ -62,12 +65,15 @@ function makeBridge(
 	const bridge = new MockBridge(files)
 	const settings: PluginSettings = {
 		...DEFAULT_SETTINGS,
-		anthropicApiKey: 'sk-ant-test',
 		transportKind: 'subscription',
 		...overrides,
 	}
 	vi.spyOn(bridge, 'getSettings').mockResolvedValue(settings)
 	return bridge
+}
+
+function makeSecretStore(): MockSecretStore {
+	return new MockSecretStore({ initial: { [SECRET_ID_ANTHROPIC]: 'sk-ant-test' } })
 }
 
 interface MountArgs {
@@ -96,6 +102,7 @@ async function mountSidebar(args: MountArgs = {}) {
 	port.cannedSessionId = asSessionId('11111111-2222-3333-4444-555555555555')
 
 	const bridge = makeBridge(args.files ?? {}, args.settings ?? {})
+	const secretStore = makeSecretStore()
 	const confirmModal = new MockConfirmModalPort()
 	confirmModal.nextResult = args.confirmResult ?? true
 	const transportKindRef = ref<TransportKind>(args.transportKind ?? 'subscription')
@@ -113,6 +120,7 @@ async function mountSidebar(args: MountArgs = {}) {
 				[LOGGER_PORT as symbol]: bridge,
 				[CONFIRM_MODAL_PORT as symbol]: confirmModal,
 				[TRANSPORT_KIND_KEY as symbol]: transportKindRef,
+				[SECRET_STORE_PORT as symbol]: secretStore,
 			},
 		},
 	})
@@ -301,7 +309,6 @@ describe('ChatSidebar — proposal flow integration (T-ASM-072)', () => {
 		// guard only ran at proposal-creation time.
 		vi.spyOn(bridge, 'getSettings').mockResolvedValue({
 			...DEFAULT_SETTINGS,
-			anthropicApiKey: 'sk-ant-test',
 			transportKind: 'subscription',
 			specsFolder: 'notes',
 		})
@@ -384,7 +391,6 @@ describe('ChatSidebar — proposal flow integration (T-ASM-072)', () => {
 		// Stale containment + writer fails on every audit append.
 		vi.spyOn(bridge, 'getSettings').mockResolvedValue({
 			...DEFAULT_SETTINGS,
-			anthropicApiKey: 'sk-ant-test',
 			transportKind: 'subscription',
 			specsFolder: 'notes',
 		})

--- a/tests/ui/components/chat/ChatSidebar.sessionPersistence.test.ts
+++ b/tests/ui/components/chat/ChatSidebar.sessionPersistence.test.ts
@@ -102,7 +102,6 @@ function makeBridge(
 	const bridge = new MockBridge(files)
 	const settings: PluginSettings = {
 		...DEFAULT_SETTINGS,
-		anthropicApiKey: 'sk-ant-test',
 		...overrides,
 	}
 	vi.spyOn(bridge, 'getSettings').mockResolvedValue(settings)
@@ -218,7 +217,7 @@ describe('ChatSidebar — session-persistence wiring (T-ASM-057)', () => {
 		// available). The thread record must reflect what actually ran,
 		// not the raw setting value.
 		const { po, store } = await mountSidebar({
-			settings: { transportKind: 'auto', anthropicApiKey: '' },
+			settings: { transportKind: 'auto' },
 			resolvedTransportKind: 'subscription',
 		})
 		await send(store, po, 'hello')
@@ -228,7 +227,7 @@ describe('ChatSidebar — session-persistence wiring (T-ASM-057)', () => {
 
 	it('records api-key when the resolved kind is api-key under auto mode (mirror of the above)', async () => {
 		const { po, store } = await mountSidebar({
-			settings: { transportKind: 'auto', anthropicApiKey: 'sk-test' },
+			settings: { transportKind: 'auto' },
 			resolvedTransportKind: 'api-key',
 		})
 		await send(store, po, 'hello')

--- a/tests/ui/components/chat/ChatSidebar.stagePrompt.test.ts
+++ b/tests/ui/components/chat/ChatSidebar.stagePrompt.test.ts
@@ -67,7 +67,6 @@ function makeBridge(
 	const bridge = new MockBridge(files)
 	const merged: PluginSettings = {
 		...DEFAULT_SETTINGS,
-		anthropicApiKey: 'sk-ant-test',
 		...settings,
 	}
 	vi.spyOn(bridge, 'getSettings').mockResolvedValue(merged)

--- a/tests/ui/components/chat/ChatSidebar.test.ts
+++ b/tests/ui/components/chat/ChatSidebar.test.ts
@@ -11,7 +11,9 @@ import { defineComponent } from 'vue'
 import ChatSidebar from '@/ui/components/chat/ChatSidebar.vue'
 import { MockClaudeCliPort } from '@/infrastructure/mock/MockClaudeCliPort'
 import { MockBridge } from '@/infrastructure/mock/MockBridge'
+import { MockSecretStore } from '@/infrastructure/mock/MockSecretStore'
 import { ClaudeCliError } from '@/domain/ports/ClaudeCliPort'
+import { SECRET_ID_ANTHROPIC } from '@/domain/ports'
 import {
 	CLAUDE_CLI_PORT,
 	IS_MOBILE_KEY,
@@ -19,6 +21,7 @@ import {
 	WORKSPACE_PORT,
 	SETTINGS_PORT,
 	LOGGER_PORT,
+	SECRET_STORE_PORT,
 } from '@/infrastructure/bridge/ports'
 import { useChatStore } from '@/ui/stores/chatStore'
 import { ChatSidebarPO } from './ChatSidebar.po'
@@ -36,6 +39,7 @@ function makeGlobal(
 	bridge: MockBridge,
 	isMobile: boolean,
 	pinia: ReturnType<typeof createPinia>,
+	secretStore: MockSecretStore = new MockSecretStore(),
 ) {
 	return {
 		plugins: [pinia],
@@ -47,23 +51,28 @@ function makeGlobal(
 			[WORKSPACE_PORT as symbol]: bridge,
 			[SETTINGS_PORT as symbol]: bridge,
 			[LOGGER_PORT as symbol]: bridge,
+			[SECRET_STORE_PORT as symbol]: secretStore,
 		},
 	}
 }
 
 function makeBridgeWithApiKey(
-	apiKey: string,
+	_apiKey: string,
 	files: Record<string, string> = {},
 	overrides: Partial<PluginSettings> = {},
 ): MockBridge {
 	const bridge = new MockBridge(files)
 	const settings: PluginSettings = {
 		...DEFAULT_SETTINGS,
-		anthropicApiKey: apiKey,
 		...overrides,
 	}
 	vi.spyOn(bridge, 'getSettings').mockResolvedValue(settings)
 	return bridge
+}
+
+function makeSecretStoreWithApiKey(apiKey: string): MockSecretStore {
+	const initial = apiKey ? { [SECRET_ID_ANTHROPIC]: apiKey } : undefined
+	return new MockSecretStore({ initial })
 }
 
 async function mountSidebar(options: {
@@ -90,9 +99,10 @@ async function mountSidebar(options: {
 		options.files ?? {},
 		options.settings ?? {},
 	)
+	const secretStore = makeSecretStoreWithApiKey(options.apiKey ?? '')
 
 	const wrapper = mount(ChatSidebar, {
-		global: makeGlobal(port, bridge, options.isMobile ?? false, pinia),
+		global: makeGlobal(port, bridge, options.isMobile ?? false, pinia, secretStore),
 	})
 
 	await flushPromises()
@@ -147,6 +157,7 @@ describe('ChatSidebar', () => {
 			const port = new MockClaudeCliPort()
 			port.available = false
 			const bridge = makeBridgeWithApiKey('', {})
+			const secretStore = makeSecretStoreWithApiKey('')
 			const openPluginSettings = vi.fn()
 			const wrapper = mount(ChatSidebar, {
 				global: {
@@ -159,6 +170,7 @@ describe('ChatSidebar', () => {
 						[WORKSPACE_PORT as symbol]: bridge,
 						[SETTINGS_PORT as symbol]: bridge,
 						[LOGGER_PORT as symbol]: bridge,
+						[SECRET_STORE_PORT as symbol]: secretStore,
 						[OPEN_PLUGIN_SETTINGS_KEY as symbol]: openPluginSettings,
 					},
 				},

--- a/tests/ui/components/chat/ChatSidebar.threadRotation.test.ts
+++ b/tests/ui/components/chat/ChatSidebar.threadRotation.test.ts
@@ -65,7 +65,6 @@ function makeBridge(): MockBridge {
 	const bridge = new MockBridge();
 	const settings: PluginSettings = {
 		...DEFAULT_SETTINGS,
-		anthropicApiKey: 'sk-ant-test',
 	};
 	vi.spyOn(bridge, 'getSettings').mockResolvedValue(settings);
 	return bridge;


### PR DESCRIPTION
## Summary

The Anthropic API key previously lived in the synced `PluginSettings`
blob, which Obsidian Sync mirrors across the user's devices — the wrong
place for a secret. Move it to `App.secretStorage` (desktop ≥1.11.4)
via a narrow `SecretStorePort` so the key persists in the OS keychain
and is explicitly NOT synced.

**Pre-release product — no migration path.** There is no read of any
prior `anthropicApiKey` location and no one-shot move/strip — if a
previously-typed key existed in a dev build, the user re-enters it in
the settings tab on first launch with the new build.

### What changes

- New domain port `SecretStorePort` + `SECRET_ID_ANTHROPIC` constant.
- Three implementations matching the existing bridge layout: `MockSecretStore`,
  `ObsidianSecretStoreAdapter`, `LocalStorageSecretStore`.
- `SECRET_STORE_PORT` InjectionKey + `useSecretStorePort` composable.
- `SpecoratorPlugin.loadSettings()` constructs the adapter and hydrates a
  synchronous `_apiKeyCache`. `ClaudeCliAdapter` and the `selectTransport`
  closures consume `_apiKeyCache` (sync) instead of an async keychain read.
- `refreshApiKeyCache()` re-hydrates after the settings tab persists a
  new value and bumps every open view (both `SpecoratorView` and
  `AgentSidepanelView`).
- `selectTransport` takes `apiKeyPresent: boolean` in `deps` so the
  SPEC §3.1 synchronous purity invariant is preserved.
- Settings tab writes via `setSecret()` wrapped in `tryAsync` (Codex P2,
  PR #387 — a locked keychain or OS denial degrades to a no-op).
- `ChatSidebar.isApiKeyMissing()` reads from `SecretStorePort` wrapped in
  `tryAsync` (Codex P2 — same degradation path as above).
- `anthropicApiKey` removed from `PluginSettings` / `DEFAULT_SETTINGS` /
  `coreSettingsModule.validateSettings()` / `loadSettings-migrate`'s
  `PLUGIN_SETTINGS_KEYS`.

### Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 errors (24 pre-existing warnings)
- [x] `npm run test` — 1682 / 1682 passing
- [x] `npm run build` — bundle builds clean (2.85 MB)
- [ ] Manual: enter an API key in the settings tab on desktop ≥1.11.4 and confirm chat reaches the live transport after reload.
- [ ] Manual: confirm `data.json` does not contain `anthropicApiKey` after the key is saved.
- [ ] Manual: on a mobile build, confirm the settings field is disabled and chat surfaces the degraded-mode notice.

https://claude.ai/code/session_01T6R5ggmbmhbmALfV9Ajn1Q
