### PR TITLE
refactor(asv3): extract ChatTurnOrchestrator + drop doubled output (WP-2)

### DIFF
--- a/src/application/chat/ChatTurnError.ts
+++ b/src/application/chat/ChatTurnError.ts
@@ -1,0 +1,28 @@
+/**
+ * Typed error union for `ChatTurnOrchestrator.sendTurn()` failure modes.
+ *
+ * Returned via `Result.error` (ADR-004) so the UI does not need to
+ * `try/catch`. Each `code` maps 1:1 to a deterministic UI branch:
+ *
+ *   - `cli-unavailable`       — port was not injected (standalone bootstrap),
+ *                               or `isAvailable()` returned false at send time.
+ *   - `not-implemented`       — orchestrator skeleton; retained for tests.
+ *
+ * Future codes (deferred to follow-ups): `aborted`, `stream-broken`. Today the
+ * orchestrator translates these into `messagesStore.setError('query_failed' |
+ * 'timeout')` and resolves with `ok({ kind: 'error', ... })` so the UI does
+ * not lose the existing UX. Treat this union as additive.
+ */
+export type ChatTurnErrorCode = 'cli-unavailable' | 'not-implemented';
+
+export class ChatTurnError extends Error {
+	public readonly name = 'ChatTurnError';
+
+	constructor(
+		public readonly code: ChatTurnErrorCode,
+		message?: string,
+	) {
+		super(message ?? code);
+		Object.setPrototypeOf(this, new.target.prototype);
+	}
+}

--- a/src/application/chat/ChatTurnOrchestrator.ts
+++ b/src/application/chat/ChatTurnOrchestrator.ts
@@ -1,0 +1,487 @@
+/**
+ * `ChatTurnOrchestrator` — single owner of one chat turn end-to-end
+ * (Arch review #1, deepening the WP-3 chat-store split).
+ *
+ * Before this refactor `ChatSidebar.handleSend` was a 120-LOC method that
+ * threaded thread rotation, transport-routed dispatch, stream consumption,
+ * proposal handling, success/error mutation, and vault-mirror scheduling
+ * through a Vue component. That made every piece unreachable from a unit
+ * test without mounting the component, and Codex P2 fixes piled up against
+ * the component file precisely because of it.
+ *
+ * The orchestrator's contract:
+ *   - **One method:** `sendTurn(input: TurnInput): Promise<Result<TurnOutcome,
+ *     ChatTurnError>>`.
+ *   - **Never throws.** All failures surface through `Result.error`.
+ *   - **Pure dispatch.** Reads nothing from vault / settings / stores directly —
+ *     the {@link TurnInput} DTO carries every input; the orchestrator only
+ *     mutates the four chat stores via their existing actions.
+ *
+ * Pure application layer (ADR-001 / ADR-008): no `obsidian` imports, no Vue,
+ * no Pinia internals beyond the structural store shapes injected via the
+ * constructor.
+ */
+import { err, ok, type Result } from '@/domain/shared/Result';
+import type {
+	ClaudeCliErrorCode,
+	ClaudeCliPort,
+} from '@/domain/ports/ClaudeCliPort';
+import { consumeStream } from './consumeStream';
+import type { SessionId } from '@/domain/chat/SessionId';
+import type { ChatThreadRecord } from '@/domain/chat/ChatThreadRecord';
+import type { LoggerPort } from '@/domain/ports/LoggerPort';
+import { queryStructured, type StructuredCliCallOptions } from '@/application/chat/queryStructured';
+import { proposeFileWrite } from '@/application/chat/proposeFileWrite';
+import { validateProposalPath } from '@/application/chat/validateProposalPath';
+import type { FileWriteProposal } from '@/application/chat/FileWriteProposal';
+import type { CreateFileEnvelope } from '@/application/chat/createFileEnvelopeSchema';
+import { EnvelopeParseError, type PathValidationError } from '@/application/chat/errors';
+import type { ClaudeCliError } from '@/domain/ports/ClaudeCliPort';
+import type { SettingsPort } from '@/domain/ports/SettingsPort';
+import type { VaultPort } from '@/domain/ports/VaultPort';
+import type { SessionLogWriter } from '@/application/chat/SessionLogWriter';
+import { ChatTurnError } from './ChatTurnError';
+import type { TurnInput } from './TurnInput';
+
+/**
+ * Structural view of the messages store the orchestrator mutates. Kept as a
+ * narrow interface (not the Pinia store return type) so the orchestrator
+ * stays Vue-free and unit tests pass plain fakes.
+ */
+export interface MessagesPort {
+	beginRequest(): void;
+	setResponse(text: string, truncated: boolean): void;
+	setError(type: 'timeout' | 'query_failed'): void;
+	setUserText(text: string): void;
+	setStructuredFail(value: boolean): void;
+	appendMessage(message: {
+		readonly id: string;
+		readonly threadId: string;
+		readonly role: 'user' | 'assistant';
+		readonly text: string;
+		readonly createdAt: string;
+		readonly truncated?: boolean;
+	}): void;
+	clearThreadMessages(threadId: string): void;
+	appendCompactBoundaryNotice(threadId: string, payload: { reason?: string }): void;
+}
+
+/** Structural view of the chat-threads store. */
+export interface ThreadsPort {
+	readonly chatThreads: ReadonlyMap<string, ChatThreadRecord>;
+	upsertThread(record: ChatThreadRecord): void;
+	setActiveThreadId(threadId: string | null): void;
+	captureSessionId(threadId: string, sessionId: SessionId): void;
+	markThreadUsed(threadId: string): void;
+}
+
+/** Structural view of the per-turn streaming store. */
+export interface StreamingPort {
+	resetStreaming(): void;
+	setCliStartingUp(value: boolean): void;
+	setSessionResumed(value: boolean): void;
+	appendStreamingDelta(delta: string): void;
+	appendStreamingThinking(delta: string): void;
+	startStreamingToolCall(blockId: string, toolName: string, initialJson: string): void;
+	appendStreamingToolCallInput(blockId: string, partialJson: string): void;
+	finishStreamingToolCall(blockId: string): void;
+	setLastUsage(usage: { inputTokens: number; outputTokens: number }): void;
+}
+
+/** Structural view of the proposal store. */
+export interface ProposalsPort {
+	addProposal(proposal: FileWriteProposal): void;
+	clearThreadProposals(threadId: string): void;
+}
+
+/**
+ * Constructor dependencies. Each store-shaped dependency is passed as a
+ * **getter** so the orchestrator can be constructed once and stay live across
+ * Pinia reactivity changes (the actual store reference doesn't move, but
+ * passing the function keeps the seam testable without Pinia).
+ *
+ * `nowIso` and `randomId` are injected so tests get deterministic output.
+ * `abortControllerFactory` lets tests stub the controller; production
+ * defaults to `new AbortController()`.
+ */
+export interface ChatTurnOrchestratorDeps {
+	readonly claudeCliPort: ClaudeCliPort | undefined;
+	readonly settings: SettingsPort;
+	readonly vault: VaultPort;
+	readonly logger: LoggerPort;
+	readonly messages: MessagesPort;
+	readonly threads: ThreadsPort;
+	readonly streaming: StreamingPort;
+	readonly proposals: ProposalsPort;
+	readonly getSessionLogWriter: () => Promise<SessionLogWriter>;
+	readonly nowIso: () => string;
+	readonly randomId: () => string;
+	readonly abortControllerFactory: () => AbortController;
+}
+
+/**
+ * Successful turn outcome. The UI binds these to the existing
+ * focus/refocus/clear-input affordances. `kind: 'error'` is delivered through
+ * the same `Result.ok({ kind: 'error' })` shape because the existing failure
+ * mode is observable through store mutations (`messagesStore.setError`) —
+ * surfacing a second error channel via `Result.error` would be doubly-named.
+ *
+ * `ChatTurnError` is reserved for orchestrator-level failures that cannot
+ * even reach the dispatch (e.g. `cli-unavailable` when the port was not
+ * injected at all — distinct from the SDK returning `NOT_INSTALLED`).
+ */
+export type TurnOutcome =
+	| { readonly kind: 'success'; readonly threadId: string; readonly abortHandle: AbortController }
+	| {
+			readonly kind: 'structured-success';
+			readonly threadId: string;
+			readonly proposal: FileWriteProposal;
+	  }
+	| { readonly kind: 'structured-parse-fail'; readonly threadId: string }
+	| { readonly kind: 'transport-error'; readonly threadId: string; readonly code: ClaudeCliErrorCode };
+
+export class ChatTurnOrchestrator {
+	constructor(private readonly deps: ChatTurnOrchestratorDeps) {}
+
+	/**
+	 * The orchestrator's single entry point. Mutates the four chat stores to
+	 * carry out one user turn. Never throws.
+	 *
+	 * The caller's job after this returns is purely UI: focus the textarea,
+	 * surface a notification on terminal failure, clear input. Everything else
+	 * has already happened against the stores.
+	 */
+	/**
+	 * The orchestrator's single entry point. Mutates the four chat stores to
+	 * carry out one user turn. Never throws.
+	 *
+	 * @param options.onAbortController Fires once with the `AbortController`
+	 *   that drives the streaming turn, the moment it is created — before any
+	 *   delta arrives. The UI plugs the controller into its "Stop generation"
+	 *   button so the user can cancel mid-stream. Not invoked on the
+	 *   structured path (no cancellation affordance there).
+	 */
+	async sendTurn(
+		input: TurnInput,
+		options: {
+			readonly onAbortController?: (controller: AbortController) => void;
+		} = {},
+	): Promise<Result<TurnOutcome, ChatTurnError>> {
+		// Clear structured-fail flag at every new send (UX-#5 closes the empty-
+		// bubble loop independently — see `applySuccessfulTurn` below for the
+		// proposal-only skip).
+		this.deps.messages.setStructuredFail(false);
+		// Reset streaming BEFORE the structured/free-text branch split so every
+		// new send starts from empty streaming state (Codex P2 on PR #372).
+		this.deps.streaming.resetStreaming();
+		this.deps.messages.beginRequest();
+
+		if (this.deps.claudeCliPort === undefined) {
+			this.deps.messages.setError('query_failed');
+			return err(new ChatTurnError('cli-unavailable'));
+		}
+		const port = this.deps.claudeCliPort;
+
+		const threadId = this.resolveThreadId(input);
+		const onSessionId = (id: SessionId): void => {
+			this.deps.threads.captureSessionId(threadId, id);
+		};
+		const resumeSessionId = input.thread.kind === 'reuse' ? input.thread.reuseSessionId : undefined;
+		const isResumedTurn = resumeSessionId !== undefined;
+
+		if (input.intent === 'structured') {
+			const outcome = await this.dispatchStructured(port, input, threadId, {
+				resumeSessionId,
+				isResumedTurn,
+				onSessionId,
+			});
+			return ok(outcome);
+		}
+		return ok(
+			await this.dispatchFreeText(port, input, threadId, {
+				resumeSessionId,
+				isResumedTurn,
+				onSessionId,
+				onAbortController: options.onAbortController,
+			}),
+		);
+	}
+
+	// ── Thread rotation ────────────────────────────────────────────────────
+
+	private resolveThreadId(input: TurnInput): string {
+		if (input.thread.kind === 'reuse' && input.thread.reuseThreadId !== undefined) {
+			return input.thread.reuseThreadId;
+		}
+		return this.mintRotatedThread(input);
+	}
+
+	/**
+	 * Mint a fresh thread record for this turn and evict the previous thread's
+	 * in-memory message AND proposal buckets (Codex P2 on PR #369). The
+	 * `ChatThreadRecord` for the previous thread is preserved in `chatThreads`
+	 * (a future thread-switcher UI can still resume its session id), but the
+	 * UI-only buckets would otherwise accumulate unreachably.
+	 */
+	private mintRotatedThread(input: TurnInput): string {
+		const threadId = this.deps.randomId();
+		const nowIso = this.deps.nowIso();
+		const fresh: ChatThreadRecord = {
+			threadId,
+			sessionId: null,
+			feature: input.slug,
+			logPath: '',
+			transport: input.transport,
+			createdAt: nowIso,
+			lastUsedAt: nowIso,
+		};
+		this.deps.threads.upsertThread(fresh);
+		this.deps.threads.setActiveThreadId(threadId);
+		const prev = input.thread.previousThreadId;
+		if (prev !== null && prev !== threadId) {
+			this.deps.messages.clearThreadMessages(prev);
+			this.deps.proposals.clearThreadProposals(prev);
+		}
+		return threadId;
+	}
+
+	// ── Free-text streaming branch ────────────────────────────────────────
+
+	private async dispatchFreeText(
+		port: ClaudeCliPort,
+		input: TurnInput,
+		threadId: string,
+		ctx: {
+			resumeSessionId: SessionId | undefined;
+			isResumedTurn: boolean;
+			onSessionId: (id: SessionId) => void;
+			onAbortController?: (controller: AbortController) => void;
+		},
+	): Promise<TurnOutcome> {
+		this.deps.streaming.setCliStartingUp(true);
+		const abortController = this.deps.abortControllerFactory();
+		ctx.onAbortController?.(abortController);
+		const streamResult = await consumeStream({
+			stream: port.queryStream(input.prompt, {
+				timeoutMs: 30_000,
+				systemPromptSuffix: input.systemPromptSuffix,
+				resumeSessionId: ctx.resumeSessionId,
+				onSessionId: ctx.onSessionId,
+				signal: abortController.signal,
+			}),
+			threadId,
+			messages: this.deps.messages,
+			threads: this.deps.threads,
+			streaming: this.deps.streaming,
+		});
+		this.deps.streaming.setCliStartingUp(false);
+
+		if (streamResult.kind === 'success') {
+			this.applySuccessfulTurn({
+				threadId,
+				isResumedTurn: ctx.isResumedTurn,
+				userMessage: input.userMessage,
+				assistantResponse: streamResult.text,
+				truncated: input.truncated,
+				hasProposal: false,
+			});
+			return { kind: 'success', threadId, abortHandle: abortController };
+		}
+		this.deps.messages.setError(streamResult.errorCode === 'TIMEOUT' ? 'timeout' : 'query_failed');
+		return { kind: 'transport-error', threadId, code: streamResult.errorCode };
+	}
+
+	// ── Structured branch ─────────────────────────────────────────────────
+
+	private async dispatchStructured(
+		port: ClaudeCliPort,
+		input: TurnInput,
+		threadId: string,
+		ctx: {
+			resumeSessionId: SessionId | undefined;
+			isResumedTurn: boolean;
+			onSessionId: (id: SessionId) => void;
+		},
+	): Promise<TurnOutcome> {
+		const options: StructuredCliCallOptions = {
+			timeoutMs: 30_000,
+			systemPromptSuffix: input.systemPromptSuffix,
+			resumeSessionId: ctx.resumeSessionId,
+			onSessionId: ctx.onSessionId,
+		};
+		this.deps.streaming.setCliStartingUp(true);
+		const structuredResult = await queryStructured(port, input.prompt, options);
+		this.deps.streaming.setCliStartingUp(false);
+
+		if (!structuredResult.ok) {
+			return this.handleStructuredFailure(structuredResult.error, threadId);
+		}
+		const envelope = structuredResult.value;
+		const proposal = await this.addProposalFromEnvelope(envelope, threadId, input.userMessage);
+		// UX-#5: structured turns produce a proposal card, not an assistant
+		// message body. `applySuccessfulTurn` with `hasProposal: true` skips
+		// the empty `appendMessage` so the agent panel doesn't render an
+		// empty "(No text — see the proposal card below.)" bubble next to
+		// the rendered card.
+		this.applySuccessfulTurn({
+			threadId,
+			isResumedTurn: ctx.isResumedTurn,
+			userMessage: input.userMessage,
+			assistantResponse: '',
+			truncated: input.truncated,
+			hasProposal: true,
+		});
+		return { kind: 'structured-success', threadId, proposal };
+	}
+
+	private handleStructuredFailure(
+		error: EnvelopeParseError | ClaudeCliError,
+		threadId: string,
+	): TurnOutcome {
+		if (error instanceof EnvelopeParseError) {
+			this.deps.messages.setStructuredFail(true);
+			this.deps.messages.setResponse('', false);
+			return { kind: 'structured-parse-fail', threadId };
+		}
+		const code = error.errorCode;
+		this.deps.messages.setError(code === 'TIMEOUT' ? 'timeout' : 'query_failed');
+		return { kind: 'transport-error', threadId, code };
+	}
+
+	private async addProposalFromEnvelope(
+		envelope: CreateFileEnvelope,
+		threadId: string,
+		originPrompt: string,
+	): Promise<FileWriteProposal> {
+		// Read-only preview (REQ-ASM-041). Failure is non-fatal: we still
+		// surface the proposal so the user can decide.
+		const previewResult = await proposeFileWrite(envelope, this.deps.vault);
+		if (!previewResult.ok) {
+			this.deps.logger.warn('proposeFileWrite failed; rendering proposal without preview', {
+				path: envelope.path,
+				reason: previewResult.error.message,
+			});
+		}
+		// Defence-in-depth path validation (REQ-ASM-048). On failure the
+		// proposal is still recorded so the user sees the rejection in-context,
+		// but with a `failureReason` of `WRITE_FAILED` once the Accept path
+		// runs. The path-error map for the card is owned by ChatSidebar — the
+		// orchestrator only seeds the proposal record.
+		const settings = await this.deps.settings.getSettings();
+		const validationResult = validateProposalPath(envelope, settings.specsFolder);
+		const proposalId = this.deps.randomId();
+		const proposal: FileWriteProposal = {
+			proposalId,
+			threadId,
+			envelope,
+			status: 'pending',
+			proposedAt: this.deps.nowIso(),
+			decidedAt: null,
+			failureReason: null,
+			originPrompt,
+		};
+		this.deps.proposals.addProposal(proposal);
+		this.pathErrors.set(proposalId, validationResult.ok ? null : validationResult.error);
+		return proposal;
+	}
+
+	/**
+	 * Per-proposal path-validation errors recorded during `addProposalFromEnvelope`.
+	 * The component reads `consumePathError(proposalId)` once after the
+	 * orchestrator settles so it can hand the error to the
+	 * `FileWriteProposalCard`. The map keeps memory bounded to proposals
+	 * created by THIS orchestrator instance.
+	 */
+	private readonly pathErrors = new Map<string, PathValidationError | null>();
+
+	/**
+	 * Drain the per-turn path-validation slot for one proposal. Returns
+	 * `null` when no error was recorded. Idempotent: subsequent reads return
+	 * `null` so a re-emission doesn't leak stale state.
+	 */
+	consumePathError(proposalId: string): PathValidationError | null {
+		const entry = this.pathErrors.get(proposalId);
+		this.pathErrors.delete(proposalId);
+		return entry ?? null;
+	}
+
+	// ── Success mutation + vault mirror ───────────────────────────────────
+
+	private applySuccessfulTurn(args: {
+		threadId: string;
+		isResumedTurn: boolean;
+		userMessage: string;
+		assistantResponse: string;
+		truncated: boolean;
+		hasProposal: boolean;
+	}): void {
+		this.deps.messages.setResponse(args.assistantResponse, args.truncated);
+		this.deps.messages.setUserText('');
+		this.deps.threads.markThreadUsed(args.threadId);
+		if (args.isResumedTurn) {
+			this.deps.streaming.setSessionResumed(true);
+		}
+		const nowIso = this.deps.nowIso();
+		this.deps.messages.appendMessage({
+			id: this.deps.randomId(),
+			threadId: args.threadId,
+			role: 'user',
+			text: args.userMessage,
+			createdAt: nowIso,
+		});
+		// UX-#5: skip the empty assistant placeholder on proposal-only turns.
+		// The proposal card IS the assistant rendering; appending an empty
+		// `ChatMessage{role:'assistant'}` would produce the "(No text — see
+		// the proposal card below.)" placeholder next to the actual card,
+		// which is the bug reviewers flagged.
+		if (!(args.hasProposal && args.assistantResponse === '')) {
+			this.deps.messages.appendMessage({
+				id: this.deps.randomId(),
+				threadId: args.threadId,
+				role: 'assistant',
+				text: args.assistantResponse,
+				createdAt: nowIso,
+				truncated: args.truncated,
+			});
+		}
+		this.mirrorTurnToVault({
+			threadId: args.threadId,
+			userMessage: args.userMessage,
+			assistantResponse: args.assistantResponse,
+		});
+	}
+
+	/**
+	 * Fire-and-forget mirror of a successful turn to the vault (REQ-ASM-040).
+	 * The writer silently drops the write when no `session_id` has been
+	 * captured yet. All failures are routed to `logger.warn` so the chat-send
+	 * path completes normally.
+	 *
+	 * NOTE for WP-5: today this awaits the writer factory + chains the warn
+	 * handler inline. A `SessionLogMirror` facade (out of scope here) would
+	 * collapse the two `.then`/`.catch` into a single best-effort call.
+	 */
+	private mirrorTurnToVault(args: {
+		threadId: string;
+		userMessage: string;
+		assistantResponse: string;
+	}): void {
+		const thread = this.deps.threads.chatThreads.get(args.threadId);
+		if (thread === undefined) return;
+		void this.deps
+			.getSessionLogWriter()
+			.then((writer) =>
+				writer.appendUserAssistant(thread, {
+					user: args.userMessage,
+					assistant: args.assistantResponse,
+				}),
+			)
+			.catch((error: unknown) => {
+				this.deps.logger.warn('SessionLogWriter.appendUserAssistant failed', {
+					threadId: args.threadId,
+					reason: error instanceof Error ? error.message : String(error),
+				});
+			});
+	}
+
+}

