### PR TITLE
refactor(asv3): ClaudeCliPort queryStream-only + TransportLifecyclePort (WP-12)

### DIFF
--- a/src/application/chat/collectStream.ts
+++ b/src/application/chat/collectStream.ts
@@ -1,0 +1,49 @@
+/**
+ * `collectStream` — pure helper that drains a `ClaudeCliPort.queryStream`
+ * iterable into a single `Result<string, ClaudeCliError>`. Replaces the
+ * legacy `port.query()` method (deleted in WP-12) and the
+ * `streamFromQuery` shim it relied on.
+ *
+ * Why this lives in `application/chat`:
+ *   - It consumes a streaming `AsyncIterable<StreamDelta>`, which is the
+ *     port-layer contract.
+ *   - It converges that stream into the same `Result<string, ClaudeCliError>`
+ *     shape the deleted `query()` method returned.
+ *   - It has no Obsidian / SDK dependencies — pure async iteration.
+ *
+ * Semantics (mirrors the deleted `ClaudeCliAdapter.query` / `ClaudeSubprocessAdapter.query`):
+ *   - Concatenate every `text` delta in order; ignore everything else
+ *     except `error` / `done`.
+ *   - On `error`, return `err(delta.error)` and stop reading.
+ *   - On `done`, return `ok(concatenatedText)`.
+ *   - If the iterable exhausts without ever emitting `done` or `error`,
+ *     return `err(ClaudeCliError{ QUERY_FAILED, "Stream closed before terminal delta" })`.
+ *     This branch matches the pre-WP-12 adapters' defensive "No result
+ *     message" / "Subprocess closed before result event" fallbacks.
+ *
+ * Never throws.
+ */
+import { ClaudeCliError, type StreamDelta } from '@/domain/ports/ClaudeCliPort';
+import { err, ok, type Result } from '@/domain/shared/Result';
+
+export async function collectStream(
+	stream: AsyncIterable<StreamDelta>,
+): Promise<Result<string, ClaudeCliError>> {
+	const chunks: string[] = [];
+	for await (const delta of stream) {
+		if (delta.type === 'text') {
+			chunks.push(delta.text);
+			continue;
+		}
+		if (delta.type === 'error') {
+			return err(delta.error);
+		}
+		if (delta.type === 'done') {
+			return ok(chunks.join(''));
+		}
+		// Other delta variants (`session-id`, `thinking`, tool-use, `usage`,
+		// `compact-boundary`) are observable side-channels for streaming
+		// consumers; the converge-to-string path simply ignores them.
+	}
+	return err(new ClaudeCliError('QUERY_FAILED', 'Stream closed before terminal delta'));
+}

--- a/src/application/chat/queryStructured.ts
+++ b/src/application/chat/queryStructured.ts
@@ -3,113 +3,41 @@
  * structured-output path on the subscription transport.
  *
  * Spec reference: SPEC-ASM-001 §2.9 (type seam) and §6.6 (module shape and
- * algorithm). ADR-008 narrow-port discipline is preserved: `ClaudeCliPort`
- * keeps its four methods (query, isAvailable, startup, shutdown). The
- * structured capability is exposed as a tagged structural extension —
- * `SubscriptionCapable` — that downstream callers narrow to via the
- * user-defined type guard `isSubscriptionCapable`. The SDK adapter
- * (`ClaudeCliAdapter`) has no `kind` field and therefore fails the guard
- * closed.
+ * algorithm).
  *
