### PR TITLE
fix(secret-storage): catch keychain read errors instead of aborting

### DIFF
--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -29,6 +29,7 @@ import { ClaudeBinaryResolver, type SpawnFn as ResolverSpawnFn } from '@/infrast
 import { degradedClaudeCliPort } from '@/infrastructure/bridge/degradedClaudeCliPort'
 import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
 import { FeedbackService } from '@/application/shared/FeedbackService'
+import { tryAsync } from '@/domain/shared/tryAsync'
 import { PluginCore } from '@/core/plugin-core'
 import { ALL_MODULES, type ModuleDescriptor } from '@/modules'
 import { i18nMerge, i18nTranslate, setLocale, type SupportedLocale } from '@/ui/i18n'
@@ -451,12 +452,15 @@ export default class SpecoratorPlugin extends Plugin {
    * stored Anthropic key is loaded into the cache. On mobile / older
    * desktop builds `available === false` and the cache stays empty — chat
    * falls back to degraded mode (see settings tab).
+   *
+   * Codex P1 on PR #393: keychain reads can reject (locked keychain, OS
+   * denial, transient platform error). Mirror the `setSecret` wrap and
+   * degrade to an empty cache on rejection so plugin startup never aborts
+   * for a transient OS-keychain failure.
    */
   private async _initializeSecretStore(): Promise<void> {
     this.secretStore = new ObsidianSecretStoreAdapter(this.app)
-    this._apiKeyCache = this.secretStore.available
-      ? ((await this.secretStore.getSecret(SECRET_ID_ANTHROPIC)) ?? '')
-      : ''
+    this._apiKeyCache = await this._readSecretSafe(this.secretStore)
   }
 
   /**
@@ -477,11 +481,25 @@ export default class SpecoratorPlugin extends Plugin {
    */
   async refreshApiKeyCache(): Promise<void> {
     if (this.secretStore === null) return
-    this._apiKeyCache = this.secretStore.available
-      ? ((await this.secretStore.getSecret(SECRET_ID_ANTHROPIC)) ?? '')
-      : ''
+    this._apiKeyCache = await this._readSecretSafe(this.secretStore)
     this._specoratorView?.bumpSettingsVersion()
     this._agentSidepanelView?.bumpSettingsVersion()
+  }
+
+  /**
+   * Read the Anthropic key from the secret store with defensive handling.
+   * Codex P1 on PR #393: keychain reads can fail (locked keychain, OS
+   * denial, transient platform error) and must not crash the plugin —
+   * degrading to "no key" matches the unavailable-store branch.
+   */
+  private async _readSecretSafe(secretStore: SecretStorePort): Promise<string> {
+    if (!secretStore.available) return ''
+    const outcome = await tryAsync(() => secretStore.getSecret(SECRET_ID_ANTHROPIC))
+    if (!outcome.ok) {
+      this.bridge?.warn('main.secretStorage.read.failed', { error: outcome.error })
+      return ''
+    }
+    return outcome.value ?? ''
   }
 
   /**


### PR DESCRIPTION
## Summary

Codex P1 on PR #393 (develop → demo). `SpecoratorPlugin._initializeSecretStore()`
and `refreshApiKeyCache()` awaited `secretStore.getSecret(...)` directly,
so any keychain read failure (locked keychain, OS denial, transient
platform error) would reject the `loadSettings()` chain — taking the
whole plugin startup down — or strand the settings tab's `onChange`
handler with an uncaught rejection.

The write side already wraps in `tryAsync` (see settings tab). This PR
mirrors that on the read side via a small `_readSecretSafe()` helper:

- Checks `available` first (returns `''` immediately when secret storage
  isn't reachable, same as before).
- Wraps `getSecret` in `tryAsync`.
- Logs a warn on failure (via `this.bridge?.warn`, which no-ops when
  called during `loadSettings()` before the bridge is constructed).
- Degrades to `''` on failure — same fallback as the unavailable branch,
  so chat lands in degraded mode rather than the plugin crashing.

Both callers (`_initializeSecretStore` during `onload()` and the
post-settings-write `refreshApiKeyCache`) now go through the same helper.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 errors (24 pre-existing warnings)
- [x] `npm run test` — 1682 / 1682 passing
- [x] `npm run build` — bundle builds clean

https://claude.ai/code/session_01T6R5ggmbmhbmALfV9Ajn1Q


---
_Generated by [Claude Code](https://claude.ai/code/session_01T6R5ggmbmhbmALfV9Ajn1Q)_