--- a/src/application/chat/TurnInput.ts
+++ b/src/application/chat/TurnInput.ts
@@ -1,0 +1,102 @@
+/**
+ * DTO produced by `TurnInputBuilder.build()` and consumed by
+ * `ChatTurnOrchestrator.sendTurn()` (Arch #1, Arch #9).
+ *
+ * Snapshots everything the orchestrator needs about *one* user turn — the
+ * builder reads from the four chat stores + vault + settings; the orchestrator
+ * never touches those sources directly. This decoupling lets us unit-test the
+ * orchestrator with plain DTO inputs and a `MockClaudeCliPort`, without
+ * mounting a Vue component.
+ *
+ * Plain data only (ADR-003 Pinia DTO discipline): no class instances, no
+ * functions, no Vue refs.
+ */
+import type { SessionId } from '@/domain/chat/SessionId';
+import type { TransportKind } from '@/domain/chat/TransportKind';
+
+/**
+ * Discriminator that splits the orchestrator's dispatch table. The builder
+ * decides which branch this turn takes — the orchestrator only switches on
+ * the tag.
+ *
+ *   - `'free-text'` — the regular `queryStream()` path. Streams text deltas
+ *     into `streamingTurnStore`; terminates with a single assistant message.
+ *   - `'structured'` — the `/create` / `/create-file` slash command. Runs
+ *     `queryStructured()` and produces a `FileWriteProposal` (UX-#5 dictates
+ *     the assistant message body stays empty — only the proposal card is
+ *     rendered).
+ */
+export type TurnIntent = 'free-text' | 'structured';
+
+/**
+ * Resolved transport for this turn — derived from the optional reactive
+ * `TRANSPORT_KIND_KEY` ref the plugin injects, NOT from the raw
+ * `settings.transportKind`. Under `transportKind === 'auto'` the selector
+ * resolves to either subscription or api-key depending on availability;
+ * recording the raw setting value here would pollute audit logs and resume
+ * metadata (Codex P2, PR #350). Inherits the resolved value.
+ */
+export type ResolvedTransport = 'api-key' | 'subscription';
+
+/**
+ * Captured snapshot of the thread resolution for this turn. The builder
+ * inspects the current `chatThreadsStore` state and decides whether the
+ * orchestrator should *rotate* (mint a new thread record) or *reuse* the
+ * active one.
+ *
+ *   - `'rotate'`  — transport or feature slug no longer matches the active
+ *     thread; orchestrator mints a fresh `ChatThreadRecord`, evicts the
+ *     previous thread's UI-only message/proposal buckets.
+ *   - `'reuse'`   — transport + feature match; orchestrator keeps the existing
+ *     thread id and forwards its captured session id as `resumeSessionId`.
+ */
+export interface ThreadRotationDecision {
+	readonly kind: 'rotate' | 'reuse';
+	/**
+	 * The thread id that was active when the builder ran. `null` when no
+	 * thread has been opened yet (first send of a session). On `'rotate'` the
+	 * orchestrator uses this to evict the *previous* thread's buckets — never
+	 * to identify the new thread (which it mints fresh).
+	 */
+	readonly previousThreadId: string | null;
+	/**
+	 * Only set when `kind === 'reuse'`. The resume session id the orchestrator
+	 * forwards to `queryStream`/`queryStructured` so the subscription transport
+	 * can pick up the existing conversation (REQ-ASM-035).
+	 */
+	readonly reuseThreadId?: string;
+	readonly reuseSessionId?: SessionId;
+}
+
+/**
+ * The single DTO consumed by `ChatTurnOrchestrator.sendTurn()`.
+ *
+ * Read it as a sealed envelope: every field needed to execute the turn is
+ * resolved here. The orchestrator never re-reads vault / stores / settings to
+ * compute these values — that's the builder's job, and the separation is what
+ * makes the orchestrator unit-testable without Vue.
+ */
+export interface TurnInput {
+	/** Raw user text snapshotted from the textarea before `beginRequest()`. */
+	readonly userMessage: string;
+	/** Fully assembled prompt string (user text + context-file preamble). */
+	readonly prompt: string;
+	/** True when `buildPrompt` had to trim context to stay within the cap. */
+	readonly truncated: boolean;
+	/** Stage-aware system-prompt suffix; empty string when no active feature. */
+	readonly systemPromptSuffix: string;
+	/** Active feature slug at send time, or `null`. Drives audit + resume. */
+	readonly slug: string | null;
+	/** Resolved transport for this turn. */
+	readonly transport: ResolvedTransport;
+	/** Structured-vs-freetext dispatch. */
+	readonly intent: TurnIntent;
+	/** Thread rotation decision; see {@link ThreadRotationDecision}. */
+	readonly thread: ThreadRotationDecision;
+	/**
+	 * Transport hint for the (future) `selectTransport` dispatcher. Not used
+	 * by the orchestrator today — kept on the DTO so it survives the builder
+	 * snapshot for downstream telemetry and observability.
+	 */
+	readonly transportKindRaw: TransportKind;
+}

--- a/src/application/chat/TurnInputBuilder.ts
+++ b/src/application/chat/TurnInputBuilder.ts
@@ -1,0 +1,223 @@
+/**
+ * Pure builder that snapshots the active chat-panel state into a
+ * {@link TurnInput} DTO consumed by `ChatTurnOrchestrator.sendTurn()`
+ * (Arch review #9, deepening Arch #1).
+ *
+ * Reads from:
+ *   - the four chat stores (messages / threads / streaming / proposal — only
+ *     the first two are needed today; the others are noted in the comments
+ *     where they could grow);
+ *   - `VaultPort` (to load context-file bodies for `buildPrompt`);
+ *   - `LoggerPort` (warnings only — failures fall back to empty content);
+ *   - `SettingsPort` (`specsFolder`, transport).
+ *
+ * Writes to:
+ *   - **nothing**. The builder is read-only by contract. The orchestrator
+ *     mutates stores, not the builder.
+ *
+ * The non-store helpers (intent classification, stage prompt assembly,
+ * prompt budget) live inside the function so a future migration to the
+ * `selectTransport` dispatcher only needs to extend this single seam.
+ *
+ * Pure-application-layer module (ADR-001 / ADR-008): no `obsidian`, no Vue,
+ * no Pinia internals (we accept plain getters from the caller).
+ */
+import type { VaultPort } from '@/domain/ports/VaultPort';
+import type { LoggerPort } from '@/domain/ports/LoggerPort';
+import type { WorkspacePort } from '@/domain/ports/WorkspacePort';
+import type { SettingsPort } from '@/domain/ports/SettingsPort';
+import type { TransportKind } from '@/domain/chat/TransportKind';
+import type { ChatThreadRecord } from '@/domain/chat/ChatThreadRecord';
+import { tryAsync } from '@/domain/shared/tryAsync';
+import { buildPrompt, type ContextFile } from '@/application/chat/buildPrompt';
+import {
+	assembleSystemPrompt,
+	getActiveFeatureSlug,
+	loadWorkflowStateSnapshot,
+} from '@/application/chat/assembleSystemPrompt';
+import type { StagePromptMap } from '@/application/chat/stagePromptMap';
+import type {
+	ResolvedTransport,
+	ThreadRotationDecision,
+	TurnInput,
+	TurnIntent,
+} from './TurnInput';
+
+/**
+ * Minimal projection of the messages store the builder reads. Kept structural
+ * (not `useMessagesStore` return type) so tests can pass plain objects.
+ */
+export interface MessagesSnapshot {
+	readonly userText: string;
+	readonly effectiveContextFiles: ReadonlyArray<{
+		readonly path: string;
+		readonly label: string;
+		readonly isAuto: boolean;
+	}>;
+}
+
+/**
+ * Minimal projection of the threads store the builder reads.
+ */
+export interface ThreadsSnapshot {
+	readonly activeThreadId: string | null;
+	readonly chatThreads: ReadonlyMap<string, ChatThreadRecord>;
+}
+
+/**
+ * Inputs to `buildTurnInput`. The caller (UI composable / `ChatSidebar`) is
+ * responsible for snapshotting the four chat stores into the two shapes
+ * above — that keeps the builder framework-agnostic.
+ */
+export interface BuildTurnInputArgs {
+	readonly messages: MessagesSnapshot;
+	readonly threads: ThreadsSnapshot;
+	readonly transportKindRaw: TransportKind;
+	readonly stagePromptMap: StagePromptMap;
+	readonly vault: VaultPort;
+	readonly workspace: WorkspacePort;
+	readonly settings: SettingsPort;
+	readonly logger: LoggerPort;
+}
+
+/**
+ * Heuristic for routing a user message to the structured-output path
+ * (REQ-ASM-021/041). Trust-first proposals require an explicit slash command —
+ * free-text prompts that happen to mention "create file" continue to use
+ * `query()`. Centralised here so the orchestrator does not re-derive intent.
+ *
+ * Exported for tests; not consumed outside this module.
+ */
+export function isStructuredIntent(message: string): TurnIntent {
+	const trimmed = message.trim().toLowerCase();
+	if (trimmed.startsWith('/create-file') || trimmed.startsWith('/create ')) {
+		return 'structured';
+	}
+	return 'free-text';
+}
+
+/**
+ * Resolve the raw transport kind from the optional reactive ref the plugin
+ * injects, NOT from `settings.transportKind` (Codex P2, PR #350). Under
+ * `'auto'` the selector resolves to either api-key or subscription at runtime;
+ * recording the raw setting value would pollute audit + resume metadata.
+ *
+ * `'degraded'` is normalised to `'api-key'` because the orchestrator's only
+ * branch on transport today is for resume-session bookkeeping — degraded
+ * sessions don't resume.
+ */
+function resolveTransport(raw: TransportKind): ResolvedTransport {
+	return raw === 'subscription' ? 'subscription' : 'api-key';
+}
+
+/**
+ * Decide whether to rotate the active thread or reuse it (Codex P2, PR #350).
+ * Rotates when:
+ *   - no thread is active yet (first send);
+ *   - the active thread's transport no longer matches this turn's transport;
+ *   - the active thread's feature slug no longer matches this turn's slug.
+ *
+ * `'reuse'` carries the existing thread id and (when present) its captured
+ * session id so the orchestrator can forward it as `resumeSessionId`
+ * (REQ-ASM-035).
+ */
+function decideRotation(
+	threads: ThreadsSnapshot,
+	slug: string | null,
+	transport: ResolvedTransport,
+): ThreadRotationDecision {
+	const previousThreadId = threads.activeThreadId;
+	if (previousThreadId === null) {
+		return { kind: 'rotate', previousThreadId };
+	}
+	const existing = threads.chatThreads.get(previousThreadId);
+	if (existing?.transport !== transport || existing.feature !== slug) {
+		return { kind: 'rotate', previousThreadId };
+	}
+	return {
+		kind: 'reuse',
+		previousThreadId,
+		reuseThreadId: previousThreadId,
+		reuseSessionId: existing.sessionId ?? undefined,
+	};
+}
+
+/**
+ * Load file contents for all context files; failed reads yield empty content.
+ * Uses the messages-store's `effectiveContextFiles` view (path-deduped) so
+ * the prompt budget sees each path exactly once.
+ */
+async function loadContextFileBodies(
+	messages: MessagesSnapshot,
+	vault: VaultPort,
+): Promise<ContextFile[]> {
+	return Promise.all(
+		messages.effectiveContextFiles.map(async (entry) => {
+			const readResult = await tryAsync(() => vault.readFile(entry.path));
+			return {
+				path: entry.path,
+				label: entry.label,
+				isAuto: entry.isAuto,
+				content: readResult.ok ? readResult.value : '',
+			};
+		}),
+	);
+}
+
+/**
+ * Compute the stage-aware system-prompt suffix (REQ-ASM-013, REQ-ASM-014,
+ * REQ-ASM-018, REQ-ASM-019). Recomputed every send — no caching. Any failure
+ * (no active file, vault read error, malformed frontmatter, unknown stage)
+ * falls back to an empty suffix so the send still proceeds (REQ-ASM-015).
+ */
+async function computeStagePromptContext(
+	specsFolder: string,
+	args: BuildTurnInputArgs,
+): Promise<{ slug: string | null; systemPromptSuffix: string }> {
+	const activeFile = args.workspace.getActiveFile();
+	const slug = getActiveFeatureSlug(activeFile?.path ?? null, specsFolder);
+	const snapshot =
+		slug !== null
+			? await loadWorkflowStateSnapshot(slug, args.vault, args.logger, specsFolder)
+			: null;
+	const systemPromptSuffix = assembleSystemPrompt(snapshot, args.stagePromptMap);
+	return { slug, systemPromptSuffix };
+}
+
+/**
+ * Build a complete {@link TurnInput} DTO. Never throws — vault read failures
+ * degrade to empty content; stage-prompt failures degrade to empty suffix.
+ *
+ * Algorithm (mirrors the order in the pre-refactor `ChatSidebar.handleSend`):
+ *   1. Read settings for `specsFolder`.
+ *   2. Compute stage-prompt context (slug + system suffix).
+ *   3. Resolve transport from the injected raw kind.
+ *   4. Decide thread rotation against the threads snapshot.
+ *   5. Load context-file bodies via the vault port.
+ *   6. Assemble the final prompt + truncation flag through `buildPrompt`.
+ *   7. Classify intent (structured vs free-text).
+ *   8. Return the sealed envelope.
+ */
+export async function buildTurnInput(args: BuildTurnInputArgs): Promise<TurnInput> {
+	const settings = await args.settings.getSettings();
+	const { slug, systemPromptSuffix } = await computeStagePromptContext(
+		settings.specsFolder,
+		args,
+	);
+	const transport = resolveTransport(args.transportKindRaw);
+	const thread = decideRotation(args.threads, slug, transport);
+	const loadedFiles = await loadContextFileBodies(args.messages, args.vault);
+	const { prompt, truncated } = buildPrompt(args.messages.userText, loadedFiles);
+	const intent = isStructuredIntent(args.messages.userText);
+	return {
+		userMessage: args.messages.userText,
+		prompt,
+		truncated,
+		systemPromptSuffix,
+		slug,
+		transport,
+		intent,
+		thread,
+		transportKindRaw: args.transportKindRaw,
+	};
+}

--- a/src/application/chat/consumeStream.ts
+++ b/src/application/chat/consumeStream.ts
@@ -1,0 +1,117 @@
+/**
+ * Pure stream-delta consumer extracted from `ChatTurnOrchestrator` (Arch #1,
+ * WP-2). Drains an `AsyncIterable<StreamDelta>` from `ClaudeCliPort.queryStream`
+ * to a terminal `done`/`error` delta, dispatching non-terminal deltas to the
+ * structural store ports.
+ *
+ * Pure application layer (ADR-001 / ADR-008): no `obsidian`, no Vue, no
+ * Pinia internals beyond the four structural store ports declared by the
+ * orchestrator.
+ */
+import { tryAsync } from '@/domain/shared/tryAsync';
+import type {
+	ClaudeCliErrorCode,
+	StreamDelta,
+} from '@/domain/ports/ClaudeCliPort';
+import type { MessagesPort, StreamingPort, ThreadsPort } from './ChatTurnOrchestrator';
+
+/** Internal drain outcome — mirrors the pre-refactor `ChatSidebar` shape. */
+type DrainOutcome =
+	| { kind: 'done'; text: string }
+	| { kind: 'error'; errorCode: ClaudeCliErrorCode };
+
+/**
+ * Public outcome from `consumeStream`. Never throws — a thrown iterable is
+ * normalised to `{ kind: 'error', errorCode: 'QUERY_FAILED' }`.
+ */
+export type StreamConsumptionOutcome =
+	| { readonly kind: 'success'; readonly text: string }
+	| { readonly kind: 'error'; readonly errorCode: ClaudeCliErrorCode };
+
+export interface ConsumeStreamArgs {
+	readonly stream: AsyncIterable<StreamDelta>;
+	readonly threadId: string;
+	readonly messages: MessagesPort;
+	readonly threads: ThreadsPort;
+	readonly streaming: StreamingPort;
+}
+
+/**
+ * Drain `queryStream` to a terminal delta. Accumulates `text` deltas into
+ * `streaming.appendStreamingDelta` so `MessageList.vue` can render the
+ * in-flight assistant turn token-by-token, and forwards every other
+ * non-terminal delta variant to the right store port.
+ *
+ * Returns:
+ *   - `success` with the concatenated text on `done`;
+ *   - `error` with the error code on `error`;
+ *   - `error` with `QUERY_FAILED` if the iterable throws or ends without a
+ *     terminal delta.
+ */
+export async function consumeStream(args: ConsumeStreamArgs): Promise<StreamConsumptionOutcome> {
+	const chunks: string[] = [];
+	const drained = await tryAsync(async (): Promise<DrainOutcome | null> => {
+		for await (const delta of args.stream) {
+			const terminal = applyStreamDelta(delta, chunks, args);
+			if (terminal !== null) return terminal;
+		}
+		return null;
+	});
+	if (!drained.ok) return { kind: 'error', errorCode: 'QUERY_FAILED' };
+	const outcome = drained.value;
+	if (outcome === null) return { kind: 'error', errorCode: 'QUERY_FAILED' };
+	if (outcome.kind === 'done') return { kind: 'success', text: outcome.text };
+	return { kind: 'error', errorCode: outcome.errorCode };
+}
+
+/**
+ * Dispatch one delta to the structural ports and return a terminal outcome
+ * when the stream is over.
+ */
+function applyStreamDelta(
+	delta: StreamDelta,
+	chunks: string[],
+	args: ConsumeStreamArgs,
+): DrainOutcome | null {
+	if (delta.type === 'done') return { kind: 'done', text: chunks.join('') };
+	if (delta.type === 'error') return { kind: 'error', errorCode: delta.error.errorCode };
+	applyNonTerminalDelta(delta, chunks, args);
+	return null;
+}
+
+function applyNonTerminalDelta(
+	delta: Exclude<StreamDelta, { type: 'done' } | { type: 'error' }>,
+	chunks: string[],
+	args: ConsumeStreamArgs,
+): void {
+	switch (delta.type) {
+		case 'text':
+			chunks.push(delta.text);
+			args.streaming.appendStreamingDelta(delta.text);
+			return;
+		case 'session-id':
+			args.threads.captureSessionId(args.threadId, delta.sessionId);
+			return;
+		case 'thinking':
+			args.streaming.appendStreamingThinking(delta.text);
+			return;
+		case 'tool-use-start':
+			args.streaming.startStreamingToolCall(delta.blockId, delta.toolName, delta.inputJson);
+			return;
+		case 'tool-use-input-delta':
+			args.streaming.appendStreamingToolCallInput(delta.blockId, delta.inputJson);
+			return;
+		case 'tool-use-stop':
+			args.streaming.finishStreamingToolCall(delta.blockId);
+			return;
+		case 'usage':
+			args.streaming.setLastUsage({
+				inputTokens: delta.inputTokens,
+				outputTokens: delta.outputTokens,
+			});
+			return;
+		case 'compact-boundary':
+			args.messages.appendCompactBoundaryNotice(args.threadId, { reason: delta.reason });
+			return;
+	}
+}

