### PR TITLE
fix(asv3): render finalised messages on mount in MarkdownBlock

### DIFF
--- a/src/ui/components/agent/MarkdownBlock.vue
+++ b/src/ui/components/agent/MarkdownBlock.vue
@@ -27,7 +27,7 @@
  *     emitted without an `href` attribute so they cannot smuggle
  *     `javascript:` URIs.
  */
-import { computed, h, inject, onBeforeUnmount, ref, watch, type VNode } from 'vue';
+import { computed, h, inject, onBeforeUnmount, onMounted, ref, watch, type VNode } from 'vue';
 import { MARKDOWN_RENDER_PORT } from '@/infrastructure/bridge/ports';
 import type { MarkdownRenderPort } from '@/domain/ports/MarkdownRenderPort';
 
@@ -358,6 +358,18 @@ let nativeDisposer: (() => void) | null = null;
  * and discards itself on resolve if `latestSeq` has moved past it.
  */
 let latestSeq = 0;
+
+onMounted(() => {
+	// The `watch(..., { immediate: true, flush: 'post' })` below can fire its
+	// immediate run before the template ref is bound (observed in Vue 3.5
+	// inside Obsidian's view lifecycle): `nativeContainer.value` is still
+	// `null`, so `rerenderNative` returns early. For completed messages whose
+	// text never changes again, that early-return is terminal and the body
+	// stays empty. Streaming bubbles only render because subsequent text
+	// deltas re-fire the watcher after the container has bound. Trigger one
+	// explicit render at mount time so finalised messages render too.
+	void rerenderNative();
+});
 
 async function rerenderNative(): Promise<void> {
 	if (renderPort === undefined) return;


### PR DESCRIPTION
## Summary

- The native-renderer branch added by PR #377 used a single `watch(() => props.text, ..., { immediate: true, flush: 'post' })` to drive every render.
- Inside Obsidian's view lifecycle with Vue 3.5, the immediate run fires **before** the template ref is bound — `nativeContainer.value` is still `null`, so `rerenderNative()` returns early.
- For completed message bubbles whose `text` never changes again after mount, that early-return is terminal: the body stays empty even though the rendered scratch div is fully populated for streaming bubbles.
- Streaming bubbles hid this because their `text` keeps growing post-mount, so subsequent watcher firings end up rendering after the container has bound.
- Fix: add an explicit `onMounted(() => void rerenderNative())` so finalised messages get one post-mount render even when their text never changes.

## How it was caught

- User reported empty user and assistant message bodies in the Obsidian Agent sidepanel; streaming bubble showed text but final bubbles were empty.
- Instrumentation in `MarkdownBlock.vue` confirmed: the watch's immediate run reported "no el" before mount; the final-message instances mounted (`onMounted` fired, container bound) but no second watcher firing followed, since `text` is immutable post-finalisation.
- Streaming bubble (whose `text` grows) re-fired the watcher and rendered correctly — masking the bug.

## Test plan

- [x] `npm run typecheck` — clean (0 errors)
- [x] `npm run lint` — 0 errors
- [x] `npm run test` — 1863 / 1863 passing
- [x] `npm run build` — clean bundle
- [x] Manual: deploy to test vault, reload plugin in Obsidian, send a fresh prompt — user message body and assistant response body now render their markdown content as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)