- * The interface lives in this application module (per spec §6.6 and the task
- * description) rather than in `@/domain/ports/ClaudeCliPort` so that the
- * domain port remains a four-method surface. `SubscriptionCapable extends
- * ClaudeCliPort` purely as a type seam; the production adapter satisfies it
- * structurally, not by `implements`-declaration.
+ * Reshaped in WP-12 (Arch review #3):
+ *   - `runStructured` is now an *optional* method on `ClaudeCliPort` itself.
+ *     Subscription-capable adapters implement it; the SDK adapter and the
+ *     `degradedClaudeCliPort` sentinel do not.
+ *   - The `SubscriptionCapable` structural sidecar interface and the
+ *     `isSubscriptionCapable` type guard are deleted (no back-compat shim
+ *     per AGENTS.md §8).
+ *   - The narrowing site is now a plain
+ *     `typeof port.runStructured === 'function'` check, with no `kind`
+ *     discriminator to keep in sync.
  *
  * Algorithm (§6.6):
- *   1. If `!isSubscriptionCapable(port)` → return `err(ClaudeCliError{
- *      NOT_INSTALLED })` — structured output requires the subscription
- *      transport.
+ *   1. If `port.runStructured` is not a function → return
+ *      `err(ClaudeCliError{ NOT_INSTALLED })` — structured output requires
+ *      the subscription transport.
  *   2. `raw = await port.runStructured(prompt, options)`.
  *   3. If `!raw.ok` → propagate the adapter's `ClaudeCliError`.
  *   4. Return `parseStructuredEnvelope(raw.value)`.
  *
  * Satisfies REQ-ASM-001, REQ-ASM-021, REQ-ASM-049.
  */
-import type { SessionId } from '@/domain/chat/SessionId'
 import {
-  ClaudeCliError,
-  type ClaudeCliPort,
-  type ClaudeCliQueryOptions,
+	ClaudeCliError,
+	type ClaudeCliPort,
+	type ClaudeCliQueryOptions,
+	type StructuredCliCallOptions,
+	type StructuredCliRawResult,
 } from '@/domain/ports/ClaudeCliPort'
 import { err, type Result } from '@/domain/shared/Result'
 
 import type { CreateFileEnvelope } from './createFileEnvelopeSchema'
 import type { EnvelopeParseError } from './errors'
 import { parseStructuredEnvelope } from './parseStructuredEnvelope'
-
-/**
- * Raw response from a structured-output Claude CLI invocation
- * (`claude -p '<prompt>' --output-format json --json-schema '<schema>'`).
- *
- * `result` is the model's free-text payload; `structured_output` is the
- * schema-validated JSON object (or `unknown` for the parser to validate via
- * Zod). Both fields are populated by the adapter from a single `JSON.parse`
- * of the subprocess's full stdout (SPEC §4.2 `runStructured` row).
- */
-export interface StructuredCliRawResult {
-  readonly result: string
-  readonly structured_output: unknown
-}
-
-/**
- * Options forwarded to the structured one-shot call. Mirror of the relevant
- * fields from `ClaudeCliQueryOptions`; kept as a separate interface so the
- * structured surface can evolve without widening the free-text port.
- */
-export interface StructuredCliCallOptions {
-  readonly systemPromptSuffix?: string
-  readonly resumeSessionId?: string
-  readonly timeoutMs?: number
-  /**
-   * Optional caller-supplied callback invoked exactly once when the structured
-   * call's response envelope yields a non-empty `session_id`. Mirrors the
-   * free-text `ClaudeCliQueryOptions.onSessionId` contract (REQ-ASM-031): the
-   * callback must be invoked before the wrapper's promise resolves so the
-   * caller can persist the session id alongside the resolved envelope.
-   *
-   * Load-bearing for proposals (REQ-ASM-046) — without it, a thread that
-   * starts with `/create-file` keeps `thread.sessionId === null` and the
-   * subsequent `appendProposalDecision` would reject with
-   * `SessionLogNoSessionError`, surfacing the trust-first violation as
-   * `SESSION_LOG_FAILED` instead of silently dropping the audit row.
-   */
-  readonly onSessionId?: (sessionId: SessionId) => void
-}
-
-/**
- * Tagged structural extension of `ClaudeCliPort`. The subscription adapter
- * declares `readonly kind = 'subscription'` and exposes `runStructured`; the
- * SDK adapter does neither. The user-defined type guard
- * `isSubscriptionCapable` is the only sanctioned way to narrow a
- * `ClaudeCliPort` to this capability — call sites must never reach for
- * `instanceof` (which would force a domain ⇄ infrastructure import).
- */
-export interface SubscriptionCapable extends ClaudeCliPort {
-  readonly kind: 'subscription'
-  runStructured(
-    prompt: string,
-    options: StructuredCliCallOptions,
-  ): Promise<Result<StructuredCliRawResult, ClaudeCliError>>
-}
-
-/**
- * Structural type guard: returns `true` iff the port both carries the
- * `'subscription'` tag and exposes a callable `runStructured` method. The
- * second check guards against a partially-mocked port that sets `kind` but
- * hasn't implemented the method.
- *
- * Fails closed for: the SDK adapter (no `kind` field), the
- * `degradedClaudeCliPort` sentinel, and any future transport that hasn't
- * opted in.
- */
-export function isSubscriptionCapable(port: ClaudeCliPort): port is SubscriptionCapable {
-  const candidate = port as Partial<SubscriptionCapable>
-  return (
-    candidate.kind === 'subscription' && typeof candidate.runStructured === 'function'
-  )
-}
 
 /**
  * Structured-output guard phrase appended to every structured call's system
@@ -125,50 +53,65 @@ export function isSubscriptionCapable(port: ClaudeCliPort): port is Subscription
  * without having to remember to append it themselves.
  */
 export const STRUCTURED_OUTPUT_GUARD_SUFFIX =
-  '\n\nRespond with a single JSON object that conforms to the provided schema. ' +
-  'Do not include any prose, explanation, code fences, or markdown formatting ' +
-  'before or after the JSON object.'
+	'\n\nRespond with a single JSON object that conforms to the provided schema. ' +
+	'Do not include any prose, explanation, code fences, or markdown formatting ' +
+	'before or after the JSON object.'
+
+/**
+ * Narrowing helper: returns `true` iff the port exposes a callable
+ * `runStructured` method. Replaces the deleted `isSubscriptionCapable`
+ * type guard (WP-12) — there is no `kind` discriminator any more, and
+ * sub-capability detection is one method-presence check.
+ */
+function hasRunStructured(
+	port: ClaudeCliPort,
+): port is ClaudeCliPort & {
+	runStructured: NonNullable<ClaudeCliPort['runStructured']>
+} {
+	return typeof port.runStructured === 'function'
+}
 
 /**
  * Application-layer wrapper around the structured-output path. See module
  * header and SPEC §6.6 for the algorithm. Never throws. The error union
  * surfaces:
- *   - `ClaudeCliError{ NOT_INSTALLED }` when the port is not subscription-capable.
+ *   - `ClaudeCliError{ NOT_INSTALLED }` when the port does not expose
+ *     `runStructured`.
  *   - `ClaudeCliError{ … }` propagated from the adapter (TIMEOUT, QUERY_FAILED, etc.).
  *   - `EnvelopeParseError` from the four-step `parseStructuredEnvelope` pipeline.
  */
 export async function queryStructured(
-  port: ClaudeCliPort,
-  prompt: string,
-  options: StructuredCliCallOptions = {},
+	port: ClaudeCliPort,
+	prompt: string,
+	options: StructuredCliCallOptions = {},
 ): Promise<Result<CreateFileEnvelope, EnvelopeParseError | ClaudeCliError>> {
-  if (!isSubscriptionCapable(port)) {
-    return err(
-      new ClaudeCliError(
-        'NOT_INSTALLED',
-        'Structured output requires the subscription transport.',
-      ),
-    )
-  }
+	if (!hasRunStructured(port)) {
+		return err(
+			new ClaudeCliError(
+				'NOT_INSTALLED',
+				'Structured output requires the subscription transport.',
+			),
+		)
+	}
 
-  // Always pin the JSON-only guard on the system prompt suffix so the model
-  // returns an object-only response (Codex P2, PR #347). The stage preamble
-  // composed by `assembleSystemPrompt` (when present) precedes the guard.
-  const callerSuffix = options.systemPromptSuffix ?? ''
-  const mergedOptions: StructuredCliCallOptions = {
-    ...options,
-    systemPromptSuffix: callerSuffix + STRUCTURED_OUTPUT_GUARD_SUFFIX,
-  }
+	// Always pin the JSON-only guard on the system prompt suffix so the model
+	// returns an object-only response (Codex P2, PR #347). The stage preamble
+	// composed by `assembleSystemPrompt` (when present) precedes the guard.
+	const callerSuffix = options.systemPromptSuffix ?? ''
+	const mergedOptions: StructuredCliCallOptions = {
+		...options,
+		systemPromptSuffix: callerSuffix + STRUCTURED_OUTPUT_GUARD_SUFFIX,
+	}
 
-  const raw = await port.runStructured(prompt, mergedOptions)
-  if (!raw.ok) {
-    return err(raw.error)
-  }
+	const raw = await port.runStructured(prompt, mergedOptions)
+	if (!raw.ok) {
+		return err(raw.error)
+	}
 
-  return parseStructuredEnvelope(raw.value)
+	return parseStructuredEnvelope(raw.value)
 }
 
-// Re-export the standard `ClaudeCliQueryOptions` so call sites that already
-// hold a free-text options bag can pass it straight through without an extra
-// import line. The structured options are a subset.
-export type { ClaudeCliQueryOptions }
+// Re-export the standard option types so call sites that already hold a
+// free-text options bag can pass it straight through without an extra import
+// line. The structured options are a subset.
+export type { ClaudeCliQueryOptions, StructuredCliCallOptions, StructuredCliRawResult }

--- a/src/domain/ports/ClaudeCliPort.ts
+++ b/src/domain/ports/ClaudeCliPort.ts
@@ -34,7 +34,9 @@ export class ClaudeCliError extends Error {
 }
 
 /**
- * Options forwarded to the underlying SDK call. All fields are optional.
+ * Options forwarded to the underlying SDK / subprocess call. All fields are
+ * optional. Shared by `queryStream` (free-text streaming) and `runStructured`
+ * (structured-output, subscription transport only).
  * Satisfies REQ-CCS-021.
  */
 export interface ClaudeCliQueryOptions {
@@ -73,7 +75,7 @@ export interface ClaudeCliQueryOptions {
 	readonly resumeSessionId?: SessionId;
 
 	/**
-	 * Optional callback invoked exactly once per `query()` call the first time a
+	 * Optional callback invoked exactly once per turn the first time a
 	 * non-empty `session_id` is captured from a `system/init` event on the
 	 * stream-json wire (REQ-ASM-031). The subscription transport invokes this
 	 * synchronously from inside the NDJSON event handler so the caller can
@@ -86,11 +88,9 @@ export interface ClaudeCliQueryOptions {
 }
 
 /**
- * Options for the streaming variant `queryStream()` introduced in Increment 2
- * of `specs/agent-sidepanel-v2/` (REQ-ASV-053). Superset of
- * `ClaudeCliQueryOptions` adding an `AbortSignal` so the UI's stop-generation
- * control can cancel an in-flight turn. The legacy `query()` method
- * intentionally lacks this; cancellation is the differentiator.
+ * Options for `queryStream()` — superset of `ClaudeCliQueryOptions` adding
+ * an `AbortSignal` so the UI's stop-generation control can cancel an
+ * in-flight turn.
  */
 export interface ClaudeCliStreamOptions extends ClaudeCliQueryOptions {
 	/**
@@ -100,9 +100,9 @@ export interface ClaudeCliStreamOptions extends ClaudeCliQueryOptions {
 	 * (or the existing `{ type: 'done' }` if the abort raced a successful
 	 * completion). The adapter MUST NOT throw on abort.
 	 *
-	 * Optional so unit tests and the legacy free-text call sites can omit it.
-	 * Production wiring threads a fresh `AbortController.signal` per turn
-	 * from `ChatSidebar`'s Stop button click handler.
+	 * Optional so unit tests can omit it. Production wiring threads a fresh
+	 * `AbortController.signal` per turn from `ChatSidebar`'s Stop button
+	 * click handler.
 	 */
 	readonly signal?: AbortSignal;
 }
@@ -122,9 +122,8 @@ export interface ClaudeCliStreamOptions extends ClaudeCliQueryOptions {
  *   - `error`       — terminal failure. No further deltas arrive after this.
  *
  * `done` and `error` are mutually exclusive: exactly one of the two ends
- * each stream. The SDK adapter currently emits final `text` + `done`;
- * future increments may add `tool-use` / `thinking` variants under the
- * same union — additive only.
+ * each stream. Future increments may add `tool-use` / `thinking` variants
+ * under the same union — additive only.
  */
 export type StreamDelta =
 	| { readonly type: 'text'; readonly text: string }
@@ -187,19 +186,59 @@ export type StreamDelta =
 	| { readonly type: 'error'; readonly error: ClaudeCliError };
 
 /**
- * Narrow port for the Claude CLI subprocess adapter (ADR-008).
- * The interface file must not import from 'obsidian' or '@anthropic-ai/claude-agent-sdk'.
- * Satisfies REQ-CCS-021.
+ * Raw response from a structured-output Claude CLI invocation
+ * (`claude -p '<prompt>' --output-format json --json-schema '<schema>'`).
+ *
+ * `result` is the model's free-text payload; `structured_output` is the
+ * schema-validated JSON object (or `unknown` for the application-layer
+ * parser to validate via Zod). Both fields are populated by the adapter
+ * from a single `JSON.parse` of the subprocess's full stdout
+ * (SPEC-ASM-001 §4.2 `runStructured` row).
+ *
+ * Moved onto the port file in WP-12 — previously lived in the application
+ * layer's `queryStructured.ts` sidecar.
+ */
+export interface StructuredCliRawResult {
+	readonly result: string;
+	readonly structured_output: unknown;
+}
+
+/**
+ * Options forwarded to `runStructured()`. Mirror of the relevant fields from
+ * `ClaudeCliQueryOptions`; kept as a separate interface so the structured
+ * surface can evolve without widening the free-text streaming surface.
+ *
+ * Moved onto the port file in WP-12.
+ */
+export interface StructuredCliCallOptions {
+	readonly systemPromptSuffix?: string;
+	readonly resumeSessionId?: string;
+	readonly timeoutMs?: number;
+	/**
+	 * Optional caller-supplied callback invoked exactly once when the
+	 * structured call's response envelope yields a non-empty `session_id`
+	 * (REQ-ASM-031, REQ-ASM-046). Mirrors the free-text streaming surface's
+	 * `onSessionId` contract.
+	 */
+	readonly onSessionId?: (sessionId: SessionId) => void;
+}
+
+/**
+ * Narrow port for the Claude CLI adapters (ADR-008).
+ *
+ * The interface file must not import from 'obsidian' or
+ * '@anthropic-ai/claude-agent-sdk'.
+ *
+ * Reshaped in WP-12 (Arch review #3) to a single canonical streaming method
+ * plus the optional structured-output method that subscription-capable
+ * adapters expose. Lifecycle (`startup` / `shutdown`) lives on the sibling
+ * `TransportLifecyclePort`; the free-text non-streaming `query()` method
+ * is gone — non-streaming callers funnel `queryStream` through
+ * `collectStream()` in `src/application/chat/collectStream.ts`.
+ *
+ * Satisfies REQ-CCS-021, REQ-ASM-001.
  */
 export interface ClaudeCliPort {
-	/**
-	 * Send a fully-assembled prompt string to Claude and return the full text response.
-	 * Never throws. Returns Result<string, ClaudeCliError>.
-	 * The promise resolves when the response arrives or when an error/timeout occurs.
-	 * Satisfies REQ-CCS-013, REQ-CCS-016, NFR-CCS-003.
-	 */
-	query(prompt: string, options?: ClaudeCliQueryOptions): Promise<Result<string, ClaudeCliError>>;
-
 	/**
 	 * Returns true if the adapter is ready to accept queries.
 	 * Returns false for all degraded conditions: missing API key, startup failure,
@@ -209,21 +248,6 @@ export interface ClaudeCliPort {
 	 * Satisfies REQ-CCS-018, REQ-CCS-019, REQ-CCS-022.
 	 */
 	isAvailable(): Promise<boolean>;
-
-	/**
-	 * Pre-warm the subprocess. Called from onload() before the first user interaction.
-	 * Must not throw; log errors internally and return.
-	 * Satisfies REQ-CCS-003, NFR-CCS-002.
-	 */
-	startup(): Promise<void>;
-
-	/**
-	 * Terminate the subprocess. Called from onunload() which is synchronous.
-	 * Must be synchronous (fire-and-forget is acceptable).
-	 * Must not throw.
-	 * Satisfies REQ-CCS-017, NFR-CCS-007.
-	 */
-	shutdown(): void;
 
 	/**
 	 * Stream a fully-assembled prompt to Claude and yield deltas as they
@@ -239,85 +263,34 @@ export interface ClaudeCliPort {
 	 *   - close the iterable after the terminal delta — no further deltas;
 	 *   - never throw; surface every error path through `error`.
 	 *
-	 * Introduced for IDEA-ASV-001 Increment 2 (streaming responses + stop
-	 * generation). The legacy `query()` method remains for call sites that
-	 * don't need streaming — both methods coexist and may be implemented
-	 * independently.
+	 * Sole canonical streaming method (WP-12). Non-streaming consumers use
+	 * `collectStream()` from `@/application/chat/collectStream` to converge
+	 * the stream to a `Result<string, ClaudeCliError>`.
 	 */
 	queryStream(prompt: string, options?: ClaudeCliStreamOptions): AsyncIterable<StreamDelta>;
-}
 
-/**
- * Build a `queryStream`-shaped async iterable from a non-streaming `query()`
- * function. Emits the resolved text as a single `text` delta + `done`, or a
- * single `error` delta on failure. Useful for ports that don't (yet) have a
- * real streaming pipeline — test fixtures, the standalone-web
- * `LocalStorageBridge`, and the bridge stubs on the real adapters in
- * PR-ASV-2-port.
- *
- * Honours `options.signal` in two phases:
- *   1. Pre-flight: if the signal is already aborted, yield an error delta
- *      without invoking `query` at all.
- *   2. Mid-flight: while `query()` is in flight, listen for an abort and
- *      race the result against the abort event. On abort, yield the error
- *      delta and return immediately — the underlying `query()` call is
- *      orphaned (it cannot be cancelled because the legacy contract has no
- *      signal parameter), but the iterable's contract is honoured.
- *
- * Codex P2 on PR #370: the original implementation only checked pre-flight,
- * which broke cancellation semantics for stub-delegating adapters.
- */
-export async function* streamFromQuery(
-	query: (
+	/**
+	 * Structured-output one-shot for subscription-capable adapters.
+	 *
+	 * Optional: the SDK adapter and the bridge / degraded sentinels do not
+	 * expose it (the `?` makes calling it a `typeof port.runStructured === 'function'`
+	 * narrowing site). The application-layer `queryStructured()` wrapper
+	 * performs that narrowing — call sites never reach for `instanceof`
+	 * (which would force a domain ⇄ infrastructure import).
+	 *
+	 * Folded onto the port in WP-12; previously lived behind the
+	 * `SubscriptionCapable` structural sidecar in
+	 * `application/chat/queryStructured.ts`. The new shape is narrower
+	 * *per responsibility* — there is one streaming port and one lifecycle
+	 * port, not one port with two unrelated halves.
+	 *
+	 * Never throws. Returns `Result<StructuredCliRawResult, ClaudeCliError>`;
+	 * envelope parsing happens in the application layer.
+	 *
+	 * Satisfies REQ-ASM-021, REQ-ASM-049.
+	 */
+	runStructured?(
 		prompt: string,
-		options?: ClaudeCliQueryOptions,
-	) => Promise<Result<string, ClaudeCliError>>,
-	prompt: string,
-	options?: ClaudeCliStreamOptions,
-): AsyncIterable<StreamDelta> {
-	const abortDelta = (): StreamDelta => ({
-		type: 'error',
-		error: new ClaudeCliError('QUERY_FAILED', 'Request was aborted'),
-	});
-
-	if (options?.signal?.aborted === true) {
-		yield abortDelta();
-		return;
-	}
-
-	const queryPromise = query(prompt, options);
-	const signal = options?.signal;
-	if (signal !== undefined) {
-		const ABORTED = Symbol('aborted');
-		const abortPromise = new Promise<typeof ABORTED>((resolve) => {
-			signal.addEventListener(
-				'abort',
-				() => {
-					resolve(ABORTED);
-				},
-				{ once: true },
-			);
-		});
-		const winner = await Promise.race([queryPromise, abortPromise]);
-		if (winner === ABORTED) {
-			yield abortDelta();
-			return;
-		}
-		const result = winner;
-		if (!result.ok) {
-			yield { type: 'error', error: result.error };
-			return;
-		}
-		yield { type: 'text', text: result.value };
-		yield { type: 'done' };
-		return;
-	}
-
-	const result = await queryPromise;
-	if (!result.ok) {
-		yield { type: 'error', error: result.error };
-		return;
-	}
-	yield { type: 'text', text: result.value };
-	yield { type: 'done' };
+		options: StructuredCliCallOptions,
+	): Promise<Result<StructuredCliRawResult, ClaudeCliError>>;
 }

--- a/src/domain/ports/TransportLifecyclePort.ts
+++ b/src/domain/ports/TransportLifecyclePort.ts
@@ -1,0 +1,46 @@
+/**
+ * Narrow port (ADR-008) for the streaming-transport lifecycle. Owns the two
+ * stateful side-effects that are *not* part of the per-turn streaming
+ * surface in `ClaudeCliPort`:
+ *
+ *   - `startup()` — pre-warm the underlying transport (SDK adapter resolves
+ *     the binary path; subscription adapter resolves the user-configured
+ *     `claude` binary).  Idempotent.  Never throws.
+ *   - `shutdown()` — synchronously tear down any in-flight subprocesses
+ *     before plugin unload.  Synchronous so it can run inside Obsidian's
+ *     `onunload()` register hook.  Never throws.
+ *
+ * Split off `ClaudeCliPort` in WP-12 (Arch review #3): the per-turn
+ * `queryStream` / `runStructured` surface has nothing to do with process
+ * lifecycle, and there is exactly one production caller per method
+ * (`AgentSidepanelView` / `SpecoratorView` startup; `main.ts` `register()`
+ * shutdown). Per ADR-008's *one responsibility per port* spirit, lifecycle
+ * is its own port — even though splitting it grows the file count from
+ * one to two.
+ *
+ * Three concrete implementations:
+ *   - `ClaudeCliAdapter`        — SDK transport, pre-warms the SDK binary.
+ *   - `ClaudeSubprocessAdapter` — subscription transport, resolves the user's
+ *                                 `claude` binary and tracks active children.
+ *   - `MockClaudeCliPort` / `MockClaudeSubprocessAdapter` — no-op stubs.
+ *
+ * Test fixtures and the standalone-web `LocalStorageBridge` deliberately
+ * do not satisfy this port: those surfaces never start a real transport, so
+ * they do not need lifecycle wiring.
+ */
+export interface TransportLifecyclePort {
+	/**
+	 * Pre-warm the transport. Called from `onLayoutReady()` before the first
+	 * user interaction. Must not throw — log errors internally and return.
+	 * Satisfies REQ-CCS-003, NFR-CCS-002, NFR-ASM-006.
+	 */
+	startup(): Promise<void>;
+
+	/**
+	 * Terminate any in-flight subprocesses. Called from `onunload()` which is
+	 * synchronous. Must be synchronous (fire-and-forget is acceptable) and
+	 * must not throw.
+	 * Satisfies REQ-CCS-017, NFR-CCS-007.
+	 */
+	shutdown(): void;
+}

--- a/src/domain/ports/index.ts
+++ b/src/domain/ports/index.ts
@@ -24,8 +24,11 @@ export type {
 	ClaudeCliStreamOptions,
 	ClaudeCliErrorCode,
 	StreamDelta,
+	StructuredCliRawResult,
+	StructuredCliCallOptions,
 } from './ClaudeCliPort';
-export { ClaudeCliError, streamFromQuery } from './ClaudeCliPort';
+export { ClaudeCliError } from './ClaudeCliPort';
+export type { TransportLifecyclePort } from './TransportLifecyclePort';
 export type { ConfirmModalPort, ConfirmModalRequest } from './ConfirmModalPort';
 export type { SecretStorePort } from './SecretStorePort';
 export { SECRET_ID_ANTHROPIC } from './SecretStorePort';

--- a/src/infrastructure/bridge/degradedClaudeCliPort.ts
+++ b/src/infrastructure/bridge/degradedClaudeCliPort.ts
@@ -1,11 +1,9 @@
 import type {
 	ClaudeCliPort,
-	ClaudeCliQueryOptions,
 	ClaudeCliStreamOptions,
 	StreamDelta,
 } from '@/domain/ports';
 import { ClaudeCliError } from '@/domain/ports';
-import { err, type Result } from '@/domain/shared/Result';
 
 /**
  * Singleton `ClaudeCliPort` returned by `selectTransport` whenever the
@@ -14,6 +12,11 @@ import { err, type Result } from '@/domain/shared/Result';
  * selector's `kind === 'degraded'`, but if any consumer accidentally invokes
  * the port, this stub fails fast with `CLI_LAUNCH_FAILED` rather than
  * crashing or making a network call.
+ *
+ * WP-12: surface narrowed to the new `ClaudeCliPort` shape (`isAvailable` +
+ * `queryStream`; no `query`, no lifecycle methods). The degraded port
+ * intentionally does not expose `runStructured` — its absence is what
+ * `queryStructured()` keys off when the transport is degraded.
  *
  * Satisfies REQ-ASM-002, REQ-ASM-009.
  *
@@ -26,23 +29,8 @@ function makeError(): ClaudeCliError {
 }
 
 export const degradedClaudeCliPort: ClaudeCliPort = Object.freeze({
-	query(
-		_prompt: string,
-		_options?: ClaudeCliQueryOptions,
-	): Promise<Result<string, ClaudeCliError>> {
-		return Promise.resolve(err(makeError()));
-	},
-
 	isAvailable(): Promise<boolean> {
 		return Promise.resolve(false);
-	},
-
-	startup(): Promise<void> {
-		return Promise.resolve();
-	},
-
-	shutdown(): void {
-		/* no-op */
 	},
 
 	// eslint-disable-next-line @typescript-eslint/require-await

--- a/src/infrastructure/bridge/ports.ts
+++ b/src/infrastructure/bridge/ports.ts
@@ -11,6 +11,7 @@ import type {
 	ClaudeCliPort,
 	ConfirmModalPort,
 	SecretStorePort,
+	TransportLifecyclePort,
 } from '@/domain/ports'
 import type { MarkdownRenderPort } from '@/domain/ports/MarkdownRenderPort'
 import type { TransportKind } from '@/domain/chat/TransportKind'
@@ -24,6 +25,16 @@ export const METADATA_CACHE_PORT: InjectionKey<MetadataCachePort> = Symbol('Meta
 export const CANVAS_PORT: InjectionKey<CanvasPort> = Symbol('CanvasPort')
 export const COMMUNITY_PLUGIN_PORT: InjectionKey<CommunityPluginPort> = Symbol('CommunityPluginPort')
 export const CLAUDE_CLI_PORT: InjectionKey<ClaudeCliPort> = Symbol('ClaudeCliPort')
+/**
+ * Lifecycle (`startup` / `shutdown`) for the active streaming transport.
+ * Split off `ClaudeCliPort` in WP-12 (Arch review #3) — see
+ * `src/domain/ports/TransportLifecyclePort.ts`. One concrete production caller
+ * (`AgentSidepanelView` / `SpecoratorView` settings-bump path); shutdown is
+ * driven by `main.ts`'s `register(() => adapter.shutdown())` hook.
+ */
+export const TRANSPORT_LIFECYCLE_PORT: InjectionKey<TransportLifecyclePort> = Symbol(
+	'TransportLifecyclePort',
+)
 export const CONFIRM_MODAL_PORT: InjectionKey<ConfirmModalPort> = Symbol('ConfirmModalPort')
 /**
  * OS-keychain-backed secret store (ADR-008). Production wraps Obsidian's

--- a/src/infrastructure/localstorage/LocalStorageBridge.ts
+++ b/src/infrastructure/localstorage/LocalStorageBridge.ts
@@ -8,13 +8,10 @@ import type {
 	ActiveFileSnapshot,
 	Unsubscriber,
 	ClaudeCliPort,
-	ClaudeCliQueryOptions,
 	ClaudeCliStreamOptions,
 	StreamDelta,
 } from '@/domain/ports';
-import { ClaudeCliError, streamFromQuery } from '@/domain/ports';
-import type { Result } from '@/domain/shared/Result';
-import { err } from '@/domain/shared/Result';
+import { ClaudeCliError } from '@/domain/ports';
 import { type PluginSettings, DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings';
 
 const FILE_PREFIX = 'specorator:file:';
@@ -197,24 +194,14 @@ export class LocalStorageBridge
 		return Promise.resolve(false);
 	}
 
-	query(
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async *queryStream(
 		_prompt: string,
-		_options?: ClaudeCliQueryOptions,
-	): Promise<Result<string, ClaudeCliError>> {
-		return Promise.resolve(
-			err(new ClaudeCliError('NOT_INSTALLED', 'LocalStorageBridge: not available')),
-		);
-	}
-
-	startup(): Promise<void> {
-		return Promise.resolve();
-	}
-
-	shutdown(): void {
-		// no-op stub
-	}
-
-	queryStream(prompt: string, options?: ClaudeCliStreamOptions): AsyncIterable<StreamDelta> {
-		return streamFromQuery((p, o) => this.query(p, o), prompt, options);
+		_options?: ClaudeCliStreamOptions,
+	): AsyncIterable<StreamDelta> {
+		yield {
+			type: 'error',
+			error: new ClaudeCliError('NOT_INSTALLED', 'LocalStorageBridge: not available'),
+		};
 	}
 }

--- a/src/infrastructure/mock/MockBridge.ts
+++ b/src/infrastructure/mock/MockBridge.ts
@@ -8,13 +8,10 @@ import type {
 	ActiveFileSnapshot,
 	Unsubscriber,
 	ClaudeCliPort,
-	ClaudeCliQueryOptions,
 	ClaudeCliStreamOptions,
 	StreamDelta,
 } from '@/domain/ports';
-import { ClaudeCliError, streamFromQuery } from '@/domain/ports';
-import type { Result } from '@/domain/shared/Result';
-import { err } from '@/domain/shared/Result';
+import { ClaudeCliError } from '@/domain/ports';
 import { type PluginSettings, DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings';
 
 function folderPrefix(parent: string): string {
@@ -246,23 +243,14 @@ export class MockBridge
 		return Promise.resolve(false);
 	}
 
-	query(
+	async *queryStream(
 		_prompt: string,
-		_options?: ClaudeCliQueryOptions,
-	): Promise<Result<string, ClaudeCliError>> {
-		return Promise.resolve(err(new ClaudeCliError('NOT_INSTALLED', 'MockBridge: not available')));
-	}
-
-	queryStream(prompt: string, options?: ClaudeCliStreamOptions): AsyncIterable<StreamDelta> {
-		return streamFromQuery((p, o) => this.query(p, o), prompt, options);
-	}
-
-	startup(): Promise<void> {
-		return Promise.resolve();
-	}
-
-	shutdown(): void {
-		// no-op stub
+		_options?: ClaudeCliStreamOptions,
+	): AsyncIterable<StreamDelta> {
+		yield {
+			type: 'error',
+			error: new ClaudeCliError('NOT_INSTALLED', 'MockBridge: not available'),
+		};
 	}
 
 	// ── CommunityPluginPort ───────────────────────────────────────────────────

--- a/src/infrastructure/mock/MockClaudeCliPort.ts
+++ b/src/infrastructure/mock/MockClaudeCliPort.ts
@@ -5,8 +5,7 @@ import type {
 	StreamDelta,
 } from '@/domain/ports/ClaudeCliPort';
 import { ClaudeCliError } from '@/domain/ports/ClaudeCliPort';
-import type { Result } from '@/domain/shared/Result';
-import { ok, err } from '@/domain/shared/Result';
+import type { TransportLifecyclePort } from '@/domain/ports/TransportLifecyclePort';
 import type { SessionId } from '@/domain/chat/SessionId';
 
 function sleep(ms: number): Promise<void> {
@@ -45,43 +44,47 @@ function interruptibleSleep(ms: number, signal: AbortSignal | undefined): Promis
 }
 
 /**
- * Stub implementation of ClaudeCliPort for use in dev mode and unit tests.
- * Satisfies REQ-CCS-022, NFR-CCS-004, SPEC-CCS-001 §6.
+ * Stub implementation of ClaudeCliPort + TransportLifecyclePort for use in
+ * dev mode and unit tests. Satisfies REQ-CCS-022, NFR-CCS-004, SPEC-CCS-001 §6.
  *
  * `available` defaults to false so the standalone browser UI (npm run dev)
  * renders the degraded state without a real subprocess.
  */
-export class MockClaudeCliPort implements ClaudeCliPort {
+export class MockClaudeCliPort implements ClaudeCliPort, TransportLifecyclePort {
 	/**
-	 * Controls the return value of isAvailable() and the no-op branch of query().
+	 * Controls the return value of isAvailable() and the no-op branch of queryStream().
 	 * Default: false — the standalone browser UI and unit tests start unavailable.
 	 */
 	available = false;
 
 	/**
-	 * Text returned from query() when available === true and queryError === null.
+	 * Text returned from queryStream() when available === true and queryError === null.
 	 */
 	cannedResponse = 'Mock response from MockClaudeCliPort.';
 
 	/**
-	 * If non-null, query() returns this error instead of cannedResponse.
+	 * If non-null, queryStream() emits this error instead of cannedResponse.
 	 */
 	queryError: ClaudeCliError | null = null;
 
 	/**
-	 * Artificial delay for query(). Unit: milliseconds. Default: 0.
+	 * Artificial delay for queryStream(). Unit: milliseconds. Default: 0.
 	 */
 	delayMs = 0;
 
 	/**
-	 * Append-only log of every prompt string passed to query().
+	 * Append-only log of every prompt string passed to queryStream().
+	 *
+	 * Retained as `queryLog` (not `streamLog`) so the established assertion
+	 * vocabulary in UI tests survives WP-12 — the underlying method is now
+	 * `queryStream` but the captured prompt history is the same shape.
 	 */
 	readonly queryLog: string[] = [];
 
 	/**
-	 * Append-only log of every options object passed to query(). Parallel to
-	 * {@link queryLog}: `optionsLog[i]` is the options for prompt `queryLog[i]`.
-	 * `undefined` is preserved as-is (caller passed no options).
+	 * Append-only log of every options object passed to queryStream().
+	 * Parallel to {@link queryLog}: `optionsLog[i]` is the options for
+	 * prompt `queryLog[i]`. `undefined` is preserved as-is.
 	 *
 	 * Added for T-ASM-040 so UI tests can assert the `systemPromptSuffix`
 	 * threaded through by `ChatSidebar.handleSend` (REQ-ASM-013, REQ-ASM-018).
@@ -98,26 +101,6 @@ export class MockClaudeCliPort implements ClaudeCliPort {
 
 	async isAvailable(): Promise<boolean> {
 		return this.available;
-	}
-
-	async query(
-		prompt: string,
-		options?: ClaudeCliQueryOptions,
-	): Promise<Result<string, ClaudeCliError>> {
-		this.queryLog.push(prompt);
-		this.optionsLog.push(options);
-
-		if (!this.available) {
-			return err(new ClaudeCliError('NOT_INSTALLED', 'MockClaudeCliPort: not available'));
-		}
-
-		if (this.delayMs > 0) await sleep(this.delayMs);
-
-		if (this.queryError !== null) {
-			return err(this.queryError);
-		}
-
-		return ok(this.cannedResponse);
 	}
 
 	/**
@@ -176,11 +159,9 @@ export class MockClaudeCliPort implements ClaudeCliPort {
 	async *queryStream(prompt: string, options?: ClaudeCliStreamOptions): AsyncIterable<StreamDelta> {
 		this.streamLog.push(prompt);
 		this.streamOptionsLog.push(options);
-		// PR-ASV-2-ui: `ChatSidebar.handleSend` switched from `query()` to
-		// `queryStream()`. Existing tests assert against `queryLog` /
-		// `optionsLog` (the legacy non-streaming log) — mirror to those
-		// arrays so backward-compatible inspection points keep working
-		// without forcing 10+ tests to migrate to `streamLog`.
+		// Mirror to the canonical `queryLog` / `optionsLog` so the established
+		// assertion vocabulary (older tests / `collectStream` callers) keeps
+		// working without migration.
 		this.queryLog.push(prompt);
 		this.optionsLog.push(options);
 

--- a/src/infrastructure/mock/MockClaudeSubprocessAdapter.ts
+++ b/src/infrastructure/mock/MockClaudeSubprocessAdapter.ts
@@ -18,19 +18,18 @@
  * raw `setTimeout` used to honour `delayMs` for synthetic latency.
  */
 import type { CreateFileEnvelope } from '@/application/chat/createFileEnvelopeSchema';
-import type {
-	StructuredCliCallOptions,
-	StructuredCliRawResult,
-} from '@/application/chat/queryStructured';
 import type { SessionId } from '@/domain/chat/SessionId';
 import type {
 	ClaudeCliPort,
 	ClaudeCliQueryOptions,
 	ClaudeCliStreamOptions,
 	StreamDelta,
-	ClaudeCliError,
+	StructuredCliCallOptions,
+	StructuredCliRawResult,
 } from '@/domain/ports/ClaudeCliPort';
-import { streamFromQuery } from '@/domain/ports/ClaudeCliPort';
+import { ClaudeCliError } from '@/domain/ports/ClaudeCliPort';
+// `ClaudeCliQueryOptions` retained for the `_recordOptions` helper signature.
+import type { TransportLifecyclePort } from '@/domain/ports/TransportLifecyclePort';
 import type { Result } from '@/domain/shared/Result';
 import { err, ok } from '@/domain/shared/Result';
 
@@ -62,12 +61,12 @@ interface RecordedQueryOptions {
  * Field-driven mock subscription adapter. Every behaviour is configurable
  * through a public field — no constructor arguments, no I/O.
  */
-export class MockClaudeSubprocessAdapter implements ClaudeCliPort {
+export class MockClaudeSubprocessAdapter implements ClaudeCliPort, TransportLifecyclePort {
 	/**
-	 * Structural discriminator for `selectTransport()` / `isSubscriptionCapable()`
-	 * narrowing (SPEC-ASM-001 §2.9). Declared here so PR-ASM-1 ships a
-	 * complete mock without waiting on the `SubscriptionCapable` interface
-	 * landing in PR-ASM-2.
+	 * Structural discriminator for `selectTransport()`. Retained as a useful
+	 * tag even after WP-12 deleted the `isSubscriptionCapable` guard — the
+	 * application layer narrows via `typeof port.runStructured === 'function'`
+	 * now, but the selector still keys off `kind`.
 	 */
 	public readonly kind = 'subscription' as const;
 
@@ -162,54 +161,94 @@ export class MockClaudeSubprocessAdapter implements ClaudeCliPort {
 	}
 
 	/**
-	 * Records the prompt and options, optionally waits `delayMs`, then resolves
-	 * with `cannedResponse` (or `queryError` if set). Never throws.
+	 * Streaming-canonical method (WP-12). Records the prompt/options, honours
+	 * `delayMs` interruptibly against `options.signal`, fires the optional
+	 * `onSessionId` callback once with `cannedSessionId`, then yields the
+	 * configured response as `text` + `done` (or `error` when `queryError`
+	 * is set, or `error` on abort).
+	 *
+	 * Replaces the previous `streamFromQuery`-delegating implementation — that
+	 * helper was deleted in WP-12 along with the `query()` method it wrapped.
 	 */
-	async query(
+	async *queryStream(
 		prompt: string,
-		options?: ClaudeCliQueryOptions,
-	): Promise<Result<string, ClaudeCliError>> {
+		options?: ClaudeCliStreamOptions,
+	): AsyncIterable<StreamDelta> {
 		this.queryLog.push(prompt);
 		this._recordOptions(options);
 
-		// Mirror the real adapter's REQ-ASM-031 contract: invoke onSessionId once
-		// with `cannedSessionId` so tests exercising the capture path see the
-		// same observable as production.
-		if (options?.onSessionId !== undefined && this.cannedSessionId !== null) {
+		const signal = options?.signal;
+		if (signal?.aborted === true) {
+			yield MockClaudeSubprocessAdapter._abortDelta();
+			return;
+		}
+
+		yield* this._yieldSessionIdIfConfigured(options);
+
+		if (this.delayMs > 0) {
+			const aborted = await this._waitOrAbort(signal);
+			if (aborted) {
+				yield MockClaudeSubprocessAdapter._abortDelta();
+				return;
+			}
+		}
+
+		if (this.queryError !== null) {
+			yield { type: 'error', error: this.queryError };
+			return;
+		}
+
+		if (this.cannedResponse.length > 0) {
+			yield { type: 'text', text: this.cannedResponse };
+		}
+		yield { type: 'done' };
+	}
+
+	private static _abortDelta(): StreamDelta {
+		return {
+			type: 'error',
+			error: new ClaudeCliError('QUERY_FAILED', 'Request was aborted'),
+		};
+	}
+
+	/**
+	 * Mirror the real adapter's REQ-ASM-031 contract: surface the canned
+	 * session id both as a `session-id` delta AND through the optional
+	 * `onSessionId` callback before any text delta. Extracted to keep
+	 * `queryStream` under the project complexity ceiling.
+	 */
+	private async *_yieldSessionIdIfConfigured(
+		options: ClaudeCliStreamOptions | undefined,
+	): AsyncIterable<StreamDelta> {
+		if (this.cannedSessionId === null) return;
+		yield { type: 'session-id', sessionId: this.cannedSessionId };
+		if (options?.onSessionId !== undefined) {
 			try {
 				options.onSessionId(this.cannedSessionId);
 			} catch {
 				// Mock mirrors the real adapter — never let a caller callback throw
-				// out of `query()`.
+				// out of `queryStream()`.
 			}
 		}
-
-		if (this.delayMs > 0) {
-			await new Promise<void>((resolve) => setTimeout(resolve, this.delayMs));
-		}
-
-		if (this.queryError !== null) {
-			return err(this.queryError);
-		}
-
-		return ok(this.cannedResponse);
 	}
 
 	/**
-	 * Streaming variant for IDEA-ASV-001 Increment 2. Delegates to `query()`
-	 * and emits the result as a single `text` delta + `done`, mirroring the
-	 * stub strategy used by the real `ClaudeSubprocessAdapter` in PR-ASV-2-port.
-	 * Honours `options.signal`: a pre-aborted signal short-circuits to an
-	 * error delta.
+	 * Sleep `this.delayMs` milliseconds, returning `true` if the signal
+	 * aborted before the timer fired. Extracted from `queryStream` to keep
+	 * its cyclomatic complexity under the project ceiling.
 	 */
-	queryStream(prompt: string, options?: ClaudeCliStreamOptions): AsyncIterable<StreamDelta> {
-		// Delegating to `streamFromQuery` instead of a hand-rolled body covers
-		// the Codex P2 mid-flight-abort gap (PR #370 review on
-		// `MockClaudeSubprocessAdapter`). The helper races the `query()`
-		// promise against an abort-signal event, so aborting while `delayMs`
-		// is elapsing terminates the stream with an `error` delta rather
-		// than emitting `text` / `done`.
-		return streamFromQuery((p, o) => this.query(p, o), prompt, options);
+	private _waitOrAbort(signal: AbortSignal | undefined): Promise<boolean> {
+		return new Promise<boolean>((resolve) => {
+			const t = setTimeout(() => {
+				signal?.removeEventListener('abort', onAbort);
+				resolve(false);
+			}, this.delayMs);
+			const onAbort = (): void => {
+				clearTimeout(t);
+				resolve(true);
+			};
+			signal?.addEventListener('abort', onAbort, { once: true });
+		});
 	}
 
 	/**

--- a/src/infrastructure/obsidian/ClaudeCliAdapter.ts
+++ b/src/infrastructure/obsidian/ClaudeCliAdapter.ts
@@ -2,13 +2,11 @@ import { query as sdkQuery } from '@anthropic-ai/claude-agent-sdk';
 import { isAbsolute } from 'path';
 import type {
 	ClaudeCliPort,
-	ClaudeCliQueryOptions,
 	ClaudeCliStreamOptions,
 	StreamDelta,
 } from '@/domain/ports/ClaudeCliPort';
 import { ClaudeCliError } from '@/domain/ports/ClaudeCliPort';
-import type { Result } from '@/domain/shared/Result';
-import { ok, err } from '@/domain/shared/Result';
+import type { TransportLifecyclePort } from '@/domain/ports/TransportLifecyclePort';
 import type { SessionId } from '@/domain/chat/SessionId';
 import type { LoggerPort } from '@/domain/ports';
 import {
@@ -33,10 +31,14 @@ interface SdkMessage {
 
 /**
  * Production implementation of ClaudeCliPort using @anthropic-ai/claude-agent-sdk.
+ * Also implements `TransportLifecyclePort` (`startup` / `shutdown`) per WP-12
+ * (Arch review #3) — lifecycle is its own narrow port now, but the same
+ * adapter class fulfils both contracts.
+ *
  * Satisfies REQ-CCS-002, REQ-CCS-003, REQ-CCS-016, REQ-CCS-017, REQ-CCS-025,
  * NFR-CCS-003, NFR-CCS-005, NFR-CCS-007, SPEC-CCS-001 §5.
  */
-export class ClaudeCliAdapter implements ClaudeCliPort {
+export class ClaudeCliAdapter implements ClaudeCliPort, TransportLifecyclePort {
 	/** True only after startup() succeeds. Never set to true if API key is missing. */
 	private _available = false;
 	/** Indicates whether SDK has been initialized. */
@@ -120,37 +122,6 @@ export class ClaudeCliAdapter implements ClaudeCliPort {
 	}
 
 	/**
-	 * Send a prompt to Claude via the SDK. Returns Result<string, ClaudeCliError>.
-	 * Never throws. Now layered on top of `queryStream()` — collects every
-	 * `text` delta into a single string so existing free-text call sites stay
-	 * unchanged. The Codex P1 audit / NFR-CCS-003 timeout + abort behaviour
-	 * is inherited from `queryStream()`.
-	 *
-	 * Satisfies REQ-CCS-013, REQ-CCS-016, NFR-CCS-003, SPEC-CCS-001 §5.3.
-	 */
-	async query(
-		prompt: string,
-		options?: ClaudeCliQueryOptions,
-	): Promise<Result<string, ClaudeCliError>> {
-		if (options?.maxTurns !== undefined && options.maxTurns > 1) {
-			this._logger.warn('ClaudeCliAdapter.query(): maxTurns > 1 is clamped to 1 in v1');
-		}
-		const chunks: string[] = [];
-		for await (const delta of this.queryStream(prompt, options)) {
-			if (delta.type === 'text') {
-				chunks.push(delta.text);
-			} else if (delta.type === 'error') {
-				return err(delta.error);
-			} else if (delta.type === 'done') {
-				return ok(chunks.join(''));
-			}
-		}
-		// Iterator exhausted without `done` — treat as failure (mirrors the
-		// original `_runSdkQuery` "No result message" behaviour).
-		return err(new ClaudeCliError('QUERY_FAILED', 'No result message received from SDK'));
-	}
-
-	/**
 	 * Returns true if the adapter is ready to accept queries.
 	 * Satisfies REQ-CCS-018, REQ-CCS-019, REQ-CCS-022, SPEC-CCS-001 §5.4.
 	 */
@@ -171,7 +142,8 @@ export class ClaudeCliAdapter implements ClaudeCliPort {
 	}
 
 	/**
-	 * Streaming variant of `query()` (IDEA-ASV-001 Increment 2, PR-ASV-2-sdk).
+	 * Canonical streaming method (WP-12 — `query()` was deleted; non-streaming
+	 * consumers use `collectStream()` from `@/application/chat/collectStream`).
 	 *
 	 * Emits real per-token text deltas by consuming the Anthropic Agent SDK's
 	 * `stream_event` messages (`includePartialMessages: true`). The SDK emits
@@ -183,9 +155,9 @@ export class ClaudeCliAdapter implements ClaudeCliPort {
 	 *
 	 * The caller's `options.signal` is wired into the SDK's `abortController`;
 	 * aborting mid-stream causes the generator to throw, which the catch
-	 * branch maps to a `QUERY_FAILED` error delta. Timeout follows the same
-	 * pattern as `query()`: a separate Promise rejects on the deadline and
-	 * aborts the SDK controller, then the catch maps it to `TIMEOUT`.
+	 * branch maps to a `QUERY_FAILED` error delta. A separate Promise rejects
+	 * on the deadline and aborts the SDK controller, then the catch maps it
+	 * to `TIMEOUT`.
 	 *
 	 * Never throws. Mid-flight errors are delivered as a terminal `error`
 	 * delta; a successful turn emits a final `done`.
@@ -415,18 +387,18 @@ export class ClaudeCliAdapter implements ClaudeCliPort {
 
 	private _mapError(e: unknown, timeoutMs: number): ClaudeCliError {
 		if (e instanceof ClaudeCliError && e.errorCode === 'TIMEOUT') {
-			this._logger.warn('ClaudeCliAdapter.query(): timeout', { timeoutMs });
+			this._logger.warn('ClaudeCliAdapter.queryStream(): timeout', { timeoutMs });
 			return e;
 		}
 		if (e instanceof Error) {
 			if (/api.key|authentication|401/i.test(e.message)) {
-				this._logger.warn('ClaudeCliAdapter.query(): API key error');
+				this._logger.warn('ClaudeCliAdapter.queryStream(): API key error');
 				return new ClaudeCliError('API_KEY_MISSING', 'Authentication failed', e);
 			}
-			this._logger.warn('ClaudeCliAdapter.query(): SDK error', { error: e.message });
+			this._logger.warn('ClaudeCliAdapter.queryStream(): SDK error', { error: e.message });
 			return new ClaudeCliError('QUERY_FAILED', 'Query failed', e);
 		}
-		this._logger.warn('ClaudeCliAdapter.query(): unknown error');
+		this._logger.warn('ClaudeCliAdapter.queryStream(): unknown error');
 		return new ClaudeCliError('QUERY_FAILED', 'Unknown error', e);
 	}
 }

--- a/src/infrastructure/obsidian/ClaudeSubprocessAdapter.ts
+++ b/src/infrastructure/obsidian/ClaudeSubprocessAdapter.ts
@@ -43,19 +43,15 @@
  * own credentials. The string literal for that directory is INTENTIONALLY
  * absent from this file; lint enforcement lives in T-ASM-049.
  *
- * `runStructured` lands in T-ASM-039 (PR-ASM-2) and is reached only through
- * the application-layer `queryStructured()` wrapper after the structural
- * type guard `isSubscriptionCapable(port)` narrows the port. The method does
- * NOT live on `ClaudeCliPort` — that interface stays at four members per
- * ADR-008 narrow-port discipline.
+ * `runStructured` is reached through the application-layer `queryStructured()`
+ * wrapper. WP-12 (Arch review #3) folded `runStructured` onto `ClaudeCliPort`
+ * itself as an *optional* method — the application layer narrows via
+ * `typeof port.runStructured === 'function'`, and the SDK adapter simply
+ * does not implement it.
  */
 import type { ChildProcess, SpawnOptions } from 'node:child_process';
 
 import { createFileEnvelopeJsonSchema } from '@/application/chat/createFileEnvelopeSchema';
-import type {
-	StructuredCliCallOptions,
-	StructuredCliRawResult,
-} from '@/application/chat/queryStructured';
 import {
 	StreamDeltaReducer,
 	type RawClaudeEvent,
@@ -64,11 +60,13 @@ import {
 import {
 	ClaudeCliError,
 	type ClaudeCliPort,
-	type ClaudeCliQueryOptions,
 	type ClaudeCliStreamOptions,
 	type StreamDelta,
+	type StructuredCliCallOptions,
+	type StructuredCliRawResult,
 } from '@/domain/ports/ClaudeCliPort';
 import type { LoggerPort } from '@/domain/ports/LoggerPort';
+import type { TransportLifecyclePort } from '@/domain/ports/TransportLifecyclePort';
 import type { PluginSettings } from '@/domain/settings/PluginSettings';
 import { asSessionId, type SessionId } from '@/domain/chat/SessionId';
 import { err, ok, type Result } from '@/domain/shared/Result';
@@ -206,12 +204,17 @@ interface TurnProc {
 /**
  * Implementation note (REQ-ASM-001, REQ-ASM-009, REQ-ASM-010).
  *
- * `kind` is intentionally declared so that downstream `selectTransport` and
- * `isSubscriptionCapable()` narrowing (§2.1 / §9.1) can identify this adapter
- * structurally without an `instanceof` check that would force a domain ⇄
- * infrastructure import.
+ * `kind` is intentionally declared so `selectTransport` can identify this
+ * adapter structurally without an `instanceof` check that would force a
+ * domain ⇄ infrastructure import. Subscription-capability narrowing in the
+ * application layer (`queryStructured()`) keys off the presence of
+ * `runStructured` rather than `kind` — see WP-12 (Arch review #3).
+ *
+ * Also implements `TransportLifecyclePort` (`startup` / `shutdown`) — split
+ * off `ClaudeCliPort` in WP-12 so the per-turn streaming surface stays
+ * narrow per ADR-008 *responsibility* spirit.
  */
-export class ClaudeSubprocessAdapter implements ClaudeCliPort {
+export class ClaudeSubprocessAdapter implements ClaudeCliPort, TransportLifecyclePort {
 	public readonly kind = 'subscription' as const;
 
 	// Internal state — all I/O-free at construction time.
@@ -353,36 +356,6 @@ export class ClaudeSubprocessAdapter implements ClaudeCliPort {
 	 */
 	queryStream(prompt: string, options?: ClaudeCliStreamOptions): AsyncIterable<StreamDelta> {
 		return this._runStream(prompt, options);
-	}
-
-	// ── query() — free-text stream-json path ─────────────────────────────────
-
-	/**
-	 * Free-text query. Layered on top of `queryStream()` — collects every
-	 * `text` delta into a single string. Existing free-text call sites stay
-	 * unchanged (same `Result<string, ClaudeCliError>` shape, same error
-	 * mapping). Mirrors the SDK adapter's `query()` ↔ `queryStream()`
-	 * decomposition introduced in PR-ASV-2-sdk.
-	 *
-	 * Satisfies REQ-ASM-010, REQ-ASM-029, REQ-ASM-030, REQ-ASM-031, REQ-ASM-035.
-	 */
-	async query(
-		prompt: string,
-		options?: ClaudeCliQueryOptions,
-	): Promise<Result<string, ClaudeCliError>> {
-		const chunks: string[] = [];
-		for await (const delta of this.queryStream(prompt, options)) {
-			if (delta.type === 'text') {
-				chunks.push(delta.text);
-			} else if (delta.type === 'error') {
-				return err(delta.error);
-			} else if (delta.type === 'done') {
-				return ok(chunks.join(''));
-			}
-		}
-		// Iterator exhausted without `done` — mirrors the SDK adapter's
-		// defensive fallback.
-		return err(new ClaudeCliError('QUERY_FAILED', 'Subprocess closed before result event'));
 	}
 
 	// ── runStructured() — one-shot structured one-shot path ──────────────────
@@ -778,7 +751,7 @@ export class ClaudeSubprocessAdapter implements ClaudeCliPort {
 	/** Build the argv vector for a `query()` invocation. Extracted for complexity. */
 	private _buildArgv(
 		prompt: string,
-		options: ClaudeCliQueryOptions | undefined,
+		options: ClaudeCliStreamOptions | undefined,
 	): readonly string[] {
 		const resume =
 			typeof options?.resumeSessionId === 'string' && options.resumeSessionId.length > 0

--- a/src/infrastructure/obsidian/ObsidianBridge.ts
+++ b/src/infrastructure/obsidian/ObsidianBridge.ts
@@ -10,13 +10,10 @@ import type {
 	ActiveFileSnapshot,
 	Unsubscriber,
 	ClaudeCliPort,
-	ClaudeCliQueryOptions,
 	ClaudeCliStreamOptions,
 	StreamDelta,
 } from '@/domain/ports';
-import { ClaudeCliError, streamFromQuery } from '@/domain/ports';
-import type { Result } from '@/domain/shared/Result';
-import { err } from '@/domain/shared/Result';
+import { ClaudeCliError } from '@/domain/ports';
 
 type FileManagerWithTrash = App['fileManager'] & {
 	trashFile?: (file: TFile) => Promise<void>;
@@ -251,24 +248,17 @@ export class ObsidianBridge
 		});
 	}
 
-	query(
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async *queryStream(
 		_prompt: string,
-		_options?: ClaudeCliQueryOptions,
-	): Promise<Result<string, ClaudeCliError>> {
-		return Promise.resolve(
-			err(new ClaudeCliError('NOT_INSTALLED', 'ObsidianBridge: use ClaudeCliAdapter for queries')),
-		);
-	}
-
-	queryStream(prompt: string, options?: ClaudeCliStreamOptions): AsyncIterable<StreamDelta> {
-		return streamFromQuery((p, o) => this.query(p, o), prompt, options);
-	}
-
-	startup(): Promise<void> {
-		return Promise.resolve();
-	}
-
-	shutdown(): void {
-		// no-op stub — ClaudeCliAdapter handles its own lifecycle
+		_options?: ClaudeCliStreamOptions,
+	): AsyncIterable<StreamDelta> {
+		yield {
+			type: 'error',
+			error: new ClaudeCliError(
+				'NOT_INSTALLED',
+				'ObsidianBridge: use ClaudeCliAdapter for queries',
+			),
+		};
 	}
 }

--- a/src/plugin/AgentSidepanelView.ts
+++ b/src/plugin/AgentSidepanelView.ts
@@ -20,7 +20,7 @@ import {
 	OPEN_PLUGIN_SETTINGS_KEY,
 } from '@/infrastructure/bridge/ports';
 import { ObsidianMarkdownRenderAdapter } from '@/infrastructure/obsidian/ObsidianMarkdownRenderAdapter';
-import type { ClaudeCliPort, ConfirmModalPort } from '@/domain/ports';
+import type { ClaudeCliPort, ConfirmModalPort, TransportLifecyclePort } from '@/domain/ports';
 import type { PluginSettings } from '@/domain/settings/PluginSettings';
 import type { TransportKind } from '@/domain/chat/TransportKind';
 import type { TransportSelection } from '@/plugin/transport/TransportSelector';
@@ -42,6 +42,16 @@ export interface AgentSidepanelViewOptions {
 	readonly subscriptionAdapter: ClaudeCliPort;
 	readonly selectTransport: SelectAgentTransportFactory;
 	readonly confirmModalAdapter?: ConfirmModalPort;
+	/**
+	 * Optional lifecycle handles for the SDK and subscription transports.
+	 * Split off `ClaudeCliPort` in WP-12 (Arch review #3) — `startup`/`shutdown`
+	 * no longer live on the streaming port. The plugin layer owns the adapter
+	 * instances and passes the same objects under both contracts. Optional so
+	 * legacy test wiring that omitted lifecycle continues to compile; missing
+	 * handles result in a no-op refresh.
+	 */
+	readonly sdkLifecycle?: TransportLifecyclePort;
+	readonly subscriptionLifecycle?: TransportLifecyclePort;
 }
 
 export const VIEW_TYPE_AGENT = 'specorator-agent';
@@ -259,11 +269,15 @@ export class AgentSidepanelView extends ItemView {
 	}
 
 	private _applyTransportRefresh(): void {
-		void this.claudeCliPort.startup().then(() => {
-			this._refreshActivePort();
-		});
-		if (this._options !== null) {
-			void this._options.subscriptionAdapter.startup().then(() => {
+		const sdkLifecycle = this._options?.sdkLifecycle;
+		if (sdkLifecycle !== undefined) {
+			void sdkLifecycle.startup().then(() => {
+				this._refreshActivePort();
+			});
+		}
+		const subscriptionLifecycle = this._options?.subscriptionLifecycle;
+		if (subscriptionLifecycle !== undefined) {
+			void subscriptionLifecycle.startup().then(() => {
 				this._refreshActivePort();
 			});
 		}

--- a/src/plugin/SpecoratorView.ts
+++ b/src/plugin/SpecoratorView.ts
@@ -24,7 +24,7 @@ import { FeatureRepository } from '@/infrastructure/bridge/FeatureRepository'
 import { FeatureService } from '@/application/feature/FeatureService'
 import { FeedbackService } from '@/application/shared/FeedbackService'
 import { FEATURE_SERVICE_KEY } from '@/ui/composables/useFeatureService'
-import type { ClaudeCliPort, ConfirmModalPort } from '@/domain/ports'
+import type { ClaudeCliPort, ConfirmModalPort, TransportLifecyclePort } from '@/domain/ports'
 import type { PluginSettings } from '@/domain/settings/PluginSettings'
 import type { TransportKind } from '@/domain/chat/TransportKind'
 import type { TransportSelection } from '@/plugin/transport/TransportSelector'
@@ -60,6 +60,16 @@ export interface SpecoratorViewOptions {
    * (Vue tolerates `undefined`).
    */
   readonly confirmModalAdapter?: ConfirmModalPort
+  /**
+   * Lifecycle handles for the SDK and subscription transports. WP-12 split
+   * `startup`/`shutdown` off `ClaudeCliPort` onto the dedicated
+   * `TransportLifecyclePort`. The plugin layer owns the adapter instances
+   * and passes the same objects under both contracts. Optional so legacy
+   * test wiring that omitted lifecycle continues to compile; missing
+   * handles result in a no-op refresh.
+   */
+  readonly sdkLifecycle?: TransportLifecyclePort
+  readonly subscriptionLifecycle?: TransportLifecyclePort
 }
 
 export const VIEW_TYPE = 'specorator'
@@ -378,11 +388,15 @@ export class SpecoratorView extends ItemView {
     // deliberately fire-and-forget and refresh synchronously now using the
     // current cached availability; the post-startup refresh below picks up
     // any new value when each resolves.
-    void this.claudeCliPort.startup().then(() => {
-      this._refreshActivePort()
-    })
-    if (this._options !== null) {
-      void this._options.subscriptionAdapter.startup().then(() => {
+    const sdkLifecycle = this._options?.sdkLifecycle
+    if (sdkLifecycle !== undefined) {
+      void sdkLifecycle.startup().then(() => {
+        this._refreshActivePort()
+      })
+    }
+    const subscriptionLifecycle = this._options?.subscriptionLifecycle
+    if (subscriptionLifecycle !== undefined) {
+      void subscriptionLifecycle.startup().then(() => {
         this._refreshActivePort()
       })
     }

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -211,6 +211,11 @@ export default class SpecoratorPlugin extends Plugin {
       const view = new SpecoratorView(leaf, this, this._claudeCliAdapter!, {
         subscriptionAdapter: this._subscriptionAdapter!,
         confirmModalAdapter: this._confirmModalAdapter!,
+        // WP-12: lifecycle is its own port; pass the adapter instances under
+        // their `TransportLifecyclePort` contract so the view can `startup()`
+        // them on settings bumps without depending on `ClaudeCliPort`.
+        sdkLifecycle: this._claudeCliAdapter!,
+        subscriptionLifecycle: this._subscriptionAdapter!,
         selectTransport: (settings) =>
           selectTransport(settings, {
             sdkAdapter: this._claudeCliAdapter!,
@@ -238,6 +243,8 @@ export default class SpecoratorPlugin extends Plugin {
       const view = new AgentSidepanelView(leaf, this, this._claudeCliAdapter!, {
         subscriptionAdapter: this._subscriptionAdapter!,
         confirmModalAdapter: this._confirmModalAdapter!,
+        sdkLifecycle: this._claudeCliAdapter!,
+        subscriptionLifecycle: this._subscriptionAdapter!,
         selectTransport: (settings) =>
           selectTransport(settings, {
             sdkAdapter: this._claudeCliAdapter!,

--- a/src/ui/composables/useTransportLifecyclePort.ts
+++ b/src/ui/composables/useTransportLifecyclePort.ts
@@ -1,0 +1,16 @@
+import { inject } from 'vue'
+import type { TransportLifecyclePort } from '@/domain/ports'
+import { TRANSPORT_LIFECYCLE_PORT } from '@/infrastructure/bridge/ports'
+
+/**
+ * Per-port composable for the streaming-transport lifecycle (ADR-008).
+ * Split off `useClaudeCliPort` in WP-12 — consumers that only need to
+ * `startup()` or `shutdown()` no longer have to depend on the streaming
+ * port.
+ *
+ * Returns `undefined` when no `TransportLifecyclePort` is provided
+ * (standalone web demo, unit tests without lifecycle wiring).
+ */
+export function useTransportLifecyclePort(): TransportLifecyclePort | undefined {
+	return inject(TRANSPORT_LIFECYCLE_PORT)
+}

--- a/tests/application/chat/collectStream.test.ts
+++ b/tests/application/chat/collectStream.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for `collectStream` (WP-12) — the pure helper that drains a
+ * `ClaudeCliPort.queryStream` iterable into `Result<string, ClaudeCliError>`.
+ *
+ * Replaces the deleted `streamFromQuery` shim (which converged the other
+ * direction). The four scenarios required by the brief:
+ *   1. Happy path — text deltas concatenate; `done` yields ok(concat).
+ *   2. Error mid-stream — `error` delta short-circuits and propagates.
+ *   3. Abort — caller may abort the upstream stream; the iterable closes
+ *      without a terminal delta, so `collectStream` returns the defensive
+ *      "Stream closed before terminal delta" err.
+ *   4. Empty stream — iterable exhausts with no deltas at all → same
+ *      defensive err.
+ *
+ * Satisfies the brief's DoD: new `collectStream` test ≥ 90% statements.
+ */
+import { describe, it, expect } from 'vitest'
+
+import { collectStream } from '@/application/chat/collectStream'
+import { ClaudeCliError, type StreamDelta } from '@/domain/ports/ClaudeCliPort'
+import { asSessionId } from '@/domain/chat/SessionId'
+
+/** Yield each delta from `deltas` once, in order. Closes after the last. */
+async function* fromArray(deltas: readonly StreamDelta[]): AsyncIterable<StreamDelta> {
+  for (const d of deltas) yield d
+}
+
+describe('collectStream', () => {
+  it('happy path — concatenates text deltas and resolves ok(text) on done', async () => {
+    const result = await collectStream(
+      fromArray([
+        { type: 'text', text: 'Hello, ' },
+        { type: 'text', text: 'world!' },
+        { type: 'done' },
+      ]),
+    )
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value).toBe('Hello, world!')
+  })
+
+  it('error mid-stream — propagates err(delta.error) and stops reading', async () => {
+    const failure = new ClaudeCliError('QUERY_FAILED', 'boom')
+    let readPastError = false
+    async function* upstream(): AsyncIterable<StreamDelta> {
+      yield { type: 'text', text: 'partial' }
+      yield { type: 'error', error: failure }
+      // The contract is "stop reading after `error`" — if collectStream pulled
+      // again we'd flip this flag and the assertion below would catch it.
+      readPastError = true
+      yield { type: 'text', text: 'never' }
+    }
+    const result = await collectStream(upstream())
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe(failure)
+    expect(readPastError).toBe(false)
+  })
+
+  it('ignores observable side-channel deltas (session-id, thinking, tool-use, usage, compact-boundary)', async () => {
+    const result = await collectStream(
+      fromArray([
+        { type: 'session-id', sessionId: asSessionId('sess-abc') },
+        { type: 'thinking', text: '(reasoning…)' },
+        { type: 'tool-use-start', blockId: 'b1', toolName: 'read', inputJson: '' },
+        { type: 'tool-use-input-delta', blockId: 'b1', inputJson: '{"a":1}' },
+        { type: 'tool-use-stop', blockId: 'b1' },
+        { type: 'usage', inputTokens: 10, outputTokens: 5 },
+        { type: 'compact-boundary' },
+        { type: 'text', text: 'visible' },
+        { type: 'done' },
+      ]),
+    )
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value).toBe('visible')
+  })
+
+  it('empty stream — iterable exhausts with no deltas → err QUERY_FAILED', async () => {
+    const result = await collectStream(fromArray([]))
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ClaudeCliError)
+      expect(result.error.errorCode).toBe('QUERY_FAILED')
+      expect(result.error.message).toBe('Stream closed before terminal delta')
+    }
+  })
+
+  it('abort / upstream closes before terminal delta — err QUERY_FAILED', async () => {
+    // Models the abort path: an upstream queryStream that begins streaming
+    // text but stops yielding (e.g. AbortController fires and the adapter
+    // closes the iterable) without ever emitting `done` or `error`.
+    async function* aborted(): AsyncIterable<StreamDelta> {
+      yield { type: 'text', text: 'half-' }
+      // Iterable returns without `done` / `error` — simulates the upstream
+      // adapter closing on abort and not emitting a terminal delta.
+    }
+    const result = await collectStream(aborted())
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ClaudeCliError)
+      expect(result.error.errorCode).toBe('QUERY_FAILED')
+    }
+  })
+
+  it('returns ok("") for a stream of only done', async () => {
+    const result = await collectStream(fromArray([{ type: 'done' }]))
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value).toBe('')
+  })
+})

--- a/tests/application/chat/queryStructured.test.ts
+++ b/tests/application/chat/queryStructured.test.ts
@@ -1,9 +1,8 @@
 /**
- * T-ASM-038 — Tests for `isSubscriptionCapable` (structural type guard) and
- * `queryStructured` (application-layer wrapper around the subscription
- * adapter's structured-output path).
+ * T-ASM-038 — Tests for `queryStructured` (application-layer wrapper around
+ * the subscription adapter's structured-output path).
  *
- * Spec reference: SPEC-ASM-001 §2.9 (`SubscriptionCapable`) and §6.6
+ * Spec reference: SPEC-ASM-001 §2.9 (port-as-runStructured-owner) and §6.6
  * (`queryStructured` algorithm).
  *
  * Maps to:
@@ -12,18 +11,25 @@
  *   - REQ-ASM-049  (one-shot proposal process; mock asserts a single `runStructured` call)
  *
  * Notes:
- *   - The SDK adapter (`ClaudeCliAdapter`) has no `kind` field — the guard must fail
- *     closed for it. We exercise this with a structural fake rather than importing the
- *     real SDK adapter, to keep this suite hermetic and free of Anthropic SDK initialisation.
- *   - The `degradedClaudeCliPort` sentinel is a frozen no-op stub with no `kind` field —
- *     also covered by the negative branch of `isSubscriptionCapable`.
- *   - The happy / error / fallback paths are exercised through `MockClaudeSubprocessAdapter`,
- *     whose `runStructured` mirrors the production surface.
+ *   - The SDK adapter (`ClaudeCliAdapter`) does NOT implement `runStructured`
+ *     — the `typeof port.runStructured === 'function'` check inside
+ *     `queryStructured` must fail closed for it. We exercise this with a
+ *     structural fake rather than importing the real SDK adapter, to keep
+ *     this suite hermetic and free of Anthropic SDK initialisation.
+ *   - The `degradedClaudeCliPort` sentinel is a frozen no-op stub with no
+ *     `runStructured` method — also covered by the negative branch.
+ *   - The happy / error / fallback paths are exercised through
+ *     `MockClaudeSubprocessAdapter`, whose `runStructured` mirrors the
+ *     production surface.
+ *
+ * Reshaped in WP-12 (Arch review #3): the `isSubscriptionCapable` guard and
+ * the `streamFromQuery` shim are gone — `runStructured` lives on the port
+ * directly, and non-streaming converge-to-string callers use
+ * `collectStream(port.queryStream(...))`.
  */
 import { describe, it, expect } from 'vitest'
 
 import {
-  isSubscriptionCapable,
   queryStructured,
   type StructuredCliCallOptions,
   type StructuredCliRawResult,
@@ -31,7 +37,6 @@ import {
 import { EnvelopeParseError } from '@/application/chat/errors'
 import {
   ClaudeCliError,
-  streamFromQuery,
   type ClaudeCliPort,
   type ClaudeCliStreamOptions,
   type StreamDelta,
@@ -41,82 +46,47 @@ import { degradedClaudeCliPort } from '@/infrastructure/bridge/degradedClaudeCli
 import { MockClaudeSubprocessAdapter } from '@/infrastructure/mock/MockClaudeSubprocessAdapter'
 
 // -----------------------------------------------------------------------------
-// Minimal structural fake for the SDK adapter (`ClaudeCliAdapter` has no
-// `kind` field). We don't import the real adapter — keeps the suite hermetic
-// and avoids pulling the Anthropic SDK into a pure-application test.
+// Minimal structural fake for the SDK adapter. `ClaudeCliAdapter` does not
+// implement `runStructured`, so the application-layer narrowing check
+// (`typeof port.runStructured === 'function'`) must fail closed for it. We
+// don't import the real adapter — keeps the suite hermetic and avoids pulling
+// the Anthropic SDK into a pure-application test.
 // -----------------------------------------------------------------------------
 
 function makeSdkLikePort(): ClaudeCliPort {
   return {
-    async query() {
-      return ok('')
-    },
     async isAvailable() {
       return true
     },
-    async startup() {
-      /* no-op */
+    async *queryStream(
+      _prompt: string,
+      _options?: ClaudeCliStreamOptions,
+    ): AsyncIterable<StreamDelta> {
+      yield { type: 'done' }
     },
-    shutdown() {
-      /* no-op */
-    },
-    queryStream(prompt: string, options?: ClaudeCliStreamOptions): AsyncIterable<StreamDelta> {
-      return streamFromQuery(async () => ok(''), prompt, options)
-    },
+    // No `runStructured` — that's the point of this fake.
   }
 }
 
 // =============================================================================
-// 1. `isSubscriptionCapable` — structural type guard.
-// =============================================================================
-
-describe('isSubscriptionCapable (SPEC §2.9)', () => {
-  it('returns true for a port with kind === "subscription" and a runStructured method', () => {
-    const port = new MockClaudeSubprocessAdapter()
-    expect(isSubscriptionCapable(port)).toBe(true)
-  })
-
-  it('returns false for an SDK-shaped port without `kind`', () => {
-    const port = makeSdkLikePort()
-    expect(isSubscriptionCapable(port)).toBe(false)
-  })
-
-  it('returns false for the degradedClaudeCliPort sentinel', () => {
-    expect(isSubscriptionCapable(degradedClaudeCliPort)).toBe(false)
-  })
-
-  it('returns false when kind is "subscription" but runStructured is missing', () => {
-    // Partial mock that sets the tag but omits the method — the guard must
-    // require both. Cast through `unknown` so the type system models the
-    // structural-check failure at runtime.
-    const partial = {
-      kind: 'subscription' as const,
-      async query() {
-        return ok('')
-      },
-      async isAvailable() {
-        return true
-      },
-      async startup() {
-        /* no-op */
-      },
-      shutdown() {
-        /* no-op */
-      },
-    }
-    expect(isSubscriptionCapable(partial as unknown as ClaudeCliPort)).toBe(false)
-  })
-})
-
-// =============================================================================
-// 2. `queryStructured` — algorithm from SPEC §6.6.
+// 1. `queryStructured` — algorithm from SPEC §6.6.
 // =============================================================================
 
 describe('queryStructured (SPEC §6.6)', () => {
-  it('non-subscription-capable port → err(ClaudeCliError{ NOT_INSTALLED })', async () => {
+  it('non-subscription-capable port (no runStructured) → err(ClaudeCliError{ NOT_INSTALLED })', async () => {
     const port = makeSdkLikePort()
 
     const result = await queryStructured(port, 'hello', {})
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ClaudeCliError)
+      expect((result.error as ClaudeCliError).errorCode).toBe('NOT_INSTALLED')
+    }
+  })
+
+  it('degradedClaudeCliPort sentinel → err(ClaudeCliError{ NOT_INSTALLED })', async () => {
+    const result = await queryStructured(degradedClaudeCliPort, 'hello', {})
 
     expect(result.ok).toBe(false)
     if (!result.ok) {
@@ -159,27 +129,19 @@ describe('queryStructured (SPEC §6.6)', () => {
   it('invalid structured_output → err(EnvelopeParseError{ PRIMARY_ZOD_FAILED })', async () => {
     // Bypass the typed default and stuff a shape the Zod schema will reject.
     const port: ClaudeCliPort & {
-      kind: 'subscription'
       runStructured: (
         p: string,
         o: StructuredCliCallOptions,
       ) => Promise<Result<StructuredCliRawResult, ClaudeCliError>>
     } = {
-      kind: 'subscription',
-      async query() {
-        return ok('')
-      },
       async isAvailable() {
         return true
       },
-      async startup() {
-        /* no-op */
-      },
-      shutdown() {
-        /* no-op */
-      },
-      queryStream(prompt: string, options?: ClaudeCliStreamOptions): AsyncIterable<StreamDelta> {
-        return streamFromQuery(async () => ok(''), prompt, options)
+      async *queryStream(
+        _prompt: string,
+        _options?: ClaudeCliStreamOptions,
+      ): AsyncIterable<StreamDelta> {
+        yield { type: 'done' }
       },
       async runStructured() {
         return ok({
@@ -260,7 +222,7 @@ describe('queryStructured (SPEC §6.6)', () => {
 })
 
 // =============================================================================
-// 3. Argv invariants — the structured path must use `--output-format json`
+// 2. Argv invariants — the structured path must use `--output-format json`
 //    and `--json-schema` (INV-4). This is asserted directly against the
 //    canonical `buildSubprocessArgs` so the test stays decoupled from
 //    `ClaudeSubprocessAdapter` internals; it confirms the inputs the adapter

--- a/tests/domain/ports/ClaudeCliPort.test.ts
+++ b/tests/domain/ports/ClaudeCliPort.test.ts
@@ -1,138 +1,59 @@
 /**
- * T-CCS-002 — Tests for ClaudeCliPort interface shape and ClaudeCliError class.
+ * T-CCS-002 — Tests for the `ClaudeCliPort` domain types: the
+ * `ClaudeCliError` class and its discriminator codes.
+ *
  * Satisfies REQ-CCS-021, SPEC-CCS-001 §2.1–§2.3, TEST-CCS-021.
+ *
+ * Reshaped in WP-12 (Arch review #3): the `streamFromQuery` helper that this
+ * file also used to cover is deleted — non-streaming consumers now use
+ * `collectStream` from `@/application/chat/collectStream` (tested in its
+ * sibling `tests/application/chat/collectStream.test.ts`).
  */
 import { describe, it, expect } from 'vitest'
-import { ClaudeCliError, streamFromQuery } from '@/domain/ports/ClaudeCliPort'
-import type { ClaudeCliQueryOptions, StreamDelta } from '@/domain/ports/ClaudeCliPort'
-import { ok, err, type Result } from '@/domain/shared/Result'
+import { ClaudeCliError } from '@/domain/ports/ClaudeCliPort'
 
-describe('REQ-CCS-021: ClaudeCliPort interface and ClaudeCliError', () => {
-  describe('ClaudeCliError', () => {
-    it('stores errorCode on construction', () => {
-      const err = new ClaudeCliError('NOT_INSTALLED', 'binary missing')
-      expect(err.errorCode).toBe('NOT_INSTALLED')
-    })
-
-    it('stores message on construction', () => {
-      const err = new ClaudeCliError('TIMEOUT', 'took too long')
-      expect(err.message).toBe('took too long')
-    })
-
-    it('stores optional cause on construction', () => {
-      const cause = new Error('original')
-      const err = new ClaudeCliError('QUERY_FAILED', 'sdk error', cause)
-      expect(err.cause).toBe(cause)
-    })
-
-    it('has cause === undefined when not provided', () => {
-      const err = new ClaudeCliError('API_KEY_MISSING', 'no key')
-      expect(err.cause).toBeUndefined()
-    })
-
-    it('name is "ClaudeCliError"', () => {
-      const err = new ClaudeCliError('NOT_INSTALLED', 'test')
-      expect(err.name).toBe('ClaudeCliError')
-    })
-
-    it('extends Error', () => {
-      const err = new ClaudeCliError('TIMEOUT', 'test')
-      expect(err).toBeInstanceOf(Error)
-    })
-
-    it('instanceof ClaudeCliError is true after prototype-chain restoration', () => {
-      const err = new ClaudeCliError('QUERY_FAILED', 'test')
-      expect(err).toBeInstanceOf(ClaudeCliError)
-    })
-
-    it('supports all ClaudeCliErrorCode values', () => {
-      const codes = ['NOT_INSTALLED', 'API_KEY_MISSING', 'TIMEOUT', 'QUERY_FAILED'] as const
-      for (const code of codes) {
-        const err = new ClaudeCliError(code, 'msg')
-        expect(err.errorCode).toBe(code)
-      }
-    })
+describe('REQ-CCS-021: ClaudeCliError', () => {
+  it('stores errorCode on construction', () => {
+    const err = new ClaudeCliError('NOT_INSTALLED', 'binary missing')
+    expect(err.errorCode).toBe('NOT_INSTALLED')
   })
 
-  describe('streamFromQuery helper (PR-ASV-2-port)', () => {
-    async function collect(stream: AsyncIterable<StreamDelta>): Promise<StreamDelta[]> {
-      const out: StreamDelta[] = []
-      for await (const d of stream) out.push(d)
-      return out
+  it('stores message on construction', () => {
+    const err = new ClaudeCliError('TIMEOUT', 'took too long')
+    expect(err.message).toBe('took too long')
+  })
+
+  it('stores optional cause on construction', () => {
+    const cause = new Error('original')
+    const err = new ClaudeCliError('QUERY_FAILED', 'sdk error', cause)
+    expect(err.cause).toBe(cause)
+  })
+
+  it('has cause === undefined when not provided', () => {
+    const err = new ClaudeCliError('API_KEY_MISSING', 'no key')
+    expect(err.cause).toBeUndefined()
+  })
+
+  it('name is "ClaudeCliError"', () => {
+    const err = new ClaudeCliError('NOT_INSTALLED', 'test')
+    expect(err.name).toBe('ClaudeCliError')
+  })
+
+  it('extends Error', () => {
+    const err = new ClaudeCliError('TIMEOUT', 'test')
+    expect(err).toBeInstanceOf(Error)
+  })
+
+  it('instanceof ClaudeCliError is true after prototype-chain restoration', () => {
+    const err = new ClaudeCliError('QUERY_FAILED', 'test')
+    expect(err).toBeInstanceOf(ClaudeCliError)
+  })
+
+  it('supports all ClaudeCliErrorCode values', () => {
+    const codes = ['NOT_INSTALLED', 'API_KEY_MISSING', 'TIMEOUT', 'QUERY_FAILED'] as const
+    for (const code of codes) {
+      const err = new ClaudeCliError(code, 'msg')
+      expect(err.errorCode).toBe(code)
     }
-
-    it('emits text + done on a successful query', async () => {
-      const query = async (
-        _p: string,
-        _o?: ClaudeCliQueryOptions,
-      ): Promise<Result<string, ClaudeCliError>> => ok('hello world')
-      const out = await collect(streamFromQuery(query, 'prompt'))
-      expect(out).toEqual([
-        { type: 'text', text: 'hello world' },
-        { type: 'done' },
-      ])
-    })
-
-    it('emits a single error delta on query failure', async () => {
-      const failure = new ClaudeCliError('QUERY_FAILED', 'boom')
-      const query = async (): Promise<Result<string, ClaudeCliError>> => err(failure)
-      const out = await collect(streamFromQuery(query, 'prompt'))
-      expect(out).toEqual([{ type: 'error', error: failure }])
-    })
-
-    it('short-circuits when signal is already aborted before send (Codex P2)', async () => {
-      const controller = new AbortController()
-      controller.abort()
-      const query = async (): Promise<Result<string, ClaudeCliError>> => ok('should not run')
-      const out = await collect(streamFromQuery(query, 'p', { signal: controller.signal }))
-      expect(out).toHaveLength(1)
-      expect(out[0]?.type).toBe('error')
-    })
-
-    it('honours mid-flight abort and returns an error delta (Codex P2 mid-flight gap)', async () => {
-      const controller = new AbortController()
-      // Query never resolves on its own — only the abort signal can end the stream.
-      const query = (): Promise<Result<string, ClaudeCliError>> =>
-        new Promise<Result<string, ClaudeCliError>>(() => {
-          /* never */
-        })
-      const streamPromise = collect(streamFromQuery(query, 'p', { signal: controller.signal }))
-      // Schedule the abort after the stream has started awaiting. Tests run
-      // in Vitest's jsdom env where the Obsidian-flavoured `activeWindow`
-      // timer rule has no meaning; the rule is silenced inline per Codex
-      // P2 mid-flight gap regression coverage.
-      // eslint-disable-next-line obsidianmd/prefer-active-window-timers
-      setTimeout(() => {
-        controller.abort()
-      }, 5)
-      const out = await streamPromise
-      expect(out).toHaveLength(1)
-      expect(out[0]?.type).toBe('error')
-      if (out[0]?.type === 'error') {
-        expect(out[0].error).toBeInstanceOf(ClaudeCliError)
-      }
-    })
-
-    it('does not yield text/done after a mid-flight abort wins the race', async () => {
-      const controller = new AbortController()
-      let resolveQuery!: (v: Result<string, ClaudeCliError>) => void
-      const query = (): Promise<Result<string, ClaudeCliError>> =>
-        new Promise<Result<string, ClaudeCliError>>((resolve) => {
-          resolveQuery = resolve
-        })
-      const streamPromise = collect(streamFromQuery(query, 'p', { signal: controller.signal }))
-      // eslint-disable-next-line obsidianmd/prefer-active-window-timers
-      setTimeout(() => {
-        controller.abort()
-      }, 5)
-      // After the abort wins, resolving the query late must NOT inject more deltas.
-      // eslint-disable-next-line obsidianmd/prefer-active-window-timers
-      setTimeout(() => {
-        resolveQuery(ok('too late'))
-      }, 20)
-      const out = await streamPromise
-      expect(out.find((d) => d.type === 'done')).toBeUndefined()
-      expect(out.find((d) => d.type === 'text')).toBeUndefined()
-    })
   })
 })

--- a/tests/infrastructure/mock/MockClaudeCliPort.test.ts
+++ b/tests/infrastructure/mock/MockClaudeCliPort.test.ts
@@ -1,10 +1,15 @@
 /**
  * T-CCS-004 — Tests for MockClaudeCliPort all method branches.
  * Satisfies REQ-CCS-022, SPEC-CCS-001 §6, TEST-CCS-022.
+ *
+ * Reshaped in WP-12 (Arch review #3): the deleted `query()` method is now
+ * a `collectStream(port.queryStream(...))` call. Every assertion that used
+ * to exercise `query` is migrated below.
  */
 import { describe, it, expect, beforeEach } from 'vitest'
 import { MockClaudeCliPort } from '@/infrastructure/mock/MockClaudeCliPort'
 import { ClaudeCliError } from '@/domain/ports/ClaudeCliPort'
+import { collectStream } from '@/application/chat/collectStream'
 
 describe('REQ-CCS-022: MockClaudeCliPort', () => {
   let mock: MockClaudeCliPort
@@ -30,45 +35,45 @@ describe('REQ-CCS-022: MockClaudeCliPort', () => {
     expect(() => { mock.shutdown() }).not.toThrow()
   })
 
-  it('query() with available=false returns err(NOT_INSTALLED)', async () => {
+  it('queryStream() with available=false yields err(NOT_INSTALLED) when collected', async () => {
     mock.available = false
-    const result = await mock.query('hello')
+    const result = await collectStream(mock.queryStream('hello'))
     expect(result.ok).toBe(false)
     if (result.ok) return
     expect(result.error).toBeInstanceOf(ClaudeCliError)
     expect(result.error.errorCode).toBe('NOT_INSTALLED')
   })
 
-  it('query() with available=true and no queryError appends to queryLog and returns ok(cannedResponse)', async () => {
+  it('queryStream() with available=true and no queryError appends to queryLog and returns ok(cannedResponse)', async () => {
     mock.available = true
-    const result = await mock.query('test prompt')
+    const result = await collectStream(mock.queryStream('test prompt'))
     expect(result.ok).toBe(true)
     if (!result.ok) return
     expect(result.value).toBe(mock.cannedResponse)
     expect(mock.queryLog).toContain('test prompt')
   })
 
-  it('query() appends to queryLog even when not available', async () => {
+  it('queryStream() appends to queryLog even when not available', async () => {
     mock.available = false
-    await mock.query('some prompt')
+    await collectStream(mock.queryStream('some prompt'))
     expect(mock.queryLog).toContain('some prompt')
   })
 
-  it('query() with queryError set returns err(queryError)', async () => {
+  it('queryStream() with queryError set yields err(queryError)', async () => {
     mock.available = true
     const customError = new ClaudeCliError('TIMEOUT', 'simulated timeout')
     mock.queryError = customError
-    const result = await mock.query('test')
+    const result = await collectStream(mock.queryStream('test'))
     expect(result.ok).toBe(false)
     if (result.ok) return
     expect(result.error).toBe(customError)
   })
 
-  it('query() respects delayMs and resolves after the delay', async () => {
+  it('queryStream() respects delayMs and resolves after the delay', async () => {
     mock.available = true
     mock.delayMs = 50
     const start = Date.now()
-    await mock.query('prompt')
+    await collectStream(mock.queryStream('prompt'))
     const elapsed = Date.now() - start
     expect(elapsed).toBeGreaterThanOrEqual(40)
   })

--- a/tests/infrastructure/mock/MockClaudeSubprocessAdapter.test.ts
+++ b/tests/infrastructure/mock/MockClaudeSubprocessAdapter.test.ts
@@ -11,17 +11,16 @@
  *   - NFR-ASM-006 (startup never throws)
  *   - NFR-ASM-007 (shutdown is idempotent / no-op-safe)
  *
- * Tests will fail with "Cannot find module" until T-ASM-013 lands the
- * implementation at `src/infrastructure/mock/MockClaudeSubprocessAdapter.ts`.
- *
- * Reference: `tests/infrastructure/mock/MockClaudeCliPort.test.ts`,
- *            `src/infrastructure/obsidian/ClaudeSubprocessAdapter.ts`.
+ * Reshaped in WP-12 (Arch review #3): the deleted `query()` method on the
+ * port is now `collectStream(port.queryStream(...))` from
+ * `@/application/chat/collectStream`.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 import { MockClaudeSubprocessAdapter } from '@/infrastructure/mock/MockClaudeSubprocessAdapter'
 import { ClaudeCliError } from '@/domain/ports/ClaudeCliPort'
 import { asSessionId } from '@/domain/chat/SessionId'
+import { collectStream } from '@/application/chat/collectStream'
 
 describe('REQ-ASM-001 / REQ-ASM-031: MockClaudeSubprocessAdapter', () => {
   let mock: MockClaudeSubprocessAdapter
@@ -74,19 +73,19 @@ describe('REQ-ASM-001 / REQ-ASM-031: MockClaudeSubprocessAdapter', () => {
     }).not.toThrow()
   })
 
-  // ── query() — observability ─────────────────────────────────────────────
+  // ── queryStream() — observability ──────────────────────────────────────
 
-  it('query() appends to queryLog even when available === false (test observability)', async () => {
+  it('queryStream() appends to queryLog even when available === false (test observability)', async () => {
     mock.available = false
-    await mock.query('observed-while-unavailable')
+    await collectStream(mock.queryStream('observed-while-unavailable'))
     expect(mock.queryLog).toContain('observed-while-unavailable')
   })
 
-  it('query() returns ok(cannedResponse) when available and no queryError', async () => {
+  it('queryStream() returns ok(cannedResponse) when available and no queryError', async () => {
     mock.available = true
     mock.cannedResponse = 'hello from mock subscription'
 
-    const result = await mock.query('any prompt')
+    const result = await collectStream(mock.queryStream('any prompt'))
 
     expect(result.ok).toBe(true)
     if (!result.ok) return
@@ -94,13 +93,13 @@ describe('REQ-ASM-001 / REQ-ASM-031: MockClaudeSubprocessAdapter', () => {
     expect(mock.queryLog).toContain('any prompt')
   })
 
-  it('query() returns err(queryError) when set, regardless of cannedResponse', async () => {
+  it('queryStream() returns err(queryError) when set, regardless of cannedResponse', async () => {
     mock.available = true
     mock.cannedResponse = 'should-not-be-returned'
     const simulated = new ClaudeCliError('QUERY_FAILED', 'simulated subprocess failure')
     mock.queryError = simulated
 
-    const result = await mock.query('prompt')
+    const result = await collectStream(mock.queryStream('prompt'))
 
     expect(result.ok).toBe(false)
     if (result.ok) return
@@ -120,12 +119,12 @@ describe('REQ-ASM-001 / REQ-ASM-031: MockClaudeSubprocessAdapter', () => {
       vi.useRealTimers()
     })
 
-    it('causes query() to await the configured delay before resolving', async () => {
+    it('causes queryStream() to await the configured delay before resolving', async () => {
       mock.available = true
       mock.delayMs = 250
 
       let settled = false
-      const pending = mock.query('delayed').then((r) => {
+      const pending = collectStream(mock.queryStream('delayed')).then((r: unknown) => {
         settled = true
         return r
       })
@@ -136,7 +135,7 @@ describe('REQ-ASM-001 / REQ-ASM-031: MockClaudeSubprocessAdapter', () => {
 
       // Cross the threshold — promise resolves.
       await vi.advanceTimersByTimeAsync(1)
-      const result = await pending
+      const result = (await pending) as { ok: boolean }
       expect(settled).toBe(true)
       expect(result.ok).toBe(true)
     })
@@ -148,12 +147,14 @@ describe('REQ-ASM-001 / REQ-ASM-031: MockClaudeSubprocessAdapter', () => {
     expect(mock.cannedSessionId).toBeNull()
   })
 
-  it('exposes the configured cannedSessionId after a successful query()', async () => {
+  it('exposes the configured cannedSessionId after a successful queryStream()', async () => {
     mock.available = true
     const sid = asSessionId('mock-session-abc123')
     mock.cannedSessionId = sid
 
-    const result = await mock.query('prompt that captures a session')
+    const result = await collectStream(
+      mock.queryStream('prompt that captures a session'),
+    )
 
     expect(result.ok).toBe(true)
     expect(mock.cannedSessionId).toBe(sid)
@@ -161,11 +162,11 @@ describe('REQ-ASM-001 / REQ-ASM-031: MockClaudeSubprocessAdapter', () => {
 
   // ── option recording for assertions ─────────────────────────────────────
 
-  it('records resumeSessionId from query() options onto queryLog entry', async () => {
+  it('records resumeSessionId from queryStream() options onto queryLog entry', async () => {
     mock.available = true
     const sid = asSessionId('mock-resume-xyz')
 
-    await mock.query('resume-prompt', { resumeSessionId: sid })
+    await collectStream(mock.queryStream('resume-prompt', { resumeSessionId: sid }))
 
     // queryLog is the canonical surface for prompt-string assertions.
     expect(mock.queryLog).toContain('resume-prompt')
@@ -178,12 +179,14 @@ describe('REQ-ASM-001 / REQ-ASM-031: MockClaudeSubprocessAdapter', () => {
     expect(serialised).toContain('mock-resume-xyz')
   })
 
-  it('records systemPromptSuffix from query() options', async () => {
+  it('records systemPromptSuffix from queryStream() options', async () => {
     mock.available = true
 
-    await mock.query('stage-aware prompt', {
-      systemPromptSuffix: 'STAGE_SUFFIX::idea',
-    })
+    await collectStream(
+      mock.queryStream('stage-aware prompt', {
+        systemPromptSuffix: 'STAGE_SUFFIX::idea',
+      }),
+    )
 
     expect(mock.queryLog).toContain('stage-aware prompt')
 

--- a/tests/infrastructure/obsidian/ClaudeCliAdapter.test.ts
+++ b/tests/infrastructure/obsidian/ClaudeCliAdapter.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { MockBridge } from '@/infrastructure/mock/MockBridge'
 import { ClaudeCliError } from '@/domain/ports/ClaudeCliPort'
+import { collectStream } from '@/application/chat/collectStream'
 
 // We mock the SDK module so no real subprocess is spawned in unit tests.
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
@@ -112,11 +113,11 @@ describe('REQ-CCS-002, REQ-CCS-003, REQ-CCS-016, REQ-CCS-017: ClaudeCliAdapter',
     })
   })
 
-  describe('query() when not available', () => {
+  describe('queryStream() when not available (collected via collectStream)', () => {
     it('with empty key returns err(API_KEY_MISSING)', async () => {
       getApiKey = () => ''
       const adapter = new ClaudeCliAdapter(getApiKey, bridge)
-      const result = await adapter.query('test prompt')
+      const result = await collectStream(adapter.queryStream('test prompt'))
       expect(result.ok).toBe(false)
       if (result.ok) return
       expect(result.error).toBeInstanceOf(ClaudeCliError)
@@ -126,7 +127,7 @@ describe('REQ-CCS-002, REQ-CCS-003, REQ-CCS-016, REQ-CCS-017: ClaudeCliAdapter',
     it('with non-empty key but not started returns err(NOT_INSTALLED)', async () => {
       getApiKey = () => 'sk-ant-test'
       const adapter = new ClaudeCliAdapter(getApiKey, bridge)
-      const result = await adapter.query('test prompt')
+      const result = await collectStream(adapter.queryStream('test prompt'))
       expect(result.ok).toBe(false)
       if (result.ok) return
       expect(result.error).toBeInstanceOf(ClaudeCliError)
@@ -134,7 +135,7 @@ describe('REQ-CCS-002, REQ-CCS-003, REQ-CCS-016, REQ-CCS-017: ClaudeCliAdapter',
     })
   })
 
-  describe('query() success path', () => {
+  describe('queryStream() success path (collected via collectStream)', () => {
     it('returns ok(responseText) from SDK result message', async () => {
       getApiKey = () => 'sk-ant-test'
       const adapter = new ClaudeCliAdapter(getApiKey, bridge, () => '/fake/claude')
@@ -145,14 +146,14 @@ describe('REQ-CCS-002, REQ-CCS-003, REQ-CCS-016, REQ-CCS-017: ClaudeCliAdapter',
         makeSuccessGen('Hello from Claude') as unknown as ReturnType<typeof sdkModule.query>,
       )
 
-      const result = await adapter.query('test')
+      const result = await collectStream(adapter.queryStream('test'))
       expect(result.ok).toBe(true)
       if (!result.ok) return
       expect(result.value).toBe('Hello from Claude')
     })
   })
 
-  describe('query() timeout', () => {
+  describe('queryStream() timeout (collected via collectStream)', () => {
     it('returns err(TIMEOUT) when query exceeds timeoutMs', async () => {
       vi.useFakeTimers()
       getApiKey = () => 'sk-ant-test'
@@ -164,7 +165,7 @@ describe('REQ-CCS-002, REQ-CCS-003, REQ-CCS-016, REQ-CCS-017: ClaudeCliAdapter',
         makeHangingGen() as unknown as ReturnType<typeof sdkModule.query>,
       )
 
-      const queryPromise = adapter.query('test', { timeoutMs: 1_000 })
+      const queryPromise = collectStream(adapter.queryStream('test', { timeoutMs: 1_000 }))
       vi.advanceTimersByTime(1_001)
       const result = await queryPromise
 
@@ -174,7 +175,7 @@ describe('REQ-CCS-002, REQ-CCS-003, REQ-CCS-016, REQ-CCS-017: ClaudeCliAdapter',
     })
   })
 
-  describe('query() SDK error mapping', () => {
+  describe('queryStream() SDK error mapping (collected via collectStream)', () => {
     it('maps generic SDK error to QUERY_FAILED', async () => {
       getApiKey = () => 'sk-ant-test'
       const adapter = new ClaudeCliAdapter(getApiKey, bridge, () => '/fake/claude')
@@ -185,7 +186,7 @@ describe('REQ-CCS-002, REQ-CCS-003, REQ-CCS-016, REQ-CCS-017: ClaudeCliAdapter',
         makeErrorGen(new Error('Some SDK failure')) as unknown as ReturnType<typeof sdkModule.query>,
       )
 
-      const result = await adapter.query('test')
+      const result = await collectStream(adapter.queryStream('test'))
       expect(result.ok).toBe(false)
       if (result.ok) return
       expect(result.error.errorCode).toBe('QUERY_FAILED')
@@ -203,7 +204,7 @@ describe('REQ-CCS-002, REQ-CCS-003, REQ-CCS-016, REQ-CCS-017: ClaudeCliAdapter',
         ) as unknown as ReturnType<typeof sdkModule.query>,
       )
 
-      const result = await adapter.query('test')
+      const result = await collectStream(adapter.queryStream('test'))
       expect(result.ok).toBe(false)
       if (result.ok) return
       expect(result.error.errorCode).toBe('API_KEY_MISSING')

--- a/tests/infrastructure/obsidian/ClaudeSubprocessAdapter.telemetry.test.ts
+++ b/tests/infrastructure/obsidian/ClaudeSubprocessAdapter.telemetry.test.ts
@@ -21,6 +21,7 @@ import type { LoggerPort } from '@/domain/ports/LoggerPort'
 import type { PluginSettings } from '@/domain/settings/PluginSettings'
 import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
 import { ClaudeSubprocessAdapter } from '@/infrastructure/obsidian/ClaudeSubprocessAdapter'
+import { collectStream } from '@/application/chat/collectStream'
 
 interface FakeChild extends EventEmitter {
   stdout: EventEmitter
@@ -193,7 +194,7 @@ describe('T-ASM-081 — ClaudeSubprocessAdapter telemetry shape', () => {
     await adapter.startup()
 
     const sessionId = '99999999-aaaa-bbbb-cccc-dddddddddddd'
-    const pending = adapter.query('hello', {})
+    const pending = collectStream(adapter.queryStream('hello', {}))
     queueMicrotask(() => {
       // system/init carries the session id; result then closes the turn.
       const lines = [

--- a/tests/infrastructure/obsidian/ClaudeSubprocessAdapter.test.ts
+++ b/tests/infrastructure/obsidian/ClaudeSubprocessAdapter.test.ts
@@ -48,6 +48,7 @@ import { ClaudeCliError } from '@/domain/ports/ClaudeCliPort'
 import type { LoggerPort } from '@/domain/ports/LoggerPort'
 import type { PluginSettings } from '@/domain/settings/PluginSettings'
 import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings'
+import { collectStream } from '@/application/chat/collectStream'
 
 // Module-under-test (created in T-ASM-011). Tests fail with
 // "Cannot find module '@/infrastructure/obsidian/ClaudeSubprocessAdapter'" until then.
@@ -432,7 +433,7 @@ describe('ClaudeSubprocessAdapter — shutdown() (REQ-CCS-017 family)', () => {
 
     // Kick off a streaming query whose response never arrives — registers a
     // streaming child in _streamingProc.
-    void adapter.query('hello', { resumeSessionId: undefined })
+    void collectStream(adapter.queryStream('hello', { resumeSessionId: undefined }))
     await Promise.resolve() // let spawn fire
     const streamingChild = spawn.lastChild()
 
@@ -472,7 +473,7 @@ describe('ClaudeSubprocessAdapter — query() unavailability (REQ-ASM-009)', () 
     })
     await adapter.startup()
 
-    const result = await adapter.query('hello')
+    const result = await collectStream(adapter.queryStream('hello'))
 
     expect(result.ok).toBe(false)
     if (!result.ok) {
@@ -497,7 +498,7 @@ describe('ClaudeSubprocessAdapter — query() happy path (REQ-ASM-029/030/031)',
     })
     await adapter.startup()
 
-    const promise = adapter.query('hello world')
+    const promise = collectStream(adapter.queryStream('hello world'))
     await Promise.resolve() // let the spawn settle
 
     const child = spawn.lastChild()
@@ -515,7 +516,7 @@ describe('ClaudeSubprocessAdapter — query() happy path (REQ-ASM-029/030/031)',
     await adapter.startup()
 
     const onSessionId = vi.fn()
-    const promise = adapter.query('hi', { onSessionId })
+    const promise = collectStream(adapter.queryStream('hi', { onSessionId }))
     await Promise.resolve()
 
     const child = spawn.lastChild()
@@ -540,7 +541,7 @@ describe('ClaudeSubprocessAdapter — query() happy path (REQ-ASM-029/030/031)',
     })
     await adapter.startup()
 
-    const promise = adapter.query('hi')
+    const promise = collectStream(adapter.queryStream('hi'))
     await Promise.resolve()
 
     const child = spawn.lastChild()
@@ -563,7 +564,7 @@ describe('ClaudeSubprocessAdapter — query() happy path (REQ-ASM-029/030/031)',
     await adapter.startup()
 
     const onSessionId = vi.fn()
-    const promise = adapter.query('hi', { onSessionId })
+    const promise = collectStream(adapter.queryStream('hi', { onSessionId }))
     await Promise.resolve()
 
     const child = spawn.lastChild()
@@ -588,7 +589,7 @@ describe('ClaudeSubprocessAdapter — query() happy path (REQ-ASM-029/030/031)',
     const onSessionId = vi.fn(() => {
       throw new Error('caller bug')
     })
-    const promise = adapter.query('hi', { onSessionId })
+    const promise = collectStream(adapter.queryStream('hi', { onSessionId }))
     await Promise.resolve()
 
     const child = spawn.lastChild()
@@ -609,7 +610,7 @@ describe('ClaudeSubprocessAdapter — query() happy path (REQ-ASM-029/030/031)',
     })
     await adapter.startup()
 
-    const promise = adapter.query('hi')
+    const promise = collectStream(adapter.queryStream('hi'))
     await Promise.resolve()
 
     const child = spawn.lastChild()
@@ -641,7 +642,7 @@ describe('ClaudeSubprocessAdapter — query() happy path (REQ-ASM-029/030/031)',
     })
     await adapter.startup()
 
-    const promise = adapter.query('hi')
+    const promise = collectStream(adapter.queryStream('hi'))
     await Promise.resolve()
 
     const child = spawn.lastChild()
@@ -684,7 +685,7 @@ describe('ClaudeSubprocessAdapter — spawn-per-turn + --resume chaining (REQ-AS
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       resumeSessionId?: any,
     ) => {
-      const p = adapter.query(text, resumeSessionId ? { resumeSessionId } : undefined)
+      const p = collectStream(adapter.queryStream(text, resumeSessionId ? { resumeSessionId } : undefined))
       await Promise.resolve()
       const child = spawn.lastChild()
       spawn.emitStdout(
@@ -736,7 +737,7 @@ describe('ClaudeSubprocessAdapter — timeout (SPEC §4.4)', () => {
     })
     await adapter.startup()
 
-    const promise = adapter.query('hangs forever', { timeoutMs: 1_500 })
+    const promise = collectStream(adapter.queryStream('hangs forever', { timeoutMs: 1_500 }))
     await Promise.resolve() // let the spawn settle
 
     const child = spawn.lastChild()
@@ -772,7 +773,7 @@ describe('ClaudeSubprocessAdapter — spawn error (SPEC §4.4)', () => {
     })
     await adapter.startup()
 
-    const result = await adapter.query('hi')
+    const result = await collectStream(adapter.queryStream('hi'))
 
     expect(result.ok).toBe(false)
     if (!result.ok) {
@@ -786,7 +787,7 @@ describe('ClaudeSubprocessAdapter — spawn error (SPEC §4.4)', () => {
     })
     await adapter.startup()
 
-    const promise = adapter.query('hi')
+    const promise = collectStream(adapter.queryStream('hi'))
     await Promise.resolve()
 
     const child = spawn.lastChild()
@@ -816,7 +817,7 @@ describe('ClaudeSubprocessAdapter — non-success exits (REQ-ASM-030, TEST-ASM-0
     })
     await adapter.startup()
 
-    const promise = adapter.query('hi')
+    const promise = collectStream(adapter.queryStream('hi'))
     await Promise.resolve()
 
     const child = spawn.lastChild()
@@ -836,7 +837,7 @@ describe('ClaudeSubprocessAdapter — non-success exits (REQ-ASM-030, TEST-ASM-0
     })
     await adapter.startup()
 
-    const promise = adapter.query('hi')
+    const promise = collectStream(adapter.queryStream('hi'))
     await Promise.resolve()
 
     const child = spawn.lastChild()
@@ -866,7 +867,7 @@ describe('ClaudeSubprocessAdapter — invalid NDJSON (SPEC §4.3)', () => {
     })
     await adapter.startup()
 
-    const promise = adapter.query('hi')
+    const promise = collectStream(adapter.queryStream('hi'))
     await Promise.resolve()
 
     const child = spawn.lastChild()
@@ -900,11 +901,11 @@ describe('ClaudeSubprocessAdapter — resumeSessionId forwarding (REQ-ASM-035)',
     })
     await adapter.startup()
 
-    const promise = adapter.query('hi', {
+    const promise = collectStream(adapter.queryStream('hi', {
       // SessionId is a branded string — cast at the test boundary only.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       resumeSessionId: 'abc-123' as any,
-    })
+    }))
     await Promise.resolve()
 
     const child = spawn.lastChild()
@@ -933,7 +934,7 @@ describe('ClaudeSubprocessAdapter — resumeSessionId forwarding (REQ-ASM-035)',
     })
 
     // Turn 1 — no prior session; capture via callback.
-    const p1 = adapter.query('msg-1', { onSessionId })
+    const p1 = collectStream(adapter.queryStream('msg-1', { onSessionId }))
     await Promise.resolve()
     const c1 = spawn.lastChild()
     spawn.emitStdout(c1, ndjson(systemInit('abc-123'), resultEvent('r-1')))
@@ -945,7 +946,7 @@ describe('ClaudeSubprocessAdapter — resumeSessionId forwarding (REQ-ASM-035)',
 
     // Turn 2 — thread the captured id back as resumeSessionId.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const p2 = adapter.query('msg-2', { resumeSessionId: captured as any })
+    const p2 = collectStream(adapter.queryStream('msg-2', { resumeSessionId: captured as any }))
     await Promise.resolve()
     const c2 = spawn.lastChild()
     spawn.emitStdout(c2, ndjson(systemInit('def-456'), resultEvent('r-2')))
@@ -964,7 +965,7 @@ describe('ClaudeSubprocessAdapter — resumeSessionId forwarding (REQ-ASM-035)',
     })
     await adapter.startup()
 
-    const promise = adapter.query('hi')
+    const promise = collectStream(adapter.queryStream('hi'))
     await Promise.resolve()
 
     const child = spawn.lastChild()
@@ -989,7 +990,7 @@ describe('ClaudeSubprocessAdapter — systemPromptSuffix forwarding (REQ-ASM-013
     await adapter.startup()
 
     const suffix = 'You are operating on feature "demo" at stage "idea".'
-    const promise = adapter.query('hi', { systemPromptSuffix: suffix })
+    const promise = collectStream(adapter.queryStream('hi', { systemPromptSuffix: suffix }))
     await Promise.resolve()
 
     const child = spawn.lastChild()
@@ -1009,7 +1010,7 @@ describe('ClaudeSubprocessAdapter — systemPromptSuffix forwarding (REQ-ASM-013
     })
     await adapter.startup()
 
-    const promise = adapter.query('hi', { systemPromptSuffix: '' })
+    const promise = collectStream(adapter.queryStream('hi', { systemPromptSuffix: '' }))
     await Promise.resolve()
 
     const child = spawn.lastChild()
@@ -1034,7 +1035,7 @@ describe('ClaudeSubprocessAdapter — argv invariants (REQ-ASM-006/027/028)', ()
     })
     await adapter.startup()
 
-    const promise = adapter.query('hi')
+    const promise = collectStream(adapter.queryStream('hi'))
     await Promise.resolve()
     const child = spawn.lastChild()
     spawn.emitStdout(child, ndjson(systemInit('s'), resultEvent('ok')))
@@ -1052,7 +1053,7 @@ describe('ClaudeSubprocessAdapter — argv invariants (REQ-ASM-006/027/028)', ()
     })
     await adapter.startup()
 
-    const promise = adapter.query('hi')
+    const promise = collectStream(adapter.queryStream('hi'))
     await Promise.resolve()
     const child = spawn.lastChild()
     spawn.emitStdout(child, ndjson(systemInit('s'), resultEvent('ok')))
@@ -1074,7 +1075,7 @@ describe('ClaudeSubprocessAdapter — argv invariants (REQ-ASM-006/027/028)', ()
     })
     await adapter.startup()
 
-    const promise = adapter.query('hi')
+    const promise = collectStream(adapter.queryStream('hi'))
     await Promise.resolve()
     const child = spawn.lastChild()
     spawn.emitStdout(child, ndjson(systemInit('s'), resultEvent('ok')))
@@ -1103,11 +1104,11 @@ describe('ClaudeSubprocessAdapter — ToS posture (NFR-ASM-004, ADR-0031)', () =
     })
     await adapter.startup()
 
-    const promise = adapter.query('hello', {
+    const promise = collectStream(adapter.queryStream('hello', {
       systemPromptSuffix: 'context',
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       resumeSessionId: 'sess-x' as any,
-    })
+    }))
     await Promise.resolve()
     const child = spawn.lastChild()
     spawn.emitStdout(child, ndjson(systemInit('sess-x'), resultEvent('ok')))
@@ -1133,7 +1134,7 @@ describe('ClaudeSubprocessAdapter — ToS posture (NFR-ASM-004, ADR-0031)', () =
     })
     await adapter.startup()
 
-    const promise = adapter.query('hello')
+    const promise = collectStream(adapter.queryStream('hello'))
     await Promise.resolve()
     const child = spawn.lastChild()
     spawn.emitStdout(child, ndjson(systemInit('s'), resultEvent('ok')))
@@ -1167,7 +1168,7 @@ describe('ClaudeSubprocessAdapter — log redaction (NFR-ASM-005, NFR-ASM-012)',
     await adapter.startup()
 
     const prompt = 'SECRET-USER-INTENT-DO-NOT-LOG'
-    const promise = adapter.query(prompt)
+    const promise = collectStream(adapter.queryStream(prompt))
     await Promise.resolve()
     const child = spawn.lastChild()
     spawn.emitStdout(child, ndjson(systemInit('s'), resultEvent('ok')))

--- a/tests/integration/ccs-inheritance.test.ts
+++ b/tests/integration/ccs-inheritance.test.ts
@@ -21,8 +21,14 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { MockClaudeSubprocessAdapter } from '@/infrastructure/mock/MockClaudeSubprocessAdapter'
-import { isSubscriptionCapable } from '@/application/chat/queryStructured'
 import { getChatStoresFacade } from '../__fakes__/chatStoresFacade'
+
+// WP-12 (Arch review #3): `isSubscriptionCapable` is deleted. The application
+// layer now narrows via `typeof port.runStructured === 'function'`; this
+// integration suite simply pins the same check inline.
+function isSubscriptionCapable(port: object): boolean {
+  return typeof (port as { runStructured?: unknown }).runStructured === 'function'
+}
 
 describe('TEST-ASM-053 — CCS auto-context inheritance under subscription transport (T-ASM-083)', () => {
   let port: MockClaudeSubprocessAdapter

--- a/tests/plugin/AgentSidepanelView.test.ts
+++ b/tests/plugin/AgentSidepanelView.test.ts
@@ -46,13 +46,13 @@ import type SpecoratorPlugin from '@/plugin/main';
 
 function makePort(label: string): ClaudeCliPort {
 	return {
-		query: vi.fn(async () => ({ ok: true as const, value: `from-${label}` })),
 		isAvailable: vi.fn(async () => true),
-		startup: vi.fn(async () => undefined),
-		shutdown: vi.fn(() => undefined),
 		queryStream: vi.fn(
 			(_prompt: string, _options?: ClaudeCliStreamOptions): AsyncIterable<StreamDelta> => {
-				return (async function* (): AsyncGenerator<StreamDelta> {})();
+				return (async function* (): AsyncGenerator<StreamDelta> {
+					yield { type: 'text', text: `from-${label}` };
+					yield { type: 'done' };
+				})();
 			},
 		),
 	};

--- a/tests/plugin/SpecoratorView.test.ts
+++ b/tests/plugin/SpecoratorView.test.ts
@@ -63,21 +63,38 @@ import type SpecoratorPlugin from '@/plugin/main'
 
 function makePort(label: string): ClaudeCliPort {
   return {
-    query: vi.fn(async () => ({ ok: true as const, value: `from-${label}` })),
     isAvailable: vi.fn(async () => true),
-    startup: vi.fn(async () => undefined),
-    shutdown: vi.fn(() => undefined),
     queryStream: vi.fn(
       (_prompt: string, _options?: ClaudeCliStreamOptions): AsyncIterable<StreamDelta> => {
-        return (async function* (): AsyncGenerator<StreamDelta> {})()
+        return (async function* (): AsyncGenerator<StreamDelta> {
+          yield { type: 'text', text: `from-${label}` }
+          yield { type: 'done' }
+        })()
       },
     ),
+  }
+}
+
+interface MockLifecycle {
+  startup: ReturnType<typeof vi.fn> & (() => Promise<void>)
+  shutdown: ReturnType<typeof vi.fn> & (() => void)
+}
+
+function makeLifecycle(): MockLifecycle {
+  // vi.fn() with a typed implementation is structurally a callable Mock; the
+  // intersection cast pins the return type for `TransportLifecyclePort` while
+  // preserving the `.toHaveBeenCalled()` matcher surface.
+  return {
+    startup: vi.fn(async () => undefined) as MockLifecycle['startup'],
+    shutdown: vi.fn(() => undefined) as MockLifecycle['shutdown'],
   }
 }
 
 interface Fixture {
   readonly sdkAdapter: ClaudeCliPort
   readonly subscriptionAdapter: ClaudeCliPort
+  readonly sdkLifecycle: MockLifecycle
+  readonly subscriptionLifecycle: MockLifecycle
   readonly degradedPort: ClaudeCliPort
   readonly selectTransportSpy: ReturnType<typeof vi.fn>
   readonly plugin: { settings: PluginSettings }
@@ -114,6 +131,8 @@ interface FixtureOptions {
 function makeFixture(opts: FixtureOptions = {}): Fixture {
   const sdkAdapter = makePort('sdk')
   const subscriptionAdapter = makePort('subscription')
+  const sdkLifecycle = makeLifecycle()
+  const subscriptionLifecycle = makeLifecycle()
   const degradedPort = degradedClaudeCliPort
   const cliResolvedRef = { value: opts.cliResolved ?? false }
   const apiKeyPresentRef = { value: opts.apiKeyPresent ?? false }
@@ -140,11 +159,15 @@ function makeFixture(opts: FixtureOptions = {}): Fixture {
     subscriptionAdapter,
     selectTransport: selectTransportSpy,
     confirmModalAdapter,
+    sdkLifecycle,
+    subscriptionLifecycle,
   }
 
   return {
     sdkAdapter,
     subscriptionAdapter,
+    sdkLifecycle,
+    subscriptionLifecycle,
     degradedPort,
     selectTransportSpy,
     plugin,
@@ -301,8 +324,8 @@ describe('SpecoratorView.bumpSettingsVersion() re-runs the selector (REQ-ASM-002
     // Before the fix, only the subscription adapter's startup() ran. Both
     // must now be invoked so the SDK adapter re-checks its availability
     // with the freshly-configured key.
-    expect(fixture.sdkAdapter.startup).toHaveBeenCalled()
-    expect(fixture.subscriptionAdapter.startup).toHaveBeenCalled()
+    expect(fixture.sdkLifecycle.startup).toHaveBeenCalled()
+    expect(fixture.subscriptionLifecycle.startup).toHaveBeenCalled()
   })
 })
 

--- a/tests/plugin/transport/TransportSelector.test.ts
+++ b/tests/plugin/transport/TransportSelector.test.ts
@@ -54,19 +54,10 @@ function makeSettings(overrides: Partial<PluginSettings>): PluginSettings {
  */
 function makeMockPort(label: string): ClaudeCliPort {
   return {
-    query: () => {
-      throw new Error(`mock port "${label}" .query() must not be called by selectTransport`)
-    },
     isAvailable: () => {
       throw new Error(
         `mock port "${label}" .isAvailable() must not be called by selectTransport`,
       )
-    },
-    startup: () => {
-      throw new Error(`mock port "${label}" .startup() must not be called by selectTransport`)
-    },
-    shutdown: () => {
-      throw new Error(`mock port "${label}" .shutdown() must not be called by selectTransport`)
     },
     queryStream: () => {
       throw new Error(

--- a/tests/ui/components/OnboardingStep3ClaudeCheck.test.ts
+++ b/tests/ui/components/OnboardingStep3ClaudeCheck.test.ts
@@ -13,9 +13,6 @@ function makePort(available: boolean | 'throw'): ClaudeCliPort {
 		isAvailable: available === 'throw'
 			? vi.fn().mockRejectedValue(new Error('boom'))
 			: vi.fn().mockResolvedValue(available),
-		query: vi.fn().mockResolvedValue({ ok: false, error: new Error('stub') }),
-		startup: vi.fn().mockResolvedValue(undefined),
-		shutdown: vi.fn(),
 		queryStream: vi.fn(
 			(_prompt: string, _options?: ClaudeCliStreamOptions): AsyncIterable<StreamDelta> => {
 				return (async function* (): AsyncGenerator<StreamDelta> {})()

--- a/tests/ui/components/chat/ChatSidebar.sessionPersistence.test.ts
+++ b/tests/ui/components/chat/ChatSidebar.sessionPersistence.test.ts
@@ -28,9 +28,7 @@ import type {
 	ClaudeCliStreamOptions,
 	StreamDelta,
 } from '@/domain/ports/ClaudeCliPort'
-import { ClaudeCliError, streamFromQuery } from '@/domain/ports/ClaudeCliPort'
-import type { Result } from '@/domain/shared/Result'
-import { ok, err } from '@/domain/shared/Result'
+import { ClaudeCliError } from '@/domain/ports/ClaudeCliPort'
 import { asSessionId } from '@/domain/chat/SessionId'
 import type { SessionId } from '@/domain/chat/SessionId'
 import { MockBridge } from '@/infrastructure/mock/MockBridge'
@@ -69,29 +67,28 @@ class ScriptedClaudeCliPort implements ClaudeCliPort {
 	readonly queryLog: string[] = []
 	readonly optionsLog: (ClaudeCliQueryOptions | undefined)[] = []
 
-	async startup(): Promise<void> {}
-	shutdown(): void {}
 	async isAvailable(): Promise<boolean> {
 		return this.available
 	}
 
-	async query(
+	async *queryStream(
 		prompt: string,
-		options?: ClaudeCliQueryOptions,
-	): Promise<Result<string, ClaudeCliError>> {
+		options?: ClaudeCliStreamOptions,
+	): AsyncIterable<StreamDelta> {
 		this.queryLog.push(prompt)
 		this.optionsLog.push(options)
 		const callIndex = this.queryLog.length - 1
 		const scripted = this.scriptedSessionIds[callIndex] ?? null
 		if (scripted !== null && options?.onSessionId) {
 			options.onSessionId(scripted)
+			yield { type: 'session-id', sessionId: scripted }
 		}
-		if (this.queryError !== null) return err(this.queryError)
-		return ok(this.cannedResponse)
-	}
-
-	queryStream(prompt: string, options?: ClaudeCliStreamOptions): AsyncIterable<StreamDelta> {
-		return streamFromQuery((p, o) => this.query(p, o), prompt, options)
+		if (this.queryError !== null) {
+			yield { type: 'error', error: this.queryError }
+			return
+		}
+		yield { type: 'text', text: this.cannedResponse }
+		yield { type: 'done' }
 	}
 }
 
@@ -341,10 +338,12 @@ describe('ChatSidebar — session-persistence wiring (T-ASM-057)', () => {
 			release = resolve
 		})
 		const { po, store, port } = await mountSidebar({})
-		const originalQuery = port.query.bind(port)
-		port.query = async (prompt, options) => {
-			await gate
-			return originalQuery(prompt, options)
+		const originalStream = port.queryStream.bind(port)
+		port.queryStream = (prompt, options): AsyncIterable<StreamDelta> => {
+			return (async function* (): AsyncGenerator<StreamDelta> {
+				await gate
+				yield* originalStream(prompt, options)
+			})()
 		}
 
 		expect(store.cliStartingUp).toBe(false)
@@ -352,7 +351,7 @@ describe('ChatSidebar — session-persistence wiring (T-ASM-057)', () => {
 		store.setUserText('go')
 		await flushPromises()
 		const sendPromise = po.clickSend()
-		// Microtasks flushed; query is awaiting the gate now.
+		// Microtasks flushed; queryStream is awaiting the gate now.
 		await flushPromises()
 		expect(store.cliStartingUp).toBe(true)
 

--- a/tests/ui/components/chat/ChatSidebar.threadRotation.test.ts
+++ b/tests/ui/components/chat/ChatSidebar.threadRotation.test.ts
@@ -12,14 +12,9 @@ import { defineComponent, ref } from 'vue';
 import ChatSidebar from '@/ui/components/chat/ChatSidebar.vue';
 import type {
 	ClaudeCliPort,
-	ClaudeCliQueryOptions,
-	ClaudeCliError,
 	ClaudeCliStreamOptions,
 	StreamDelta,
 } from '@/domain/ports/ClaudeCliPort';
-import { streamFromQuery } from '@/domain/ports/ClaudeCliPort';
-import type { Result } from '@/domain/shared/Result';
-import { ok } from '@/domain/shared/Result';
 import { MockBridge } from '@/infrastructure/mock/MockBridge';
 import {
 	CLAUDE_CLI_PORT,
@@ -45,19 +40,15 @@ const RouterLinkStub = defineComponent({
 
 class FixedClaudeCliPort implements ClaudeCliPort {
 	available = true;
-	async startup(): Promise<void> {}
-	shutdown(): void {}
 	async isAvailable(): Promise<boolean> {
 		return this.available;
 	}
-	async query(
+	async *queryStream(
 		_prompt: string,
-		_options?: ClaudeCliQueryOptions,
-	): Promise<Result<string, ClaudeCliError>> {
-		return ok('assistant reply');
-	}
-	queryStream(prompt: string, options?: ClaudeCliStreamOptions): AsyncIterable<StreamDelta> {
-		return streamFromQuery((p, o) => this.query(p, o), prompt, options);
+		_options?: ClaudeCliStreamOptions,
+	): AsyncIterable<StreamDelta> {
+		yield { type: 'text', text: 'assistant reply' };
+		yield { type: 'done' };
 	}
 }
 


### PR DESCRIPTION
## Summary

Collapses `ClaudeCliPort` to its canonical streaming method (`queryStream`) and replaces the `port.query()` consumers with a pure `collectStream` helper. Pulls `runStructured` onto the port itself for subscription-capable adapters (dropping the `SubscriptionCapable` structural sidecar from `queryStructured.ts`). Adds a `TransportLifecyclePort` for `startup` / `shutdown`. Part of the agent-sidepanel v3 hardening wave (WP-12).

Closes **Architecture review #3** — "Collapse `ClaudeCliPort` to one method behind a `ChatTransport` facade":

- `query` was no longer load-bearing — it was a sink for non-streaming call sites whose only role was to converge a stream to a string. Both adapters implemented it by draining `queryStream`.
- `streamFromQuery.ts` was a shim that did the same thing as the new `collectStream` helper but on the wrong layer.
- `runStructured` lived off to the side as a structural extension `SubscriptionCapable` to dodge the "four-method narrow port" rule — a quiet contract violation. Now it's an optional method on the port itself.
- `startup`/`shutdown` had one caller (`AgentSidepanelView`) — separate concern, separate port.

### What changed

**Removed (no facade per CLAUDE.md no-back-compat):**

- `ClaudeCliPort.query` method.
- `src/application/chat/streamFromQuery.ts` shim.
- `SubscriptionCapable` interface from `queryStructured.ts`.

**Added:**

- `src/application/chat/collectStream.ts` — pure helper `collectStream(stream: AsyncIterable<StreamDelta>): Promise<Result<string, ClaudeCliError>>`. Drains the stream, concatenates text deltas, surfaces error deltas as `err()`. 100% coverage.
- `src/domain/ports/TransportLifecyclePort.ts` — new port with `startup()` / `shutdown()`.
- `src/ui/composables/useTransportLifecyclePort.ts` — composable.
- `tests/application/chat/collectStream.test.ts` — unit tests.

**Modified:** 29 src + test files repointed onto the new port shape; every `port.query(...)` call site now `collectStream(port.queryStream(...))`.

### ADR-008 reopening rationale

This change splits one concern (lifecycle) into its own port and absorbs another (`runStructured`) onto the existing port. The method-count on `ClaudeCliPort` doesn't shrink dramatically — but the port is now narrower per *responsibility*: it owns "talk to the Claude CLI as a transport" only. Lifecycle is its own port. The `SubscriptionCapable` sidecar — which existed *because* of an ADR-008 letter-of-the-law reading — is gone.

### Diff stats

- 33 files changed, +838 / −835 (net ~0 LOC; the 4 new files balance the 4 deletions).
- `ClaudeCliPort.ts`: 323 → 296 LOC (mostly removed `query` + `streamFromQuery` references).
- No callers of `port.query()` remain. Verified: `grep -r "\\.query(" src/ tests/ | grep -v queryStream | grep -v queryStructured` returns no matches.

## Test plan

- [x] `npm audit --audit-level=high --omit=dev` — 0 vulnerabilities.
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — 0 errors, 24 pre-existing warnings unchanged.
- [x] `npm run test` — 1742 / 1742 passing across 142 files.
- [x] `npm run build` — succeeds.
- [x] `npm run build:web` — succeeds.
- [x] `npm run docs:api` — succeeds (1 unrelated pre-existing TypeDoc link warning).
- [x] `streamFromQuery.ts` deleted.
- [x] `SubscriptionCapable` interface no longer exported from `queryStructured.ts`.

## Implementer notes

This PR landed via two RALPH-loop iterations. Both subagents got the work to green but neither successfully ran the final commit/push step — the parent finished the close-out manually. The work itself is the implementer's; the loop-state recovery summary in `specs/agent-sidepanel-v3/wp-12-claudecli-port-cleanup/loop-state.md` documents the discipline gap so future implementer briefs can require the commit/push step more explicitly.

Closes Arch-#3.

https://claude.ai/code/session_01UWDtzLuFJU3QmQmLrXCxWj

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWDtzLuFJU3QmQmLrXCxWj)_