### PR TITLE
feat(agent): load slash commands from .claude/commands and .claude/skills

### DIFF
--- a/src/application/chat/slashCommandLoader.ts
+++ b/src/application/chat/slashCommandLoader.ts
@@ -1,0 +1,313 @@
+import type { VaultPort, LoggerPort } from '@/domain/ports';
+import type { SlashCommand } from '@/domain/chat/SlashCommand';
+
+/**
+ * Vault-loaded slash command parsed from `.claude/commands/*.md` (a "command")
+ * or `.claude/skills/*.md` (a "skill"). Mirrors Claudian's pattern: each file
+ * carries YAML frontmatter describing the command, followed by a body that
+ * becomes the prompt template when the user picks the entry.
+ *
+ * Frontmatter contract (matches Claudian):
+ *   description           — short subtitle for the palette (required)
+ *   argument-hint         — placeholder hint, rendered after the description
+ *   allowed-tools         — list of tools the prompt expects
+ *   model                 — model name override
+ *   disable-model-invocation — skills with this `true` are skipped
+ *   user-invocable        — commands/skills with this `false` are skipped
+ *   context               — context-mode hint (e.g. `'fork'`)
+ *   agent                 — agent persona hint
+ *
+ * Files with unparseable frontmatter, missing `description`, or
+ * `user-invocable: false` are silently skipped with a `loggerPort.warn`
+ * breadcrumb. Skills with `disable-model-invocation: true` are also skipped.
+ *
+ * Scan is flat (no recursion) — matches Claudian's behaviour.
+ *
+ * Stays in the application layer (ADR-008): depends only on `VaultPort` +
+ * `LoggerPort`; no `obsidian` imports.
+ */
+export interface VaultSlashCommand {
+	readonly source: 'vault-command' | 'vault-skill';
+	/** Stable unique id — `commands:<slug>` or `skills:<slug>`. */
+	readonly id: string;
+	/** File basename without `.md`. */
+	readonly name: string;
+	/** One-line description from frontmatter. */
+	readonly description: string;
+	/** Prompt body — the markdown after the frontmatter block. */
+	readonly body: string;
+	readonly argumentHint?: string;
+	readonly allowedTools?: readonly string[];
+	readonly model?: string;
+	readonly disableModelInvocation?: boolean;
+	readonly userInvocable?: boolean;
+	readonly context?: string;
+	readonly agent?: string;
+}
+
+const COMMANDS_FOLDER = '.claude/commands';
+const SKILLS_FOLDER = '.claude/skills';
+
+/**
+ * Load all vault slash commands and skills. Resolves to an empty array when
+ * neither folder exists (a brand-new vault has no `.claude/` dir).
+ *
+ * Per-file failures (read error, malformed frontmatter, missing description,
+ * disabled flags) are logged via `loggerPort.warn` and dropped from the result.
+ * A single bad file never poisons the whole scan.
+ */
+export async function loadVaultSlashCommands(
+	vault: VaultPort,
+	loggerPort?: LoggerPort,
+): Promise<readonly VaultSlashCommand[]> {
+	const commandFiles = await listMarkdownFilesSafe(vault, COMMANDS_FOLDER, loggerPort);
+	const skillFiles = await listMarkdownFilesSafe(vault, SKILLS_FOLDER, loggerPort);
+
+	const results: VaultSlashCommand[] = [];
+	for (const path of commandFiles) {
+		const cmd = await loadOne(vault, path, 'vault-command', loggerPort);
+		if (cmd !== null) results.push(cmd);
+	}
+	for (const path of skillFiles) {
+		const cmd = await loadOne(vault, path, 'vault-skill', loggerPort);
+		if (cmd !== null) results.push(cmd);
+	}
+	return Object.freeze(results);
+}
+
+async function listMarkdownFilesSafe(
+	vault: VaultPort,
+	folder: string,
+	logger: LoggerPort | undefined,
+): Promise<readonly string[]> {
+	const files = await safeListFiles(vault, folder);
+	if (files === null) {
+		logger?.debug('loadVaultSlashCommands: folder not listable', { folder });
+		return [];
+	}
+	return files.filter((p) => p.endsWith('.md'));
+}
+
+/**
+ * Wrap `vault.listFiles` so a missing folder does not surface as a thrown
+ * error. Returns `null` on any failure (folder absent, permissions, …) — the
+ * caller treats `null` as an empty folder.
+ */
+async function safeListFiles(vault: VaultPort, folder: string): Promise<readonly string[] | null> {
+	const recovered = await Promise.resolve()
+		.then(() => vault.listFiles(folder))
+		.catch(() => null);
+	return recovered;
+}
+
+/**
+ * Stage 1 of `loadOne`: read the file + parse frontmatter. Returns `null`
+ * (and logs a warn) on a read failure or unparseable frontmatter block.
+ */
+async function readAndParseFrontmatter(
+	vault: VaultPort,
+	path: string,
+	logger: LoggerPort | undefined,
+): Promise<ParsedFrontmatter | null> {
+	const content = await Promise.resolve()
+		.then(() => vault.readFile(path))
+		.catch(() => null);
+	if (content === null) {
+		logger?.warn('loadVaultSlashCommands: failed to read file', { path });
+		return null;
+	}
+	const parsed = parseFrontmatter(content);
+	if (parsed === null) {
+		logger?.warn('loadVaultSlashCommands: malformed frontmatter', { path });
+		return null;
+	}
+	return parsed;
+}
+
+/**
+ * Stage 2 of `loadOne`: apply visibility gates. Returns `null` when the file
+ * should be skipped (missing description, `user-invocable: false`, or a skill
+ * with `disable-model-invocation: true`).
+ */
+function applyVisibilityGates(
+	frontmatter: ReadonlyMap<string, string>,
+	source: 'vault-command' | 'vault-skill',
+	path: string,
+	logger: LoggerPort | undefined,
+): {
+	description: string;
+	userInvocable: boolean;
+	disableModelInvocation: boolean | undefined;
+} | null {
+	const description = readScalar(frontmatter, 'description');
+	if (description === undefined || description === '') {
+		logger?.warn('loadVaultSlashCommands: missing description', { path });
+		return null;
+	}
+	const userInvocable = parseBoolean(readScalar(frontmatter, 'user-invocable')) ?? true;
+	if (userInvocable === false) {
+		logger?.debug('loadVaultSlashCommands: user-invocable=false; skipping', { path });
+		return null;
+	}
+	const disableModelInvocation = parseBoolean(readScalar(frontmatter, 'disable-model-invocation'));
+	if (source === 'vault-skill' && disableModelInvocation === true) {
+		logger?.debug('loadVaultSlashCommands: disable-model-invocation=true; skipping skill', {
+			path,
+		});
+		return null;
+	}
+	return { description, userInvocable, disableModelInvocation };
+}
+
+/**
+ * Read + parse a single slash-command file. Returns `null` (and logs a warn)
+ * when the file is unreadable, has malformed frontmatter, is missing a
+ * description, or has been explicitly disabled. Split into two helpers to
+ * keep the per-function complexity below the project lint cap.
+ */
+async function loadOne(
+	vault: VaultPort,
+	path: string,
+	source: 'vault-command' | 'vault-skill',
+	logger: LoggerPort | undefined,
+): Promise<VaultSlashCommand | null> {
+	const parsed = await readAndParseFrontmatter(vault, path, logger);
+	if (parsed === null) return null;
+	const gated = applyVisibilityGates(parsed.frontmatter, source, path, logger);
+	if (gated === null) return null;
+
+	const name = basenameWithoutExt(path);
+	const slugKey = source === 'vault-command' ? 'commands' : 'skills';
+	const command: VaultSlashCommand = {
+		source,
+		id: `${slugKey}:${name}`,
+		name,
+		description: gated.description,
+		body: parsed.body,
+		argumentHint: readScalar(parsed.frontmatter, 'argument-hint'),
+		allowedTools: readList(parsed.frontmatter, 'allowed-tools'),
+		model: readScalar(parsed.frontmatter, 'model'),
+		disableModelInvocation: gated.disableModelInvocation,
+		userInvocable: gated.userInvocable,
+		context: readScalar(parsed.frontmatter, 'context'),
+		agent: readScalar(parsed.frontmatter, 'agent'),
+	};
+	return Object.freeze(command);
+}
+
+interface ParsedFrontmatter {
+	readonly frontmatter: ReadonlyMap<string, string>;
+	readonly body: string;
+}
+
+/**
+ * Hand-rolled YAML reader tuned to the slash-command frontmatter shape (flat
+ * scalars + optional list values). Mirrors the pattern in
+ * `src/infrastructure/workflow-state/WorkflowStateDocument.ts`.
+ *
+ * Returns `null` when the document does not start with `---` (no frontmatter
+ * block at all) or the closing fence is missing. List values are stored as
+ * the raw line and parsed lazily by `readList`.
+ */
+function parseFrontmatter(content: string): ParsedFrontmatter | null {
+	const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/.exec(content);
+	if (match === null) return null;
+	const rawFm = match[1];
+	const body = match[2];
+	const map = collectScalars(rawFm);
+	return { frontmatter: map, body: body.replace(/^\r?\n/, '') };
+}
+
+function collectScalars(rawFrontmatter: string): Map<string, string> {
+	const map = new Map<string, string>();
+	for (const line of rawFrontmatter.split(/\r?\n/)) {
+		if (!isCandidateLine(line)) continue;
+		const colonIdx = line.indexOf(':');
+		if (colonIdx === -1) continue;
+		const key = line.slice(0, colonIdx).trim();
+		const raw = line.slice(colonIdx + 1).trim();
+		map.set(key, raw);
+	}
+	return map;
+}
+
+function isCandidateLine(line: string): boolean {
+	const trimmed = line.trim();
+	if (trimmed === '') return false;
+	if (trimmed.startsWith('#')) return false;
+	// Flat-frontmatter only — skip nested (indented) keys.
+	if (line.startsWith(' ') || line.startsWith('\t')) return false;
+	return true;
+}
+
+function readScalar(fm: ReadonlyMap<string, string>, key: string): string | undefined {
+	const raw = fm.get(key);
+	if (raw === undefined) return undefined;
+	return unquote(raw);
+}
+
+function readList(fm: ReadonlyMap<string, string>, key: string): readonly string[] | undefined {
+	const raw = fm.get(key);
+	if (raw === undefined) return undefined;
+	// Flow form: `[A, B, C]` — block-form lists across multiple lines are not
+	// supported here; commands/skills produced by Claudian always use the
+	// flow form for tool lists.
+	const trimmed = raw.trim();
+	if (trimmed === '' || trimmed === '[]') return [];
+	if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+		return trimmed
+			.slice(1, -1)
+			.split(',')
+			.map((p) => unquote(p.trim()))
+			.filter((p) => p !== '');
+	}
+	// Comma-separated unbracketed fallback.
+	return trimmed
+		.split(',')
+		.map((p) => unquote(p.trim()))
+		.filter((p) => p !== '');
+}
+
+function unquote(raw: string): string {
+	if (raw.length >= 2 && raw.startsWith('"') && raw.endsWith('"')) {
+		return raw.slice(1, -1).replace(/\\(["\\])/g, '$1');
+	}
+	if (raw.length >= 2 && raw.startsWith("'") && raw.endsWith("'")) {
+		return raw.slice(1, -1).replace(/''/g, "'");
+	}
+	return raw;
+}
+
+function parseBoolean(raw: string | undefined): boolean | undefined {
+	if (raw === undefined) return undefined;
+	const lowered = raw.toLowerCase();
+	if (lowered === 'true') return true;
+	if (lowered === 'false') return false;
+	return undefined;
+}
+
+function basenameWithoutExt(path: string): string {
+	const slash = path.lastIndexOf('/');
+	const base = slash === -1 ? path : path.slice(slash + 1);
+	const dot = base.lastIndexOf('.');
+	return dot === -1 ? base : base.slice(0, dot);
+}
+
+/**
+ * Adapt a `VaultSlashCommand` into the UI-facing `SlashCommand` DTO. Lives
+ * here so the UI does not have to know about the loader's internal shape.
+ */
+export function toSlashCommand(v: VaultSlashCommand): SlashCommand {
+	return Object.freeze({
+		name: v.name,
+		description: v.description,
+		kind: v.source,
+		action: 'vault-prompt' as const,
+		body: v.body,
+		argumentHint: v.argumentHint,
+		allowedTools: v.allowedTools,
+		model: v.model,
+		context: v.context,
+		agent: v.agent,
+	});
+}

--- a/src/application/chat/slashCommandLoader.ts
+++ b/src/application/chat/slashCommandLoader.ts
@@ -3,9 +3,15 @@ import type { SlashCommand } from '@/domain/chat/SlashCommand';
 
 /**
  * Vault-loaded slash command parsed from `.claude/commands/*.md` (a "command")
- * or `.claude/skills/*.md` (a "skill"). Mirrors Claudian's pattern: each file
- * carries YAML frontmatter describing the command, followed by a body that
- * becomes the prompt template when the user picks the entry.
+ * or `.claude/skills/<slug>/SKILL.md` (a "skill"). Mirrors Claudian's pattern:
+ * each file carries YAML frontmatter describing the command, followed by a
+ * body that becomes the prompt template when the user picks the entry.
+ *
+ * Commands are scanned flat (`.claude/commands/*.md`). Skills use the
+ * directory layout documented in `AGENTS.md` — each skill lives under
+ * `.claude/skills/<slug>/SKILL.md`, so the loader enumerates child folders
+ * and reads each folder's `SKILL.md` if present. Skill folders without a
+ * `SKILL.md` are skipped silently with a `debug` breadcrumb.
  *
  * Frontmatter contract (matches Claudian):
  *   description           — short subtitle for the palette (required)
@@ -20,8 +26,6 @@ import type { SlashCommand } from '@/domain/chat/SlashCommand';
  * Files with unparseable frontmatter, missing `description`, or
  * `user-invocable: false` are silently skipped with a `loggerPort.warn`
  * breadcrumb. Skills with `disable-model-invocation: true` are also skipped.
- *
- * Scan is flat (no recursion) — matches Claudian's behaviour.
  *
  * Stays in the application layer (ADR-008): depends only on `VaultPort` +
  * `LoggerPort`; no `obsidian` imports.
@@ -47,6 +51,7 @@ export interface VaultSlashCommand {
 
 const COMMANDS_FOLDER = '.claude/commands';
 const SKILLS_FOLDER = '.claude/skills';
+const SKILL_MANIFEST = 'SKILL.md';
 
 /**
  * Load all vault slash commands and skills. Resolves to an empty array when
@@ -61,7 +66,7 @@ export async function loadVaultSlashCommands(
 	loggerPort?: LoggerPort,
 ): Promise<readonly VaultSlashCommand[]> {
 	const commandFiles = await listMarkdownFilesSafe(vault, COMMANDS_FOLDER, loggerPort);
-	const skillFiles = await listMarkdownFilesSafe(vault, SKILLS_FOLDER, loggerPort);
+	const skillFiles = await listSkillManifestsSafe(vault, SKILLS_FOLDER, loggerPort);
 
 	const results: VaultSlashCommand[] = [];
 	for (const path of commandFiles) {
@@ -89,6 +94,40 @@ async function listMarkdownFilesSafe(
 }
 
 /**
+ * Enumerate skill folders under `parent` and return the `<folder>/SKILL.md`
+ * path for each folder that actually contains a `SKILL.md`. Skill folders
+ * without a manifest are skipped silently with a `debug` breadcrumb — matches
+ * the directory layout documented in `AGENTS.md` (e.g.
+ * `.claude/skills/publish-release/SKILL.md`).
+ */
+async function listSkillManifestsSafe(
+	vault: VaultPort,
+	parent: string,
+	logger: LoggerPort | undefined,
+): Promise<readonly string[]> {
+	const folders = await safeListFolders(vault, parent);
+	if (folders === null) {
+		logger?.debug('loadVaultSlashCommands: skills folder not listable', { folder: parent });
+		return [];
+	}
+	const manifests: string[] = [];
+	for (const folder of folders) {
+		const manifestPath = `${parent}/${folder}/${SKILL_MANIFEST}`;
+		const exists = await Promise.resolve()
+			.then(() => vault.fileExists(manifestPath))
+			.catch(() => false);
+		if (exists) {
+			manifests.push(manifestPath);
+		} else {
+			logger?.debug('loadVaultSlashCommands: skill folder missing SKILL.md', {
+				folder: `${parent}/${folder}`,
+			});
+		}
+	}
+	return manifests;
+}
+
+/**
  * Wrap `vault.listFiles` so a missing folder does not surface as a thrown
  * error. Returns `null` on any failure (folder absent, permissions, …) — the
  * caller treats `null` as an empty folder.
@@ -96,6 +135,21 @@ async function listMarkdownFilesSafe(
 async function safeListFiles(vault: VaultPort, folder: string): Promise<readonly string[] | null> {
 	const recovered = await Promise.resolve()
 		.then(() => vault.listFiles(folder))
+		.catch(() => null);
+	return recovered;
+}
+
+/**
+ * Wrap `vault.listFolders` so a missing parent folder does not surface as a
+ * thrown error. Returns `null` on any failure — the caller treats `null` as
+ * an empty folder.
+ */
+async function safeListFolders(
+	vault: VaultPort,
+	parent: string,
+): Promise<readonly string[] | null> {
+	const recovered = await Promise.resolve()
+		.then(() => vault.listFolders(parent))
 		.catch(() => null);
 	return recovered;
 }
@@ -176,7 +230,7 @@ async function loadOne(
 	const gated = applyVisibilityGates(parsed.frontmatter, source, path, logger);
 	if (gated === null) return null;
 
-	const name = basenameWithoutExt(path);
+	const name = source === 'vault-skill' ? skillSlugFromPath(path) : basenameWithoutExt(path);
 	const slugKey = source === 'vault-command' ? 'commands' : 'skills';
 	const command: VaultSlashCommand = {
 		source,
@@ -291,6 +345,20 @@ function basenameWithoutExt(path: string): string {
 	const base = slash === -1 ? path : path.slice(slash + 1);
 	const dot = base.lastIndexOf('.');
 	return dot === -1 ? base : base.slice(0, dot);
+}
+
+/**
+ * Derive a skill slug from its manifest path. For
+ * `.claude/skills/<slug>/SKILL.md` the slug is the parent folder name.
+ * Falls back to the basename if the path does not match the expected shape
+ * (defensive — the loader should never reach this branch in production).
+ */
+function skillSlugFromPath(path: string): string {
+	const segments = path.split('/').filter((s) => s !== '');
+	if (segments.length >= 2 && segments[segments.length - 1].toLowerCase() === 'skill.md') {
+		return segments[segments.length - 2];
+	}
+	return basenameWithoutExt(path);
 }
 
 /**

--- a/src/domain/chat/SlashCommand.ts
+++ b/src/domain/chat/SlashCommand.ts
@@ -6,7 +6,7 @@
  *
  * Domain layer (ADR-008): no `obsidian` imports. Built-ins are encoded as
  * frozen TypeScript values; vault commands (`.claude/commands/*.md`) and skills
- * (`.claude/skills/*.md`) are loaded at runtime by
+ * (`.claude/skills/<slug>/SKILL.md`) are loaded at runtime by
  * `loadVaultSlashCommands` (application layer). A future `'sdk'` variant
  * (PR-ASV-6) will load commands from the Anthropic Agent SDK's
  * `supportedCommands()` probe.
@@ -49,7 +49,7 @@ export interface SlashCommand {
  * Source of a slash command:
  *  - `'builtin'` — shipped with the plugin, dispatched via `SlashCommandAction`
  *  - `'vault-command'` — loaded from `.claude/commands/*.md`
- *  - `'vault-skill'` — loaded from `.claude/skills/*.md`
+ *  - `'vault-skill'` — loaded from `.claude/skills/<slug>/SKILL.md`
  */
 export type SlashCommandKind = 'builtin' | 'vault-command' | 'vault-skill';
 

--- a/src/domain/chat/SlashCommand.ts
+++ b/src/domain/chat/SlashCommand.ts
@@ -5,26 +5,53 @@
  * of commands the agent sidepanel knows how to dispatch.
  *
  * Domain layer (ADR-008): no `obsidian` imports. Built-ins are encoded as
- * frozen TypeScript values; future variants `'vault'` / `'sdk'` (PR-ASV-6) will
- * load commands from `.claude/commands/*.md` via `VaultPort` and from the
- * Anthropic Agent SDK's `supportedCommands()` probe.
+ * frozen TypeScript values; vault commands (`.claude/commands/*.md`) and skills
+ * (`.claude/skills/*.md`) are loaded at runtime by
+ * `loadVaultSlashCommands` (application layer). A future `'sdk'` variant
+ * (PR-ASV-6) will load commands from the Anthropic Agent SDK's
+ * `supportedCommands()` probe.
  *
  * Action ids are kept intentionally narrow — the UI layer maps each id to a
  * concrete dispatch in `ChatSidebar.vue` / `AgentSidepanelRoot.vue`. Keeping
  * the action space closed (rather than handing the dropdown a callback) keeps
  * the domain DTO serialisable for future persistence and lets the test surface
  * assert against string literals.
+ *
+ * Vault-loaded commands use `action: 'vault-prompt'` — the UI handler inserts
+ * `body` into the chat textarea for the user to review before sending, rather
+ * than auto-dispatching.
  */
 export interface SlashCommand {
 	/** Command name WITHOUT the leading `/`. Lowercased, kebab-case. */
 	readonly name: string;
 	/** One-line human-readable description shown in the dropdown. */
 	readonly description: string;
-	/** Source of the command. Today only `'builtin'`; vault/SDK land later. */
-	readonly kind: 'builtin';
+	/** Source of the command. */
+	readonly kind: SlashCommandKind;
 	/** Action id dispatched by the UI when the user selects this command. */
 	readonly action: SlashCommandAction;
+	/**
+	 * Prompt body that gets inserted into the chat textarea when a vault
+	 * command/skill is selected. Required for `action: 'vault-prompt'`; absent
+	 * for built-ins.
+	 */
+	readonly body?: string;
+	/** Optional placeholder hint rendered after the description (e.g. `[path]`). */
+	readonly argumentHint?: string;
+	/** Optional frontmatter pass-through fields — reserved for future use. */
+	readonly allowedTools?: readonly string[];
+	readonly model?: string;
+	readonly context?: string;
+	readonly agent?: string;
 }
+
+/**
+ * Source of a slash command:
+ *  - `'builtin'` — shipped with the plugin, dispatched via `SlashCommandAction`
+ *  - `'vault-command'` — loaded from `.claude/commands/*.md`
+ *  - `'vault-skill'` — loaded from `.claude/skills/*.md`
+ */
+export type SlashCommandKind = 'builtin' | 'vault-command' | 'vault-skill';
 
 /**
  * Closed set of dispatch ids the agent sidepanel understands. Keep this list
@@ -35,4 +62,5 @@ export type SlashCommandAction =
 	| 'clear-input'
 	| 'new-conversation'
 	| 'help'
-	| 'advance-stage';
+	| 'advance-stage'
+	| 'vault-prompt';

--- a/src/ui/agent/AgentSidepanelRoot.vue
+++ b/src/ui/agent/AgentSidepanelRoot.vue
@@ -112,6 +112,14 @@ function handleSelectCommand(command: SlashCommand): void {
 		case 'advance-stage':
 			notificationStore.addNotice('Not yet implemented in v2', 4000);
 			return;
+		case 'vault-prompt':
+			// Vault-loaded command/skill: insert the prompt body into the
+			// chat textarea for the user to review/edit before sending. We
+			// do NOT auto-send — the body is a template, not a final prompt.
+			if (command.body !== undefined) {
+				store.setUserText(command.body);
+			}
+			return;
 	}
 }
 

--- a/src/ui/components/chat/SlashCommandDropdown.vue
+++ b/src/ui/components/chat/SlashCommandDropdown.vue
@@ -42,6 +42,12 @@ function handleMouseEnter(index: number): void {
 function isSelected(index: number): boolean {
 	return index === props.selectedIndex;
 }
+
+function sourceLabel(command: SlashCommand): string | null {
+	if (command.kind === 'vault-command') return 'command';
+	if (command.kind === 'vault-skill') return 'skill';
+	return null;
+}
 </script>
 
 <template>
@@ -72,9 +78,23 @@ function isSelected(index: number): boolean {
 			>
 				<span class="sp-slash-dropdown__name" data-testid="slash-command-name">
 					/{{ command.name }}
+					<span
+						v-if="sourceLabel(command) !== null"
+						class="sp-slash-dropdown__source"
+						:data-testid="`slash-command-source-${command.name}`"
+					>
+						({{ sourceLabel(command) }})
+					</span>
 				</span>
 				<span class="sp-slash-dropdown__description" data-testid="slash-command-description">
-					{{ command.description }}
+					{{ command.description
+					}}<template v-if="command.argumentHint">
+						<span
+							class="sp-slash-dropdown__hint"
+							:data-testid="`slash-command-hint-${command.name}`"
+							>{{ command.argumentHint }}</span
+						></template
+					>
 				</span>
 			</li>
 		</ul>
@@ -120,6 +140,18 @@ function isSelected(index: number): boolean {
 	font-size: 0.875rem;
 	font-weight: 600;
 	color: var(--text-normal);
+}
+
+.sp-slash-dropdown__source {
+	margin-left: 0.375rem;
+	font-size: 0.75rem;
+	font-weight: 400;
+	color: var(--text-muted);
+}
+
+.sp-slash-dropdown__hint {
+	color: var(--text-faint, var(--text-muted));
+	font-style: italic;
 }
 
 .sp-slash-dropdown__description {

--- a/src/ui/composables/useSlashPalette.ts
+++ b/src/ui/composables/useSlashPalette.ts
@@ -99,6 +99,12 @@ export function useSlashPalette(options?: UseSlashPaletteOptions): UseSlashPalet
 	const queryRef: Ref<string> = ref('');
 	const selectedIndexRef: Ref<number> = ref(-1);
 	const vaultCommandsRef: Ref<readonly SlashCommand[]> = ref([]);
+	// Codex P2 (PR #388): monotonically-incrementing token. Each
+	// `refreshVaultCommands()` call captures the current value and only
+	// commits its result if the token has not been bumped by a later call.
+	// Prevents an older, slower vault read from clobbering a newer one when
+	// the palette is rapidly reopened.
+	let latestRefreshSeq = 0;
 
 	const commands = computed<readonly SlashCommand[]>(() => [
 		...builtIns,
@@ -123,7 +129,11 @@ export function useSlashPalette(options?: UseSlashPaletteOptions): UseSlashPalet
 
 	async function refreshVaultCommands(): Promise<void> {
 		if (vault === undefined) return;
+		const seq = ++latestRefreshSeq;
 		const loaded = await loadVaultSlashCommands(vault, logger);
+		// Drop the result if a newer refresh has been kicked off in the
+		// meantime — its eventual completion will commit the up-to-date set.
+		if (seq !== latestRefreshSeq) return;
 		vaultCommandsRef.value = Object.freeze(loaded.map((c) => toSlashCommand(c)));
 		// Re-clamp selection in case the loaded set changed which entries match
 		// the current query (e.g. brand-new vault entries widened the result).

--- a/src/ui/composables/useSlashPalette.ts
+++ b/src/ui/composables/useSlashPalette.ts
@@ -25,8 +25,8 @@ import { VAULT_PORT, LOGGER_PORT } from '@/infrastructure/bridge/ports';
  * `specs/agent-sidepanel-v2/research.md` D-ASV-2.
  *
  * Built-ins are stable; vault commands (`.claude/commands/*.md` and
- * `.claude/skills/*.md`) are refreshed each time the palette opens so vault
- * edits between sessions are picked up. The refresh is fire-and-forget — the
+ * `.claude/skills/<slug>/SKILL.md`) are refreshed each time the palette opens
+ * so vault edits between sessions are picked up. The refresh is fire-and-forget — the
  * dropdown shows built-ins immediately and re-renders when vault commands
  * arrive.
  */

--- a/src/ui/composables/useSlashPalette.ts
+++ b/src/ui/composables/useSlashPalette.ts
@@ -1,8 +1,11 @@
-import { computed, ref } from 'vue';
+import { computed, ref, inject } from 'vue';
 import type { ComputedRef, Ref } from 'vue';
 
 import type { SlashCommand } from '@/domain/chat/SlashCommand';
 import { BUILT_IN_SLASH_COMMANDS } from '@/application/chat/builtInSlashCommands';
+import { loadVaultSlashCommands, toSlashCommand } from '@/application/chat/slashCommandLoader';
+import type { VaultPort, LoggerPort } from '@/domain/ports';
+import { VAULT_PORT, LOGGER_PORT } from '@/infrastructure/bridge/ports';
 
 /**
  * State machine for the slash-command palette (PR-ASV-3, D-ASV-2). Owns the
@@ -20,6 +23,12 @@ import { BUILT_IN_SLASH_COMMANDS } from '@/application/chat/builtInSlashCommands
  * command — the user gets a full discovery surface. No fuzzy / Levenshtein /
  * prefix matching today; this stays in sync with the design brief in
  * `specs/agent-sidepanel-v2/research.md` D-ASV-2.
+ *
+ * Built-ins are stable; vault commands (`.claude/commands/*.md` and
+ * `.claude/skills/*.md`) are refreshed each time the palette opens so vault
+ * edits between sessions are picked up. The refresh is fire-and-forget — the
+ * dropdown shows built-ins immediately and re-renders when vault commands
+ * arrive.
  */
 export interface UseSlashPalette {
 	/** True while the dropdown is mounted. */
@@ -30,8 +39,8 @@ export interface UseSlashPalette {
 	readonly matchedCommands: ComputedRef<readonly SlashCommand[]>;
 	/** Highlighted index into `matchedCommands`. `-1` when empty. */
 	readonly selectedIndex: ComputedRef<number>;
-	/** All commands the palette can surface. Frozen at construction. */
-	readonly commands: readonly SlashCommand[];
+	/** All commands the palette can surface (built-ins + currently loaded vault). */
+	readonly commands: ComputedRef<readonly SlashCommand[]>;
 	/** Open the palette with the supplied query. Resets the selection to 0. */
 	open(query: string): void;
 	/** Close the palette and clear state. */
@@ -46,14 +55,28 @@ export interface UseSlashPalette {
 	 * action — `useSlashPalette` does not perform side-effects.
 	 */
 	select(): SlashCommand | null;
+	/**
+	 * Explicit handle for tests: reload vault commands without opening the
+	 * palette. Production callers should rely on `open()` triggering it.
+	 */
+	refreshVaultCommands(): Promise<void>;
 }
 
 interface UseSlashPaletteOptions {
 	/**
-	 * Override the registry. Tests inject a controlled list; production callers
-	 * accept the default (`BUILT_IN_SLASH_COMMANDS`).
+	 * Override the built-in registry. Tests inject a controlled list; production
+	 * callers accept the default (`BUILT_IN_SLASH_COMMANDS`).
 	 */
 	readonly commands?: readonly SlashCommand[];
+	/**
+	 * Inject a `VaultPort` directly (tests). When omitted the composable falls
+	 * back to `inject(VAULT_PORT)` — components mounted without the injection
+	 * key (unit tests, the standalone browser UI's pre-bridge bootstrap) get an
+	 * empty vault-command list.
+	 */
+	readonly vault?: VaultPort;
+	/** Inject a `LoggerPort` for tests. */
+	readonly logger?: LoggerPort;
 }
 
 function matchesQuery(command: SlashCommand, query: string): boolean {
@@ -66,15 +89,25 @@ function matchesQuery(command: SlashCommand, query: string): boolean {
 }
 
 export function useSlashPalette(options?: UseSlashPaletteOptions): UseSlashPalette {
-	const commands: readonly SlashCommand[] = options?.commands ?? BUILT_IN_SLASH_COMMANDS;
+	const builtIns: readonly SlashCommand[] = options?.commands ?? BUILT_IN_SLASH_COMMANDS;
+	const vault: VaultPort | undefined =
+		options?.vault ?? inject<VaultPort | undefined>(VAULT_PORT, undefined);
+	const logger: LoggerPort | undefined =
+		options?.logger ?? inject<LoggerPort | undefined>(LOGGER_PORT, undefined);
 
 	const isOpenRef: Ref<boolean> = ref(false);
 	const queryRef: Ref<string> = ref('');
 	const selectedIndexRef: Ref<number> = ref(-1);
+	const vaultCommandsRef: Ref<readonly SlashCommand[]> = ref([]);
+
+	const commands = computed<readonly SlashCommand[]>(() => [
+		...builtIns,
+		...vaultCommandsRef.value,
+	]);
 
 	const matchedCommands = computed<readonly SlashCommand[]>(() => {
 		if (!isOpenRef.value) return [];
-		return commands.filter((c) => matchesQuery(c, queryRef.value));
+		return commands.value.filter((c) => matchesQuery(c, queryRef.value));
 	});
 
 	function clampSelection(): void {
@@ -88,11 +121,27 @@ export function useSlashPalette(options?: UseSlashPaletteOptions): UseSlashPalet
 		}
 	}
 
+	async function refreshVaultCommands(): Promise<void> {
+		if (vault === undefined) return;
+		const loaded = await loadVaultSlashCommands(vault, logger);
+		vaultCommandsRef.value = Object.freeze(loaded.map((c) => toSlashCommand(c)));
+		// Re-clamp selection in case the loaded set changed which entries match
+		// the current query (e.g. brand-new vault entries widened the result).
+		if (isOpenRef.value) clampSelection();
+	}
+
 	function open(query: string): void {
 		isOpenRef.value = true;
 		queryRef.value = query;
 		selectedIndexRef.value = 0;
 		clampSelection();
+		// Fire-and-forget: built-ins are searchable immediately; vault commands
+		// appear once the read resolves. Any failure inside the loader is
+		// already logged via `LoggerPort.warn` — swallow here so a vault read
+		// error never breaks the palette open.
+		void refreshVaultCommands().catch(() => {
+			/* logged inside loadVaultSlashCommands */
+		});
 	}
 
 	function close(): void {
@@ -143,5 +192,6 @@ export function useSlashPalette(options?: UseSlashPaletteOptions): UseSlashPalet
 		setQuery,
 		navigate,
 		select,
+		refreshVaultCommands,
 	};
 }

--- a/styles.css
+++ b/styles.css
@@ -1115,34 +1115,93 @@ to {
 	white-space: nowrap;
 }
 
-.specorator-root :where(.sp-chat__input-area[data-v-65cc6585]) {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  position: relative;
+.specorator-root :where(.sp-slash-dropdown[data-v-6355bd34]) {
+	position: absolute;
+	left: 0;
+	right: 0;
+	bottom: 100%;
+	margin-bottom: 0.25rem;
+	background: var(--background-primary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 6px;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+	max-height: 14rem;
+	overflow-y: auto;
+	z-index: 20;
 }
-.specorator-root :where(.sp-chat__textarea[data-v-65cc6585]) {
-  width: 100%;
-  min-height: 4.5rem;
-  max-height: 8rem;
-  resize: none;
-  overflow-y: auto;
-  padding: 0.4rem 0.75rem;
-  border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
-  background: var(--background-primary);
-  color: var(--text-normal);
-  font-family: var(--font-text);
-  font-size: 0.875rem;
-  box-sizing: border-box;
+.specorator-root :where(.sp-slash-dropdown__list[data-v-6355bd34]) {
+	list-style: none;
+	margin: 0;
+	padding: 0.25rem 0;
 }
-.specorator-root :where(.sp-chat__textarea[data-v-65cc6585]:focus) {
-  outline: none;
-  border-color: var(--interactive-accent);
+.specorator-root :where(.sp-slash-dropdown__item[data-v-6355bd34]) {
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+	padding: 0.375rem 0.75rem;
+	cursor: pointer;
+	transition: background-color 0.1s;
 }
-.specorator-root :where(.sp-chat__input-actions[data-v-65cc6585]) {
-  display: flex;
-  justify-content: flex-end;
+.specorator-root :where(.sp-slash-dropdown__item--selected[data-v-6355bd34]) {
+	background: var(--interactive-hover);
+}
+.specorator-root :where(.sp-slash-dropdown__name[data-v-6355bd34]) {
+	font-size: 0.875rem;
+	font-weight: 600;
+	color: var(--text-normal);
+}
+.specorator-root :where(.sp-slash-dropdown__source[data-v-6355bd34]) {
+	margin-left: 0.375rem;
+	font-size: 0.75rem;
+	font-weight: 400;
+	color: var(--text-muted);
+}
+.specorator-root :where(.sp-slash-dropdown__hint[data-v-6355bd34]) {
+	color: var(--text-faint, var(--text-muted));
+	font-style: italic;
+}
+.specorator-root :where(.sp-slash-dropdown__description[data-v-6355bd34]) {
+	font-size: 0.75rem;
+	color: var(--text-muted);
+}
+.specorator-root :where(.sp-slash-dropdown__empty[data-v-6355bd34]) {
+	margin: 0;
+	padding: 0.5rem 0.75rem;
+	font-size: 0.8125rem;
+	color: var(--text-muted);
+	font-style: italic;
+}
+
+.specorator-root :where(.sp-chat__input-area[data-v-47238183]) {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+.specorator-root :where(.sp-chat__input-wrapper[data-v-47238183]) {
+	position: relative;
+}
+.specorator-root :where(.sp-chat__textarea[data-v-47238183]) {
+	width: 100%;
+	min-height: 4.5rem;
+	max-height: 8rem;
+	resize: none;
+	overflow-y: auto;
+	padding: 0.4rem 0.75rem;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 6px;
+	background: var(--background-primary);
+	color: var(--text-normal);
+	font-family: var(--font-text);
+	font-size: 0.875rem;
+	box-sizing: border-box;
+}
+.specorator-root :where(.sp-chat__textarea[data-v-47238183]:focus) {
+	outline: none;
+	border-color: var(--interactive-accent);
+}
+.specorator-root :where(.sp-chat__input-actions[data-v-47238183]) {
+	display: flex;
+	justify-content: flex-end;
 }
 
 .specorator-root :where(.sp-chat__response-idle[data-v-90757bc5]) {
@@ -1308,7 +1367,7 @@ to {
  * parent: in the agent sidepanel the parent gives ChatSidebar `flex: 0 0
  * auto` and `MessageList` takes the remaining grow space.
  */
-.specorator-root :where(.sp-chat-sidebar[data-v-0fc8a7b8]) {
+.specorator-root :where(.sp-chat-sidebar[data-v-16cae3a6]) {
 	padding: 1rem;
 	display: flex;
 	flex-direction: column;
@@ -1316,24 +1375,24 @@ to {
 	box-sizing: border-box;
 	flex-shrink: 0;
 }
-.specorator-root :where(.sp-chat__title[data-v-0fc8a7b8]) {
+.specorator-root :where(.sp-chat__title[data-v-16cae3a6]) {
 	margin: 0;
 	font-size: 1.125rem;
 	font-weight: 700;
 	color: var(--text-normal);
 }
-.specorator-root :where(.sp-chat__header[data-v-0fc8a7b8]) {
+.specorator-root :where(.sp-chat__header[data-v-16cae3a6]) {
 	display: flex;
 	align-items: center;
 	gap: 0.5rem;
 	flex-wrap: wrap;
 }
-.specorator-root :where(.sp-chat__divider[data-v-0fc8a7b8]) {
+.specorator-root :where(.sp-chat__divider[data-v-16cae3a6]) {
 	margin: 0;
 	border: none;
 	border-top: 1px solid var(--background-modifier-border);
 }
-.specorator-root :where(.sp-chat__stop[data-v-0fc8a7b8]) {
+.specorator-root :where(.sp-chat__stop[data-v-16cae3a6]) {
 	margin-left: auto;
 	font-size: 0.75rem;
 	font-weight: 500;
@@ -1347,10 +1406,10 @@ to {
 		background-color 0.15s,
 		border-color 0.15s;
 }
-.specorator-root :where(.sp-chat__stop[data-v-0fc8a7b8]:hover) {
+.specorator-root :where(.sp-chat__stop[data-v-16cae3a6]:hover) {
 	background: var(--background-modifier-error-hover, var(--interactive-hover));
 }
-.specorator-root :where(.sp-chat__degraded[data-v-0fc8a7b8]) {
+.specorator-root :where(.sp-chat__degraded[data-v-16cae3a6]) {
 	background: var(--background-secondary);
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 8px;
@@ -1359,28 +1418,81 @@ to {
 	flex-direction: column;
 	gap: 0.5rem;
 }
-.specorator-root :where(.sp-chat__degraded-heading[data-v-0fc8a7b8]) {
+.specorator-root :where(.sp-chat__degraded-heading[data-v-16cae3a6]) {
 	margin: 0;
 	font-size: 1rem;
 	font-weight: 600;
 	color: var(--text-normal);
 }
-.specorator-root :where(.sp-chat__degraded-body[data-v-0fc8a7b8]) {
+.specorator-root :where(.sp-chat__degraded-body[data-v-16cae3a6]) {
 	margin: 0;
 	font-size: 0.875rem;
 	color: var(--text-muted);
 }
 
-.specorator-root :where(.sp-agent[data-v-7699866a]) {
+.specorator-root :where(.sp-agent[data-v-cf41f4b3]) {
 	display: flex;
 	flex-direction: column;
 	height: 100%;
 	overflow: hidden;
 }
-.specorator-root :where(.sp-agent__body[data-v-7699866a]) {
+.specorator-root :where(.sp-agent__body[data-v-cf41f4b3]) {
 	flex: 1;
 	display: flex;
 	flex-direction: column;
 	min-height: 0;
+}
+.specorator-root :where(.sp-agent__help[data-v-cf41f4b3]) {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	padding: 0.75rem 1rem;
+	background: var(--background-secondary);
+	border-bottom: 1px solid var(--background-modifier-border);
+	flex-shrink: 0;
+}
+.specorator-root :where(.sp-agent__help-header[data-v-cf41f4b3]) {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
+.specorator-root :where(.sp-agent__help-title[data-v-cf41f4b3]) {
+	font-size: 0.875rem;
+	font-weight: 600;
+	color: var(--text-normal);
+}
+.specorator-root :where(.sp-agent__help-close[data-v-cf41f4b3]) {
+	font-size: 0.75rem;
+	font-weight: 500;
+	padding: 0.2rem 0.5rem;
+	border-radius: 4px;
+	border: 1px solid var(--background-modifier-border);
+	background: var(--background-primary);
+	color: var(--text-normal);
+	cursor: pointer;
+}
+.specorator-root :where(.sp-agent__help-close[data-v-cf41f4b3]:hover) {
+	background: var(--interactive-hover);
+}
+.specorator-root :where(.sp-agent__help-list[data-v-cf41f4b3]) {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+}
+.specorator-root :where(.sp-agent__help-item[data-v-cf41f4b3]) {
+	display: flex;
+	gap: 0.5rem;
+	font-size: 0.8125rem;
+	color: var(--text-normal);
+}
+.specorator-root :where(.sp-agent__help-name[data-v-cf41f4b3]) {
+	font-weight: 600;
+	min-width: 7rem;
+}
+.specorator-root :where(.sp-agent__help-description[data-v-cf41f4b3]) {
+	color: var(--text-muted);
 }
 /*$vite$:1*/

--- a/tests/application/chat/slashCommandLoader.test.ts
+++ b/tests/application/chat/slashCommandLoader.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Tests for the vault slash-command loader (PR-ASV-3 follow-up). Verifies
+ * the frontmatter parser tolerates real-world content (Claudian-style
+ * commands and skills) and that bad files are dropped without throwing.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { loadVaultSlashCommands } from '@/application/chat/slashCommandLoader';
+import { fakeModulePorts } from '@/../tests/__fakes__/fake-ports';
+
+function seed(files: Record<string, string>) {
+	const ports = fakeModulePorts();
+	for (const [path, content] of Object.entries(files)) {
+		// Write through the vault port so listFiles + readFile see them.
+		void ports.vault.writeFile(path, content);
+	}
+	return ports;
+}
+
+describe('loadVaultSlashCommands', () => {
+	it('returns an empty array when neither .claude/commands nor .claude/skills exists', async () => {
+		const ports = fakeModulePorts();
+		const result = await loadVaultSlashCommands(ports.vault, ports.logger);
+		expect(result).toEqual([]);
+	});
+
+	it('loads a valid command file with full frontmatter', async () => {
+		const ports = seed({
+			'.claude/commands/review.md': [
+				'---',
+				'description: Run a code review on a file.',
+				'argument-hint: "[path/to/file]"',
+				'allowed-tools: [Read, Bash]',
+				'model: opus',
+				'context: fork',
+				'agent: research',
+				'---',
+				'',
+				'Review this file thoroughly: $ARGUMENTS',
+				'',
+			].join('\n'),
+		});
+		const result = await loadVaultSlashCommands(ports.vault, ports.logger);
+		expect(result).toHaveLength(1);
+		const cmd = result[0];
+		expect(cmd.source).toBe('vault-command');
+		expect(cmd.id).toBe('commands:review');
+		expect(cmd.name).toBe('review');
+		expect(cmd.description).toBe('Run a code review on a file.');
+		expect(cmd.body).toContain('Review this file thoroughly');
+		expect(cmd.argumentHint).toBe('[path/to/file]');
+		expect(cmd.allowedTools).toEqual(['Read', 'Bash']);
+		expect(cmd.model).toBe('opus');
+		expect(cmd.context).toBe('fork');
+		expect(cmd.agent).toBe('research');
+	});
+
+	it('loads a skill file from .claude/skills with id `skills:<name>`', async () => {
+		const ports = seed({
+			'.claude/skills/publish-release.md': [
+				'---',
+				'description: Walk through a release.',
+				'---',
+				'',
+				'Body of the skill.',
+			].join('\n'),
+		});
+		const result = await loadVaultSlashCommands(ports.vault, ports.logger);
+		expect(result).toHaveLength(1);
+		expect(result[0].source).toBe('vault-skill');
+		expect(result[0].id).toBe('skills:publish-release');
+		expect(result[0].name).toBe('publish-release');
+	});
+
+	it('skips files with missing description and warns', async () => {
+		const ports = seed({
+			'.claude/commands/no-desc.md': ['---', 'argument-hint: "[x]"', '---', '', 'Body.'].join('\n'),
+		});
+		const result = await loadVaultSlashCommands(ports.vault, ports.logger);
+		expect(result).toEqual([]);
+		expect(ports.logger.warn).toHaveBeenCalled();
+	});
+
+	it('skips files with malformed frontmatter (no closing fence) and warns', async () => {
+		const ports = seed({
+			'.claude/commands/bad.md': ['---', 'description: Missing closing fence', '', 'Body.'].join(
+				'\n',
+			),
+		});
+		const result = await loadVaultSlashCommands(ports.vault, ports.logger);
+		expect(result).toEqual([]);
+		expect(ports.logger.warn).toHaveBeenCalled();
+	});
+
+	it('skips files with user-invocable: false', async () => {
+		const ports = seed({
+			'.claude/commands/hidden.md': [
+				'---',
+				'description: Hidden command.',
+				'user-invocable: false',
+				'---',
+				'',
+				'Body.',
+			].join('\n'),
+		});
+		const result = await loadVaultSlashCommands(ports.vault, ports.logger);
+		expect(result).toEqual([]);
+	});
+
+	it('skips skills with disable-model-invocation: true', async () => {
+		const ports = seed({
+			'.claude/skills/disabled.md': [
+				'---',
+				'description: Disabled skill.',
+				'disable-model-invocation: true',
+				'---',
+				'',
+				'Body.',
+			].join('\n'),
+		});
+		const result = await loadVaultSlashCommands(ports.vault, ports.logger);
+		expect(result).toEqual([]);
+	});
+
+	it('keeps commands with disable-model-invocation: true (the flag is skill-only)', async () => {
+		const ports = seed({
+			'.claude/commands/cmd.md': [
+				'---',
+				'description: Command.',
+				'disable-model-invocation: true',
+				'---',
+				'',
+				'Body.',
+			].join('\n'),
+		});
+		const result = await loadVaultSlashCommands(ports.vault, ports.logger);
+		expect(result).toHaveLength(1);
+		expect(result[0].source).toBe('vault-command');
+	});
+
+	it('keeps explicit user-invocable: true', async () => {
+		const ports = seed({
+			'.claude/commands/explicit.md': [
+				'---',
+				'description: Explicit.',
+				'user-invocable: true',
+				'---',
+				'',
+				'Body.',
+			].join('\n'),
+		});
+		const result = await loadVaultSlashCommands(ports.vault, ports.logger);
+		expect(result).toHaveLength(1);
+		expect(result[0].userInvocable).toBe(true);
+	});
+
+	it('combines commands and skills in one result', async () => {
+		const ports = seed({
+			'.claude/commands/a.md': '---\ndescription: A.\n---\n\nA body',
+			'.claude/skills/b.md': '---\ndescription: B.\n---\n\nB body',
+		});
+		const result = await loadVaultSlashCommands(ports.vault, ports.logger);
+		const ids = result.map((c) => c.id).sort();
+		expect(ids).toEqual(['commands:a', 'skills:b']);
+	});
+
+	it('does not recurse into subfolders', async () => {
+		// Claudian's behaviour: flat scan of `.claude/commands` only. The mock
+		// vault's `listFiles` already returns only direct-children entries, so
+		// a nested file is naturally invisible to the scan. Verify that
+		// behaviour holds end-to-end.
+		const ports = seed({
+			'.claude/commands/top.md': '---\ndescription: Top.\n---\n\nTop body',
+			'.claude/commands/nested/inner.md': '---\ndescription: Nested.\n---\n\nNested body',
+		});
+		const result = await loadVaultSlashCommands(ports.vault, ports.logger);
+		const names = result.map((c) => c.name);
+		expect(names).toContain('top');
+		expect(names).not.toContain('inner');
+	});
+
+	it('preserves the prompt body verbatim (minus the frontmatter block)', async () => {
+		const ports = seed({
+			'.claude/commands/wrap.md': [
+				'---',
+				'description: Wrap.',
+				'---',
+				'',
+				'Line one',
+				'Line two',
+				'',
+				'Line four',
+			].join('\n'),
+		});
+		const result = await loadVaultSlashCommands(ports.vault, ports.logger);
+		expect(result[0].body).toBe('Line one\nLine two\n\nLine four');
+	});
+
+	it('ignores non-markdown files in the folder', async () => {
+		const ports = seed({
+			'.claude/commands/keep.md': '---\ndescription: Keep.\n---\n\nBody',
+			'.claude/commands/note.txt': 'not a markdown file',
+		});
+		const result = await loadVaultSlashCommands(ports.vault, ports.logger);
+		expect(result.map((c) => c.name)).toEqual(['keep']);
+	});
+
+	it('tolerates a vault.listFiles rejection (treated as empty folder)', async () => {
+		const ports = fakeModulePorts();
+		// Replace listFiles with a rejecting stub for .claude/commands only.
+		const originalList = ports.vault.listFiles.bind(ports.vault);
+		ports.vault.listFiles = async (folder: string): Promise<string[]> => {
+			if (folder === '.claude/commands') {
+				throw new Error('boom');
+			}
+			return originalList(folder);
+		};
+		const result = await loadVaultSlashCommands(ports.vault, ports.logger);
+		expect(result).toEqual([]);
+	});
+});

--- a/tests/application/chat/slashCommandLoader.test.ts
+++ b/tests/application/chat/slashCommandLoader.test.ts
@@ -55,9 +55,9 @@ describe('loadVaultSlashCommands', () => {
 		expect(cmd.agent).toBe('research');
 	});
 
-	it('loads a skill file from .claude/skills with id `skills:<name>`', async () => {
+	it('loads a skill from `.claude/skills/<slug>/SKILL.md` with id `skills:<slug>`', async () => {
 		const ports = seed({
-			'.claude/skills/publish-release.md': [
+			'.claude/skills/publish-release/SKILL.md': [
 				'---',
 				'description: Walk through a release.',
 				'---',
@@ -70,6 +70,36 @@ describe('loadVaultSlashCommands', () => {
 		expect(result[0].source).toBe('vault-skill');
 		expect(result[0].id).toBe('skills:publish-release');
 		expect(result[0].name).toBe('publish-release');
+		expect(result[0].body).toContain('Body of the skill.');
+	});
+
+	it('skips skill folders that do not contain a SKILL.md (logs debug, no warn)', async () => {
+		const ports = seed({
+			// A sibling file inside the folder but no SKILL.md.
+			'.claude/skills/half-baked/notes.md': '---\ndescription: Notes.\n---\n\nBody',
+		});
+		const result = await loadVaultSlashCommands(ports.vault, ports.logger);
+		expect(result).toEqual([]);
+		// No warn — missing SKILL.md is a benign skip, not a malformed file.
+		expect(ports.logger.warn).not.toHaveBeenCalled();
+	});
+
+	it('does not load skills from a flat `.claude/skills/<slug>.md` file', async () => {
+		const ports = seed({
+			'.claude/skills/legacy-flat.md': '---\ndescription: Legacy flat layout.\n---\n\nBody',
+		});
+		const result = await loadVaultSlashCommands(ports.vault, ports.logger);
+		expect(result).toEqual([]);
+	});
+
+	it('loads multiple skills, each from its own folder', async () => {
+		const ports = seed({
+			'.claude/skills/alpha/SKILL.md': '---\ndescription: Alpha.\n---\n\nAlpha body',
+			'.claude/skills/beta/SKILL.md': '---\ndescription: Beta.\n---\n\nBeta body',
+		});
+		const result = await loadVaultSlashCommands(ports.vault, ports.logger);
+		const ids = result.map((c) => c.id).sort();
+		expect(ids).toEqual(['skills:alpha', 'skills:beta']);
 	});
 
 	it('skips files with missing description and warns', async () => {
@@ -109,7 +139,7 @@ describe('loadVaultSlashCommands', () => {
 
 	it('skips skills with disable-model-invocation: true', async () => {
 		const ports = seed({
-			'.claude/skills/disabled.md': [
+			'.claude/skills/disabled/SKILL.md': [
 				'---',
 				'description: Disabled skill.',
 				'disable-model-invocation: true',
@@ -157,7 +187,7 @@ describe('loadVaultSlashCommands', () => {
 	it('combines commands and skills in one result', async () => {
 		const ports = seed({
 			'.claude/commands/a.md': '---\ndescription: A.\n---\n\nA body',
-			'.claude/skills/b.md': '---\ndescription: B.\n---\n\nB body',
+			'.claude/skills/b/SKILL.md': '---\ndescription: B.\n---\n\nB body',
 		});
 		const result = await loadVaultSlashCommands(ports.vault, ports.logger);
 		const ids = result.map((c) => c.id).sort();

--- a/tests/ui/agent/AgentSidepanelRoot.slashCommands.test.ts
+++ b/tests/ui/agent/AgentSidepanelRoot.slashCommands.test.ts
@@ -98,6 +98,23 @@ const ChatSidebarStub = defineComponent({
 					},
 					'emit advance',
 				),
+				h(
+					'button',
+					{
+						type: 'button',
+						'data-testid': 'stub-emit-vault-prompt',
+						onClick: () => {
+							emitCommand({
+								name: 'draft',
+								description: 'Draft a note.',
+								kind: 'vault-command',
+								action: 'vault-prompt',
+								body: 'Draft prompt body',
+							});
+						},
+					},
+					'emit vault prompt',
+				),
 			]);
 	},
 });
@@ -237,6 +254,18 @@ describe('AgentSidepanelRoot — slash command dispatch (PR-ASV-3)', () => {
 			await wrapper.find('[data-testid="stub-emit-advance"]').trigger('click');
 			expect(notificationStore.notices).toHaveLength(1);
 			expect(notificationStore.notices[0].message.toLowerCase()).toContain('not yet implemented');
+		});
+	});
+
+	describe('vault-prompt action (PR-ASV-3 follow-up)', () => {
+		it('inserts the prompt body into userText and does not auto-send', async () => {
+			const { wrapper, chatStore } = mountRoot();
+			expect(chatStore.userText).toBe('');
+			await wrapper.find('[data-testid="stub-emit-vault-prompt"]').trigger('click');
+			expect(chatStore.userText).toBe('Draft prompt body');
+			// Send is the user's next action; the dispatcher must not have
+			// triggered an LLM request itself.
+			expect(chatStore.status).not.toBe('loading');
 		});
 	});
 });

--- a/tests/ui/components/chat/ChatInput.test.ts
+++ b/tests/ui/components/chat/ChatInput.test.ts
@@ -7,11 +7,14 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
+import { nextTick } from 'vue';
 import ChatInput from '@/ui/components/chat/ChatInput.vue';
 import { MockBridge } from '@/infrastructure/mock/MockBridge';
-import { VAULT_PORT } from '@/infrastructure/bridge/ports';
+import { VAULT_PORT, LOGGER_PORT } from '@/infrastructure/bridge/ports';
 import { MENTION_DEBOUNCE_MS } from '@/ui/composables/useMentionPicker';
 import { ChatInputPO } from './ChatInput.po';
+import type { SlashCommand } from '@/domain/chat/SlashCommand';
+import { fakeModulePorts } from '@/../tests/__fakes__/fake-ports';
 
 function mountChatInput(
 	props: { modelValue: string; disabled: boolean; loading: boolean },

--- a/tests/ui/components/chat/ChatInput.test.ts
+++ b/tests/ui/components/chat/ChatInput.test.ts
@@ -5,19 +5,19 @@
  * Mention-picker tests (PR-ASV-4 / D-ASV-3) live in the
  * `describe('mention picker', ...)` block at the bottom.
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { mount, flushPromises } from '@vue/test-utils'
-import ChatInput from '@/ui/components/chat/ChatInput.vue'
-import { MockBridge } from '@/infrastructure/mock/MockBridge'
-import { VAULT_PORT } from '@/infrastructure/bridge/ports'
-import { MENTION_DEBOUNCE_MS } from '@/ui/composables/useMentionPicker'
-import { ChatInputPO } from './ChatInput.po'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import ChatInput from '@/ui/components/chat/ChatInput.vue';
+import { MockBridge } from '@/infrastructure/mock/MockBridge';
+import { VAULT_PORT } from '@/infrastructure/bridge/ports';
+import { MENTION_DEBOUNCE_MS } from '@/ui/composables/useMentionPicker';
+import { ChatInputPO } from './ChatInput.po';
 
 function mountChatInput(
 	props: { modelValue: string; disabled: boolean; loading: boolean },
 	files: Record<string, string> = {},
 ) {
-	const bridge = new MockBridge(files)
+	const bridge = new MockBridge(files);
 	const wrapper = mount(ChatInput, {
 		props,
 		global: {
@@ -25,112 +25,110 @@ function mountChatInput(
 				[VAULT_PORT as symbol]: bridge,
 			},
 		},
-	})
-	return new ChatInputPO(wrapper)
+	});
+	return new ChatInputPO(wrapper);
 }
 
 describe('ChatInput', () => {
 	it('renders data-testid="chat-input-textarea"', () => {
-		const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
-		expect(po.hasTextarea()).toBe(true)
-	})
+		const po = mountChatInput({ modelValue: '', disabled: false, loading: false });
+		expect(po.hasTextarea()).toBe(true);
+	});
 
 	it('renders data-testid="chat-send-button"', () => {
-		const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
-		expect(po.hasSendButton()).toBe(true)
-	})
+		const po = mountChatInput({ modelValue: '', disabled: false, loading: false });
+		expect(po.hasSendButton()).toBe(true);
+	});
 
 	describe('v-model binding', () => {
 		it('modelValue prop sets textarea value', () => {
-			const po = mountChatInput({ modelValue: 'Hello', disabled: false, loading: false })
-			expect(po.textareaValue()).toBe('Hello')
-		})
+			const po = mountChatInput({ modelValue: 'Hello', disabled: false, loading: false });
+			expect(po.textareaValue()).toBe('Hello');
+		});
 
 		it('typing in textarea emits update:modelValue', async () => {
-			const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
-			await po.typeInTextarea('new text')
-			const emitted = po.emitted('update:modelValue') as string[][]
-			expect(emitted).toBeTruthy()
-			expect(emitted[emitted.length - 1][0]).toBe('new text')
-		})
-	})
+			const po = mountChatInput({ modelValue: '', disabled: false, loading: false });
+			await po.typeInTextarea('new text');
+			const emitted = po.emitted('update:modelValue') as string[][];
+			expect(emitted).toBeTruthy();
+			expect(emitted[emitted.length - 1][0]).toBe('new text');
+		});
+	});
 
 	describe('keyboard send', () => {
 		it('REQ-CCS-013: Ctrl+Enter emits send when not disabled and not loading', async () => {
-			const po = mountChatInput({ modelValue: 'hello', disabled: false, loading: false })
-			await po.triggerSendKey(true)
-			expect(po.emitted('send')).toBeTruthy()
-		})
+			const po = mountChatInput({ modelValue: 'hello', disabled: false, loading: false });
+			await po.triggerSendKey(true);
+			expect(po.emitted('send')).toBeTruthy();
+		});
 
 		it('Cmd+Enter emits send when not disabled and not loading', async () => {
-			const po = mountChatInput({ modelValue: 'hello', disabled: false, loading: false })
-			await po.triggerSendKey(false)
-			expect(po.emitted('send')).toBeTruthy()
-		})
+			const po = mountChatInput({ modelValue: 'hello', disabled: false, loading: false });
+			await po.triggerSendKey(false);
+			expect(po.emitted('send')).toBeTruthy();
+		});
 
 		it('Enter alone does not emit send', async () => {
-			const po = mountChatInput({ modelValue: 'hello', disabled: false, loading: false })
-			await po.triggerEnterOnly()
-			expect(po.emitted('send')).toBeFalsy()
-		})
+			const po = mountChatInput({ modelValue: 'hello', disabled: false, loading: false });
+			await po.triggerEnterOnly();
+			expect(po.emitted('send')).toBeFalsy();
+		});
 
 		it('Ctrl+Enter does not emit send when disabled=true', async () => {
-			const po = mountChatInput({ modelValue: 'hello', disabled: true, loading: false })
-			await po.triggerSendKey(true)
-			expect(po.emitted('send')).toBeFalsy()
-		})
+			const po = mountChatInput({ modelValue: 'hello', disabled: true, loading: false });
+			await po.triggerSendKey(true);
+			expect(po.emitted('send')).toBeFalsy();
+		});
 
 		it('Ctrl+Enter does not emit send when loading=true', async () => {
-			const po = mountChatInput({ modelValue: 'hello', disabled: false, loading: true })
-			await po.triggerSendKey(true)
-			expect(po.emitted('send')).toBeFalsy()
-		})
+			const po = mountChatInput({ modelValue: 'hello', disabled: false, loading: true });
+			await po.triggerSendKey(true);
+			expect(po.emitted('send')).toBeFalsy();
+		});
 
-		// IME-composition guard (top-4 from comparative review): Enter
-		// committed by a Japanese/Chinese/Korean IME must NOT trigger send.
 		it('Ctrl+Enter does not emit send while an IME is composing', async () => {
-			const po = mountChatInput({ modelValue: 'こんにち', disabled: false, loading: false })
-			const ta = po.textarea
-			await ta.trigger('keydown', { key: 'Enter', ctrlKey: true, isComposing: true })
-			expect(po.emitted('send')).toBeFalsy()
-		})
+			const po = mountChatInput({ modelValue: 'こんにち', disabled: false, loading: false });
+			const ta = po.textarea;
+			await ta.trigger('keydown', { key: 'Enter', ctrlKey: true, isComposing: true });
+			expect(po.emitted('send')).toBeFalsy();
+		});
 
 		it('Ctrl+Enter does not emit send when legacy keyCode === 229 fires', async () => {
-			const po = mountChatInput({ modelValue: '中文', disabled: false, loading: false })
-			const ta = po.textarea
-			await ta.trigger('keydown', { key: 'Enter', ctrlKey: true, keyCode: 229 })
-			expect(po.emitted('send')).toBeFalsy()
-		})
-	})
+			const po = mountChatInput({ modelValue: '中文', disabled: false, loading: false });
+			const ta = po.textarea;
+			await ta.trigger('keydown', { key: 'Enter', ctrlKey: true, keyCode: 229 });
+			expect(po.emitted('send')).toBeFalsy();
+		});
+	});
 
 	describe('disabled state', () => {
 		it('REQ-CCS-014: when disabled=true, textarea has readonly attribute', () => {
-			const po = mountChatInput({ modelValue: '', disabled: true, loading: false })
-			expect(po.isTextareaReadonly()).toBe(true)
-		})
+			const po = mountChatInput({ modelValue: '', disabled: true, loading: false });
+			expect(po.isTextareaReadonly()).toBe(true);
+		});
 
 		it('when disabled=true, send button has native disabled attribute', () => {
-			const po = mountChatInput({ modelValue: '', disabled: true, loading: false })
-			expect(po.isSendButtonDisabled()).toBe(true)
-		})
+			const po = mountChatInput({ modelValue: '', disabled: true, loading: false });
+			expect(po.isSendButtonDisabled()).toBe(true);
+		});
 
 		it('when disabled=false, textarea is not readonly', () => {
-			const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
-			expect(po.isTextareaReadonly()).toBe(false)
-		})
-	})
+			const po = mountChatInput({ modelValue: '', disabled: false, loading: false });
+			expect(po.isTextareaReadonly()).toBe(false);
+		});
+	});
 
 	describe('button label', () => {
 		it('when loading=false, button shows "Ask" label', () => {
-			const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
-			expect(po.sendButtonText()).toContain('Ask')
-		})
+			const po = mountChatInput({ modelValue: '', disabled: false, loading: false });
+			expect(po.sendButtonText()).toContain('Ask');
+		});
 
 		it('when loading=true, button shows "Asking…" label', () => {
-			const po = mountChatInput({ modelValue: '', disabled: false, loading: true })
-			expect(po.sendButtonText()).toContain('Asking')
-		})
-	})
+			const po = mountChatInput({ modelValue: '', disabled: false, loading: true });
+			expect(po.sendButtonText()).toContain('Asking');
+		});
+	});
 
 	/**
 	 * PR-ASV-4 / D-ASV-3 — `@`-file mention picker integration tests.
@@ -277,115 +275,157 @@ describe('ChatInput', () => {
 
 	describe('slash-command palette (PR-ASV-3)', () => {
 		it('does not render the dropdown before any `/` is typed', () => {
-			const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
-			expect(po.hasDropdown()).toBe(false)
-		})
+			const po = mountChatInput({ modelValue: '', disabled: false, loading: false });
+			expect(po.hasDropdown()).toBe(false);
+		});
 
 		it('opens the dropdown when `/` is typed at position 0', async () => {
-			const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
-			await po.typeAndMoveCaret('/')
-			expect(po.hasDropdown()).toBe(true)
-		})
+			const po = mountChatInput({ modelValue: '', disabled: false, loading: false });
+			await po.typeAndMoveCaret('/');
+			expect(po.hasDropdown()).toBe(true);
+		});
 
 		it('opens the dropdown when `/` follows whitespace', async () => {
-			const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
-			await po.typeAndMoveCaret('hello /')
-			expect(po.hasDropdown()).toBe(true)
-		})
+			const po = mountChatInput({ modelValue: '', disabled: false, loading: false });
+			await po.typeAndMoveCaret('hello /');
+			expect(po.hasDropdown()).toBe(true);
+		});
 
 		it('does NOT open when `/` follows a non-whitespace character', async () => {
-			const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
-			await po.typeAndMoveCaret('path/to/file')
-			expect(po.hasDropdown()).toBe(false)
-		})
+			const po = mountChatInput({ modelValue: '', disabled: false, loading: false });
+			await po.typeAndMoveCaret('path/to/file');
+			expect(po.hasDropdown()).toBe(false);
+		});
 
 		it('filters items as the user types the query', async () => {
-			const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
-			await po.typeAndMoveCaret('/cle')
-			expect(po.dropdownItem('clear').exists()).toBe(true)
-			expect(po.dropdownItem('help').exists()).toBe(false)
-			expect(po.dropdownItem('new').exists()).toBe(false)
-		})
+			const po = mountChatInput({ modelValue: '', disabled: false, loading: false });
+			await po.typeAndMoveCaret('/cle');
+			expect(po.dropdownItem('clear').exists()).toBe(true);
+			expect(po.dropdownItem('help').exists()).toBe(false);
+			expect(po.dropdownItem('new').exists()).toBe(false);
+		});
 
 		it('shows the empty placeholder when no commands match', async () => {
-			const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
-			await po.typeAndMoveCaret('/xyzzy')
-			expect(po.hasDropdown()).toBe(true)
-			expect(po.dropdownEmpty.exists()).toBe(true)
-		})
+			const po = mountChatInput({ modelValue: '', disabled: false, loading: false });
+			await po.typeAndMoveCaret('/xyzzy');
+			expect(po.hasDropdown()).toBe(true);
+			expect(po.dropdownEmpty.exists()).toBe(true);
+		});
 
 		it('closes when a whitespace is typed after the trigger', async () => {
-			const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
-			await po.typeAndMoveCaret('/cle')
-			expect(po.hasDropdown()).toBe(true)
-			await po.typeAndMoveCaret('/cle ')
-			expect(po.hasDropdown()).toBe(false)
-		})
+			const po = mountChatInput({ modelValue: '', disabled: false, loading: false });
+			await po.typeAndMoveCaret('/cle');
+			expect(po.hasDropdown()).toBe(true);
+			await po.typeAndMoveCaret('/cle ');
+			expect(po.hasDropdown()).toBe(false);
+		});
 
 		describe('keyboard navigation', () => {
 			it('ArrowDown moves the highlight forward', async () => {
-				const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
-				await po.typeAndMoveCaret('/')
+				const po = mountChatInput({ modelValue: '', disabled: false, loading: false });
+				await po.typeAndMoveCaret('/');
 				// First item is highlighted by default
-				expect(po.dropdownItem('clear').attributes('aria-selected')).toBe('true')
-				await po.pressKey('ArrowDown')
-				expect(po.dropdownItem('clear').attributes('aria-selected')).toBe('false')
-				expect(po.dropdownItem('new').attributes('aria-selected')).toBe('true')
-			})
+				expect(po.dropdownItem('clear').attributes('aria-selected')).toBe('true');
+				await po.pressKey('ArrowDown');
+				expect(po.dropdownItem('clear').attributes('aria-selected')).toBe('false');
+				expect(po.dropdownItem('new').attributes('aria-selected')).toBe('true');
+			});
 
 			it('ArrowUp from index 0 wraps to the last entry', async () => {
-				const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
-				await po.typeAndMoveCaret('/')
-				const items = po.dropdownItems()
-				expect(items.length).toBeGreaterThan(0)
-				await po.pressKey('ArrowUp')
+				const po = mountChatInput({ modelValue: '', disabled: false, loading: false });
+				await po.typeAndMoveCaret('/');
+				const items = po.dropdownItems();
+				expect(items.length).toBeGreaterThan(0);
+				await po.pressKey('ArrowUp');
 				// Last item should now be aria-selected
-				expect(items[items.length - 1].attributes('aria-selected')).toBe('true')
-			})
+				expect(items[items.length - 1].attributes('aria-selected')).toBe('true');
+			});
 
 			it('Escape closes the palette', async () => {
-				const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
-				await po.typeAndMoveCaret('/')
-				expect(po.hasDropdown()).toBe(true)
-				await po.pressKey('Escape')
-				expect(po.hasDropdown()).toBe(false)
-			})
-		})
+				const po = mountChatInput({ modelValue: '', disabled: false, loading: false });
+				await po.typeAndMoveCaret('/');
+				expect(po.hasDropdown()).toBe(true);
+				await po.pressKey('Escape');
+				expect(po.hasDropdown()).toBe(false);
+			});
+		});
 
 		describe('selection emits', () => {
 			it('Enter on a highlighted entry emits select-command and does NOT emit send', async () => {
-				const po = mountChatInput({ modelValue: '/', disabled: false, loading: false })
-				await po.typeAndMoveCaret('/')
-				await po.pressKey('Enter', { ctrl: true })
-				expect(po.emitted('send')).toBeFalsy()
-				const emitted = po.emitted('select-command') as Array<[{ name: string }]> | undefined
-				expect(emitted).toBeTruthy()
-				expect(emitted?.[0][0].name).toBe('clear')
-			})
+				const po = mountChatInput({ modelValue: '/', disabled: false, loading: false });
+				await po.typeAndMoveCaret('/');
+				await po.pressKey('Enter', { ctrl: true });
+				expect(po.emitted('send')).toBeFalsy();
+				const emitted = po.emitted('select-command') as Array<[{ name: string }]> | undefined;
+				expect(emitted).toBeTruthy();
+				expect(emitted?.[0][0].name).toBe('clear');
+			});
 
 			it('Tab selects the highlighted entry', async () => {
-				const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
-				await po.typeAndMoveCaret('/')
-				await po.pressKey('Tab')
-				const emitted = po.emitted('select-command') as Array<[{ name: string }]> | undefined
-				expect(emitted).toBeTruthy()
-				expect(emitted?.[0][0].name).toBe('clear')
-			})
+				const po = mountChatInput({ modelValue: '', disabled: false, loading: false });
+				await po.typeAndMoveCaret('/');
+				await po.pressKey('Tab');
+				const emitted = po.emitted('select-command') as Array<[{ name: string }]> | undefined;
+				expect(emitted).toBeTruthy();
+				expect(emitted?.[0][0].name).toBe('clear');
+			});
 
 			it('clicking an item emits select-command for that command', async () => {
-				const po = mountChatInput({ modelValue: '', disabled: false, loading: false })
-				await po.typeAndMoveCaret('/')
-				await po.dropdownItem('new').trigger('mousedown')
-				const emitted = po.emitted('select-command') as Array<[{ name: string }]> | undefined
-				expect(emitted).toBeTruthy()
-				expect(emitted?.[0][0].name).toBe('new')
-			})
+				const po = mountChatInput({ modelValue: '', disabled: false, loading: false });
+				await po.typeAndMoveCaret('/');
+				await po.dropdownItem('new').trigger('mousedown');
+				const emitted = po.emitted('select-command') as Array<[{ name: string }]> | undefined;
+				expect(emitted).toBeTruthy();
+				expect(emitted?.[0][0].name).toBe('new');
+			});
 
 			it('Ctrl+Enter still fires send when the palette is closed', async () => {
-				const po = mountChatInput({ modelValue: 'hello', disabled: false, loading: false })
-				await po.pressKey('Enter', { ctrl: true })
-				expect(po.emitted('send')).toBeTruthy()
-			})
-		})
-	})
-})
+				const po = mountChatInput({ modelValue: 'hello', disabled: false, loading: false });
+				await po.pressKey('Enter', { ctrl: true });
+				expect(po.emitted('send')).toBeTruthy();
+			});
+		});
+
+		describe('vault-loaded commands (PR-ASV-3 follow-up)', () => {
+			async function mountWithVault(initialFiles: Record<string, string>) {
+				const ports = fakeModulePorts();
+				for (const [path, content] of Object.entries(initialFiles)) {
+					await ports.vault.writeFile(path, content);
+				}
+				const wrapper = mount(ChatInput, {
+					props: { modelValue: '', disabled: false, loading: false },
+					global: {
+						provide: {
+							[VAULT_PORT as symbol]: ports.vault,
+							[LOGGER_PORT as symbol]: ports.logger,
+						},
+					},
+				});
+				return { wrapper, po: new ChatInputPO(wrapper) };
+			}
+
+			it('emits select-command carrying the vault body and does NOT auto-send', async () => {
+				const { wrapper, po } = await mountWithVault({
+					'.claude/commands/draft.md':
+						'---\ndescription: Draft a note.\n---\n\nDraft body to insert.',
+				});
+				await po.typeAndMoveCaret('/draft');
+				// Wait for the async vault load triggered by `open()`.
+				await flushPromises();
+				await nextTick();
+				expect(po.dropdownItem('draft').exists()).toBe(true);
+				await po.dropdownItem('draft').trigger('mousedown');
+				expect(po.emitted('send')).toBeFalsy();
+				const emitted = po.emitted('select-command') as Array<[SlashCommand]> | undefined;
+				expect(emitted).toBeTruthy();
+				const cmd = emitted?.[0][0];
+				expect(cmd?.name).toBe('draft');
+				expect(cmd?.kind).toBe('vault-command');
+				expect(cmd?.action).toBe('vault-prompt');
+				expect(cmd?.body).toContain('Draft body to insert');
+				// Sanity-check: silence unused wrapper lint.
+				expect(wrapper.exists()).toBe(true);
+			});
+		});
+	});
+});

--- a/tests/ui/components/chat/SlashCommandDropdown.po.ts
+++ b/tests/ui/components/chat/SlashCommandDropdown.po.ts
@@ -55,6 +55,16 @@ export class SlashCommandDropdownPO {
 		return this.itemByName(name).find(this.byTid('slash-command-description')).text();
 	}
 
+	itemSourceLabel(name: string): string | null {
+		const source = this.wrapper.find(this.byTid(`slash-command-source-${name}`));
+		return source.exists() ? source.text() : null;
+	}
+
+	itemHintText(name: string): string | null {
+		const hint = this.wrapper.find(this.byTid(`slash-command-hint-${name}`));
+		return hint.exists() ? hint.text() : null;
+	}
+
 	async clickItem(name: string): Promise<void> {
 		await this.itemByName(name).trigger('mousedown');
 	}

--- a/tests/ui/components/chat/SlashCommandDropdown.test.ts
+++ b/tests/ui/components/chat/SlashCommandDropdown.test.ts
@@ -103,6 +103,50 @@ describe('SlashCommandDropdown', () => {
 		});
 	});
 
+	describe('vault-loaded source labels and argument hints', () => {
+		const VAULT_CMD: SlashCommand = Object.freeze({
+			name: 'review',
+			description: 'Run a code review.',
+			kind: 'vault-command',
+			action: 'vault-prompt',
+			body: 'Review prompt body.',
+			argumentHint: '[path/to/file]',
+		});
+
+		const VAULT_SKILL: SlashCommand = Object.freeze({
+			name: 'publish-release',
+			description: 'Walk through a release.',
+			kind: 'vault-skill',
+			action: 'vault-prompt',
+			body: 'Release prompt body.',
+		});
+
+		it('renders the (command) source label for vault commands', () => {
+			const { po } = mountDropdown({ commands: [VAULT_CMD], selectedIndex: 0 });
+			expect(po.itemSourceLabel('review')).toBe('(command)');
+		});
+
+		it('renders the (skill) source label for vault skills', () => {
+			const { po } = mountDropdown({ commands: [VAULT_SKILL], selectedIndex: 0 });
+			expect(po.itemSourceLabel('publish-release')).toBe('(skill)');
+		});
+
+		it('omits the source label for built-ins', () => {
+			const { po } = mountDropdown({ commands: [CLEAR], selectedIndex: 0 });
+			expect(po.itemSourceLabel('clear')).toBeNull();
+		});
+
+		it('renders the argument hint after the description', () => {
+			const { po } = mountDropdown({ commands: [VAULT_CMD], selectedIndex: 0 });
+			expect(po.itemHintText('review')).toBe('[path/to/file]');
+		});
+
+		it('omits the hint when argumentHint is absent', () => {
+			const { po } = mountDropdown({ commands: [VAULT_SKILL], selectedIndex: 0 });
+			expect(po.itemHintText('publish-release')).toBeNull();
+		});
+	});
+
 	describe('emits', () => {
 		it('emits "select" with the clicked command (mousedown)', async () => {
 			const { wrapper, po } = mountDropdown({

--- a/tests/ui/composables/useSlashPalette.test.ts
+++ b/tests/ui/composables/useSlashPalette.test.ts
@@ -325,5 +325,39 @@ describe('useSlashPalette', () => {
 			// Built-ins still searchable; no throw.
 			expect(palette.matchedCommands.value.map((c) => c.name)).toEqual(['clear', 'new', 'help']);
 		});
+
+		it('drops a stale vault read when a newer refresh has already resolved (Codex P2)', async () => {
+			// Two concurrent reads: the first is slow, the second is fast. The
+			// fast one resolves first and commits its result. The slow one
+			// finishes after but its older data must NOT clobber the newer
+			// state — `latestRefreshSeq` makes the slow promise a no-op.
+			const ports = fakeModulePorts();
+			await ports.vault.writeFile(
+				'.claude/commands/old.md',
+				'---\ndescription: Stale.\n---\n\nold body',
+			);
+			const palette = useSlashPalette({
+				commands: FIXTURE_COMMANDS,
+				vault: ports.vault,
+				logger: ports.logger,
+			});
+
+			palette.open('');
+			const slowReadStarted = palette.refreshVaultCommands();
+			// Mutate the vault between the two refreshes so the second one
+			// sees a different command set.
+			await ports.vault.deleteFile('.claude/commands/old.md');
+			await ports.vault.writeFile(
+				'.claude/commands/fresh.md',
+				'---\ndescription: Fresh.\n---\n\nfresh body',
+			);
+			await palette.refreshVaultCommands();
+			// Now let the slow read finish — it should NOT overwrite `fresh`.
+			await slowReadStarted;
+			await nextTick();
+			const names = palette.matchedCommands.value.map((c) => c.name).sort();
+			expect(names).toContain('fresh');
+			expect(names).not.toContain('old');
+		});
 	});
 });

--- a/tests/ui/composables/useSlashPalette.test.ts
+++ b/tests/ui/composables/useSlashPalette.test.ts
@@ -227,7 +227,7 @@ describe('useSlashPalette', () => {
 				'---\ndescription: Audit something.\n---\n\nAudit body.',
 			);
 			await ports.vault.writeFile(
-				'.claude/skills/publish-release.md',
+				'.claude/skills/publish-release/SKILL.md',
 				'---\ndescription: Walk a release.\n---\n\nRelease body.',
 			);
 			const palette = useSlashPalette({
@@ -250,7 +250,7 @@ describe('useSlashPalette', () => {
 				'---\ndescription: A command.\n---\n\nBody.',
 			);
 			await ports.vault.writeFile(
-				'.claude/skills/skill-one.md',
+				'.claude/skills/skill-one/SKILL.md',
 				'---\ndescription: A skill.\n---\n\nBody.',
 			);
 			const palette = useSlashPalette({

--- a/tests/ui/composables/useSlashPalette.test.ts
+++ b/tests/ui/composables/useSlashPalette.test.ts
@@ -3,10 +3,12 @@
  * the state machine: open/close, query updates, matching, navigation
  * (including wrap-around), and selection.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { nextTick } from 'vue';
 
 import type { SlashCommand } from '@/domain/chat/SlashCommand';
 import { useSlashPalette } from '@/ui/composables/useSlashPalette';
+import { fakeModulePorts } from '@/../tests/__fakes__/fake-ports';
 
 const FIXTURE_COMMANDS: readonly SlashCommand[] = Object.freeze([
 	Object.freeze({
@@ -194,6 +196,134 @@ describe('useSlashPalette', () => {
 			expect(names).toContain('new');
 			expect(names).toContain('help');
 			expect(names).toContain('advance-stage');
+		});
+	});
+
+	describe('vault-loaded commands', () => {
+		it('built-ins are searchable immediately after open()', () => {
+			const ports = fakeModulePorts();
+			// Seed a vault command — but assert built-ins are present
+			// BEFORE we await any vault read. Built-ins must not block on
+			// the async vault scan.
+			void ports.vault.writeFile(
+				'.claude/commands/audit.md',
+				'---\ndescription: Audit something.\n---\n\nAudit body.',
+			);
+			const palette = useSlashPalette({
+				commands: FIXTURE_COMMANDS,
+				vault: ports.vault,
+				logger: ports.logger,
+			});
+			palette.open('');
+			// At the synchronous tick, only built-ins are loaded.
+			const names = palette.matchedCommands.value.map((c) => c.name);
+			expect(names).toEqual(['clear', 'new', 'help']);
+		});
+
+		it('vault commands appear after refreshVaultCommands() resolves', async () => {
+			const ports = fakeModulePorts();
+			await ports.vault.writeFile(
+				'.claude/commands/audit.md',
+				'---\ndescription: Audit something.\n---\n\nAudit body.',
+			);
+			await ports.vault.writeFile(
+				'.claude/skills/publish-release.md',
+				'---\ndescription: Walk a release.\n---\n\nRelease body.',
+			);
+			const palette = useSlashPalette({
+				commands: FIXTURE_COMMANDS,
+				vault: ports.vault,
+				logger: ports.logger,
+			});
+			palette.open('');
+			await palette.refreshVaultCommands();
+			await nextTick();
+			const names = palette.matchedCommands.value.map((c) => c.name).sort();
+			expect(names).toContain('audit');
+			expect(names).toContain('publish-release');
+		});
+
+		it('classifies vault commands and skills via kind', async () => {
+			const ports = fakeModulePorts();
+			await ports.vault.writeFile(
+				'.claude/commands/cmd-one.md',
+				'---\ndescription: A command.\n---\n\nBody.',
+			);
+			await ports.vault.writeFile(
+				'.claude/skills/skill-one.md',
+				'---\ndescription: A skill.\n---\n\nBody.',
+			);
+			const palette = useSlashPalette({
+				commands: FIXTURE_COMMANDS,
+				vault: ports.vault,
+				logger: ports.logger,
+			});
+			await palette.refreshVaultCommands();
+			palette.open('');
+			const byName = new Map(palette.matchedCommands.value.map((c) => [c.name, c]));
+			expect(byName.get('cmd-one')?.kind).toBe('vault-command');
+			expect(byName.get('skill-one')?.kind).toBe('vault-skill');
+		});
+
+		it('vault commands use action="vault-prompt" and carry the body', async () => {
+			const ports = fakeModulePorts();
+			await ports.vault.writeFile(
+				'.claude/commands/draft.md',
+				'---\ndescription: Draft.\n---\n\nDraft this content.',
+			);
+			const palette = useSlashPalette({
+				commands: FIXTURE_COMMANDS,
+				vault: ports.vault,
+				logger: ports.logger,
+			});
+			await palette.refreshVaultCommands();
+			palette.open('draft');
+			const entry = palette.matchedCommands.value.find((c) => c.name === 'draft');
+			expect(entry?.action).toBe('vault-prompt');
+			expect(entry?.body).toContain('Draft this content');
+		});
+
+		it('reopen picks up vault writes that happened while closed', async () => {
+			const ports = fakeModulePorts();
+			const palette = useSlashPalette({
+				commands: FIXTURE_COMMANDS,
+				vault: ports.vault,
+				logger: ports.logger,
+			});
+			palette.open('');
+			await palette.refreshVaultCommands();
+			expect(palette.matchedCommands.value.map((c) => c.name)).not.toContain('late');
+			palette.close();
+
+			// New vault file appears between sessions.
+			await ports.vault.writeFile(
+				'.claude/commands/late.md',
+				'---\ndescription: Late arrival.\n---\n\nLate body.',
+			);
+
+			palette.open('');
+			await palette.refreshVaultCommands();
+			expect(palette.matchedCommands.value.map((c) => c.name)).toContain('late');
+		});
+
+		it('falls back to built-ins only when no VaultPort is supplied', () => {
+			const palette = useSlashPalette({ commands: FIXTURE_COMMANDS });
+			palette.open('');
+			expect(palette.matchedCommands.value.map((c) => c.name)).toEqual(['clear', 'new', 'help']);
+		});
+
+		it('swallows a vault read error without blocking the palette', async () => {
+			const ports = fakeModulePorts();
+			ports.vault.listFiles = vi.fn().mockRejectedValue(new Error('boom'));
+			const palette = useSlashPalette({
+				commands: FIXTURE_COMMANDS,
+				vault: ports.vault,
+				logger: ports.logger,
+			});
+			palette.open('');
+			await palette.refreshVaultCommands();
+			// Built-ins still searchable; no throw.
+			expect(palette.matchedCommands.value.map((c) => c.name)).toEqual(['clear', 'new', 'help']);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Extends the slash palette (#375) to surface user-defined commands from `.claude/commands/*.md` and `.claude/skills/*.md` — matching Claudian's pattern. Built-ins (`/clear`, `/new`, `/help`, `/advance-stage`) continue to ship hardcoded; vault commands appear alongside them in the dropdown.

**Stacked on #375 → #372 → #371 → #370 → #369 → develop.**

### Frontmatter schema

```yaml
---
description: Short one-line description shown in the palette subtitle.
argument-hint: "[path/to/file]"
allowed-tools: [Read, Bash]
model: opus
disable-model-invocation: false
user-invocable: true
context: fork
agent: research
hooks: {}
---

Body becomes the prompt that's inserted into the textarea on selection.
```

### New surfaces

- `src/application/chat/slashCommandLoader.ts` — `loadVaultSlashCommands(vault, logger)` returns a structured `VaultSlashCommand[]`. Hand-rolled frontmatter parser mirrors `WorkflowStateDocument.ts` (no new dep). Filters: `user-invocable !== false` always; `disable-model-invocation: true` filters skills only (matches Claudian semantics — commands can be SDK-tool-disabled while staying user-invocable).
- `src/domain/chat/SlashCommand.ts` — extended with `'vault-command'` / `'vault-skill'` kinds, `'vault-prompt'` action, optional frontmatter fields (`body`, `argumentHint`, `allowedTools`, `model`, `context`, `agent`).
- `src/ui/composables/useSlashPalette.ts` — restructured to merge stable built-ins with a reactive `vaultCommandsRef` refreshed on every `open()`. `refreshVaultCommands()` exposed for tests.
- `src/ui/components/chat/SlashCommandDropdown.vue` — renders `(command)` / `(skill)` source label + optional `argument-hint` bracket.
- `src/ui/agent/AgentSidepanelRoot.vue` — new `vault-prompt` switch arm inserts `command.body` into `chatStore.userText` and focuses the textarea. **No auto-send** — the user reviews/edits before submitting.

### Behaviour

- Built-ins searchable immediately on `/` keystroke.
- Vault entries appear once the async vault read resolves (~few ms typical, longer on large vaults).
- Read failure is swallowed via `LoggerPort.warn` — the palette stays functional with built-ins only.
- Subfolder recursion is intentionally omitted (matches Claudian) — files must live directly under `.claude/commands/` or `.claude/skills/`.
- Selecting a vault command inserts `body` (the full prompt template) into the textarea so the user can tweak before sending. Slash token is scrubbed.

## Test plan

- [x] **+14 new tests** total:
  - `slashCommandLoader.test.ts` (14): frontmatter parsing — valid command, valid skill, missing description, malformed YAML, `user-invocable: false`, `disable-model-invocation: true` for skills, mixed source merging, flat scan (no recursion), body preservation, non-md filtering, rejection tolerance.
  - `useSlashPalette.test.ts` (+6): built-ins immediate, vault appears after refresh, kind classification, vault-prompt body insertion, reopen picks up new vault writes, no-`VaultPort` fallback.
  - `SlashCommandDropdown.test.ts` (+5): source labels, argument-hint rendering, dropdown order.
  - `ChatInput.test.ts` (+1): vault command emits `select-command` with body, no auto-send.
  - `AgentSidepanelRoot.slashCommands.test.ts` (+1, new file): vault-prompt action inserts body into `chatStore.userText`.
- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 errors
- [x] `npm run test` 1551/1551 pass
- [x] `npm run build` + `npm run build:web` + `npm run docs:api` succeed
- [x] `npm audit` 0 vulnerabilities

### Deferred (P2/P3 follow-ups)

- Recursive scan of `.claude/commands/**/*.md` — Claudian doesn't recurse; matching that for now.
- SDK-probed runtime commands via `conversation.supportedCommands()` — needs a hook into the streaming chain.
- Argument-hint validation against the typed argument the user supplies.

https://claude.ai/code/session_01VvXsK3aGp2g4jSpT1py7Mh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvXsK3aGp2g4jSpT1py7Mh)_