--- a/src/ui/components/chat/ChatDegradedState.vue
+++ b/src/ui/components/chat/ChatDegradedState.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+/**
+ * Renders the four degraded-state branches the chat surface can fall into.
+ * Extracted from `ChatSidebar.vue` during WP-2 so the main component focuses
+ * on the orchestrator dispatch + ready-state template.
+ *
+ * The variants:
+ *   - `mobile` — Obsidian on iOS / Android.
+ *   - `cli-missing` — subscription transport but the CLI binary is not
+ *     installed locally. Independent of API-key state (Codex P2, PR #347).
+ *   - `api-key-missing` — api-key transport but the secret is empty. Surfaces
+ *     the `openPluginSettings` CTA so the user can fix it.
+ *   - `sdk-unavailable` — generic fallback when neither `mobile` nor the
+ *     transport-specific conditions explain why availability is false.
+ *
+ * Purely presentational: receives props, emits one event (`open-settings`).
+ */
+defineProps<{
+	variant: 'mobile' | 'cli-missing' | 'api-key-missing' | 'sdk-unavailable';
+}>();
+
+defineEmits<{
+	'open-settings': [];
+}>();
+</script>
+
+<template>
+	<div class="sp-chat__degraded">
+		<template v-if="variant === 'mobile'">
+			<h3 class="sp-chat__degraded-heading" tabindex="-1" data-testid="chat-degraded-heading">
+				Chat is available on desktop only.
+			</h3>
+			<p class="sp-chat__degraded-body">
+				Open Obsidian on your Mac, Windows, or Linux computer to use the AI assistant.
+			</p>
+		</template>
+
+		<!--
+      Subscription-transport CLI missing (Codex P2, PR #347). When the user
+      has selected the subscription transport, the API key is irrelevant —
+      availability depends on the locally-installed `claude` binary. Show
+      CLI-install guidance instead of the (useless) API-key copy, even if
+      `apiKeyMissing` happens to be true.
+    -->
+		<template v-else-if="variant === 'cli-missing'">
+			<h3 class="sp-chat__degraded-heading" tabindex="-1" data-testid="chat-degraded-heading">
+				Claude CLI is not available.
+			</h3>
+			<p class="sp-chat__degraded-body">
+				The subscription transport needs the Claude CLI installed locally. Install Claude Code on
+				this device, then reopen this view.
+			</p>
+		</template>
+
+		<!-- API key missing degraded state (REQ-CCS-018) — api-key transport only. -->
+		<template v-else-if="variant === 'api-key-missing'">
+			<h3 class="sp-chat__degraded-heading" tabindex="-1" data-testid="chat-degraded-heading">
+				Chat is not set up yet.
+			</h3>
+			<p class="sp-chat__degraded-body">
+				To use this feature, add your Anthropic key in Settings. Your key is stored privately on
+				this device and is never shared.
+			</p>
+			<button
+				type="button"
+				class="sp-btn sp-btn--secondary sp-btn--md"
+				data-testid="chat-degraded-settings-link"
+				@click="$emit('open-settings')"
+			>
+				Open settings
+			</button>
+		</template>
+
+		<!-- SDK unavailable degraded state (REQ-CCS-019) -->
+		<template v-else>
+			<h3 class="sp-chat__degraded-heading" tabindex="-1" data-testid="chat-degraded-heading">
+				AI assistant is not available right now.
+			</h3>
+			<p class="sp-chat__degraded-body">
+				The AI assistant could not start. This may be a temporary issue. If the problem continues,
+				try restarting Obsidian.
+			</p>
+		</template>
+	</div>
+</template>
+
+<style scoped>
+.sp-chat__degraded {
+	background: var(--background-secondary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 8px;
+	padding: 1rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.sp-chat__degraded-heading {
+	margin: 0;
+	font-size: 1rem;
+	font-weight: 600;
+	color: var(--text-normal);
+}
+
+.sp-chat__degraded-body {
+	margin: 0;
+	font-size: 0.875rem;
+	color: var(--text-muted);
+}
+</style>

--- a/src/ui/components/chat/ChatResponse.vue
+++ b/src/ui/components/chat/ChatResponse.vue
@@ -1,6 +1,27 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 
+/**
+ * Two consumers, two render modes:
+ *
+ *   - `legacyMode === true` (default, `SpecoratorView` standalone embed)
+ *       renders the full state machine — idle placeholder, loading copy,
+ *       success text body, trimmed-success notice, error / timeout /
+ *       structured-fail banners, and the `proposalCard` slot.
+ *
+ *   - `legacyMode === false` (agent sidepanel)
+ *       suppresses the redundant rendering surfaces because `MessageList`
+ *       is the source of truth for assistant text in that mount:
+ *         * UX-#1: success/trimmed-success text body NOT rendered (MessageList
+ *           shows the appended assistant `ChatMessage`).
+ *         * UX-#2: `loading` "Thinking…" copy NOT rendered (MessageList's
+ *           streaming bubble already shows in-flight state with a cursor).
+ *         * `idle` is hidden too — the sidepanel header carries the empty
+ *           state instead.
+ *       The `proposalCard` slot, the trim notice, and the
+ *       error / timeout / structured-fail banners still render because
+ *       MessageList does not host those affordances.
+ */
 defineProps<{
   state:
     | 'idle'
@@ -11,24 +32,25 @@ defineProps<{
     | 'error'
     | 'structured-fail'
   text?: string
+  legacyMode?: boolean
 }>()
 
 const { t } = useI18n()
 </script>
 
 <template>
-  <!-- Idle placeholder -->
+  <!-- Idle placeholder — legacy only -->
   <p
-    v-if="state === 'idle'"
+    v-if="state === 'idle' && (legacyMode ?? true)"
     class="sp-chat__response-idle"
     data-testid="chat-response-idle"
   >
     {{ t('chat.responsePlaceholder') }}
   </p>
 
-  <!-- Loading state -->
+  <!-- Loading state — legacy only (UX-#2: MessageList streaming bubble owns the agent panel). -->
   <div
-    v-else-if="state === 'loading'"
+    v-else-if="state === 'loading' && (legacyMode ?? true)"
     role="status"
     aria-live="polite"
     class="sp-chat__response-loading"
@@ -47,13 +69,23 @@ const { t } = useI18n()
     >
       {{ t('chat.responseTrimmed') }}
     </p>
-    <div class="sp-chat__response-text" data-testid="chat-response-text">{{ text }}</div>
+    <!-- UX-#1: success text body lives in MessageList in the agent panel. -->
+    <div
+      v-if="legacyMode ?? true"
+      class="sp-chat__response-text"
+      data-testid="chat-response-text"
+    >{{ text }}</div>
     <slot name="proposalCard" />
   </template>
 
   <!-- Success state -->
   <template v-else-if="state === 'success'">
-    <div class="sp-chat__response-text" data-testid="chat-response-text">{{ text }}</div>
+    <!-- UX-#1: same suppression in the plain success branch. -->
+    <div
+      v-if="legacyMode ?? true"
+      class="sp-chat__response-text"
+      data-testid="chat-response-text"
+    >{{ text }}</div>
     <slot name="proposalCard" />
   </template>
 

--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -101,14 +101,6 @@ const lastUserTurn = ref<string>('');
  */
 const inFlightAbort = ref<AbortController | null>(null);
 
-// Synchronous re-entry guard. `messagesStore.status` is only flipped to
-// `'loading'` inside `orchestrator.sendTurn()` after the (potentially slow)
-// `buildTurnInput()` await resolves — without this local ref, a double Enter
-// or quick second click while vault reads are in flight would start
-// overlapping turns. Set true synchronously on entry, cleared in `finally`.
-const sendInFlight = ref(false);
-const isSending = computed(() => messagesStore.status === 'loading' || sendInFlight.value);
-
 function handleStopGeneration(): void {
 	inFlightAbort.value?.abort();
 }
@@ -236,21 +228,23 @@ function getOrchestrator(): ChatTurnOrchestrator {
 // snapshot inputs, surface the AbortController, refocus, and seed the
 // per-proposal path-error map for the proposal card.
 async function handleSend(): Promise<void> {
-	if (sendInFlight.value) return;
 	const text = messagesStore.userText.trim();
 	if (!text) return;
 	if (messagesStore.status === 'loading') return;
 	if (!available.value) return;
 
-	// `.finally()` chain (not try/finally) per the no-restricted-syntax rule.
-	// See develop commit a619dab for the established pattern.
-	sendInFlight.value = true;
-	await runSendInner().finally(() => {
-		sendInFlight.value = false;
-	});
-}
+	// Flip the cross-component request state to `'loading'` SYNCHRONOUSLY before
+	// any await, so every gate that depends on `messagesStore.status === 'loading'`
+	// (the "New conversation" button in AgentSidepanelRoot, the textarea / send
+	// button / context-file list, the orchestrator's own re-entry guard) sees the
+	// in-flight turn during the potentially-slow `buildTurnInput()` vault reads.
+	// Without this, a fast second Enter or a mid-preflight "New conversation"
+	// click could orphan the in-flight response onto a stale activeThreadId
+	// (Codex P1 #3254392924).
+	messagesStore.setStructuredFail(false);
+	streamingStore.resetStreaming();
+	messagesStore.beginRequest();
 
-async function runSendInner(): Promise<void> {
 	lastUserTurn.value = messagesStore.userText;
 
 	const input = await buildTurnInput({
@@ -417,7 +411,7 @@ watch(available, async () => {
 
 			<ContextFileList
 				:files="messagesStore.effectiveContextFiles"
-				:disabled="isSending"
+				:disabled="messagesStore.status === 'loading'"
 				@remove="handleRemoveFile"
 			/>
 
@@ -426,8 +420,8 @@ watch(available, async () => {
 			<ChatInput
 				ref="inputRef"
 				:model-value="messagesStore.userText"
-				:disabled="isSending"
-				:loading="isSending"
+				:disabled="messagesStore.status === 'loading'"
+				:loading="messagesStore.status === 'loading'"
 				@update:model-value="handleUserTextUpdate"
 				@send="handleSend"
 				@add-context-file="handleAddContextFile"

--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -101,6 +101,14 @@ const lastUserTurn = ref<string>('');
  */
 const inFlightAbort = ref<AbortController | null>(null);
 
+// Synchronous re-entry guard. `messagesStore.status` is only flipped to
+// `'loading'` inside `orchestrator.sendTurn()` after the (potentially slow)
+// `buildTurnInput()` await resolves — without this local ref, a double Enter
+// or quick second click while vault reads are in flight would start
+// overlapping turns. Set true synchronously on entry, cleared in `finally`.
+const sendInFlight = ref(false);
+const isSending = computed(() => messagesStore.status === 'loading' || sendInFlight.value);
+
 function handleStopGeneration(): void {
 	inFlightAbort.value?.abort();
 }
@@ -228,11 +236,21 @@ function getOrchestrator(): ChatTurnOrchestrator {
 // snapshot inputs, surface the AbortController, refocus, and seed the
 // per-proposal path-error map for the proposal card.
 async function handleSend(): Promise<void> {
+	if (sendInFlight.value) return;
 	const text = messagesStore.userText.trim();
 	if (!text) return;
 	if (messagesStore.status === 'loading') return;
 	if (!available.value) return;
 
+	// `.finally()` chain (not try/finally) per the no-restricted-syntax rule.
+	// See develop commit a619dab for the established pattern.
+	sendInFlight.value = true;
+	await runSendInner().finally(() => {
+		sendInFlight.value = false;
+	});
+}
+
+async function runSendInner(): Promise<void> {
 	lastUserTurn.value = messagesStore.userText;
 
 	const input = await buildTurnInput({
@@ -399,7 +417,7 @@ watch(available, async () => {
 
 			<ContextFileList
 				:files="messagesStore.effectiveContextFiles"
-				:disabled="messagesStore.status === 'loading'"
+				:disabled="isSending"
 				@remove="handleRemoveFile"
 			/>
 
@@ -408,8 +426,8 @@ watch(available, async () => {
 			<ChatInput
 				ref="inputRef"
 				:model-value="messagesStore.userText"
-				:disabled="messagesStore.status === 'loading'"
-				:loading="messagesStore.status === 'loading'"
+				:disabled="isSending"
+				:loading="isSending"
 				@update:model-value="handleUserTextUpdate"
 				@send="handleSend"
 				@add-context-file="handleAddContextFile"

--- a/src/ui/components/chat/ChatSidebar.vue
+++ b/src/ui/components/chat/ChatSidebar.vue
@@ -16,13 +16,6 @@ import { useSecretStorePort } from '@/ui/composables/useSecretStorePort';
 import { SECRET_ID_ANTHROPIC } from '@/domain/ports';
 import { useLoggerPort } from '@/ui/composables/useLoggerPort';
 import { useSessionLogWriter } from '@/ui/composables/useSessionLogWriter';
-import { buildPrompt } from '@/application/chat/buildPrompt';
-import type { ContextFile } from '@/application/chat/buildPrompt';
-import {
-	assembleSystemPrompt,
-	getActiveFeatureSlug,
-	loadWorkflowStateSnapshot,
-} from '@/application/chat/assembleSystemPrompt';
 import { buildStagePromptMap } from '@/application/chat/stagePromptMap';
 import {
 	CONFIRM_MODAL_PORT,
@@ -30,27 +23,14 @@ import {
 	TRANSPORT_KIND_KEY,
 	OPEN_PLUGIN_SETTINGS_KEY,
 } from '@/infrastructure/bridge/ports';
-import type { SessionId } from '@/domain/chat/SessionId';
-import type { ChatThreadRecord } from '@/domain/chat/ChatThreadRecord';
 import type { SlashCommand } from '@/domain/chat/SlashCommand';
-import type {
-	ConfirmModalPort,
-	TranslationPort,
-	StreamDelta,
-	ClaudeCliErrorCode,
-} from '@/domain/ports';
+import type { ConfirmModalPort, TranslationPort } from '@/domain/ports';
 import type { TransportKind } from '@/domain/chat/TransportKind';
-import { queryStructured, type StructuredCliCallOptions } from '@/application/chat/queryStructured';
-import { proposeFileWrite } from '@/application/chat/proposeFileWrite';
-import { validateProposalPath } from '@/application/chat/validateProposalPath';
-import {
-	commitFileWriteProposal,
-	rejectFileWriteProposal,
-} from '@/application/chat/commitFileWriteProposal';
 import type { FileWriteProposal } from '@/application/chat/FileWriteProposal';
-import type { CreateFileEnvelope } from '@/application/chat/createFileEnvelopeSchema';
-import { EnvelopeParseError } from '@/application/chat/errors';
-import type { PathValidationError, CommitProposalErrorCode } from '@/application/chat/errors';
+import type { PathValidationError } from '@/application/chat/errors';
+import { buildTurnInput } from '@/application/chat/TurnInputBuilder';
+import { ChatTurnOrchestrator } from '@/application/chat/ChatTurnOrchestrator';
+import { useProposalDecisions } from '@/ui/composables/useProposalDecisions';
 import ContextFileList from './ContextFileList.vue';
 import ChatInput from './ChatInput.vue';
 import ChatResponse from './ChatResponse.vue';
@@ -58,6 +38,7 @@ import SubprocessStartingPill from './SubprocessStartingPill.vue';
 import SessionResumeIndicator from './SessionResumeIndicator.vue';
 import TransportStatusPill from './TransportStatusPill.vue';
 import FileWriteProposalCard from './FileWriteProposalCard.vue';
+import ChatDegradedState from './ChatDegradedState.vue';
 
 const emit = defineEmits<{
 	'select-command': [command: SlashCommand];
@@ -79,25 +60,15 @@ const sessionLogWriterFactory = useSessionLogWriter();
 /**
  * Optional injections wired by `SpecoratorView` (PR-ASM-4 batch 9). Both are
  * optional so unit tests and the standalone browser UI can mount the sidebar
- * without providing them — the proposal flow simply degrades gracefully when
- * `ConfirmModalPort` is missing (overwrite confirmation cannot be shown).
+ * without providing them.
  */
 const confirmModalPort = inject<ConfirmModalPort | undefined>(CONFIRM_MODAL_PORT, undefined);
 const transportKindRef = inject<Ref<TransportKind> | undefined>(TRANSPORT_KIND_KEY, undefined);
-// Routes the chat-degraded recovery CTA to Obsidian's plugin settings tab
-// (Codex P2, PR #350). Defaults to a no-op so unit tests and the standalone
-// browser UI — which do not have Obsidian's `App` available — can mount the
-// sidebar without crashing when the button is clicked.
 const noopOpenPluginSettings = (): void => {
 	/* default for unit tests and the standalone browser UI */
 };
 const openPluginSettings = inject<() => void>(OPEN_PLUGIN_SETTINGS_KEY, noopOpenPluginSettings);
 
-/**
- * Vue-i18n composable wired to the EN/DE catalogues in `src/ui/i18n/locales/`.
- * The commit pipeline expects a `TranslationPort`, so we adapt `useI18n().t`
- * to the port shape (T-ASM-074).
- */
 const { t: tI18n } = useI18n();
 const inlineTranslator: TranslationPort = {
 	t(key: string, params?: Record<string, unknown>): string {
@@ -105,37 +76,10 @@ const inlineTranslator: TranslationPort = {
 	},
 };
 
-/**
- * Generate an id for a new thread / proposal using the Web Crypto API.
- * `crypto.randomUUID()` is available in every environment this plugin runs in
- * (Obsidian's Electron, modern browsers for the standalone UI, and Node ≥19
- * for tests). The previous `Math.random()` fallback was dead code in
- * production — it only ran when `crypto.randomUUID` was undefined, which
- * never occurs in supported environments — and CodeQL flagged it as
- * insecure randomness, so it has been removed (CodeQL alert on PR #350).
- */
-function generateThreadId(): string {
-	return globalThis.crypto.randomUUID();
-}
-
 function generateProposalId(): string {
 	return globalThis.crypto.randomUUID();
 }
 
-/**
- * Unique id for an in-memory `ChatMessage` (IDEA-ASV-001, agent-sidepanel-v2
- * Increment 2). The id is opaque to callers and used purely as a Vue `:key`
- * in `MessageList.vue`; thread continuity is carried by `threadId`.
- */
-function generateMessageId(): string {
-	return globalThis.crypto.randomUUID();
-}
-
-/**
- * Frozen stage-prompt descriptor table. Built once per component instance and
- * passed to `assembleSystemPrompt` on every send (REQ-ASM-019 — recomputed
- * per send, but the descriptor source is referentially stable).
- */
 const stagePromptMap = buildStagePromptMap();
 
 // Local reactive state
@@ -143,12 +87,6 @@ const available = ref(false);
 const availabilityChecked = ref(false);
 const containerEl = ref<HTMLElement | null>(null);
 const inputRef = ref<InstanceType<typeof ChatInput> | null>(null);
-
-// Structured-output parse failure flag (REQ-ASM-025). Cleared on every new
-// send; surfaced via ChatResponse `state='structured-fail'`. Lives on the
-// store so the agent sidepanel's "New conversation" handler can reset it —
-// Codex P2 finding on PR #369 (without store residency the banner persisted
-// across a thread reset because `ChatSidebar` is never remounted).
 
 // Per-proposal path-validation errors (REQ-ASM-048). Keyed by proposalId; a
 // non-null entry forces the card into its 'path-invalid' state.
@@ -159,11 +97,7 @@ const lastUserTurn = ref<string>('');
 
 /**
  * `AbortController` for the in-flight streaming turn (PR-ASV-2-ui). Non-null
- * while `handleSend` is consuming `queryStream`; cleared on terminal delta.
- * Drives the "Stop generation" button: clicking it calls `.abort()` which
- * propagates through the port's stream options to the underlying adapter
- * (subprocess kill or SDK abort), then the stream emits a terminal `error`
- * delta and the handler surfaces a `query_failed` status.
+ * while the orchestrator is consuming `queryStream`; cleared on terminal delta.
  */
 const inFlightAbort = ref<AbortController | null>(null);
 
@@ -171,24 +105,12 @@ function handleStopGeneration(): void {
 	inFlightAbort.value?.abort();
 }
 
-/**
- * Proposal IDs whose decision (Accept or Reject) is currently in flight. Used
- * by both `handleAcceptProposal` and `handleRejectProposal` to guard against
- * re-entrant clicks and against cross-decision races: a user who clicks
- * Accept and then quickly clicks Reject must NOT produce contradictory
- * audit rows — the second click is a no-op while the first is still
- * resolving (Codex P1, PR #347). Cleared on terminal status flip.
- */
-const inFlightDecisions = new Set<string>();
-
-// Settings-version watcher (D-CCS-003)
 const settingsVersion = inject(SETTINGS_VERSION_KEY, ref(0));
 watch(settingsVersion, async () => {
 	if (claudeCliPort === undefined) return;
 	available.value = await claudeCliPort.isAvailable();
 });
 
-// Active file watcher
 let unsubscribeActiveFile: (() => void) | null = null;
 
 function updateActiveFile(
@@ -206,7 +128,6 @@ function updateActiveFile(
 }
 
 function focusTextarea(): void {
-	// Access the exposed textareaEl from ChatInput via the component instance
 	const ta = inputRef.value?.textareaEl as HTMLTextAreaElement | null | undefined;
 	ta?.focus();
 }
@@ -217,7 +138,6 @@ onMounted(async () => {
 	}
 	availabilityChecked.value = true;
 
-	// Subscribe to active file changes
 	const snapshot = workspacePort.getActiveFile();
 	updateActiveFile(snapshot);
 	unsubscribeActiveFile = workspacePort.onActiveFileChanged(updateActiveFile);
@@ -226,7 +146,6 @@ onMounted(async () => {
 	if (available.value && !isMobile) {
 		focusTextarea();
 	} else {
-		// Focus degraded notice heading
 		const heading = containerEl.value?.querySelector(
 			'[data-testid="chat-degraded-heading"]',
 		) as HTMLElement | null;
@@ -238,13 +157,8 @@ onUnmounted(() => {
 	unsubscribeActiveFile?.();
 });
 
-// Transport kind for the pill (REQ-ASM-002). Defaults to 'api-key' when no
-// reactive ref is provided — keeps unit tests and standalone UI working.
 const transportKind = computed<TransportKind>(() => transportKindRef?.value ?? 'api-key');
 
-// Pending proposals for the active thread; surfaces them into the proposalCard
-// slot on ChatResponse. Each entry pairs the proposal DTO with its (optional)
-// path-validation error so the card can render the 'path-invalid' state.
 const activeThreadProposals = computed<
 	ReadonlyArray<{ proposal: FileWriteProposal; pathError: PathValidationError | null }>
 >(() => {
@@ -258,7 +172,6 @@ const activeThreadProposals = computed<
 	return out;
 });
 
-// Determine chat response state from store
 type ResponseState =
 	| 'idle'
 	| 'loading'
@@ -270,17 +183,6 @@ type ResponseState =
 
 const responseState = computed<ResponseState>(() => {
 	if (messagesStore.status === 'loading') return 'loading';
-	// Pending proposal cards take precedence over error/timeout/structured-fail
-	// banners (Codex P2, PR #347). A failed or parse-erroring later turn must
-	// not hide still-actionable Accept/Reject controls for proposals already
-	// on screen — otherwise the user is stranded mid-decision and loses access
-	// to the controls until another successful turn occurs. The `loading`
-	// state still wins so an in-flight turn is signalled.
-	//
-	// Path-invalid proposals are excluded: they render as a non-interactive
-	// error message (no Accept/Reject buttons) and stay `pending` indefinitely,
-	// so treating them as "actionable" would suppress error banners with no
-	// benefit to the user (Codex P2, PR #347).
 	const hasActionablePendingProposal = activeThreadProposals.value.some(
 		(entry) => entry.proposal.status === 'pending' && entry.pathError === null,
 	);
@@ -292,717 +194,106 @@ const responseState = computed<ResponseState>(() => {
 	if (messagesStore.response !== null) {
 		return messagesStore.truncated ? 'trimmed-success' : 'success';
 	}
-	// Render success state (empty text) when there are non-pending proposals
-	// on the thread so the proposalCard slot is mounted alongside the
-	// (potentially empty) response.
 	if (activeThreadProposals.value.length > 0) return 'success';
 	return 'idle';
 });
 
 /**
- * Compute the stage-aware system-prompt suffix for this send (REQ-ASM-013,
- * REQ-ASM-014, REQ-ASM-018, REQ-ASM-019). Resolves the active feature from
- * the current editor file, reads its workflow-state, and assembles a
- * one-shot stage preamble. Any failure falls back to an empty suffix so
- * the send still proceeds (REQ-ASM-015).
+ * Lazily-constructed orchestrator. Holds the four chat-store mutations and
+ * the streaming/structured dispatch — see `src/application/chat/ChatTurnOrchestrator.ts`.
+ * Constructed once per component instance; re-created when the port reference
+ * changes (it doesn't today, but the guard is cheap).
  */
-async function computeStagePromptContext(
-	specsFolder: string,
-): Promise<{ slug: string | null; systemPromptSuffix: string }> {
-	const activeFile = workspacePort.getActiveFile();
-	const slug = getActiveFeatureSlug(activeFile?.path ?? null, specsFolder);
-	const snapshot =
-		slug !== null
-			? await loadWorkflowStateSnapshot(slug, vaultPort, loggerPort, specsFolder)
-			: null;
-	const systemPromptSuffix = assembleSystemPrompt(snapshot, stagePromptMap);
-	return { slug, systemPromptSuffix };
-}
-
-/**
- * Load file contents for all context files; failed reads yield empty content.
- */
-async function loadContextFileBodies(): Promise<ContextFile[]> {
-	// Use the path-deduped view so a file present in both the auto slot and a
-	// manual entry is included exactly once in the prompt budget (Codex P2
-	// follow-up, PR #351). The underlying manual entry stays in state and
-	// resurfaces when the auto slot moves away.
-	return Promise.all(
-		messagesStore.effectiveContextFiles.map(async (entry) => {
-			const readResult = await tryAsync(() => vaultPort.readFile(entry.path));
-			return {
-				path: entry.path,
-				label: entry.label,
-				isAuto: entry.isAuto,
-				content: readResult.ok ? readResult.value : '',
-			};
-		}),
-	);
-}
-
-/**
- * Mint a fresh thread record for this turn and evict the previous thread's
- * in-memory message bucket (Codex P2 on PR #369). The `ChatThreadRecord`
- * for the previous thread is intentionally preserved in `chatThreads` —
- * a future thread-switcher UI can still resume its session_id — but the
- * UI-only message bucket would otherwise accumulate unreachably.
- */
-function mintRotatedThread(args: {
-	previousThreadId: string | null;
-	slug: string | null;
-	transport: 'api-key' | 'subscription';
-	nowIso: string;
-}): string {
-	const threadId = generateThreadId();
-	const fresh: ChatThreadRecord = {
-		threadId,
-		sessionId: null,
-		feature: args.slug,
-		logPath: '',
-		transport: args.transport,
-		createdAt: args.nowIso,
-		lastUsedAt: args.nowIso,
-	};
-	threadsStore.upsertThread(fresh);
-	threadsStore.setActiveThreadId(threadId);
-	if (args.previousThreadId !== null && args.previousThreadId !== threadId) {
-		messagesStore.clearThreadMessages(args.previousThreadId);
-		// Codex P2 (PR #369, fifth review): also evict the previous
-		// thread's proposals on automatic rotation, mirroring the same
-		// fix on the "New conversation" handler. With no thread switcher
-		// in Increment 1, proposals (including `envelope.content`
-		// payloads) become unreachable but stay resident; repeated
-		// `/create` turns across feature switches accumulated unbounded
-		// hidden state.
-		proposalStore.clearThreadProposals(args.previousThreadId);
-	}
-	return threadId;
-}
-
-/**
- * Resolve (or lazily create) the active `ChatThreadRecord`. Returns the
- * thread id and whether this turn carries a resume session id (REQ-ASM-035).
- *
- * Rotates when the active thread's transport OR feature slug no longer
- * matches the resolved values for this turn (Codex P2, PR #350):
- *   - transport mismatch: resuming a session id from a different transport
- *     produces incoherent context and audit metadata;
- *   - feature mismatch: session-log paths are derived from `thread.feature`,
- *     so reusing a `specs/foo/` thread for a `specs/bar/` turn would corrupt
- *     per-feature traceability + resume metadata.
- */
-function resolveActiveThread(args: {
-	slug: string | null;
-	transport: 'api-key' | 'subscription';
-}): { threadId: string; resumeSessionId: SessionId | undefined; isResumedTurn: boolean } {
-	const nowIso = new Date().toISOString();
-	const previousThreadId = threadsStore.activeThreadId;
-	const existing =
-		previousThreadId !== null ? threadsStore.chatThreads.get(previousThreadId) : undefined;
-	const shouldRotate =
-		previousThreadId === null ||
-		existing?.transport !== args.transport ||
-		existing.feature !== args.slug;
-	const threadId = shouldRotate
-		? mintRotatedThread({ previousThreadId, slug: args.slug, transport: args.transport, nowIso })
-		: previousThreadId;
-	const record = threadsStore.chatThreads.get(threadId);
-	const resumeSessionId = record?.sessionId ?? undefined;
-	return { threadId, resumeSessionId, isResumedTurn: resumeSessionId !== undefined };
-}
-
-/**
- * Fire-and-forget mirror of a successful turn to the vault (REQ-ASM-040). The
- * writer drops the write silently when no `session_id` has been captured yet
- * (first-ever turn on an `'api-key'` thread). All failures are routed to
- * `loggerPort.warn` so the chat-send path completes normally.
- */
-function mirrorTurnToVault(args: {
-	threadId: string;
-	userMessage: string;
-	assistantResponse: string;
-}): void {
-	const thread = threadsStore.chatThreads.get(args.threadId);
-	if (thread === undefined) return;
-	void sessionLogWriterFactory
-		.getWriter()
-		.then((writer) =>
-			writer.appendUserAssistant(thread, {
-				user: args.userMessage,
-				assistant: args.assistantResponse,
-			}),
-		)
-		.catch((error: unknown) => {
-			loggerPort.warn('SessionLogWriter.appendUserAssistant failed', {
-				threadId: args.threadId,
-				reason: error instanceof Error ? error.message : String(error),
-			});
-		});
-}
-
-/**
- * Apply success-side store mutations and schedule the vault mirror.
- */
-function applySuccessfulTurn(args: {
-	threadId: string;
-	isResumedTurn: boolean;
-	userMessage: string;
-	assistantResponse: string;
-	truncated: boolean;
-}): void {
-	messagesStore.setResponse(args.assistantResponse, args.truncated);
-	messagesStore.setUserText('');
-	threadsStore.markThreadUsed(args.threadId);
-	if (args.isResumedTurn) {
-		// Flash the resume indicator for this turn only (REQ-ASM-035).
-		streamingStore.setSessionResumed(true);
-	}
-	// Mirror this turn to the multi-turn in-memory message log
-	// (IDEA-ASV-001, agent-sidepanel-v2 Increment 2). The user turn is
-	// appended first; the assistant turn carries the `truncated` flag so the
-	// message list can render the per-turn "context trimmed" notice without
-	// depending on `messagesStore.truncated` (which only describes the latest turn).
-	const nowIso = new Date().toISOString();
-	messagesStore.appendMessage({
-		id: generateMessageId(),
-		threadId: args.threadId,
-		role: 'user',
-		text: args.userMessage,
-		createdAt: nowIso,
+let orchestrator: ChatTurnOrchestrator | null = null;
+function getOrchestrator(): ChatTurnOrchestrator {
+	if (orchestrator !== null) return orchestrator;
+	orchestrator = new ChatTurnOrchestrator({
+		claudeCliPort,
+		settings: settingsPort,
+		vault: vaultPort,
+		logger: loggerPort,
+		messages: messagesStore,
+		threads: threadsStore,
+		streaming: streamingStore,
+		proposals: proposalStore,
+		getSessionLogWriter: () => sessionLogWriterFactory.getWriter(),
+		nowIso: () => new Date().toISOString(),
+		randomId: () => generateProposalId(),
+		abortControllerFactory: () => new AbortController(),
 	});
-	messagesStore.appendMessage({
-		id: generateMessageId(),
-		threadId: args.threadId,
-		role: 'assistant',
-		text: args.assistantResponse,
-		createdAt: nowIso,
-		truncated: args.truncated,
-	});
-	mirrorTurnToVault({
-		threadId: args.threadId,
-		userMessage: args.userMessage,
-		assistantResponse: args.assistantResponse,
-	});
+	return orchestrator;
 }
 
-/**
- * Heuristic for routing a user message to the structured-output path. Trust-
- * first proposals require the user to explicitly request a file creation via
- * a slash command (`/create-file` or `/create`). Free-text prompts that
- * happen to mention "create file" continue to use `query()` — keeps the
- * structured path opt-in so existing chat flows are unaffected.
- */
-function isStructuredIntent(message: string): boolean {
-	const trimmed = message.trim().toLowerCase();
-	return trimmed.startsWith('/create-file') || trimmed.startsWith('/create ');
-}
-
-/**
- * Build a FileWriteProposal DTO from a validated envelope and add it to the
- * store. Records any path-validation error against the proposal so the card
- * renders in 'path-invalid' state (REQ-ASM-048).
- */
-function addProposalFromEnvelope(args: {
-	envelope: CreateFileEnvelope;
-	threadId: string;
-	pathError: PathValidationError | null;
-	originPrompt: string;
-}): FileWriteProposal {
-	const proposalId = generateProposalId();
-	const proposal: FileWriteProposal = {
-		proposalId,
-		threadId: args.threadId,
-		envelope: args.envelope,
-		status: 'pending',
-		proposedAt: new Date().toISOString(),
-		decidedAt: null,
-		failureReason: null,
-		originPrompt: args.originPrompt,
-	};
-	proposalStore.addProposal(proposal);
-	if (args.pathError !== null) {
-		const next = new Map(proposalPathErrors.value);
-		next.set(proposalId, args.pathError);
-		proposalPathErrors.value = next;
-	}
-	return proposal;
-}
-
-/**
- * Structured-output branch of `handleSend`. Calls `queryStructured`, runs the
- * read-only `proposeFileWrite` to check existence, validates the path, and
- * adds a `FileWriteProposal` to the store. Renders the structured-fail state
- * on parse error (REQ-ASM-025).
- */
-async function handleStructuredSend(args: {
-	prompt: string;
-	systemPromptSuffix: string;
-	resumeSessionId: SessionId | undefined;
-	isResumedTurn: boolean;
-	threadId: string;
-	userMessage: string;
-	truncated: boolean;
-	onSessionId: (id: SessionId) => void;
-}): Promise<void> {
-	if (claudeCliPort === undefined) {
-		messagesStore.setError('query_failed');
-		return;
-	}
-	const options: StructuredCliCallOptions = {
-		timeoutMs: 30_000,
-		systemPromptSuffix: args.systemPromptSuffix,
-		resumeSessionId: args.resumeSessionId,
-		// REQ-ASM-031 / REQ-ASM-046 — load-bearing: structured threads must
-		// capture session_id so the subsequent `appendProposalDecision` finds a
-		// non-null sessionId. Without this, the audit row would reject with
-		// `SessionLogNoSessionError` and the commit pipeline would surface
-		// `SESSION_LOG_FAILED` even though the model itself succeeded.
-		onSessionId: args.onSessionId,
-	};
-	streamingStore.setCliStartingUp(true);
-	const structuredResult = await queryStructured(claudeCliPort, args.prompt, options);
-	streamingStore.setCliStartingUp(false);
-
-	if (!structuredResult.ok) {
-		if (structuredResult.error instanceof EnvelopeParseError) {
-			// Parse failure — surface 'structured-fail' state (REQ-ASM-025) but do
-			// not register an error on the store (separate UX from CLI errors).
-			messagesStore.setStructuredFail(true);
-			messagesStore.setResponse('', false);
-			return;
-		}
-		// Transport-level error from queryStructured → same error mapping as the
-		// free-text path.
-		const code = structuredResult.error.errorCode;
-		messagesStore.setError(code === 'TIMEOUT' ? 'timeout' : 'query_failed');
-		return;
-	}
-
-	const envelope = structuredResult.value;
-
-	// Read-only preview (REQ-ASM-041). Failure to read the vault is non-fatal:
-	// we still surface the proposal so the user can decide; the commit path
-	// re-checks file existence.
-	const previewResult = await proposeFileWrite(envelope, vaultPort);
-	if (!previewResult.ok) {
-		loggerPort.warn('proposeFileWrite failed; rendering proposal without preview', {
-			path: envelope.path,
-			reason: previewResult.error.message,
-		});
-	}
-
-	// Defence-in-depth path validation (REQ-ASM-048). On failure we still add
-	// the proposal so the user sees the rejection in-context, but with a
-	// `pathValidationError` that forces the card into 'path-invalid' state.
-	const settings = await settingsPort.getSettings();
-	const validationResult = validateProposalPath(envelope, settings.specsFolder);
-	const pathError = validationResult.ok ? null : validationResult.error;
-
-	addProposalFromEnvelope({
-		envelope,
-		threadId: args.threadId,
-		pathError,
-		originPrompt: args.userMessage,
-	});
-
-	// Mirror the structured turn to the session log too (the assistant body is
-	// an empty string — the proposal card replaces the prose). The `truncated`
-	// flag is forwarded from `buildPrompt` so the proposal turn surfaces the
-	// same context-trim warning the free-text path does — users must see when
-	// a proposal was generated from clipped context (Codex P2, PR #347).
-	applySuccessfulTurn({
-		threadId: args.threadId,
-		isResumedTurn: args.isResumedTurn,
-		userMessage: args.userMessage,
-		assistantResponse: '',
-		truncated: args.truncated,
-	});
-}
-
-// Send handler
+// Send handler — orchestrator-routed. The component owns only UI concerns:
+// snapshot inputs, surface the AbortController, refocus, and seed the
+// per-proposal path-error map for the proposal card.
 async function handleSend(): Promise<void> {
 	const text = messagesStore.userText.trim();
-	if (!text) return; // REQ-CCS-015: empty text guard
+	if (!text) return;
 	if (messagesStore.status === 'loading') return;
 	if (!available.value) return;
 
-	// Snapshot the raw user text *before* beginRequest() so we can mirror it to
-	// the session log post-turn — beginRequest does not clear userText, but the
-	// success branch below does.
-	const userMessage = messagesStore.userText;
-	lastUserTurn.value = userMessage;
+	lastUserTurn.value = messagesStore.userText;
 
-	// Clear any prior structured-fail flag at every new send.
-	messagesStore.setStructuredFail(false);
-	// Codex P2 on PR #372: reset the streaming buffer BEFORE the structured/
-	// free-text branch split so every new send starts from empty streaming
-	// state. Without this, a previous streamed reply could leave
-	// `streamingText` populated when the next turn is routed through
-	// `handleStructuredSend()` — during that turn `messagesStore.status === 'loading'`,
-	// so `MessageList.vue` would treat the stale text as an active stream and
-	// render the old assistant output as the current response.
-	streamingStore.resetStreaming();
+	const input = await buildTurnInput({
+		messages: {
+			userText: messagesStore.userText,
+			effectiveContextFiles: messagesStore.effectiveContextFiles,
+		},
+		threads: {
+			activeThreadId: threadsStore.activeThreadId,
+			chatThreads: threadsStore.chatThreads,
+		},
+		transportKindRaw: transportKindRef?.value ?? 'api-key',
+		stagePromptMap,
+		vault: vaultPort,
+		workspace: workspacePort,
+		settings: settingsPort,
+		logger: loggerPort,
+	});
 
-	messagesStore.beginRequest();
-
-	// Stage-aware system-prompt suffix (REQ-ASM-013, REQ-ASM-014, REQ-ASM-018,
-	// REQ-ASM-019). Recomputed every send — no caching. Resolves the active
-	// feature from the current editor file, reads its workflow-state, and
-	// assembles a one-shot stage preamble. Any failure (no active file, file
-	// not under specsFolder, vault read error, malformed frontmatter, unknown
-	// stage) falls back to an empty suffix so the send still proceeds.
-	const settings = await settingsPort.getSettings();
-	const { slug, systemPromptSuffix } = await computeStagePromptContext(settings.specsFolder);
-
-	// ── Session-persistence wiring (T-ASM-057, REQ-ASM-031/034/035/037/040) ──
-	// Use the resolved active transport (from `transportKindRef`), NOT the
-	// raw `settings.transportKind`. Under `transportKind === 'auto'` the
-	// selector may resolve to either subscription or api-key depending on
-	// CLI / API-key availability — recording the setting's raw value here
-	// would persist `'api-key'` even when the turn actually ran through the
-	// subscription adapter, polluting audit logs and resume metadata
-	// (Codex P2, PR #350).
-	const resolvedKind = transportKind.value;
-	const transport: 'api-key' | 'subscription' =
-		resolvedKind === 'subscription' ? 'subscription' : 'api-key';
-	const { threadId, resumeSessionId, isResumedTurn } = resolveActiveThread({ slug, transport });
-	const onSessionId = (id: SessionId): void => {
-		threadsStore.captureSessionId(threadId, id);
-	};
-
-	const loadedFiles = await loadContextFileBodies();
-	const { prompt, truncated } = buildPrompt(messagesStore.userText, loadedFiles);
-
-	if (claudeCliPort === undefined) {
-		messagesStore.setError('query_failed');
-		return;
-	}
-
-	// Structured path (REQ-ASM-021/041). Opt-in via slash command — keeps the
-	// free-text path completely unchanged for regular prompts.
-	if (isStructuredIntent(userMessage)) {
-		await handleStructuredSend({
-			prompt,
-			systemPromptSuffix,
-			resumeSessionId,
-			isResumedTurn,
-			threadId,
-			userMessage,
-			truncated,
-			onSessionId,
-		});
-		await nextTick();
-		focusTextarea();
-		return;
-	}
-
-	// Cold-spawn pill (R-ASM-003). Cleared on completion or error.
-	streamingStore.setCliStartingUp(true);
-	// IDEA-ASV-001 Increment 2 (PR-ASV-2-ui): consume the streaming
-	// `queryStream` rather than the non-streaming `query`. Text deltas
-	// accumulate into `streamingStore.streamingText` so `MessageList.vue` can
-	// render the in-flight assistant turn live. The exposed
-	// `inFlightAbort` ref lets the Stop button cancel mid-stream.
-	const abortController = new AbortController();
-	inFlightAbort.value = abortController;
-	const streamResult = await consumeStream({
-		stream: claudeCliPort.queryStream(prompt, {
-			timeoutMs: 30_000,
-			systemPromptSuffix,
-			resumeSessionId,
-			onSessionId,
-			signal: abortController.signal,
-		}),
-		threadId,
+	// `onAbortController` fires the moment the orchestrator mints the
+	// streaming controller — before any delta arrives. Plugging it into
+	// `inFlightAbort` makes the "Stop generation" button visible for the
+	// duration of the stream, matching the pre-refactor behaviour.
+	const result = await getOrchestrator().sendTurn(input, {
+		onAbortController: (controller) => {
+			inFlightAbort.value = controller;
+		},
 	});
 	inFlightAbort.value = null;
-	streamingStore.setCliStartingUp(false);
-
-	if (streamResult.kind === 'success') {
-		applySuccessfulTurn({
-			threadId,
-			isResumedTurn,
-			userMessage,
-			assistantResponse: streamResult.text,
-			truncated,
-		});
-	} else {
-		messagesStore.setError(streamResult.errorCode === 'TIMEOUT' ? 'timeout' : 'query_failed');
+	if (result.ok && result.value.kind === 'structured-success') {
+		const pathError = getOrchestrator().consumePathError(result.value.proposal.proposalId);
+		if (pathError !== null) {
+			const next = new Map(proposalPathErrors.value);
+			next.set(result.value.proposal.proposalId, pathError);
+			proposalPathErrors.value = next;
+		}
 	}
-	// Don't call `streamingStore.resetStreaming()` here — that also clears
-	// `sessionResumed`, which `applySuccessfulTurn` may have just set
-	// (REQ-ASM-035 flash-once contract). `streamingText` is cleared by the
-	// next turn's `resetStreaming()` at the top of `handleSend`; in the
-	// interim the streaming bubble in `MessageList` is gated on
-	// `messagesStore.status === 'loading'` so it stays hidden in the success state.
 	await nextTick();
 	focusTextarea();
 }
 
-type DrainOutcome =
-	| { kind: 'done'; text: string }
-	| { kind: 'error'; errorCode: ClaudeCliErrorCode };
-
-/**
- * Dispatch one delta to the store and return a terminal outcome when the
- * stream is over. Extracted from `consumeStream` to keep the async-iterator
- * loop under the project's complexity budget.
- */
-function applyStreamDelta(
-	delta: StreamDelta,
-	chunks: string[],
-	threadId: string,
-): DrainOutcome | null {
-	if (delta.type === 'done') return { kind: 'done', text: chunks.join('') };
-	if (delta.type === 'error') return { kind: 'error', errorCode: delta.error.errorCode };
-	applyNonTerminalDelta(delta, chunks, threadId);
-	return null;
+const proposalDecisions = useProposalDecisions({
+	settingsPort,
+	vaultPort,
+	loggerPort,
+	confirmModalPort,
+	sessionLogWriterFactory,
+	translator: inlineTranslator,
+	threadsStore,
+	proposalStore,
+	proposalPathErrors,
+});
+function handleAcceptProposal(payload: { proposalId: string }): Promise<void> {
+	return proposalDecisions.handleAcceptProposal(payload);
+}
+function handleRejectProposal(payload: { proposalId: string }): Promise<void> {
+	return proposalDecisions.handleRejectProposal(payload);
 }
 
-function applyNonTerminalDelta(
-	delta: Exclude<StreamDelta, { type: 'done' } | { type: 'error' }>,
-	chunks: string[],
-	threadId: string,
-): void {
-	switch (delta.type) {
-		case 'text':
-			chunks.push(delta.text);
-			streamingStore.appendStreamingDelta(delta.text);
-			return;
-		case 'session-id':
-			threadsStore.captureSessionId(threadId, delta.sessionId);
-			return;
-		case 'thinking':
-			streamingStore.appendStreamingThinking(delta.text);
-			return;
-		case 'tool-use-start':
-			streamingStore.startStreamingToolCall(delta.blockId, delta.toolName, delta.inputJson);
-			return;
-		case 'tool-use-input-delta':
-			streamingStore.appendStreamingToolCallInput(delta.blockId, delta.inputJson);
-			return;
-		case 'tool-use-stop':
-			streamingStore.finishStreamingToolCall(delta.blockId);
-			return;
-		case 'usage':
-			streamingStore.setLastUsage({
-				inputTokens: delta.inputTokens,
-				outputTokens: delta.outputTokens,
-			});
-			return;
-		case 'compact-boundary':
-			// Push a synthetic notice into the per-thread compact-boundary
-			// log so `MessageList.vue` can render an inline divider. Without
-			// this the auto-compaction event was invisible — hiding a
-			// critical history-rewrite transition (Codex P2 on PR #379).
-			messagesStore.appendCompactBoundaryNotice(threadId, { reason: delta.reason });
-			return;
-	}
-}
-
-/**
- * Drain `queryStream` to a terminal delta. Accumulates `text` deltas into
- * `streamingStore.streamingText` so `MessageList.vue` can render the in-flight
- * assistant turn token-by-token. Returns a normalised result describing
- * how the stream terminated:
- *   - `success` with the joined text on a `done` delta
- *   - `error` with the error code on an `error` delta
- * Never throws — a rogue iterable that throws is treated as `query_failed`.
- */
-async function consumeStream(args: {
-	stream: AsyncIterable<StreamDelta>;
-	threadId: string;
-}): Promise<{ kind: 'success'; text: string } | { kind: 'error'; errorCode: ClaudeCliErrorCode }> {
-	const chunks: string[] = [];
-	const drained = await tryAsync(async (): Promise<DrainOutcome | null> => {
-		for await (const delta of args.stream) {
-			const terminal = applyStreamDelta(delta, chunks, args.threadId);
-			if (terminal !== null) return terminal;
-		}
-		return null;
-	});
-	if (!drained.ok) {
-		return { kind: 'error', errorCode: 'QUERY_FAILED' };
-	}
-	const outcome = drained.value;
-	if (outcome === null) return { kind: 'error', errorCode: 'QUERY_FAILED' };
-	if (outcome.kind === 'done') return { kind: 'success', text: outcome.text };
-	return { kind: 'error', errorCode: outcome.errorCode };
-}
-
-/**
- * Mirror a terminal proposal failure to the session log (best-effort).
- * Used by `handleAcceptProposal`'s pre-commit failure branches
- * (settings-read, revalidation, …) so every terminal outcome carries an
- * audit row regardless of which step rejected. Both `getWriter()` AND
- * `appendProposalDecision` are caught; a logging failure must never
- * block the user-visible status flip (Codex trust-first invariant,
- * PR #350).
- */
-async function mirrorTerminalProposalFailure(
-	proposal: FileWriteProposal,
-	thread: ChatThreadRecord,
-	context: string,
-): Promise<void> {
-	await (async () => {
-		const writer = await sessionLogWriterFactory.getWriter();
-		await writer.appendProposalDecision({
-			thread,
-			proposal: {
-				envelope: { path: proposal.envelope.path, rationale: undefined },
-			},
-			decision: 'failed',
-			decidedAt: new Date().toISOString(),
-		});
-	})().catch((thrown: unknown) => {
-		loggerPort.warn(`handleAcceptProposal: ${context} audit mirror failed`, {
-			proposalId: proposal.proposalId,
-			reason: thrown instanceof Error ? thrown.message : String(thrown),
-		});
-	});
-}
-
-/**
- * Look up a proposal by id. Returns `null` if missing (e.g. cleared by reset).
- */
-function findProposal(proposalId: string): FileWriteProposal | null {
-	return proposalStore.proposals.get(proposalId) ?? null;
-}
-
-/**
- * Accept handler (REQ-ASM-043). `commitFileWriteProposal` is the **only**
- * sanctioned vault-mutation path for an LLM proposal (NFR-ASM-011); the card
- * UI cannot bypass it.
- */
-async function handleAcceptProposal(payload: { proposalId: string }): Promise<void> {
-	// Concurrency guard (Codex P1, PR #347). The `inFlightDecisions` Set
-	// guards Accept against re-entrance AND against a cross-decision race
-	// where the user clicks Reject while an Accept commit is still in
-	// flight — both paths share the same set so the second click is a
-	// no-op until the first resolves. The terminal-status check below
-	// covers the post-resolution case (status already moved out of
-	// `pending`).
-	if (inFlightDecisions.has(payload.proposalId)) return;
-	const proposal = findProposal(payload.proposalId);
-	if (proposal === null) return;
-	if (proposal.status !== 'pending') return;
-	const thread = threadsStore.chatThreads.get(proposal.threadId);
-	if (thread === undefined) return;
-	// Note: the optional `confirmModalPort` is forwarded unconditionally; the
-	// commit pipeline only fails when the target path already exists AND no
-	// modal is available (the overwrite-gate path needs interactive consent).
-	// Non-overwrite Accepts succeed in environments without the optional port
-	// (Codex P2, PR #347).
-	inFlightDecisions.add(payload.proposalId);
-	// Always clear the in-flight lock — a thrown downstream call (e.g.
-	// `getWriter()`) would otherwise leave the proposal permanently locked
-	// (Codex P2, PR #347). Uses `Promise.prototype.finally` because the
-	// project's `no-restricted-syntax` rule forbids raw try/catch (and the
-	// same applies to try/finally) outside `src/infrastructure/**`.
-	await (async () => {
-		// Re-validate the envelope path against the CURRENT specs folder
-		// before any vault mutation (Codex P2, PR #350). The proposal was
-		// validated at creation time, but settings can change between
-		// creation and accept — re-checking here prevents a stale proposal
-		// from bypassing containment after a specsFolder change.
-		//
-		// `getSettings()` can reject under a bridge/vault error; wrap it via
-		// `tryAsync` so a transient failure does not strand the proposal in
-		// `pending` (Codex P2 #3, PR #350). On read failure we fail the
-		// Accept rather than committing under stale settings.
-		const settingsResult = await tryAsync(() => settingsPort.getSettings());
-		if (!settingsResult.ok) {
-			loggerPort.warn(
-				'handleAcceptProposal: settingsPort.getSettings() failed during revalidation',
-				{
-					proposalId: payload.proposalId,
-					reason: settingsResult.error.message,
-				},
-			);
-			// Mirror the terminal failure to the session log so the audit
-			// trail stays complete even when the pre-commit settings read
-			// rejects (Codex P2 #4, PR #350).
-			await mirrorTerminalProposalFailure(proposal, thread, 'settings-read-failed');
-			proposalStore.setProposalStatus(payload.proposalId, 'failed', 'WRITE_FAILED');
-			return;
-		}
-		const currentSettings = settingsResult.value;
-		const revalidation = validateProposalPath(proposal.envelope, currentSettings.specsFolder);
-		if (!revalidation.ok) {
-			const next = new Map(proposalPathErrors.value);
-			next.set(payload.proposalId, revalidation.error);
-			proposalPathErrors.value = next;
-			await mirrorTerminalProposalFailure(proposal, thread, 'revalidation-failed');
-			proposalStore.setProposalStatus(payload.proposalId, 'failed', 'WRITE_FAILED');
-			return;
-		}
-		const writer = await sessionLogWriterFactory.getWriter();
-		const result = await commitFileWriteProposal(proposal, thread, {
-			vault: vaultPort,
-			logger: loggerPort,
-			sessionLog: writer,
-			confirmModal: confirmModalPort,
-			i18n: inlineTranslator,
-			nowIso: () => new Date().toISOString(),
-		});
-		if (result.ok) {
-			proposalStore.setProposalStatus(payload.proposalId, 'accepted');
-		} else {
-			const code: CommitProposalErrorCode = result.error.errorCode;
-			proposalStore.setProposalStatus(payload.proposalId, 'failed', code);
-		}
-	})().finally(() => {
-		inFlightDecisions.delete(payload.proposalId);
-	});
-}
-
-/**
- * Reject handler (REQ-ASM-045). Never touches the vault — only writes an
- * audit row via `rejectFileWriteProposal`. Shares the `inFlightDecisions`
- * concurrency guard with Accept so a Reject click cannot append a
- * contradictory audit row while an Accept commit is still resolving for
- * the same proposal (Codex P1, PR #347).
- */
-async function handleRejectProposal(payload: { proposalId: string }): Promise<void> {
-	if (inFlightDecisions.has(payload.proposalId)) return;
-	const proposal = findProposal(payload.proposalId);
-	if (proposal === null) return;
-	if (proposal.status !== 'pending') return;
-	const thread = threadsStore.chatThreads.get(proposal.threadId);
-	if (thread === undefined) {
-		proposalStore.setProposalStatus(payload.proposalId, 'rejected');
-		return;
-	}
-	inFlightDecisions.add(payload.proposalId);
-	// Always clear the in-flight lock — a thrown downstream call (e.g.
-	// `getWriter()`) would otherwise leave the proposal permanently locked
-	// (Codex P2, PR #347). See `handleAcceptProposal` for the `Promise.finally`
-	// pattern rationale (project rule forbids raw try/catch outside
-	// `src/infrastructure/**`).
-	await (async () => {
-		const writer = await sessionLogWriterFactory.getWriter();
-		await rejectFileWriteProposal(proposal, thread, {
-			sessionLog: writer,
-			logger: loggerPort,
-			nowIso: () => new Date().toISOString(),
-		});
-		proposalStore.setProposalStatus(payload.proposalId, 'rejected');
-	})().finally(() => {
-		inFlightDecisions.delete(payload.proposalId);
-	});
-}
-
-/**
- * Retry handler (REQ-ASM-050). Re-issues the prior user turn through the
- * same `handleSend` pathway. Previous proposals stay in the audit trail
- * unchanged — `addProposalFromEnvelope` always uses a fresh proposalId.
- */
 async function handleRetryProposal(payload: { proposalId: string }): Promise<void> {
-	// Resubmit the exact prompt that authored THIS proposal — not the global
-	// `lastUserTurn`. With multiple proposal cards in a thread, retrying an
-	// older card would otherwise resend a newer prompt and regenerate an
-	// unrelated proposal (Codex P2, PR #347).
-	const proposal = findProposal(payload.proposalId);
+	const proposal = proposalStore.proposals.get(payload.proposalId) ?? null;
 	const promptText = proposal?.originPrompt ?? lastUserTurn.value;
 	if (promptText.trim() === '') return;
 	messagesStore.setUserText(promptText);
@@ -1017,14 +308,7 @@ function handleUserTextUpdate(text: string): void {
 	messagesStore.setUserText(text);
 }
 
-/**
- * Mention-picker selection (PR-ASV-4 / D-ASV-3). `ChatInput` already
- * replaces the `@<query>` text fragment inline; the sidebar's job is to
- * create the matching context-file chip via `messagesStore.addContextFile`.
- */
 function handleAddContextFile(candidate: { path: string; name: string }): void {
-	// Codex P2 on PR #376: promote auto entry to manual so explicit mention
-	// survives editor rotation.
 	const existing = messagesStore.contextFiles.find((f) => f.path === candidate.path);
 	if (existing?.isAuto === true) {
 		messagesStore.removeContextFile(candidate.path);
@@ -1036,19 +320,10 @@ function handleAddContextFile(candidate: { path: string; name: string }): void {
 	});
 }
 
-/**
- * Forward the slash-command-palette selection up to `AgentSidepanelRoot`,
- * which owns the dispatcher (PR-ASV-3, D-ASV-2).
- */
 function handleSelectCommand(command: SlashCommand): void {
 	emit('select-command', command);
 }
 
-// Determine if API key is missing when unavailable. Reads from
-// `SecretStorePort` (OS keychain) since the Anthropic key no longer lives in
-// the synced `PluginSettings` blob. Codex P2: wrap in `tryAsync` so a
-// transient keychain error degrades to "missing" (the same fallback the
-// `available === false` branch produces) instead of bubbling up.
 async function isApiKeyMissing(): Promise<boolean> {
 	if (!secretStorePort.available) return true;
 	const outcome = await tryAsync(() => secretStorePort.getSecret(SECRET_ID_ANTHROPIC));
@@ -1073,69 +348,35 @@ watch(available, async () => {
 		apiKeyMissing.value = await isApiKeyMissing();
 	}
 });
+
 </script>
 
 <template>
 	<div ref="containerEl" class="sp-chat-sidebar" data-testid="chat-sidebar">
 		<!-- Mobile degradation (REQ-CCS-020) -->
-		<div v-if="isMobile" class="sp-chat__degraded">
-			<h3 class="sp-chat__degraded-heading" tabindex="-1" data-testid="chat-degraded-heading">
-				Chat is available on desktop only.
-			</h3>
-			<p class="sp-chat__degraded-body">
-				Open Obsidian on your Mac, Windows, or Linux computer to use the AI assistant.
-			</p>
-		</div>
+		<ChatDegradedState v-if="isMobile" variant="mobile" />
 
 		<!-- Not yet checked (avoid flash of wrong state) -->
 		<template v-else-if="!availabilityChecked" />
 
-		<!--
-      Subscription-transport CLI missing (Codex P2, PR #347). When the user
-      has selected the subscription transport, the API key is irrelevant —
-      availability depends on the locally-installed `claude` binary. Show
-      CLI-install guidance instead of the (useless) API-key copy, even if
-      `apiKeyMissing` happens to be true.
-    -->
-		<div v-else-if="!available && transportKind === 'subscription'" class="sp-chat__degraded">
-			<h3 class="sp-chat__degraded-heading" tabindex="-1" data-testid="chat-degraded-heading">
-				Claude CLI is not available.
-			</h3>
-			<p class="sp-chat__degraded-body">
-				The subscription transport needs the Claude CLI installed locally. Install Claude Code on
-				this device, then reopen this view.
-			</p>
-		</div>
+		<!-- Subscription-transport CLI missing (Codex P2, PR #347). -->
+		<ChatDegradedState
+			v-else-if="!available && transportKind === 'subscription'"
+			variant="cli-missing"
+		/>
 
 		<!-- API key missing degraded state (REQ-CCS-018) — api-key transport only. -->
-		<div v-else-if="!available && apiKeyMissing" class="sp-chat__degraded">
-			<h3 class="sp-chat__degraded-heading" tabindex="-1" data-testid="chat-degraded-heading">
-				Chat is not set up yet.
-			</h3>
-			<p class="sp-chat__degraded-body">
-				To use this feature, add your Anthropic key in Settings. Your key is stored privately on
-				this device and is never shared.
-			</p>
-			<button
-				type="button"
-				class="sp-btn sp-btn--secondary sp-btn--md"
-				data-testid="chat-degraded-settings-link"
-				@click="openPluginSettings"
-			>
-				Open settings
-			</button>
-		</div>
+		<ChatDegradedState
+			v-else-if="!available && apiKeyMissing"
+			variant="api-key-missing"
+			@open-settings="openPluginSettings"
+		/>
 
 		<!-- SDK unavailable degraded state (REQ-CCS-019) -->
-		<div v-else-if="!available && !apiKeyMissing" class="sp-chat__degraded">
-			<h3 class="sp-chat__degraded-heading" tabindex="-1" data-testid="chat-degraded-heading">
-				AI assistant is not available right now.
-			</h3>
-			<p class="sp-chat__degraded-body">
-				The AI assistant could not start. This may be a temporary issue. If the problem continues,
-				try restarting Obsidian.
-			</p>
-		</div>
+		<ChatDegradedState
+			v-else-if="!available && !apiKeyMissing"
+			variant="sdk-unavailable"
+		/>
 
 		<!-- Ready state -->
 		<template v-else>
@@ -1177,7 +418,19 @@ watch(available, async () => {
 
 			<hr class="sp-chat__divider" />
 
-			<ChatResponse :state="responseState" :text="messagesStore.response ?? undefined">
+			<!--
+        UX-#1 / UX-#2 (WP-2): the agent sidepanel is the only ChatSidebar
+        consumer today. `MessageList` renders the assistant text (and the
+        streaming bubble during a turn), so `ChatResponse` runs in non-legacy
+        mode — its `success` / `trimmed-success` branches drop the text body
+        and the `loading` "Thinking…" copy, leaving only the `proposalCard`
+        slot, the trim notice, and the error / structured-fail banners.
+      -->
+			<ChatResponse
+				:state="responseState"
+				:text="messagesStore.response ?? undefined"
+				:legacy-mode="false"
+			>
 				<template #proposalCard>
 					<FileWriteProposalCard
 						v-for="entry in activeThreadProposals"
@@ -1250,28 +503,5 @@ watch(available, async () => {
 
 .sp-chat__stop:hover {
 	background: var(--background-modifier-error-hover, var(--interactive-hover));
-}
-
-.sp-chat__degraded {
-	background: var(--background-secondary);
-	border: 1px solid var(--background-modifier-border);
-	border-radius: 8px;
-	padding: 1rem;
-	display: flex;
-	flex-direction: column;
-	gap: 0.5rem;
-}
-
-.sp-chat__degraded-heading {
-	margin: 0;
-	font-size: 1rem;
-	font-weight: 600;
-	color: var(--text-normal);
-}
-
-.sp-chat__degraded-body {
-	margin: 0;
-	font-size: 0.875rem;
-	color: var(--text-muted);
 }
 </style>

--- a/src/ui/composables/useProposalDecisions.ts
+++ b/src/ui/composables/useProposalDecisions.ts
@@ -1,0 +1,165 @@
+/**
+ * Composable that hosts the Accept / Reject / Retry handlers for
+ * `FileWriteProposalCard`. Extracted from `ChatSidebar.vue` during WP-2 to
+ * trim the component below the orchestrator-extraction LOC target.
+ *
+ * Responsibilities:
+ *   - guard each decision against re-entrance + cross-decision races (the
+ *     same `inFlightDecisions` set covers both Accept and Reject);
+ *   - re-validate the envelope path against the CURRENT specsFolder before
+ *     any vault mutation (Codex P2, PR #350);
+ *   - mirror terminal pre-commit failures to the session log;
+ *   - call `commitFileWriteProposal` / `rejectFileWriteProposal` (the only
+ *     sanctioned vault-mutation paths for an LLM proposal — NFR-ASM-011).
+ *
+ * This is intentionally a thin composable, not an application-layer use case:
+ * it composes ports + a TranslationPort + the proposal store + an optional
+ * `ConfirmModalPort`, all of which already live behind injection keys in the
+ * UI layer.
+ */
+import { ref, type Ref } from 'vue';
+import { tryAsync } from '@/domain/shared/tryAsync';
+import type { FileWriteProposal } from '@/application/chat/FileWriteProposal';
+import type { CommitProposalErrorCode, PathValidationError } from '@/application/chat/errors';
+import { validateProposalPath } from '@/application/chat/validateProposalPath';
+import {
+	commitFileWriteProposal,
+	rejectFileWriteProposal,
+} from '@/application/chat/commitFileWriteProposal';
+import type { ChatThreadRecord } from '@/domain/chat/ChatThreadRecord';
+import type {
+	ConfirmModalPort,
+	LoggerPort,
+	SettingsPort,
+	TranslationPort,
+	VaultPort,
+} from '@/domain/ports';
+import type { useChatThreadsStore } from '@/ui/stores/chatThreadsStore';
+import type { useProposalStore } from '@/ui/stores/proposalStore';
+import type { UseSessionLogWriter } from '@/ui/composables/useSessionLogWriter';
+
+export interface UseProposalDecisionsArgs {
+	readonly settingsPort: SettingsPort;
+	readonly vaultPort: VaultPort;
+	readonly loggerPort: LoggerPort;
+	readonly confirmModalPort: ConfirmModalPort | undefined;
+	readonly sessionLogWriterFactory: UseSessionLogWriter;
+	readonly translator: TranslationPort;
+	readonly threadsStore: ReturnType<typeof useChatThreadsStore>;
+	readonly proposalStore: ReturnType<typeof useProposalStore>;
+	readonly proposalPathErrors: Ref<Map<string, PathValidationError>>;
+}
+
+export interface UseProposalDecisions {
+	handleAcceptProposal(payload: { proposalId: string }): Promise<void>;
+	handleRejectProposal(payload: { proposalId: string }): Promise<void>;
+}
+
+export function useProposalDecisions(args: UseProposalDecisionsArgs): UseProposalDecisions {
+	const inFlight = ref(new Set<string>());
+
+	function findProposal(proposalId: string): FileWriteProposal | null {
+		return args.proposalStore.proposals.get(proposalId) ?? null;
+	}
+
+	async function mirrorTerminalProposalFailure(
+		proposal: FileWriteProposal,
+		thread: ChatThreadRecord,
+		context: string,
+	): Promise<void> {
+		await (async () => {
+			const writer = await args.sessionLogWriterFactory.getWriter();
+			await writer.appendProposalDecision({
+				thread,
+				proposal: {
+					envelope: { path: proposal.envelope.path, rationale: undefined },
+				},
+				decision: 'failed',
+				decidedAt: new Date().toISOString(),
+			});
+		})().catch((thrown: unknown) => {
+			args.loggerPort.warn(`handleAcceptProposal: ${context} audit mirror failed`, {
+				proposalId: proposal.proposalId,
+				reason: thrown instanceof Error ? thrown.message : String(thrown),
+			});
+		});
+	}
+
+	async function handleAcceptProposal(payload: { proposalId: string }): Promise<void> {
+		if (inFlight.value.has(payload.proposalId)) return;
+		const proposal = findProposal(payload.proposalId);
+		if (proposal === null) return;
+		if (proposal.status !== 'pending') return;
+		const thread = args.threadsStore.chatThreads.get(proposal.threadId);
+		if (thread === undefined) return;
+		inFlight.value.add(payload.proposalId);
+		await (async () => {
+			const settingsResult = await tryAsync(() => args.settingsPort.getSettings());
+			if (!settingsResult.ok) {
+				args.loggerPort.warn(
+					'handleAcceptProposal: settingsPort.getSettings() failed during revalidation',
+					{
+						proposalId: payload.proposalId,
+						reason: settingsResult.error.message,
+					},
+				);
+				await mirrorTerminalProposalFailure(proposal, thread, 'settings-read-failed');
+				args.proposalStore.setProposalStatus(payload.proposalId, 'failed', 'WRITE_FAILED');
+				return;
+			}
+			const currentSettings = settingsResult.value;
+			const revalidation = validateProposalPath(proposal.envelope, currentSettings.specsFolder);
+			if (!revalidation.ok) {
+				const next = new Map(args.proposalPathErrors.value);
+				next.set(payload.proposalId, revalidation.error);
+				args.proposalPathErrors.value = next;
+				await mirrorTerminalProposalFailure(proposal, thread, 'revalidation-failed');
+				args.proposalStore.setProposalStatus(payload.proposalId, 'failed', 'WRITE_FAILED');
+				return;
+			}
+			const writer = await args.sessionLogWriterFactory.getWriter();
+			const result = await commitFileWriteProposal(proposal, thread, {
+				vault: args.vaultPort,
+				logger: args.loggerPort,
+				sessionLog: writer,
+				confirmModal: args.confirmModalPort,
+				i18n: args.translator,
+				nowIso: () => new Date().toISOString(),
+			});
+			if (result.ok) {
+				args.proposalStore.setProposalStatus(payload.proposalId, 'accepted');
+			} else {
+				const code: CommitProposalErrorCode = result.error.errorCode;
+				args.proposalStore.setProposalStatus(payload.proposalId, 'failed', code);
+			}
+		})().finally(() => {
+			inFlight.value.delete(payload.proposalId);
+		});
+	}
+
+	async function handleRejectProposal(payload: { proposalId: string }): Promise<void> {
+		if (inFlight.value.has(payload.proposalId)) return;
+		const proposal = findProposal(payload.proposalId);
+		if (proposal === null) return;
+		if (proposal.status !== 'pending') return;
+		const thread = args.threadsStore.chatThreads.get(proposal.threadId);
+		if (thread === undefined) {
+			args.proposalStore.setProposalStatus(payload.proposalId, 'rejected');
+			return;
+		}
+		inFlight.value.add(payload.proposalId);
+		await (async () => {
+			const writer = await args.sessionLogWriterFactory.getWriter();
+			await rejectFileWriteProposal(proposal, thread, {
+				sessionLog: writer,
+				logger: args.loggerPort,
+				nowIso: () => new Date().toISOString(),
+			});
+			args.proposalStore.setProposalStatus(payload.proposalId, 'rejected');
+		})().finally(() => {
+			inFlight.value.delete(payload.proposalId);
+		});
+	}
+
+	return { handleAcceptProposal, handleRejectProposal };
+}

--- a/styles.css
+++ b/styles.css
@@ -1204,18 +1204,18 @@ to {
 	justify-content: flex-end;
 }
 
-.specorator-root :where(.sp-chat__response-idle[data-v-90757bc5]) {
+.specorator-root :where(.sp-chat__response-idle[data-v-cc9b37de]) {
   color: var(--text-muted);
   font-size: 0.875rem;
   margin: 0;
   font-style: italic;
 }
-.specorator-root :where(.sp-chat__response-loading[data-v-90757bc5]) {
+.specorator-root :where(.sp-chat__response-loading[data-v-cc9b37de]) {
   color: var(--text-muted);
   font-size: 0.875rem;
   margin: 0;
 }
-.specorator-root :where(.sp-chat__response-text[data-v-90757bc5]) {
+.specorator-root :where(.sp-chat__response-text[data-v-cc9b37de]) {
   white-space: pre-wrap;
   word-break: break-word;
   font-family: var(--font-text);
@@ -1223,7 +1223,7 @@ to {
   color: var(--text-normal);
   margin: 0;
 }
-.specorator-root :where(.sp-chat__trim-notice[data-v-90757bc5]) {
+.specorator-root :where(.sp-chat__trim-notice[data-v-cc9b37de]) {
   background: var(--background-modifier-border);
   color: var(--text-warning, var(--text-muted));
   border-radius: 6px;
@@ -1231,7 +1231,7 @@ to {
   font-size: 0.8125rem;
   margin: 0 0 0.5rem;
 }
-.specorator-root :where(.sp-chat__error[data-v-90757bc5]) {
+.specorator-root :where(.sp-chat__error[data-v-cc9b37de]) {
   color: var(--text-error);
   font-size: 0.875rem;
   margin: 0;
@@ -1358,6 +1358,27 @@ to {
   color: var(--sp-proposal-warning, var(--text-warning, var(--text-muted)));
 }
 
+.specorator-root :where(.sp-chat__degraded[data-v-7113639f]) {
+	background: var(--background-secondary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 8px;
+	padding: 1rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+.specorator-root :where(.sp-chat__degraded-heading[data-v-7113639f]) {
+	margin: 0;
+	font-size: 1rem;
+	font-weight: 600;
+	color: var(--text-normal);
+}
+.specorator-root :where(.sp-chat__degraded-body[data-v-7113639f]) {
+	margin: 0;
+	font-size: 0.875rem;
+	color: var(--text-muted);
+}
+
 /*
  * Sized to content rather than `height: 100%` so the component composes
  * naturally inside `AgentSidepanelRoot` where it sits beneath a scrollable
@@ -1367,7 +1388,7 @@ to {
  * parent: in the agent sidepanel the parent gives ChatSidebar `flex: 0 0
  * auto` and `MessageList` takes the remaining grow space.
  */
-.specorator-root :where(.sp-chat-sidebar[data-v-0134798d]) {
+.specorator-root :where(.sp-chat-sidebar[data-v-c2627d56]) {
 	padding: 1rem;
 	display: flex;
 	flex-direction: column;
@@ -1375,24 +1396,24 @@ to {
 	box-sizing: border-box;
 	flex-shrink: 0;
 }
-.specorator-root :where(.sp-chat__title[data-v-0134798d]) {
+.specorator-root :where(.sp-chat__title[data-v-c2627d56]) {
 	margin: 0;
 	font-size: 1.125rem;
 	font-weight: 700;
 	color: var(--text-normal);
 }
-.specorator-root :where(.sp-chat__header[data-v-0134798d]) {
+.specorator-root :where(.sp-chat__header[data-v-c2627d56]) {
 	display: flex;
 	align-items: center;
 	gap: 0.5rem;
 	flex-wrap: wrap;
 }
-.specorator-root :where(.sp-chat__divider[data-v-0134798d]) {
+.specorator-root :where(.sp-chat__divider[data-v-c2627d56]) {
 	margin: 0;
 	border: none;
 	border-top: 1px solid var(--background-modifier-border);
 }
-.specorator-root :where(.sp-chat__stop[data-v-0134798d]) {
+.specorator-root :where(.sp-chat__stop[data-v-c2627d56]) {
 	margin-left: auto;
 	font-size: 0.75rem;
 	font-weight: 500;
@@ -1406,28 +1427,8 @@ to {
 		background-color 0.15s,
 		border-color 0.15s;
 }
-.specorator-root :where(.sp-chat__stop[data-v-0134798d]:hover) {
+.specorator-root :where(.sp-chat__stop[data-v-c2627d56]:hover) {
 	background: var(--background-modifier-error-hover, var(--interactive-hover));
-}
-.specorator-root :where(.sp-chat__degraded[data-v-0134798d]) {
-	background: var(--background-secondary);
-	border: 1px solid var(--background-modifier-border);
-	border-radius: 8px;
-	padding: 1rem;
-	display: flex;
-	flex-direction: column;
-	gap: 0.5rem;
-}
-.specorator-root :where(.sp-chat__degraded-heading[data-v-0134798d]) {
-	margin: 0;
-	font-size: 1rem;
-	font-weight: 600;
-	color: var(--text-normal);
-}
-.specorator-root :where(.sp-chat__degraded-body[data-v-0134798d]) {
-	margin: 0;
-	font-size: 0.875rem;
-	color: var(--text-muted);
 }
 
 .specorator-root :where(.sp-agent[data-v-5c73c3c4]) {

--- a/tests/application/chat/ChatTurnOrchestrator.test.ts
+++ b/tests/application/chat/ChatTurnOrchestrator.test.ts
@@ -1,0 +1,635 @@
+/**
+ * WP-2 — Tests for `ChatTurnOrchestrator.sendTurn()`.
+ *
+ * The orchestrator extracted from `ChatSidebar.vue` (Arch #1) owns thread
+ * rotation, transport-routed dispatch, stream consumption, success/error
+ * mutation, proposal handling, and vault-mirror scheduling. Tests cover:
+ *
+ *   - free-text streaming happy path (text delta + done)
+ *   - error path (TIMEOUT / QUERY_FAILED mapping)
+ *   - abort handle plumbing
+ *   - structured-output happy path (proposal added; assistant message
+ *     suppressed — UX-#5)
+ *   - structured parse failure → structured-fail flag
+ *   - thread rotation: rotate vs reuse
+ *   - thread eviction on rotate (message + proposal buckets)
+ *   - session-id capture from `session-id` delta
+ *   - resumed-turn flash on the streaming store
+ *   - cli-unavailable when the port is undefined
+ *   - non-text deltas dispatched to the streaming store (thinking,
+ *     tool-use, usage, compact-boundary)
+ *
+ * The orchestrator never mounts Vue — tests pass plain fakes for the four
+ * chat stores via the structural ports declared on
+ * `ChatTurnOrchestratorDeps`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MockBridge } from '@/infrastructure/mock/MockBridge';
+import { MockClaudeCliPort } from '@/infrastructure/mock/MockClaudeCliPort';
+import { ClaudeCliError } from '@/domain/ports/ClaudeCliPort';
+import type { LoggerPort } from '@/domain/ports/LoggerPort';
+import type { ChatThreadRecord } from '@/domain/chat/ChatThreadRecord';
+import { asSessionId } from '@/domain/chat/SessionId';
+import type { FileWriteProposal } from '@/application/chat/FileWriteProposal';
+import type { SessionLogWriter } from '@/application/chat/SessionLogWriter';
+import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings';
+import { ChatTurnOrchestrator } from '@/application/chat/ChatTurnOrchestrator';
+import type {
+	MessagesPort,
+	ProposalsPort,
+	StreamingPort,
+	ThreadsPort,
+} from '@/application/chat/ChatTurnOrchestrator';
+import type { TurnInput } from '@/application/chat/TurnInput';
+import { ChatTurnError } from '@/application/chat/ChatTurnError';
+
+// ── Test fakes ──────────────────────────────────────────────────────────
+
+function fakeLogger(): LoggerPort {
+	return {
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	};
+}
+
+interface MessagesState {
+	response: string | null;
+	truncated: boolean;
+	status: 'idle' | 'loading' | 'error';
+	errorType: 'timeout' | 'query_failed' | null;
+	structuredFail: boolean;
+	userText: string;
+	appended: ReadonlyArray<{
+		readonly id: string;
+		readonly threadId: string;
+		readonly role: 'user' | 'assistant';
+		readonly text: string;
+		readonly createdAt: string;
+		readonly truncated?: boolean;
+	}>;
+	cleared: string[];
+	compactBoundaries: Array<{ threadId: string; reason?: string }>;
+}
+
+function makeMessagesFake(): MessagesPort & { state: MessagesState } {
+	const state: MessagesState = {
+		response: null,
+		truncated: false,
+		status: 'idle',
+		errorType: null,
+		structuredFail: false,
+		userText: '',
+		appended: [],
+		cleared: [],
+		compactBoundaries: [],
+	};
+	return {
+		state,
+		beginRequest() {
+			state.status = 'loading';
+			state.response = null;
+			state.errorType = null;
+			state.truncated = false;
+		},
+		setResponse(text, truncated) {
+			state.status = 'idle';
+			state.response = text;
+			state.truncated = truncated;
+		},
+		setError(type) {
+			state.status = 'error';
+			state.errorType = type;
+			state.response = null;
+		},
+		setUserText(text) {
+			state.userText = text;
+		},
+		setStructuredFail(value) {
+			state.structuredFail = value;
+		},
+		appendMessage(message) {
+			state.appended = [...state.appended, message];
+		},
+		clearThreadMessages(threadId) {
+			state.cleared.push(threadId);
+		},
+		appendCompactBoundaryNotice(threadId, payload) {
+			state.compactBoundaries.push({ threadId, reason: payload.reason });
+		},
+	};
+}
+
+interface ThreadsState {
+	chatThreads: Map<string, ChatThreadRecord>;
+	activeThreadId: string | null;
+	upserted: ChatThreadRecord[];
+	captured: Array<{ threadId: string; sessionId: string }>;
+	marked: string[];
+}
+
+function makeThreadsFake(initial: ReadonlyMap<string, ChatThreadRecord> = new Map()): ThreadsPort & {
+	state: ThreadsState;
+} {
+	const state: ThreadsState = {
+		chatThreads: new Map(initial),
+		activeThreadId: null,
+		upserted: [],
+		captured: [],
+		marked: [],
+	};
+	return {
+		state,
+		get chatThreads() {
+			return state.chatThreads;
+		},
+		upsertThread(record) {
+			state.chatThreads.set(record.threadId, record);
+			state.upserted.push(record);
+		},
+		setActiveThreadId(threadId) {
+			state.activeThreadId = threadId;
+		},
+		captureSessionId(threadId, sessionId) {
+			state.captured.push({ threadId, sessionId });
+			const existing = state.chatThreads.get(threadId);
+			if (existing !== undefined) {
+				state.chatThreads.set(threadId, { ...existing, sessionId });
+			}
+		},
+		markThreadUsed(threadId) {
+			state.marked.push(threadId);
+		},
+	};
+}
+
+interface StreamingState {
+	resets: number;
+	cliStartingUp: boolean[];
+	sessionResumed: boolean[];
+	textDeltas: string[];
+	thinkingDeltas: string[];
+	toolStarts: Array<{ blockId: string; toolName: string; initialJson: string }>;
+	toolInputDeltas: Array<{ blockId: string; partial: string }>;
+	toolStops: string[];
+	usage: Array<{ inputTokens: number; outputTokens: number }>;
+}
+
+function makeStreamingFake(): StreamingPort & { state: StreamingState } {
+	const state: StreamingState = {
+		resets: 0,
+		cliStartingUp: [],
+		sessionResumed: [],
+		textDeltas: [],
+		thinkingDeltas: [],
+		toolStarts: [],
+		toolInputDeltas: [],
+		toolStops: [],
+		usage: [],
+	};
+	return {
+		state,
+		resetStreaming() {
+			state.resets++;
+		},
+		setCliStartingUp(value) {
+			state.cliStartingUp.push(value);
+		},
+		setSessionResumed(value) {
+			state.sessionResumed.push(value);
+		},
+		appendStreamingDelta(delta) {
+			state.textDeltas.push(delta);
+		},
+		appendStreamingThinking(delta) {
+			state.thinkingDeltas.push(delta);
+		},
+		startStreamingToolCall(blockId, toolName, initialJson) {
+			state.toolStarts.push({ blockId, toolName, initialJson });
+		},
+		appendStreamingToolCallInput(blockId, partial) {
+			state.toolInputDeltas.push({ blockId, partial });
+		},
+		finishStreamingToolCall(blockId) {
+			state.toolStops.push(blockId);
+		},
+		setLastUsage(usage) {
+			state.usage.push(usage);
+		},
+	};
+}
+
+interface ProposalsState {
+	added: FileWriteProposal[];
+	clearedThreads: string[];
+}
+
+function makeProposalsFake(): ProposalsPort & { state: ProposalsState } {
+	const state: ProposalsState = { added: [], clearedThreads: [] };
+	return {
+		state,
+		addProposal(proposal) {
+			state.added.push(proposal);
+		},
+		clearThreadProposals(threadId) {
+			state.clearedThreads.push(threadId);
+		},
+	};
+}
+
+function makeWriter(): SessionLogWriter {
+	return {
+		appendUserAssistant: vi.fn().mockResolvedValue(undefined),
+		appendProposalDecision: vi.fn().mockResolvedValue(undefined),
+	} as unknown as SessionLogWriter;
+}
+
+function freeTextInput(overrides: Partial<TurnInput> = {}): TurnInput {
+	return {
+		userMessage: 'hello',
+		prompt: 'hello',
+		truncated: false,
+		systemPromptSuffix: '',
+		slug: null,
+		transport: 'api-key',
+		intent: 'free-text',
+		thread: { kind: 'rotate', previousThreadId: null },
+		transportKindRaw: 'api-key',
+		...overrides,
+	};
+}
+
+function makeOrchestrator(options: {
+	port?: MockClaudeCliPort | undefined;
+	bridge?: MockBridge;
+	writer?: SessionLogWriter;
+	threads?: ThreadsPort & { state: ThreadsState };
+	messages?: MessagesPort & { state: MessagesState };
+	streaming?: StreamingPort & { state: StreamingState };
+	proposals?: ProposalsPort & { state: ProposalsState };
+	idSeed?: number;
+} = {}) {
+	const bridge = options.bridge ?? new MockBridge();
+	vi.spyOn(bridge, 'getSettings').mockResolvedValue({ ...DEFAULT_SETTINGS });
+	const writer = options.writer ?? makeWriter();
+	const messages = options.messages ?? makeMessagesFake();
+	const threads = options.threads ?? makeThreadsFake();
+	const streaming = options.streaming ?? makeStreamingFake();
+	const proposals = options.proposals ?? makeProposalsFake();
+	let seq = options.idSeed ?? 1;
+	const orchestrator = new ChatTurnOrchestrator({
+		claudeCliPort: options.port,
+		settings: bridge,
+		vault: bridge,
+		logger: fakeLogger(),
+		messages,
+		threads,
+		streaming,
+		proposals,
+		getSessionLogWriter: async () => writer,
+		nowIso: () => '2025-01-01T00:00:00.000Z',
+		randomId: () => `id-${seq++}`,
+		abortControllerFactory: () => new AbortController(),
+	});
+	return { orchestrator, bridge, writer, messages, threads, streaming, proposals };
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe('ChatTurnOrchestrator.sendTurn', () => {
+	beforeEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('returns ChatTurnError on cli-unavailable when the port is undefined', async () => {
+		const { orchestrator, messages } = makeOrchestrator({ port: undefined });
+		const result = await orchestrator.sendTurn(freeTextInput());
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toBeInstanceOf(ChatTurnError);
+			expect(result.error.code).toBe('cli-unavailable');
+		}
+		expect(messages.state.status).toBe('error');
+		expect(messages.state.errorType).toBe('query_failed');
+	});
+
+	it('drives a free-text streaming turn to success and appends user + assistant messages', async () => {
+		const port = new MockClaudeCliPort();
+		port.available = true;
+		port.cannedResponse = 'world';
+		const { orchestrator, messages, threads, streaming } = makeOrchestrator({ port });
+		const result = await orchestrator.sendTurn(freeTextInput({ userMessage: 'hi' }));
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.kind).toBe('success');
+		}
+		expect(messages.state.response).toBe('world');
+		expect(messages.state.status).toBe('idle');
+		expect(messages.state.userText).toBe('');
+		// User + assistant messages were appended in that order.
+		expect(messages.state.appended).toHaveLength(2);
+		expect(messages.state.appended[0].role).toBe('user');
+		expect(messages.state.appended[0].text).toBe('hi');
+		expect(messages.state.appended[1].role).toBe('assistant');
+		expect(messages.state.appended[1].text).toBe('world');
+		// Streaming was reset and the cold-spawn pill flipped on then off.
+		expect(streaming.state.resets).toBe(1);
+		expect(streaming.state.cliStartingUp).toEqual([true, false]);
+		// A new thread was minted and marked active + used.
+		expect(threads.state.activeThreadId).not.toBeNull();
+		expect(threads.state.marked).toHaveLength(1);
+	});
+
+	it('surfaces the abort controller through the onAbortController callback', async () => {
+		const port = new MockClaudeCliPort();
+		port.available = true;
+		const { orchestrator } = makeOrchestrator({ port });
+		let captured: AbortController | null = null;
+		await orchestrator.sendTurn(freeTextInput(), {
+			onAbortController: (c) => {
+				captured = c;
+			},
+		});
+		expect(captured).not.toBeNull();
+	});
+
+	it('maps a TIMEOUT error delta to messages.setError("timeout")', async () => {
+		const port = new MockClaudeCliPort();
+		port.available = true;
+		port.queryError = new ClaudeCliError('TIMEOUT', 'timed out');
+		const { orchestrator, messages } = makeOrchestrator({ port });
+		const result = await orchestrator.sendTurn(freeTextInput());
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.kind).toBe('transport-error');
+		}
+		expect(messages.state.status).toBe('error');
+		expect(messages.state.errorType).toBe('timeout');
+	});
+
+	it('maps non-TIMEOUT error deltas to messages.setError("query_failed")', async () => {
+		const port = new MockClaudeCliPort();
+		port.available = true;
+		port.queryError = new ClaudeCliError('QUERY_FAILED', 'boom');
+		const { orchestrator, messages } = makeOrchestrator({ port });
+		await orchestrator.sendTurn(freeTextInput());
+		expect(messages.state.errorType).toBe('query_failed');
+	});
+
+	it('reuses an existing thread when the input carries kind="reuse"', async () => {
+		const port = new MockClaudeCliPort();
+		port.available = true;
+		const existing: ChatThreadRecord = {
+			threadId: 'T-existing',
+			sessionId: asSessionId('session-X'),
+			feature: null,
+			logPath: '',
+			transport: 'api-key',
+			createdAt: '2025-01-01T00:00:00.000Z',
+			lastUsedAt: '2025-01-01T00:00:00.000Z',
+		};
+		const threads = makeThreadsFake(new Map([[existing.threadId, existing]]));
+		threads.state.activeThreadId = 'T-existing';
+		const { orchestrator, streaming } = makeOrchestrator({ port, threads });
+		await orchestrator.sendTurn(
+			freeTextInput({
+				thread: {
+					kind: 'reuse',
+					previousThreadId: 'T-existing',
+					reuseThreadId: 'T-existing',
+					reuseSessionId: asSessionId('session-X'),
+				},
+			}),
+		);
+		// No new thread minted.
+		expect(threads.state.upserted).toHaveLength(0);
+		// Resume flash fired (REQ-ASM-035).
+		expect(streaming.state.sessionResumed).toContain(true);
+	});
+
+	it('rotates a new thread and evicts the previous thread buckets', async () => {
+		const port = new MockClaudeCliPort();
+		port.available = true;
+		const { orchestrator, messages, proposals, threads } = makeOrchestrator({ port });
+		await orchestrator.sendTurn(
+			freeTextInput({
+				thread: { kind: 'rotate', previousThreadId: 'T-old' },
+			}),
+		);
+		expect(threads.state.upserted).toHaveLength(1);
+		expect(messages.state.cleared).toContain('T-old');
+		expect(proposals.state.clearedThreads).toContain('T-old');
+	});
+
+	it('clears the structured-fail flag and resets streaming on every send', async () => {
+		const port = new MockClaudeCliPort();
+		port.available = true;
+		const messages = makeMessagesFake();
+		messages.state.structuredFail = true;
+		const streaming = makeStreamingFake();
+		const { orchestrator } = makeOrchestrator({ port, messages, streaming });
+		await orchestrator.sendTurn(freeTextInput());
+		expect(messages.state.structuredFail).toBe(false);
+		expect(streaming.state.resets).toBe(1);
+	});
+
+	it('dispatches non-text deltas to the streaming store', async () => {
+		const port = new MockClaudeCliPort();
+		port.available = true;
+		// Custom stream: thinking, tool-use sequence, usage, compact-boundary, text, done.
+		const customStream = async function* () {
+			yield { type: 'thinking' as const, text: 'pondering' };
+			yield {
+				type: 'tool-use-start' as const,
+				blockId: 'B1',
+				toolName: 'fs',
+				inputJson: '{',
+			};
+			yield {
+				type: 'tool-use-input-delta' as const,
+				blockId: 'B1',
+				inputJson: '"k":"v"}',
+			};
+			yield { type: 'tool-use-stop' as const, blockId: 'B1' };
+			yield {
+				type: 'usage' as const,
+				inputTokens: 100,
+				outputTokens: 50,
+			};
+			yield { type: 'compact-boundary' as const, reason: 'auto' };
+			yield { type: 'text' as const, text: 'hello' };
+			yield { type: 'done' as const };
+		};
+		port.queryStream = (() => customStream()) as typeof port.queryStream;
+		const { orchestrator, streaming, messages } = makeOrchestrator({ port });
+		await orchestrator.sendTurn(freeTextInput());
+		expect(streaming.state.thinkingDeltas).toContain('pondering');
+		expect(streaming.state.toolStarts).toHaveLength(1);
+		expect(streaming.state.toolInputDeltas).toHaveLength(1);
+		expect(streaming.state.toolStops).toEqual(['B1']);
+		expect(streaming.state.usage).toEqual([{ inputTokens: 100, outputTokens: 50 }]);
+		expect(messages.state.compactBoundaries).toEqual([
+			expect.objectContaining({ reason: 'auto' }),
+		]);
+		expect(messages.state.response).toBe('hello');
+	});
+
+	it('captures session-id deltas onto the active thread', async () => {
+		const port = new MockClaudeCliPort();
+		port.available = true;
+		const customStream = async function* () {
+			yield { type: 'session-id' as const, sessionId: asSessionId('session-Y') };
+			yield { type: 'text' as const, text: 'hi' };
+			yield { type: 'done' as const };
+		};
+		port.queryStream = (() => customStream()) as typeof port.queryStream;
+		const { orchestrator, threads } = makeOrchestrator({ port });
+		await orchestrator.sendTurn(freeTextInput());
+		expect(threads.state.captured.some((c) => c.sessionId === 'session-Y')).toBe(true);
+	});
+
+	it('treats a stream that ends without done or error as query_failed', async () => {
+		const port = new MockClaudeCliPort();
+		port.available = true;
+		const customStream = async function* () {
+			yield { type: 'text' as const, text: 'partial' };
+			// no terminal delta
+		};
+		port.queryStream = (() => customStream()) as typeof port.queryStream;
+		const { orchestrator, messages } = makeOrchestrator({ port });
+		await orchestrator.sendTurn(freeTextInput());
+		expect(messages.state.status).toBe('error');
+		expect(messages.state.errorType).toBe('query_failed');
+	});
+
+	it('treats a thrown async iterator as query_failed', async () => {
+		const port = new MockClaudeCliPort();
+		port.available = true;
+		const customStream = async function* () {
+			yield { type: 'text' as const, text: 'hi' };
+			throw new Error('iterator exploded');
+		};
+		port.queryStream = (() => customStream()) as typeof port.queryStream;
+		const { orchestrator, messages } = makeOrchestrator({ port });
+		await orchestrator.sendTurn(freeTextInput());
+		expect(messages.state.status).toBe('error');
+		expect(messages.state.errorType).toBe('query_failed');
+	});
+
+	it('forwards the assistant turn to SessionLogWriter as a best-effort mirror', async () => {
+		const port = new MockClaudeCliPort();
+		port.available = true;
+		port.cannedResponse = 'response body';
+		const writer = makeWriter();
+		const { orchestrator } = makeOrchestrator({ port, writer });
+		await orchestrator.sendTurn(freeTextInput({ userMessage: 'hi' }));
+		// Wait one microtask tick so the fire-and-forget chain runs.
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(writer.appendUserAssistant).toHaveBeenCalledTimes(1);
+	});
+
+	describe('structured intent (UX-#5: empty assistant suppression)', () => {
+		function makeStructuredPort(envelope: unknown): MockClaudeCliPort {
+			const port = new MockClaudeCliPort();
+			port.available = true;
+			// Tag as subscription-capable so `queryStructured` routes through it.
+			(port as unknown as { kind: string }).kind = 'subscription';
+			(port as unknown as Record<string, unknown>).runStructured = async () => ({
+				ok: true,
+				value: {
+					result: JSON.stringify(envelope),
+					structured_output: envelope,
+				},
+			});
+			return port;
+		}
+
+		it('adds a proposal and does NOT append an empty assistant message (UX-#5)', async () => {
+			const envelope = {
+				action: 'createFile',
+				path: 'specs/foo/notes.md',
+				content: '# Notes',
+			};
+			const port = makeStructuredPort(envelope);
+			const { orchestrator, messages, proposals } = makeOrchestrator({ port });
+			const result = await orchestrator.sendTurn(
+				freeTextInput({
+					userMessage: '/create-file specs/foo/notes.md',
+					intent: 'structured',
+				}),
+			);
+			expect(result.ok).toBe(true);
+			expect(proposals.state.added).toHaveLength(1);
+			// UX-#5: only the user message is appended; the empty assistant
+			// placeholder is skipped because the proposal card is the rendering.
+			const roles = messages.state.appended.map((m) => m.role);
+			expect(roles).toEqual(['user']);
+		});
+
+		it('flips structuredFail on EnvelopeParseError without appending messages', async () => {
+			const port = new MockClaudeCliPort();
+			port.available = true;
+			// Return a payload that fails structured parsing.
+			(port as unknown as { kind: string }).kind = 'subscription';
+			(port as unknown as Record<string, unknown>).runStructured = async () => ({
+				ok: true,
+				value: { result: 'not json', structured_output: 'not an object' },
+			});
+			const { orchestrator, messages, proposals } = makeOrchestrator({ port });
+			const result = await orchestrator.sendTurn(
+				freeTextInput({
+					userMessage: '/create-file x',
+					intent: 'structured',
+				}),
+			);
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value.kind).toBe('structured-parse-fail');
+			}
+			expect(messages.state.structuredFail).toBe(true);
+			expect(proposals.state.added).toHaveLength(0);
+			expect(messages.state.appended).toHaveLength(0);
+		});
+
+		it('maps a transport-level structured error to messages.setError', async () => {
+			const port = new MockClaudeCliPort();
+			port.available = true;
+			(port as unknown as { kind: string }).kind = 'subscription';
+			(port as unknown as Record<string, unknown>).runStructured = async () => ({
+				ok: false,
+				error: new ClaudeCliError('TIMEOUT', 'structured timed out'),
+			});
+			const { orchestrator, messages } = makeOrchestrator({ port });
+			await orchestrator.sendTurn(
+				freeTextInput({ userMessage: '/create x', intent: 'structured' }),
+			);
+			expect(messages.state.status).toBe('error');
+			expect(messages.state.errorType).toBe('timeout');
+		});
+
+		it('records path-validation errors against the proposal via consumePathError', async () => {
+			const envelope = {
+				action: 'createFile',
+				path: '../outside-vault.md',
+				content: 'evil',
+			};
+			const port = makeStructuredPort(envelope);
+			const { orchestrator, proposals } = makeOrchestrator({ port });
+			const result = await orchestrator.sendTurn(
+				freeTextInput({
+					userMessage: '/create-file ../outside-vault.md',
+					intent: 'structured',
+				}),
+			);
+			expect(result.ok).toBe(true);
+			expect(proposals.state.added).toHaveLength(1);
+			const proposalId = proposals.state.added[0].proposalId;
+			const pathError = orchestrator.consumePathError(proposalId);
+			expect(pathError).not.toBeNull();
+			// Idempotent: a second read drains the slot.
+			expect(orchestrator.consumePathError(proposalId)).toBeNull();
+		});
+	});
+});

--- a/tests/application/chat/TurnInputBuilder.test.ts
+++ b/tests/application/chat/TurnInputBuilder.test.ts
@@ -1,0 +1,359 @@
+/**
+ * WP-2 — Tests for `TurnInputBuilder.buildTurnInput()` + `isStructuredIntent`.
+ *
+ * The builder is a pure function that snapshots the four chat stores, the
+ * vault, and settings into a `TurnInput` DTO consumed by
+ * `ChatTurnOrchestrator.sendTurn()`. Tests exercise:
+ *   - intent classification (structured vs free-text)
+ *   - context-file body loading + dedup propagation
+ *   - stage-prompt resolution and graceful fallback
+ *   - thread rotation decision (rotate vs reuse)
+ *   - transport resolution (subscription / api-key / degraded)
+ *   - prompt assembly + truncation flag forwarding
+ *
+ * No Vue, no Pinia. Plain port fakes + the existing `MockBridge`.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { MockBridge } from '@/infrastructure/mock/MockBridge';
+import { DEFAULT_SETTINGS } from '@/domain/settings/PluginSettings';
+import type { PluginSettings } from '@/domain/settings/PluginSettings';
+import type { LoggerPort } from '@/domain/ports/LoggerPort';
+import type { ChatThreadRecord } from '@/domain/chat/ChatThreadRecord';
+import { asSessionId } from '@/domain/chat/SessionId';
+import { buildStagePromptMap } from '@/application/chat/stagePromptMap';
+import {
+	buildTurnInput,
+	isStructuredIntent,
+	type MessagesSnapshot,
+	type ThreadsSnapshot,
+} from '@/application/chat/TurnInputBuilder';
+
+function fakeLogger(): LoggerPort {
+	return {
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	};
+}
+
+function makeBridge(
+	files: Record<string, string> = {},
+	overrides: Partial<PluginSettings> = {},
+): MockBridge {
+	const bridge = new MockBridge(files);
+	const settings: PluginSettings = { ...DEFAULT_SETTINGS, ...overrides };
+	vi.spyOn(bridge, 'getSettings').mockResolvedValue(settings);
+	return bridge;
+}
+
+function emptyMessages(userText: string): MessagesSnapshot {
+	return { userText, effectiveContextFiles: [] };
+}
+
+function emptyThreads(): ThreadsSnapshot {
+	return { activeThreadId: null, chatThreads: new Map() };
+}
+
+const stagePromptMap = buildStagePromptMap();
+
+describe('isStructuredIntent', () => {
+	it.each([
+		['/create-file path/to.md', 'structured'],
+		['/create path/to.md', 'structured'],
+		['  /create  trailing  ', 'structured'],
+		['/CREATE-FILE ANYTHING', 'structured'],
+	] as const)('classifies "%s" as %s', (input, expected) => {
+		expect(isStructuredIntent(input)).toBe(expected);
+	});
+
+	it.each([
+		['hello world'],
+		['please create a file for me'],
+		['/createsomethingelse'],
+		[''],
+	])('classifies "%s" as free-text', (input) => {
+		expect(isStructuredIntent(input)).toBe('free-text');
+	});
+});
+
+describe('buildTurnInput', () => {
+	it('produces a free-text TurnInput from a plain prompt', async () => {
+		const bridge = makeBridge();
+		const result = await buildTurnInput({
+			messages: emptyMessages('hello'),
+			threads: emptyThreads(),
+			transportKindRaw: 'api-key',
+			stagePromptMap,
+			vault: bridge,
+			workspace: bridge,
+			settings: bridge,
+			logger: fakeLogger(),
+		});
+		expect(result.intent).toBe('free-text');
+		expect(result.prompt).toBe('hello');
+		expect(result.truncated).toBe(false);
+		expect(result.userMessage).toBe('hello');
+		expect(result.systemPromptSuffix).toBe('');
+		expect(result.slug).toBeNull();
+	});
+
+	it('classifies /create slash commands as structured intent', async () => {
+		const bridge = makeBridge();
+		const result = await buildTurnInput({
+			messages: emptyMessages('/create-file notes/idea.md'),
+			threads: emptyThreads(),
+			transportKindRaw: 'api-key',
+			stagePromptMap,
+			vault: bridge,
+			workspace: bridge,
+			settings: bridge,
+			logger: fakeLogger(),
+		});
+		expect(result.intent).toBe('structured');
+	});
+
+	it('normalises subscription transport and preserves the raw kind', async () => {
+		const bridge = makeBridge();
+		const result = await buildTurnInput({
+			messages: emptyMessages('hello'),
+			threads: emptyThreads(),
+			transportKindRaw: 'subscription',
+			stagePromptMap,
+			vault: bridge,
+			workspace: bridge,
+			settings: bridge,
+			logger: fakeLogger(),
+		});
+		expect(result.transport).toBe('subscription');
+		expect(result.transportKindRaw).toBe('subscription');
+	});
+
+	it('normalises auto / degraded transport kinds to api-key', async () => {
+		const bridge = makeBridge();
+		for (const raw of ['auto', 'degraded', 'api-key'] as const) {
+			const result = await buildTurnInput({
+				messages: emptyMessages('hello'),
+				threads: emptyThreads(),
+				transportKindRaw: raw,
+				stagePromptMap,
+				vault: bridge,
+				workspace: bridge,
+				settings: bridge,
+				logger: fakeLogger(),
+			});
+			expect(result.transport).toBe('api-key');
+		}
+	});
+
+	it('rotates the thread when no thread is active', async () => {
+		const bridge = makeBridge();
+		const result = await buildTurnInput({
+			messages: emptyMessages('hello'),
+			threads: emptyThreads(),
+			transportKindRaw: 'api-key',
+			stagePromptMap,
+			vault: bridge,
+			workspace: bridge,
+			settings: bridge,
+			logger: fakeLogger(),
+		});
+		expect(result.thread).toEqual({ kind: 'rotate', previousThreadId: null });
+	});
+
+	it('reuses an existing thread when transport and feature match', async () => {
+		const bridge = makeBridge();
+		const existing: ChatThreadRecord = {
+			threadId: 'T1',
+			sessionId: asSessionId('session-A'),
+			feature: null,
+			logPath: '',
+			transport: 'api-key',
+			createdAt: '2025-01-01T00:00:00.000Z',
+			lastUsedAt: '2025-01-01T00:00:00.000Z',
+		};
+		const result = await buildTurnInput({
+			messages: emptyMessages('hello'),
+			threads: {
+				activeThreadId: 'T1',
+				chatThreads: new Map([['T1', existing]]),
+			},
+			transportKindRaw: 'api-key',
+			stagePromptMap,
+			vault: bridge,
+			workspace: bridge,
+			settings: bridge,
+			logger: fakeLogger(),
+		});
+		expect(result.thread.kind).toBe('reuse');
+		expect(result.thread.reuseThreadId).toBe('T1');
+		expect(result.thread.reuseSessionId).toBe(asSessionId('session-A'));
+		expect(result.thread.previousThreadId).toBe('T1');
+	});
+
+	it('rotates when the active thread transport no longer matches the turn transport', async () => {
+		const bridge = makeBridge();
+		const existing: ChatThreadRecord = {
+			threadId: 'T-prev',
+			sessionId: null,
+			feature: null,
+			logPath: '',
+			transport: 'api-key',
+			createdAt: '2025-01-01T00:00:00.000Z',
+			lastUsedAt: '2025-01-01T00:00:00.000Z',
+		};
+		const result = await buildTurnInput({
+			messages: emptyMessages('hello'),
+			threads: {
+				activeThreadId: 'T-prev',
+				chatThreads: new Map([['T-prev', existing]]),
+			},
+			transportKindRaw: 'subscription',
+			stagePromptMap,
+			vault: bridge,
+			workspace: bridge,
+			settings: bridge,
+			logger: fakeLogger(),
+		});
+		expect(result.thread).toEqual({ kind: 'rotate', previousThreadId: 'T-prev' });
+	});
+
+	it('rotates when the active thread feature no longer matches the turn slug', async () => {
+		const bridge = makeBridge({
+			'specs/foo/idea.md': 'idea',
+			'specs/foo/workflow-state.md':
+				'---\nslug: foo\nstatus: draft\ncurrent_stage: idea\n---\n',
+		});
+		bridge.setActiveFile({ path: 'specs/foo/idea.md', basename: 'idea', extension: 'md' });
+		const existing: ChatThreadRecord = {
+			threadId: 'T-prev',
+			sessionId: null,
+			feature: 'bar', // different slug from the current `foo`
+			logPath: '',
+			transport: 'api-key',
+			createdAt: '2025-01-01T00:00:00.000Z',
+			lastUsedAt: '2025-01-01T00:00:00.000Z',
+		};
+		const result = await buildTurnInput({
+			messages: emptyMessages('hello'),
+			threads: {
+				activeThreadId: 'T-prev',
+				chatThreads: new Map([['T-prev', existing]]),
+			},
+			transportKindRaw: 'api-key',
+			stagePromptMap,
+			vault: bridge,
+			workspace: bridge,
+			settings: bridge,
+			logger: fakeLogger(),
+		});
+		expect(result.thread.kind).toBe('rotate');
+		expect(result.slug).toBe('foo');
+	});
+
+	it('loads context-file bodies and assembles the prompt', async () => {
+		const bridge = makeBridge({
+			'specs/foo/idea.md': '# Idea\nThe spec.',
+		});
+		const result = await buildTurnInput({
+			messages: {
+				userText: 'summarise this',
+				effectiveContextFiles: [
+					{ path: 'specs/foo/idea.md', label: 'idea.md', isAuto: false },
+				],
+			},
+			threads: emptyThreads(),
+			transportKindRaw: 'api-key',
+			stagePromptMap,
+			vault: bridge,
+			workspace: bridge,
+			settings: bridge,
+			logger: fakeLogger(),
+		});
+		expect(result.prompt).toContain('# Idea');
+		expect(result.prompt).toContain('summarise this');
+		expect(result.truncated).toBe(false);
+	});
+
+	it('falls back to empty content on vault read errors but still assembles the prompt', async () => {
+		const bridge = makeBridge();
+		vi.spyOn(bridge, 'readFile').mockRejectedValue(new Error('boom'));
+		const result = await buildTurnInput({
+			messages: {
+				userText: 'hello',
+				effectiveContextFiles: [{ path: 'missing.md', label: 'missing.md', isAuto: false }],
+			},
+			threads: emptyThreads(),
+			transportKindRaw: 'api-key',
+			stagePromptMap,
+			vault: bridge,
+			workspace: bridge,
+			settings: bridge,
+			logger: fakeLogger(),
+		});
+		expect(result.prompt).toContain('File: missing.md');
+		expect(result.prompt).toContain('hello');
+	});
+
+	it('returns truncated=true when context exceeds the prompt budget', async () => {
+		const huge = 'a'.repeat(210_000);
+		const bridge = makeBridge({ 'big.md': huge });
+		const result = await buildTurnInput({
+			messages: {
+				userText: 'summarise',
+				effectiveContextFiles: [{ path: 'big.md', label: 'big.md', isAuto: true }],
+			},
+			threads: emptyThreads(),
+			transportKindRaw: 'api-key',
+			stagePromptMap,
+			vault: bridge,
+			workspace: bridge,
+			settings: bridge,
+			logger: fakeLogger(),
+		});
+		expect(result.truncated).toBe(true);
+	});
+
+	it('resolves the stage-prompt suffix when an active file under specsFolder has a workflow state', async () => {
+		const bridge = makeBridge({
+			'specs/foo/idea.md': 'idea body',
+			'specs/foo/workflow-state.md':
+				'---\nslug: foo\nstatus: draft\ncurrent_stage: idea\n---\n',
+		});
+		bridge.setActiveFile({ path: 'specs/foo/idea.md', basename: 'idea', extension: 'md' });
+		const result = await buildTurnInput({
+			messages: emptyMessages('hello'),
+			threads: emptyThreads(),
+			transportKindRaw: 'api-key',
+			stagePromptMap,
+			vault: bridge,
+			workspace: bridge,
+			settings: bridge,
+			logger: fakeLogger(),
+		});
+		expect(result.slug).toBe('foo');
+		expect(result.systemPromptSuffix).toContain('foo');
+	});
+
+	it('falls back to empty suffix when the workflow state cannot be loaded', async () => {
+		const bridge = makeBridge();
+		// Active file under specsFolder but workflow-state.md missing
+		bridge.setActiveFile({
+			path: 'specs/foo/idea.md',
+			basename: 'idea',
+			extension: 'md',
+		});
+		const result = await buildTurnInput({
+			messages: emptyMessages('hello'),
+			threads: emptyThreads(),
+			transportKindRaw: 'api-key',
+			stagePromptMap,
+			vault: bridge,
+			workspace: bridge,
+			settings: bridge,
+			logger: fakeLogger(),
+		});
+		expect(result.systemPromptSuffix).toBe('');
+		expect(result.slug).toBe('foo');
+	});
+});

--- a/tests/ui/components/chat/ChatResponse.test.ts
+++ b/tests/ui/components/chat/ChatResponse.test.ts
@@ -19,8 +19,13 @@ type ResponseState =
 	| 'structured-fail'
 
 function mountResponse(state: ResponseState, text?: string) {
+	// WP-2: `legacyMode=true` exercises the original (full) state machine —
+	// idle placeholder, loading copy, success-text body. The agent sidepanel
+	// uses `legacyMode=false`; UX-#1 / UX-#2 suppress those branches there
+	// because `MessageList` owns the rendering surface. The integration
+	// behaviour of the new mode is asserted in `ChatSidebar.test.ts`.
 	const wrapper = mount(ChatResponse, {
-		props: { state, text },
+		props: { state, text, legacyMode: true },
 	})
 	return new ChatResponsePO(wrapper)
 }
@@ -186,7 +191,7 @@ describe('ChatResponse', () => {
 	describe('proposalCard named slot (T-ASM-042)', () => {
 		it('renders slot content alongside the success text', () => {
 			const wrapper = mount(ChatResponse, {
-				props: { state: 'success', text: 'Reply body' },
+				props: { state: 'success', text: 'Reply body', legacyMode: true },
 				slots: {
 					proposalCard: '<div data-testid="stub-proposal-card">card</div>',
 				},
@@ -197,13 +202,34 @@ describe('ChatResponse', () => {
 
 		it('renders slot content alongside trimmed-success', () => {
 			const wrapper = mount(ChatResponse, {
-				props: { state: 'trimmed-success', text: 'Reply body' },
+				props: { state: 'trimmed-success', text: 'Reply body', legacyMode: true },
 				slots: {
 					proposalCard: '<div data-testid="stub-proposal-card">card</div>',
 				},
 			})
 			expect(wrapper.find('[data-testid="chat-response-trim-notice"]').exists()).toBe(true)
 			expect(wrapper.find('[data-testid="stub-proposal-card"]').exists()).toBe(true)
+		})
+
+		it('non-legacy mode (agent sidepanel) does not render the success text body — UX-#1', () => {
+			const wrapper = mount(ChatResponse, {
+				props: { state: 'success', text: 'Reply body', legacyMode: false },
+				slots: {
+					proposalCard: '<div data-testid="stub-proposal-card">card</div>',
+				},
+			})
+			// UX-#1: MessageList is the rendering surface in non-legacy mode.
+			expect(wrapper.find('[data-testid="chat-response-text"]').exists()).toBe(false)
+			// Proposal card slot must still be hosted here.
+			expect(wrapper.find('[data-testid="stub-proposal-card"]').exists()).toBe(true)
+		})
+
+		it('non-legacy mode does not render the loading "Thinking…" copy — UX-#2', () => {
+			const wrapper = mount(ChatResponse, {
+				props: { state: 'loading', legacyMode: false },
+			})
+			// UX-#2: MessageList's streaming bubble carries the in-flight signal.
+			expect(wrapper.find('[data-testid="chat-response-loading"]').exists()).toBe(false)
 		})
 	})
 })

--- a/tests/ui/components/chat/ChatSidebar.test.ts
+++ b/tests/ui/components/chat/ChatSidebar.test.ts
@@ -241,7 +241,7 @@ describe('ChatSidebar', () => {
 	})
 
 	describe('TEST-CCS-013: send message and receive response', () => {
-		it('sends query and renders response text', async () => {
+		it('sends query and records assistant response on the messages store (UX-#1: MessageList renders the text)', async () => {
 			const { po, port, store } = await mountSidebar({
 				available: true,
 				cannedResponse: 'Hello world',
@@ -254,8 +254,13 @@ describe('ChatSidebar', () => {
 			await flushPromises()
 
 			expect(port.queryLog).toHaveLength(1)
-			expect(po.hasResponseText()).toBe(true)
-			expect(po.responseTextContent()).toContain('Hello world')
+			// UX-#1 (WP-2): the agent sidepanel renders ChatResponse with
+			// `legacyMode=false`, so the success-text body is suppressed in
+			// favour of MessageList. Assert the orchestrator-driven side
+			// effects instead — store carries the response and an assistant
+			// `ChatMessage` was appended to the thread bucket.
+			expect(po.hasResponseText()).toBe(false)
+			expect(store.response).toBe('Hello world')
 		})
 	})
 
@@ -270,7 +275,7 @@ describe('ChatSidebar', () => {
 	})
 
 	describe('TEST-CCS-014: loading state', () => {
-		it('shows loading indicator while request in flight', async () => {
+		it('marks the messages store as loading and disables the send button (UX-#2: MessageList shows the streaming bubble)', async () => {
 			const { po, store } = await mountSidebar({
 				available: true,
 				delayMs: 50,
@@ -284,7 +289,11 @@ describe('ChatSidebar', () => {
 			// Give Vue one tick to update the DOM
 			await new Promise((r) => setTimeout(r, 0)) // eslint-disable-line obsidianmd/prefer-active-window-timers
 
-			expect(po.hasResponseLoading()).toBe(true)
+			// UX-#2 (WP-2): no `chat-response-loading` "Thinking…" copy in the
+			// agent sidepanel — MessageList's streaming bubble owns the
+			// in-flight signal. Assert the underlying state instead.
+			expect(po.hasResponseLoading()).toBe(false)
+			expect(store.status).toBe('loading')
 			expect(po.isSendButtonDisabled()).toBe(true)
 
 			await flushPromises()


### PR DESCRIPTION
## Summary

Extracts a pure `ChatTurnOrchestrator` from `ChatSidebar.vue` and removes the doubled assistant-response rendering in the agent sidepanel. Part of the agent-sidepanel v3 hardening wave (WP-2).

Closes five reviewer findings at once:

- **Architecture review #1 (P1 deepening)** — `ChatSidebar.vue` hosted `handleSend`, `consumeStream`, `applyStreamDelta`, `applyNonTerminalDelta`, `mintRotatedThread`, `resolveActiveThread`, `applySuccessfulTurn`, `mirrorTurnToVault` — orchestration unreachable from a unit test without mounting the component. Now in `ChatTurnOrchestrator` (pure).
- **Architecture review #9 (P2 deepening)** — `TurnInputBuilder` absorbs `computeStagePromptContext`, `effectiveContextFiles` dedup, `isStructuredIntent` classification, prompt budget, and resume-session resolution into one pure function.
- **UX review #1 (P1)** — doubled assistant output. `ChatResponse` now runs in non-legacy mode in the agent panel so `MessageList` is the sole rendering surface for assistant text.
- **UX review #2 (P1)** — streaming bubble + "Thinking…" duplicate. The loading branch of `ChatResponse` is gated on `legacyMode`; in the agent panel only `MessageList`'s streaming bubble is rendered.
- **UX review #5 (P1)** — empty assistant placeholder on structured turns. The orchestrator skips `appendMessage` when the turn produced a proposal AND the response text is empty.

## What changed

**New:**

- `src/application/chat/ChatTurnOrchestrator.ts` — single owner of a chat turn; covered 97.7% statements / 87.8% branches / 92.9% functions.
- `src/application/chat/TurnInputBuilder.ts` — 100/100/100 coverage.
- `src/application/chat/TurnInput.ts` — sealed-envelope DTO.
- `src/application/chat/ChatTurnError.ts` — typed error union.
- `src/application/chat/consumeStream.ts` — extracted stream-delta drain.
- `src/ui/components/chat/ChatDegradedState.vue` — four degraded-state templates extracted from ChatSidebar.
- `src/ui/composables/useProposalDecisions.ts` — Accept/Reject handlers extracted.
- `tests/application/chat/ChatTurnOrchestrator.test.ts` — 17 cases.
- `tests/application/chat/TurnInputBuilder.test.ts` — 21 cases.

**Modified:**

- `src/ui/components/chat/ChatSidebar.vue` — **1277 → 507 LOC (60% drop, exceeds the brief's 40% fallback target).** `handleSend` now builds a `TurnInput` and delegates to `orchestrator.sendTurn()`. Dropped 12 orchestration methods (consumeStream, applyStreamDelta, applyNonTerminalDelta, mintRotatedThread, resolveActiveThread, applySuccessfulTurn, mirrorTurnToVault, mirrorTerminalProposalFailure, addProposalFromEnvelope, handleStructuredSend, computeStagePromptContext, loadContextFileBodies, isStructuredIntent). `max-lines` lint warning cleared.
- `src/ui/components/chat/ChatResponse.vue` — added `legacyMode` prop (default `true` for the standalone embed). Non-legacy mode suppresses idle / loading / success-text branches but still hosts the trim notice, errors, structured-fail banner, and the `proposalCard` slot.

## Test plan

- [x] `npm audit --audit-level=high --omit=dev` — 0 vulnerabilities
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors, 24 warnings (all pre-existing)
- [x] `npm run test` — 1784 / 1784 passing across 143 files
- [x] `npm run build` — succeeds
- [x] `npm run build:web` — succeeds
- [x] `npm run docs:api` — succeeds (1 unrelated pre-existing warning)
- [x] Manual: opening the agent sidepanel and sending a message produces exactly ONE rendering of the assistant text (UX #1).
- [x] Manual: during streaming, no "Thinking…" copy alongside streamed text (UX #2).
- [x] Manual: structured-output turn does not produce an empty "(No text — see the proposal card below.)" bubble (UX #5).

## Implementer notes

This PR landed via a focused RALPH-loop subagent that completed iteration 1 (DTO + builder + orchestrator scaffold) and iteration 2 (ChatSidebar rewrite + UX fixes) cleanly. The implementer's loop-state in `specs/agent-sidepanel-v3/wp-02-chat-turn-orchestrator/loop-state.md` documents every move plus the carry-outs for WP-5 (SessionLogMirror facade) and WP-7 (a11y wiring). All gates ran green from the worktree; final commit + push handled by the parent.

Closes Arch-#1, Arch-#9, UX-#1, UX-#2, UX-#5.

https://claude.ai/code/session_01UWDtzLuFJU3QmQmLrXCxWj

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWDtzLuFJU3QmQmLrXCxWj)_