### PR TITLE
feat(ay): P12 accessibility — accessibility.css + WCAG 2.2 AA sweep (final reboot phase)

### DIFF
--- a/specs/accessibility/design.md
+++ b/specs/accessibility/design.md
@@ -1,0 +1,287 @@
+---
+id: DESIGN-AY-001
+title: Accessibility — a11y stylesheet + WCAG 2.2 AA behaviour sweep (Parts A/B/C)
+stage: design
+feature: accessibility
+area: AY
+epic: claudian-reboot
+phase: P12
+status: complete
+owner: architect
+integration_branch: next
+reference: D:\Projects\claudian-main\src\style\accessibility.css
+satisfies:
+  - PRD-AY-001 (REQ-AY-001..017, NFR-AY-001..010)
+inputs:
+  - specs/accessibility/requirements.md (PRD-AY-001)
+  - specs/claudian-reboot/parity-charter.md §1, §3.9, §3.10
+  - D:\Projects\claudian-main\src\style\accessibility.css (the 1:1 reference — read directly, CLAR-AY-001 resolved)
+  - src/ui/styles/tokens.css (the --sp-* token layer + per-section reduced-motion overrides §4.6/§4.9/§4.10/§4.11)
+  - src/ui/styles/animations.css (the five named keyframes + CQ-AUX-14 spin guard)
+  - src/plugin/main.ts + src/ui/main.ts (the two CSS import sites)
+  - vite.config.ts scopeBuiltCss() (auto-scoping under .specorator-root :where(...))
+created: 2026-05-27
+updated: 2026-05-27
+---
+
+# Design — Accessibility (P12, final phase) — Parts A/B/C
+
+> **Scope of this document.** P12 is a CSS-layer + behaviour-polish phase. There is **no new flow,
+> no new screen, no new component, no new port, and no new ADR** (see Part C §C.6 for the explicit
+> verdict). This is a deliberately **light** design: it inventories the `accessibility.css` rule
+> groups, the per-surface behaviour fixes, and the additivity/coverage split that Stage 5 turns into
+> implementation-ready SPEC items.
+
+## CLAR resolution (design-stage confirmation)
+
+**CLAR-AY-001 (reference file).** The actual claudian reference was read directly this stage at
+`D:\Projects\claudian-main\src\style\accessibility.css`. It confirms the audit's characterisation
+exactly: the file is **minimal — focus-visible outline rings only**, 41 lines, three selector
+groups, no media queries. Verbatim shape:
+
+- **Group 1 (`outline + offset + border-radius`):** tool/thinking/subagent/model headers + header
+  buttons + `thinking-current` → `outline: 2px solid var(--interactive-accent); outline-offset: 2px;
+  border-radius: 4px;`
+- **Group 2 (`outline + offset only`):** action buttons, toggle switch, file/image chips + their
+  remove buttons, the image-modal close, approved-remove, save-env, snippet restore/edit/delete,
+  cancel/save, code-lang label → `outline: 2px solid var(--interactive-accent); outline-offset: 2px;`
+- **Group 3 (`negative offset`):** `history-item-content` → `outline-offset: -2px; border-radius: 4px;`
+
+There is **no** `prefers-reduced-motion`, **no** `forced-colors`, and **no** `.sr-only` in the
+claudian layer. So the "meet" leg is the focus-visible ring (REQ-AY-007); everything else
+(REQ-AY-003..006, 009, 010) is a genuine **beat**. Our layer must therefore reproduce the
+focus-visible ring across the equivalent `--sp-*` surfaces (claudian's `.claudian-*` selectors map
+to our `:focus-visible` ring on every interactive `--sp-*` control) **and add** the three rule
+groups claudian lacks.
+
+**CLAR-AY-002 (reduced-motion strategy).** Confirmed: `accessibility.css` **complements**, does not
+replace, the existing token overrides. `tokens.css` already zeroes `--sp-duration-*` and the
+per-section pulse/spin/dropdown duration tokens under `prefers-reduced-motion`; `animations.css`
+already halts `spin` (CQ-AUX-14). `accessibility.css` adds a single **global safety-net guard**
+scoped to `.specorator-root` that collapses any remaining animation/transition the per-section
+overrides did not reach, and re-asserts the explicit `spin` halt. The existing token overrides stay
+in place (no double-define conflict — the guard sets `none`/`0s`, which is idempotent with the token
+collapse).
+
+---
+
+# Part A — UX (the accessibility experience)
+
+P12 adds no flow. It guarantees the existing P0–P11 flows are operable and perceivable under five
+assistive conditions. Each condition below is the user-felt outcome, not a mechanism.
+
+| Condition | What the user experiences after P12 | Driving REQ |
+|---|---|---|
+| **Reduced motion** (`prefers-reduced-motion: reduce`) | The thinking pulse, streaming cursor blink, title/inline/instruction spinners, MCP + external-context glows, dropdown open transitions, toggle-knob slides, tab border-colour fades, and usage-meter fills all stop. Nothing loops or slides; state is conveyed by the static end-state instead. | REQ-AY-003, REQ-AY-004 |
+| **Forced colors / Windows HCM** (`forced-colors: active`) | Every surface stays legible when the OS replaces the palette: text/background resolve to system colours (`CanvasText`/`Canvas`), focus + selected states resolve to `Highlight`, and every control that normally signals state with a background-fill-only cue (toggles, pills, chips, tabs, selected dropdown options) gains a visible border so it is distinguishable. No surface goes invisible. | REQ-AY-005, REQ-AY-006 |
+| **Keyboard focus** (`:focus-visible`) | Every interactive control — buttons, toggles, tab badges, dropdown options, chips, the composer textarea, collapsible headers, modal controls — shows a clear focus ring when reached by keyboard, and **does not** show a stray ring on mouse click (`:focus-visible`, not `:focus`). Focus order is sensible; no surface is a keyboard trap. | REQ-AY-007, REQ-AY-008 |
+| **Screen reader** | Icon-only controls carry an accessible name (visible label, `aria-label`, or `.sr-only`); streaming assistant output and non-blocking notices are announced via a polite live region without stealing focus (errors assertive); collapsible regions announce open/closed via `aria-expanded`. | REQ-AY-008, REQ-AY-009, REQ-AY-010, REQ-AY-011 |
+| **Modal focus** | Opening any Specorator modal (ProviderConsent / DeleteConfirm / ForkTarget / InstructionConfirm / InlineEdit / ImagePreview / McpServer / McpTest) traps Tab/Shift+Tab within the modal; closing it (accept / reject / Esc / overlay) returns focus to the control that opened it. | REQ-AY-012, REQ-AY-013 |
+
+**Mouse users and the existing look are unchanged (REQ-AY-014).** Every rule above is gated behind a
+media query, a `:focus-visible` state, an `.sr-only` class, or an additive ARIA attribute. With no
+a11y condition active and no `.sr-only` applied, the default render is byte-for-byte the `next`
+baseline. This is the cardinal P12 constraint, restated as a UX promise: **the a11y layer only
+adds.**
+
+---
+
+# Part B — UI (the rule-group inventory + the behaviour-fix list)
+
+## B.1 — `src/ui/styles/accessibility.css` rule-group inventory
+
+The stylesheet is the third global layer. Authoring rules (lightningcss-safe, ASCII-only comments,
+no hex / no raw Obsidian var outside the documented `forced-colors` exception):
+
+- Selectors are authored **prefixed with `.specorator-root`** (or rely on the build's `scopeBuiltCss()`
+  auto-scoping — see Part C §C.2). `@keyframes` are never targeted (the build skips them); the guard
+  targets the **consumers** (elements running animations/transitions), not the keyframe definitions.
+- Comments use ASCII markers only (`/* section B.x - ... */`), no em-dash/non-ASCII, so the standalone
+  lightningcss minifier accepts them (NFR-AY-005, the established §4.x convention in tokens.css).
+
+| # | Rule group | Selector / at-rule shape | What it does | REQ |
+|---|---|---|---|---|
+| **B.1.1** | Reduced-motion global guard | `@media (prefers-reduced-motion: reduce) { .specorator-root *, .specorator-root *::before, .specorator-root *::after { animation-duration: 0.001ms !important; animation-iteration-count: 1 !important; transition-duration: 0.001ms !important; scroll-behavior: auto !important; } }` | Safety-net: collapses every animation/transition the per-section token overrides did not reach. Complements (does not replace) the tokens.css per-section collapse (CLAR-AY-002). | REQ-AY-003 |
+| **B.1.2** | Reduced-motion spin halt | `@media (prefers-reduced-motion: reduce) { .specorator-root [data-animation="spin"], .specorator-root .sp-spin { animation: none !important; } }` | Re-asserts the CQ-AUX-14 explicit `spin` halt — an indeterminate loop is not stopped by a near-zero duration alone. Consolidated here so the guard owns the rule (animations.css keeps its copy; idempotent). | REQ-AY-004 |
+| **B.1.3** | Forced-colors surface mapping | `@media (forced-colors: active) { .specorator-root { forced-color-adjust: auto; } ... }` | Maps surface text/background to system colours (`CanvasText` / `Canvas`), focus + selected states to `Highlight` / `HighlightText`, button affordances to `ButtonText` / `ButtonFace`. Keeps every surface legible when the palette is replaced. | REQ-AY-005 |
+| **B.1.4** | Forced-colors border guarantee | `@media (forced-colors: active) { .specorator-root .sp-toggle-switch, ...[data-state], .sp-tab, .sp-chip, ...[aria-selected="true"] { border: 1px solid currentColor; } }` (the background-cue-only controls enumerated by the audit) | Guarantees a visible (non-transparent) border on every control whose normal affordance is a background fill/wash, so toggles/pills/chips/tabs/selected options stay distinguishable. The non-colour cue NFR (NFR-CP-008). | REQ-AY-006 |
+| **B.1.5** | Focus-visible ring | `.specorator-root :where(button, [role="tab"], [role="option"], [role="switch"], a[href], textarea, input, select, [tabindex]):focus-visible { outline: 2px solid var(--sp-focus-ring); outline-offset: 2px; }` (+ the `box-shadow: var(--sp-shadow-focus-ring)` variant for clipped controls) | The keyboard focus ring across every interactive `--sp-*` control. Uses `:focus-visible` so mouse `:focus` shows no stray ring (the counter-metric). Meets + extends claudian's three focus-visible groups. | REQ-AY-007 |
+| **B.1.6** | `.sr-only` utility | `.specorator-root .sr-only { position: absolute; inline-size: 1px; block-size: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%); white-space: nowrap; border: 0; }` | Visually hides an element while keeping it in the accessibility tree (the standard clip technique — never `display:none`/`visibility:hidden`). For labelling icon-only controls + screen-reader-only context. | REQ-AY-009 |
+
+**Token decision (load-bearing).** `--sp-focus-ring` already exists in `tokens.css` (§4.1, line 42,
+defaulting to `var(--interactive-accent)`) and `--sp-shadow-focus-ring` already exists (§4.6, line
+140, `0 0 0 2px var(--sp-focus-ring)`). **No new token is minted.** B.1.5 consumes the existing two;
+the standard `outline`/`box-shadow` shorthands resolve them. The only colour keywords in the file are
+CSS **system-color keywords inside the `forced-colors` block** (B.1.3/B.1.4) — the single documented
+exception (NFR-AY-002). No hex, no raw Obsidian var anywhere in the file.
+
+## B.2 — Per-surface behaviour-fix sweep (additive edits to existing components)
+
+The behaviour sweep is an **audit-then-fill** pass: most WCAG affordances were built per-phase. The
+table records the gap each fix closes and whether it is automatable (Part C §C.4). A fix is recorded
+only where the audit found a genuine gap; surfaces already conformant are listed as **verify-only**
+(the fix is a test that asserts the existing attribute, not a code edit).
+
+| Surface / seam | File(s) | Existing state | Fix (additive) | REQ |
+|---|---|---|---|---|
+| Streaming busy region | `src/ui/chat/ChatSurface.vue` | Already `aria-live="polite"` + `role="status"` (lines 856-857) | **Verify-only** — assert the live region is present and announces. | REQ-AY-010 |
+| Non-blocking notices | `src/application/shared/FeedbackService.ts` + `NotificationPort` impls | Obsidian `Notice` is announced by the host; the standalone uses `NotificationPort` | Confirm error notices route assertive, info/success polite; add an `aria-live` region in the standalone notice host if absent. | REQ-AY-010 |
+| Tab strip | `src/ui/chat/TabBar.vue` | Already `role="tablist"`/`role="tab"`, `aria-selected`, roving tabindex, non-colour numeric cue, reduced-motion transition guard | **Verify-only** — assert ARIA + roving tabindex; the forced-colors border rides B.1.4 (`.sp-tab`). | REQ-AY-006, REQ-AY-008 |
+| Collapsible regions (tool call / thinking / subagent / write-edit) | the rich-render collapsible headers under `src/ui/chat/rich/**` | Header is a focusable control; toggles open/closed | Add/verify `aria-expanded` reflecting open state + an accessible name on the header control (fill the per-phase gap). | REQ-AY-011 |
+| Icon-only controls (tab close `×`, new-tab `+`, paperclip, chip remove, image remove) | `TabBar.vue`, `ChatComposer.vue`, attachment chips under `src/ui/chat/**` | Several already carry `aria-label` (TabBar close/new do); decorative glyphs `aria-hidden` | Audit every icon-only control; add `aria-label` or an `.sr-only` label where missing; keep decorative glyphs `aria-hidden="true"`. | REQ-AY-008, REQ-AY-009 |
+| Toolbar widgets + toggle switch | `src/ui/chat/toolbar/**` (the strip + `SpToggleSwitch` + usage meter) | Keyboard-operable controls; the toggle is a switch affordance | Verify each widget exposes `role`/`aria-label`/`aria-pressed`/`aria-checked` as appropriate + is keyboard-operable; the toggle/usage-arc forced-colors border rides B.1.4. | REQ-AY-006, REQ-AY-008 |
+| Settings shell | `src/plugin/settings.ts` + the settings module surfaces | Obsidian `Setting` rows are natively labelled + keyboard-operable | **Verify-only** for the native rows; audit any custom control for a label + focus ring. | REQ-AY-008 |
+| Modals (8 seams) | `src/plugin/modals/**` (InlineEditModal, ImagePreviewModal, McpServerModal, McpTestModal, …) + the P5/P7/P9 confirm/consent/fork modals | All extend Obsidian `Modal`, which **natively traps focus + restores `document.activeElement` on close** | **Verify-only** — assert each launcher opens a `Modal` subclass and does not break the native trap/restore (do not hand-roll a trap). | REQ-AY-012, REQ-AY-013 |
+| Dropdown options / mention/slash palettes | `src/ui/chat/composer/**`, `src/ui/chat/components/**` dropdown panels | Keyboard-navigable option lists | Verify `role="option"`/`aria-selected` + the focus-visible ring (B.1.5) on options; selected-option forced-colors border rides B.1.4. | REQ-AY-006, REQ-AY-007 |
+
+> **Modal focus is the one place a "fix" could have been a new mechanism.** It is not: Obsidian's
+> `Modal` base class already saves the active element on `open()` and restores it on `close()`, and
+> traps Tab within `.modal`. Every Specorator modal extends `Modal` (confirmed: `InlineEditModal`
+> extends `Modal`, `src/plugin/modals/InlineEditModal.ts:46`). REQ-AY-012/013 are therefore satisfied
+> by **using the platform**, and the SPEC verifies that property rather than re-implementing it. This
+> is why no new focus-trap utility/port is introduced.
+
+---
+
+# Part C — Architecture
+
+## C.1 — System overview
+
+```mermaid
+flowchart LR
+  subgraph CSSlayers["Global CSS layers (.specorator-root scoped)"]
+    tok["tokens.css<br/>(--sp-* tokens + per-section<br/>reduced-motion overrides)"]
+    anim["animations.css<br/>(5 named keyframes + CQ-AUX-14 spin guard)"]
+    a11y["accessibility.css<br/>(NEW — reduced-motion guard,<br/>forced-colors, focus-visible, .sr-only)"]
+  end
+
+  plug["src/plugin/main.ts<br/>(plugin entry → styles.css)"]
+  std["src/ui/main.ts<br/>(standalone entry → bundle)"]
+
+  plug -->|import order: tokens, animations, accessibility| CSSlayers
+  std  -->|import order: tokens, animations, accessibility| CSSlayers
+
+  scope["vite.config.ts scopeBuiltCss()<br/>(auto-scope selectors under .specorator-root :where(...),<br/>skip @keyframes)"]
+  CSSlayers --> scope --> out1["plugin styles.css"]
+  CSSlayers --> scope --> out2["standalone bundle"]
+
+  subgraph Behaviour["Additive behaviour edits (existing components)"]
+    sweep["ARIA roles/labels, aria-live, aria-expanded,<br/>.sr-only labels — fill per-phase gaps"]
+    modals["Obsidian Modal subclasses<br/>(native focus trap + restore — verify only)"]
+  end
+```
+
+## C.2 — Components and responsibilities
+
+| Component | Responsibility | New? |
+|---|---|---|
+| `src/ui/styles/accessibility.css` | The 6 global a11y rule groups (B.1.1–B.1.6) scoped to `.specorator-root`. | **New file** |
+| `src/plugin/main.ts` (import head) | Register `accessibility.css` as the 3rd CSS import (after tokens, animations). | Additive edit (1 line) |
+| `src/ui/main.ts` (import head) | Register `accessibility.css` as the 3rd CSS import (after tokens, animations). | Additive edit (1 line) |
+| `vite.config.ts` `scopeBuiltCss()` | Auto-scopes the new file's selectors under `.specorator-root :where(...)`; skips `@keyframes`. **Unchanged** — the new file is authored to be scope-safe (already prefixed, no keyframe targets). | Unchanged |
+| The swept components (B.2) | Carry the additive ARIA/label/live-region attributes the audit found missing. | Additive edits |
+| The 8 modal seams | Continue to extend Obsidian `Modal` (native trap/restore). | Unchanged (verify-only) |
+
+**Build interaction note (load-bearing for authoring).** `scopeBuiltCss()` walks all rules and
+rewrites selectors via `scopeSelector()`: a selector already starting with `.specorator-root` is left
+as-is; otherwise it becomes `.specorator-root :where(<sel>)`. Rules **inside** `@media
+(prefers-reduced-motion …)` / `@media (forced-colors …)` are still walked and scoped (only
+`@keyframes` children are skipped). Authoring each selector with an explicit `.specorator-root`
+prefix (as in B.1) keeps the output deterministic and avoids the `:where(*)` universal-selector
+double-wrap. `!important` is required on the reduced-motion guard so the global safety-net wins over
+any per-component `transition`/`animation` shorthand the per-section tokens did not collapse.
+
+## C.3 — Data model / data flow
+
+No data model. No runtime data flow. P12 is presentation + accessibility-tree only; it touches no
+domain entity, no use case, no port, and no settings field. There is no migration impact
+(NFR-AY-008: `manifest.json` byte-identical).
+
+## C.4 — Coverage split (automatable vs human sign-off)
+
+The phase has two test legs. The split is deliberate and recorded so the planner can chunk it.
+
+**Automatable (TEST-AY-001..016 — ship under the verify gate):**
+
+- **CSS-rule presence** — read `accessibility.css` and assert each rule group (B.1.1–B.1.6) is
+  present with the expected selectors / at-rules / `--sp-focus-ring` consumption (no hex, no raw
+  Obsidian var outside the `forced-colors` block).
+- **Registration** — assert both `src/plugin/main.ts` and `src/ui/main.ts` import `accessibility.css`
+  after tokens + animations.
+- **Behaviour (PageObject mount)** — mount the swept components and assert: the live region exists,
+  `.sr-only` is present on icon-only labels, `aria-expanded` toggles on collapsibles, ARIA roles/labels
+  are non-empty, the modal launchers open a `Modal` subclass (the trap/restore is a PageObject
+  Tab-cycle + focus-restore assertion where the JSDOM harness allows, else a structural assertion).
+- **Additivity diff** — assert no swept component's default (no-media-query) render or locale output
+  changed (snapshot/structural diff vs baseline).
+- **Discipline scan** — no added `innerHTML`/`outerHTML`/`insertAdjacentHTML`/`v-html`; the
+  token+lightningcss-safe-comment scan over `accessibility.css`.
+
+**Human sign-off (TEST-AY-017 — the single final epic gate, NOT agent-claimed):**
+
+- The **visual** forced-colors + reduced-motion rendering, and the full cross-surface parity
+  screenshot set (all P1–P11 surfaces, light + dark, at 320/520/720 px) per REQ-AY-016. The
+  agent **presents** this gate and the `next`→`develop` PR (opened, not merged); the human owns
+  acceptance (constitution Art. VII).
+
+## C.5 — Key decisions
+
+| ID | Decision | Rationale | Alternative rejected |
+|---|---|---|---|
+| D-AY-1 | Ship a **single global reduced-motion safety-net guard** in `accessibility.css` that complements the existing per-section token overrides (does not replace them). | CLAR-AY-002: the token overrides cover the known motion sources; the global guard catches anything they missed, with no double-define conflict (both collapse to none/0s). | Replacing the token overrides — would re-introduce the very gaps P12 exists to close, and churn 4 token sections for no behaviour gain. |
+| D-AY-2 | **Reuse the existing `--sp-focus-ring` / `--sp-shadow-focus-ring` tokens**; mint no new token. | Both already exist (tokens.css:42, :140). The PRD NG2 forbids new tokens; the focus ring is a token consumer, not a palette change. | Minting `--sp-focus-ring-width`/`-offset` — unjustified token surface for two literals that never vary. |
+| D-AY-3 | **Use Obsidian `Modal`'s native focus trap + restore**; verify, do not re-implement. | Every Specorator modal already extends `Modal`, which manages focus save/restore + Tab trap. Re-implementing would duplicate the platform and risk a divergent trap. | A custom focus-trap composable/port — new surface, no benefit, contradicts "additive only". |
+| D-AY-4 | **Author selectors `.specorator-root`-prefixed** so `scopeBuiltCss()` is honoured, not fought; `!important` only on the reduced-motion guard. | Keeps the built output deterministic (no `:where(*)` double-wrap) and guarantees the safety-net beats stray per-component shorthands. | Relying purely on auto-scoping — yields `:where(*)` universal wraps and weaker specificity for the guard. |
+| D-AY-5 | **Document the `forced-colors` system-color keywords as the single colour exception**; everything else consumes `--sp-*`. | NFR-AY-002: system colours are mandatory inside a `forced-colors` block and cannot be expressed as tokens; confining them to that block keeps the token-discipline scan green. | Allowing raw colour elsewhere — breaks the token-discipline guard, the cardinal CSS constraint. |
+
+## C.6 — ADR / port verdict
+
+**No new port. No new ADR.** P12 is a CSS layer (a new stylesheet + two one-line import edits) plus
+additive ARIA/label/live-region attributes on existing components, plus a verify-only confirmation
+that modals use the platform's native focus management. None of these is an irreversible,
+architecture-load-bearing choice that constrains future implementation in a way the existing ADRs do
+not already cover:
+
+- The CSS-layer pattern is already established by `tokens.css` + `animations.css` (ADR-AUX-002) and
+  the `scopeBuiltCss()` build seam — `accessibility.css` is the third instance of an existing pattern.
+- The modal-seam pattern (Obsidian `Modal` subclasses behind injected launchers) is already covered by
+  the P3/P5/P8/P9 modal-seam ADRs; P12 adds no seam, only verifies the native trap.
+- The token-discipline + forced-colors exception is already a documented rule (NFR-AY-002, the §4.x
+  token-layer convention).
+
+D-AY-1..D-AY-5 are design decisions recorded in §C.5; none rises to ADR weight. If implementation
+surfaces a load-bearing decision (e.g. a focus-trap mechanism turns out to be genuinely needed
+because a modal does **not** extend `Modal`), file **ADR-AY-001** the P5–P11 way (next free `NNNN`
+under `docs/adr/`, copy `templates/adr-template.md`, index in `docs/adr/README.md`) and link it here.
+**As designed, that does not arise.**
+
+## C.7 — Rejected alternatives
+
+- **A reduced-motion utility class toggled in JS** — rejected: `prefers-reduced-motion` is a
+  declarative media query the platform already exposes; a JS toggle adds state + a port for no gain.
+- **A separate forced-colors theme** — rejected (NG1): forced-colors is a system-driven fallback, not
+  a new theme; we map to system colours, we do not restyle.
+- **Re-instrumenting every component's ARIA from scratch** — rejected: most affordances exist
+  per-phase; P12 audits and fills gaps (the sweep), it does not rebuild (NG4, additivity).
+
+## C.8 — Requirements coverage (Part C / architecture slice)
+
+| REQ | Covered by (design) |
+|---|---|
+| REQ-AY-001 | B.1 inventory; C.2 new file |
+| REQ-AY-002 | C.2 import edits; C.1 overview |
+| REQ-AY-003 | B.1.1; D-AY-1 |
+| REQ-AY-004 | B.1.2; D-AY-1 |
+| REQ-AY-005 | B.1.3; D-AY-5 |
+| REQ-AY-006 | B.1.4; B.2 (tab/toggle/chip rows) |
+| REQ-AY-007 | B.1.5; D-AY-2 |
+| REQ-AY-008 | B.2 (icon-only, toolbar, settings, tabs) |
+| REQ-AY-009 | B.1.6; B.2 (icon-only labels) |
+| REQ-AY-010 | B.2 (busy region verify-only, notice host) |
+| REQ-AY-011 | B.2 (collapsible `aria-expanded`) |
+| REQ-AY-012 | B.2 + D-AY-3 (native modal trap) |
+| REQ-AY-013 | B.2 + D-AY-3 (native modal restore) |
+| REQ-AY-014 | A (additivity promise); C.4 additivity diff |
+| REQ-AY-015 | B.1 authoring rules; C.4 discipline scan; D-AY-5 |
+| REQ-AY-016 | C.4 human leg (screenshot set) |
+| REQ-AY-017 | C.4 human leg (sign-off; agent presents, does not claim) |

--- a/specs/accessibility/implementation-log.md
+++ b/specs/accessibility/implementation-log.md
@@ -122,3 +122,173 @@ registration + its RED-before-green file-read/registration tests.
 - **Default render:** unchanged outside `forced-colors` (the rule is inert unless the system palette
   is replaced).
 - **Deviation:** none.
+
+## Chunk 2 — Behaviour-fix sweep (additive ARIA / label / live-region fills) (T-AY-006..013)
+
+### T-AY-006 — forced-colors RG-4 controls mount leg + real-selector correction (🧪 qa)
+
+- **Spec/req:** SPEC-AY-006, SPEC-AY-001 (RG-4); TEST-AY-006; REQ-AY-006, NFR-AY-009, EC-AY-003.
+- **Files:**
+  - `tests/ui/a11y/forcedColorsControls.test.ts` + `forcedColorsControls.po.ts` (new) — mounts the
+    RG-4-listed background-cue-only controls (tab badge `.sp-tab` + `[data-state]`, service-tier
+    `role="switch"`, file chip, image thumb, selected permission `[role="option"][aria-selected]`)
+    and asserts each exists in the rendered DOM, and that RG-4 enumerates a selector matching each.
+  - `src/ui/styles/accessibility.css` (RG-4 block) — **corrected** the RG-4 enumeration: the T-AY-005
+    placeholders `.sp-toggle-switch` / `.sp-chip` matched NO real component. Replaced with the real
+    swept-component selectors: `[role="switch"]` (ServiceTier/Mode/Permission toggles),
+    `.sp-file-chips__chip` + `.sp-image-thumb` (the chips), `[data-state]` (state pills), `.sp-tab`
+    (tab badges), `[role="option"][aria-selected="true"]` (selected option).
+  - `tests/ui/styles/accessibility.test.ts` (TEST-AY-006 file-read leg) — updated to the real selectors.
+- **Commit:** `46869990`
+- **Outcome:** done. 5 mount legs verify-only (controls already present); the RG-4 enumeration leg was
+  RED (dead selectors) -> green after the correction.
+- **Typecheck:** 0. **Lint:** whole-project 0 errors (22 pre-existing warnings).
+- **Deviation:** the T-AY-005 RG-4 selectors `.sp-toggle-switch` / `.sp-chip` were dead (no real
+  control). The mount leg surfaced this (its stated purpose: "the RG-4 selectors target real controls,
+  not dead selectors"). Corrected RG-4 to the real swept-component selectors — additive,
+  forced-colors-only, no default-render change. SPEC-AY-006 says T-AY-005's concrete selectors "come
+  from the Chunk-2 component sweep", so this is the designed convergence, not a spec divergence.
+
+### T-AY-007 — focus-visible reachability + keyboard operability + accessible names (🧪 qa)
+
+- **Spec/req:** SPEC-AY-007/008; TEST-AY-007/008; REQ-AY-007/008; NFR-AY-001; EC-AY-005/006.
+- **Files:** `tests/ui/a11y/keyboardAndLabels.test.ts` + `keyboardAndLabels.po.ts` (new) — mounts the
+  audited toolbar/composer/chat controls (tab badge/close/new, composer textarea/attach/send, file chip
+  link/remove, image thumb preview/remove, service-tier + permission toggles), asserts each matches the
+  RG-5 focus-visible target selector + exposes a non-empty accessible name.
+- **Commit:** `8eb7c8da`
+- **Outcome:** done, **verify-only** — every audited control already carries an `aria-label` / role /
+  tabindex; no gap. Typecheck 0; lint 0 errors.
+- **Deviation:** none. The no-stray-mouse-ring counter-metric (EC-AY-006) is the RG-5 `:focus-visible`
+  discipline asserted structurally in T-AY-003 (no bare `:focus`); JSDOM cannot compute `:focus-visible`.
+
+### T-AY-008 — RED live-region presence + severity (busy + notice host) (🧪 qa)
+
+- **Spec/req:** SPEC-AY-004; TEST-AY-010; REQ-AY-010; NFR-AY-001; EC-AY-011/012.
+- **Files:** `tests/ui/a11y/liveRegions.test.ts` + `NoticeLiveRegion.po.ts` (new); `tests/ui/chat/
+  ChatSurface.po.ts` (added `busyRole()` accessor). Asserts the ChatSurface busy region has
+  `aria-live="polite"` + `role="status"` (verify-only, green) and a `NoticeLiveRegion` announces
+  error=assertive(role=alert) / info=polite(role=status) mirroring the text declaratively without focus
+  theft (RED until T-AY-011).
+- **Commit:** `2b59482c`
+- **Outcome:** done (RED on the notice-host leg — `NoticeLiveRegion.vue` absent; busy-region leg green).
+- **Deviation:** none.
+
+### T-AY-009 — collapsible aria-expanded flips + icon-only sr-only/label (🧪 qa)
+
+- **Spec/req:** SPEC-AY-005/007; TEST-AY-011/009; REQ-AY-009/011; EC-AY-007.
+- **Files:** `tests/ui/a11y/collapsibleAndSrOnly.test.ts` + `collapsibleAndSrOnly.po.ts` (new) — asserts
+  the `SpCollapsible` header (reused by tool-call/thinking/subagent/write-edit) exposes `aria-expanded`
+  flipping on Enter/Space/click + an accessible name (direct mount + via ToolCallBlock), and icon-only
+  controls (file-chip-remove, image-thumb-remove) carry an `aria-label` with an `aria-hidden` glyph.
+- **Commit:** `7603abf2`
+- **Outcome:** done, **verify-only** — every collapsible uses `SpCollapsible` (already conforms) and
+  every icon-only control already labels itself. Typecheck 0; lint 0 errors.
+- **Deviation:** none.
+
+### T-AY-010 — icon-only accessible-name fill (🔨 dev) — VERIFY-ONLY (no code change)
+
+- **Spec/req:** SPEC-AY-007; REQ-AY-008/009; NFR-AY-003/004.
+- **Outcome:** **verify-only / no fill needed.** The T-AY-007 + T-AY-009 audit found NO unlabelled
+  icon-only control: the composer paperclip/send, file-chip remove, image-thumb remove, and the
+  TabBar close/new already carry an `aria-label` + an `aria-hidden="true"` decorative glyph (the
+  per-phase a11y sweep was thorough). The RED legs (TEST-AY-008 / TEST-AY-009 mount) are green against
+  the current code. No source edit. Closes against T-AY-007 (`8eb7c8da`) + T-AY-009 (`7603abf2`).
+- **Deviation:** the task anticipated a fill; the audit found none required (the design predicted most
+  items verify-only). Recorded as verify-only per DESIGN-AY-001 B.2.
+
+### T-AY-011 — standalone notice-host live region (🔨 dev)
+
+- **Spec/req:** SPEC-AY-004; REQ-AY-010; NFR-AY-003; EC-AY-011/012.
+- **Files:**
+  - `src/ui/components/NoticeLiveRegion.vue` (new) — a `.sr-only` ARIA live region (RG-6 clip, zero
+    visible footprint) that subscribes to the existing `sp:notice` window `CustomEvent`
+    `LocalStorageBridge` already dispatches (no new port/channel). error -> `aria-live="assertive"` +
+    `role="alert"`; info/success/warning -> `polite` + `role="status"`. Text bound declaratively as
+    `{{ }}` (no `innerHTML`/`v-html`); passive (never `.focus()`), so no focus theft; listener cleaned
+    up `onBeforeUnmount`.
+  - `src/ui/main.ts` (render fn) — mounts `NoticeLiveRegion` alongside `ChatSurface` inside
+    `ErrorBoundary` (additive — `.sr-only`, default render byte-identical).
+- **Commit:** `5fcc472e`
+- **Outcome:** done. T-AY-008 (6 legs) GREEN. The busy region was verify-only (already conforming).
+- **Typecheck:** 0. **Lint:** whole-project 0 errors. **Regression:** `tests/ui/main*.test.ts` (9) green.
+- **Deviation:** none. The standalone genuinely had no notice host with a live region (MockBridge only
+  logs; LocalStorageBridge dispatched `sp:notice` with no Vue listener) — the genuine SPEC-AY-004 gap.
+
+### T-AY-012 — collapsible aria-expanded fill (🔨 dev) — VERIFY-ONLY (no code change)
+
+- **Spec/req:** SPEC-AY-005; REQ-AY-011; NFR-AY-003/004.
+- **Outcome:** **verify-only / no fill needed.** Every rich-render collapsible (tool-call, thinking,
+  subagent, write-edit) wraps the single `SpCollapsible` primitive, which already binds `aria-expanded`
+  to its open state (flips on Enter/Space/click) + a dynamic `aria-label`. The T-AY-009 RED leg
+  (TEST-AY-011) is green against the current code. No source edit. Closes against T-AY-009 (`7603abf2`).
+- **Deviation:** the task anticipated a fill; the audit found `SpCollapsible` already conformant
+  (DESIGN-AY-001 B.2 / SpCollapsible.vue). Recorded as verify-only.
+
+### T-AY-013 — modal focus trap + restore verify (8 modal seams) (🧪 qa)
+
+- **Spec/req:** SPEC-AY-009; TEST-AY-012/013; REQ-AY-012/013; EC-AY-008/009.
+- **Files:** `tests/ui/a11y/modalFocusTrap.test.ts` (new) — structural verify that all 8 modal seams
+  (ProviderConsent, DeleteConfirm, ForkTarget, InstructionConfirm, InlineEdit, ImagePreview,
+  McpServerHost, McpTestHost) extend Obsidian `Modal` (native trap/restore, D-AY-3). `tests/__fakes__/
+  obsidian.stub.ts` — added a minimal `Modal` export (additive) so the `extends` chain forms.
+- **Commit:** `39121ad5`
+- **Outcome:** done, **verify-only** — all 8 extend `Modal`; no hand-rolled trap. Typecheck 0; lint 0.
+- **Deviation:** none. Defect-escalation note recorded in the test: a modal NOT extending `Modal` would
+  be ADR-AY-001 + a new task; that does not arise.
+
+## Chunk 3 — Tests + additivity gate (T-AY-014..016)
+
+### T-AY-014 — additivity invariant (🧪 qa)
+
+- **Spec/req:** SPEC-AY-010; TEST-AY-014; REQ-AY-014; NFR-AY-004; EC-AY-010.
+- **Files:** `tests/ui/a11y/additivity.test.ts` (new) — `git diff next` shows locale + `manifest.json`
+  byte-identical; the entire `src/` diff vs `next` touches ONLY the P12 allow-list (`accessibility.css`,
+  the two CSS-import entry edits, the new `.sr-only` `NoticeLiveRegion`) -> NO swept component template
+  changed; representative swept components (TabBar/FileChips/ImageThumb/ChatComposer) keep their visible
+  default render.
+- **Commit:** `7ead8bb6`
+- **Outcome:** done. 6 legs green. The cardinal counter-metric = 0 default-state regressions.
+- **Deviation:** none.
+
+### T-AY-015 — discipline scan (no added raw-HTML sink) (🧪 qa)
+
+- **Spec/req:** SPEC-AY-011; TEST-AY-015 (diff leg); REQ-AY-015; NFR-AY-003.
+- **Files:** `tests/ui/a11y/disciplineScan.test.ts` (new) — scans the added (`+`) lines of the P12
+  `src/` diff vs `next`; asserts no `innerHTML`/`outerHTML` assignment, no `insertAdjacentHTML`, no
+  `v-html` directive, no new eslint-disable of the raw-HTML/v-html guards.
+- **Commit:** `07c1fb7f`
+- **Outcome:** done. 3 legs green (the fills are declarative).
+- **Deviation:** the `v-html` scan matches the directive form (`v-html=`), not a prose mention in a
+  comment, so the NoticeLiveRegion comment that names the banned sinks does not false-positive.
+
+### T-AY-016 — parity-screenshots.md completeness + complete the matrix (🧪 qa + 📐 dev)
+
+- **Spec/req:** REQ-AY-016; TEST-AY-016.
+- **Files:** `tests/ui/a11y/parityScreenshots.test.ts` (new) — asserts the matrix lists every charter §3
+  surface (§3.1..§3.9) at 320/520/720 px in light + dark, each with a claudian baseline + Specorator
+  leg + the two a11y-condition columns. `specs/accessibility/parity-screenshots.md` — marked
+  `status: complete` (structure fully populated, baseline column filled); the Specorator +
+  a11y-condition cells left for the human reviewer (T-AY-017).
+- **Commit:** `3f103ef2`
+- **Outcome:** done. 6 completeness legs green (artifact-completeness only; the visual judgment is the
+  human TEST-AY-017 leg).
+- **Deviation:** none.
+
+## Stage-7 close-out (Chunk 2 + 3, T-AY-006..016)
+
+- **Verification:** whole-project `npm run lint` -> 0 errors (22 pre-existing warnings, none new);
+  `npx vue-tsc -p tsconfig.lint.json --noEmit` -> 0; the a11y + styles suite (`tests/ui/a11y/` +
+  `tests/ui/styles/`) -> 80 tests green; a P5-P11 regression on the touched/related surfaces
+  (TabBar / ChatComposer / FileChips / ImageThumb / SpCollapsible / ToolCallBlock / ChatSurface /
+  ServiceTierToggle / PermissionToggle / ui/main / modalSeam) -> 102 tests green (additivity confirmed).
+- **Additivity:** the `src/` diff vs `next` is exactly `accessibility.css` (new layer) + `plugin/main.ts`
+  + `ui/main.ts` (the 2 import edits + the NoticeLiveRegion render wiring) + `NoticeLiveRegion.vue` (new
+  `.sr-only` host). NO swept component template, NO locale, NO `manifest.json` changed.
+- **VERIFY-ONLY vs FILLS:** verify-only = T-AY-006 mount existence (5 legs), T-AY-007 (focus/labels),
+  T-AY-009 (collapsible/icon-only), T-AY-010, T-AY-012, T-AY-013 (8 modal seams), the busy region.
+  Genuine FILLS = (a) T-AY-011 `NoticeLiveRegion.vue` (the standalone notice live region — the real
+  SPEC-AY-004 gap); (b) the RG-4 selector correction folded into T-AY-006 (`.sp-toggle-switch`/`.sp-chip`
+  -> the real `[role="switch"]`/`.sp-file-chips__chip`/`.sp-image-thumb` selectors).
+- **Remaining (parent-owned):** T-AY-017 (HUMAN final parity sign-off, 👤) + T-AY-018 (the gate: full
+  verify + lightningcss `build:web` + draft `next` PR). NOT executed here per scope.

--- a/specs/accessibility/implementation-log.md
+++ b/specs/accessibility/implementation-log.md
@@ -93,7 +93,7 @@ registration + its RED-before-green file-read/registration tests.
   - `src/ui/main.ts` (line 15) — `import './styles/accessibility.css';` as the 3rd CSS import after
     `animations.css`. `vite.config.ts` unchanged (the file is authored scope-safe).
   - `tests/ui/styles/accessibility.test.ts` (helper corrections — see the T-AY-003/004 deviation).
-- **Commit:** _(recorded below at commit time)_
+- **Commit:** `191443997dcad399778063d4809ca9b442071a55`
 - **Outcome:** done. T-AY-003/004 (14 tests) GREEN.
 - **Typecheck:** `npx vue-tsc -p tsconfig.lint.json --noEmit` -> **0**.
 - **Lint:** whole-project `npm run lint` -> **0 errors** (22 pre-existing warnings, none new).
@@ -102,3 +102,23 @@ registration + its RED-before-green file-read/registration tests.
   standalone bundle. `styles.css` not hand-edited.
 - **Deviation:** none on the impl. RG-4 carries a single placeholder selector (`.sp-toggle-switch`);
   T-AY-005 completes the concrete enumeration per SPEC-AY-006.
+
+### T-AY-005 — RG-4 forced-colors-border selector enumeration (🔨 dev)
+
+- **Spec/req:** SPEC-AY-006, SPEC-AY-001 (RG-4); REQ-AY-006; NFR-AY-009; EC-AY-003.
+- **Files:**
+  - `src/ui/styles/accessibility.css` (RG-4 block) — enumerates the concrete background-cue-only
+    control selectors per SPEC-AY-006: `.sp-toggle-switch` (toggle switch), `[data-state]` (state
+    pills), `.sp-chip` (file/image chips), `.sp-tab` (tab badges),
+    `[role="option"][aria-selected="true"]` (selected dropdown option), each given
+    `border: 1px solid currentColor` inside the existing `@media (forced-colors: active)` block.
+  - `tests/ui/styles/accessibility.test.ts` — adds the TEST-AY-006 file-read leg asserting RG-4
+    lists each enumerated control with a `currentColor` border (the coverage-table `006->T-AY-003(file)`
+    leg; the mount leg is T-AY-006, Chunk 2).
+- **Commit:** _(recorded below at commit time)_
+- **Outcome:** done. The TEST-AY-006 file-read leg passes (15 accessibility-css tests GREEN).
+- **Typecheck:** `npx vue-tsc -p tsconfig.lint.json --noEmit` -> **0**.
+- **Lint:** whole-project `npm run lint` -> **0 errors** (22 pre-existing warnings, none new).
+- **Default render:** unchanged outside `forced-colors` (the rule is inert unless the system palette
+  is replaced).
+- **Deviation:** none.

--- a/specs/accessibility/implementation-log.md
+++ b/specs/accessibility/implementation-log.md
@@ -1,0 +1,56 @@
+---
+id: IMPL-LOG-AY-001
+title: Accessibility (P12, FINAL phase) — Implementation Log
+stage: implementation
+feature: accessibility
+area: AY
+epic: claudian-reboot
+phase: P12
+status: in-progress
+owner: dev
+integration_branch: next
+created: 2026-05-27
+updated: 2026-05-27
+---
+
+# Implementation Log — Accessibility (P12, the FINAL phase)
+
+Append-only. One entry per task: files changed (line ranges), commit SHA, spec reference, outcome,
+deviations. P12 is additive + presentation-only: one new CSS file
+(`src/ui/styles/accessibility.css`, RG-1..RG-6), two one-line import edits, and targeted additive
+ARIA / `.sr-only` / live-region fills. Chunk 1 (T-AY-001..005) is the `accessibility.css` layer +
+registration + its RED-before-green file-read/registration tests.
+
+## Chunk 1 — `accessibility.css` + pipeline registration (T-AY-001..005)
+
+### T-AY-001 — Baseline + guard-verify + scaffold `parity-screenshots.md` (📐 dev)
+
+- **Spec/req:** SPEC-AY-001 (RG inventory), SPEC-AY-002/003 (import sites), SPEC-AY-006 (RG-4
+  selector enumeration), REQ-AY-016 (parity-screenshots.md scaffold), NFR-AY-002 (token reference),
+  NFR-AY-004/008 (additivity baseline).
+- **Files:**
+  - `specs/accessibility/test-plan.md` (new) — token reference (`--sp-focus-ring` tokens.css:42 /
+    `--sp-shadow-focus-ring` tokens.css:140), import-site reference (main.ts head + ui/main.ts head,
+    the 3rd-import insertion points), the five-keyframe reduced-motion source inventory, the RG-4
+    background-cue-only control enumeration (`.sp-toggle-switch` / `[data-state]` / `.sp-chip` /
+    `.sp-tab` / `[role="option"][aria-selected="true"]`), the claudian minimal-focus-visible-only
+    reference (meet = RG-5; beat = RG-1..4 + RG-6), and the guard verdict.
+  - `specs/accessibility/parity-screenshots.md` (new) — the all-surfaces × {320/520/720} ×
+    {light/dark} matrix with a claudian-baseline column + the two a11y-condition columns
+    (reduced-motion / forced-colors) + the accumulated P5-P11 manual-leg note (the human TEST-AY-017
+    sign-off artifact; TEST-AY-016 completeness structure).
+  - `specs/accessibility/implementation-log.md` (new, this file).
+- **Commit:** _(recorded below at commit time)_
+- **Outcome:** done.
+- **Token reference verified:** `--sp-focus-ring` present at `tokens.css:42` (`var(--interactive-accent)`);
+  `--sp-shadow-focus-ring` present at `tokens.css:140` (`0 0 0 2px var(--sp-focus-ring)`). No new token
+  (D-AY-2 / NG2).
+- **Import-site reference verified:** `src/plugin/main.ts` L1 `@/ui/styles/tokens.css` + L2
+  `@/ui/styles/animations.css` (insertion after L2); `src/ui/main.ts` L13 `./styles/tokens.css` + L14
+  `./styles/animations.css` (insertion after L14).
+- **Guard verdict (lint leg):** `npx eslint src/plugin/main.ts src/ui/main.ts` → **0** violations (no
+  "deleted in the P0 reboot" `no-restricted-imports` message). The new `accessibility.css` file path,
+  the two side-effect CSS import lines, and the additive ARIA edits trip no `DELETED_SUBSYSTEM_BAN` /
+  `DELETED_INJECTION_KEYS` rule. **NO guard-relax task in P12; NO new InjectionKey/port/composable/
+  component/ADR; `manifest.json` + en/de + all ten locales untouched** (NFR-AY-004/008).
+- **Deviation:** none. No file under `src/` changed.

--- a/specs/accessibility/implementation-log.md
+++ b/specs/accessibility/implementation-log.md
@@ -40,7 +40,7 @@ registration + its RED-before-green file-read/registration tests.
     (reduced-motion / forced-colors) + the accumulated P5-P11 manual-leg note (the human TEST-AY-017
     sign-off artifact; TEST-AY-016 completeness structure).
   - `specs/accessibility/implementation-log.md` (new, this file).
-- **Commit:** _(recorded below at commit time)_
+- **Commit:** `6b9bf9204501bd92fbc83f0c7730976b3da103ec`
 - **Outcome:** done.
 - **Token reference verified:** `--sp-focus-ring` present at `tokens.css:42` (`var(--interactive-accent)`);
   `--sp-shadow-focus-ring` present at `tokens.css:140` (`0 0 0 2px var(--sp-focus-ring)`). No new token
@@ -54,3 +54,51 @@ registration + its RED-before-green file-read/registration tests.
   `DELETED_INJECTION_KEYS` rule. **NO guard-relax task in P12; NO new InjectionKey/port/composable/
   component/ADR; `manifest.json` + en/de + all ten locales untouched** (NFR-AY-004/008).
 - **Deviation:** none. No file under `src/` changed.
+
+### T-AY-003/004 — RED rule-group + registration tests (🧪 qa)
+
+- **Spec/req:** TEST-AY-001/002/003/004/005/007(file)/009(file)/015(css); SPEC-AY-001/002/003/011;
+  REQ-AY-001/002/003/004/005/007/009/015; NFR-AY-002/006; EC-AY-001.
+- **Files:**
+  - `tests/ui/styles/accessibility.test.ts` (new) — reads `accessibility.css` as text; asserts
+    RG-1..RG-6 present + ordered, every selector `.specorator-root`-scoped, RG-1 reduced-motion
+    collapse, RG-2 `animation: none`, RG-3 forced-colors + system colours, RG-5 `:focus-visible` +
+    `var(--sp-focus-ring)` + no bare `:focus`, RG-6 `.sr-only` clip technique (no `display:none`/
+    `visibility:hidden`), discipline scan (no hex / no raw non-`--sp-*` var outside `forced-colors`,
+    ASCII-only).
+  - `tests/ui/styles/accessibility-registration.test.ts` (new) — reads both entry files; asserts
+    `accessibility.css` imported after tokens + animations (3rd CSS import, line-order contract).
+- **Commit:** `46dc389691c6608c1e571c23ccf1df800f1e685f`
+- **Outcome:** done (RED). All 14 tests failed before T-AY-002 (file ENOENT + imports absent).
+- **Deviation:** the file-read test helpers (`mediaBlock` collecting all matching `@media` blocks;
+  the group-order marker scan keying off `RG-N -` section markers; the scoped-selector tokeniser)
+  were corrected when greening T-AY-002 — the **assertions were not weakened** (a missing group,
+  bare `:focus`, `display:none` `.sr-only`, or out-of-`forced-colors` hex still fails). Folded into
+  the T-AY-002 commit and recorded there.
+
+### T-AY-002 — `accessibility.css` (RG-1..RG-6) + register at both CSS import sites (🔨 dev)
+
+- **Spec/req:** SPEC-AY-001/002/003; REQ-AY-001/002/003/004/005/006/007/009/015; NFR-AY-002/005/006.
+- **Files:**
+  - `src/ui/styles/accessibility.css` (new, 1-130) — RG-1 reduced-motion guard (`!important` only
+    here), RG-2 spin halt (`animation: none !important`), RG-3 forced-colors surface mapping
+    (`forced-color-adjust` + `CanvasText`/`Canvas`/`Highlight`/`HighlightText`/`ButtonText`/
+    `ButtonFace`), RG-4 forced-colors border (`.sp-toggle-switch` placeholder, enumerated by
+    T-AY-005), RG-5 `:focus-visible` ring consuming `var(--sp-focus-ring)` + the
+    `var(--sp-shadow-focus-ring)` clipped-control variant, RG-6 `.sr-only` clip utility. Every
+    selector `.specorator-root`-prefixed; ASCII-only comments (no `/`/backtick/`{}` in comments); no
+    hex / no raw non-`--sp-*` var outside `forced-colors`.
+  - `src/plugin/main.ts` (line 3) — `import '@/ui/styles/accessibility.css';` as the 3rd CSS import
+    after `animations.css`.
+  - `src/ui/main.ts` (line 15) — `import './styles/accessibility.css';` as the 3rd CSS import after
+    `animations.css`. `vite.config.ts` unchanged (the file is authored scope-safe).
+  - `tests/ui/styles/accessibility.test.ts` (helper corrections — see the T-AY-003/004 deviation).
+- **Commit:** _(recorded below at commit time)_
+- **Outcome:** done. T-AY-003/004 (14 tests) GREEN.
+- **Typecheck:** `npx vue-tsc -p tsconfig.lint.json --noEmit` -> **0**.
+- **Lint:** whole-project `npm run lint` -> **0 errors** (22 pre-existing warnings, none new).
+- **lightningcss:** `npm run build:web` -> **green** (no CSS minify error, EC-AY-013); the RG rules
+  (`prefers-reduced-motion`, `forced-colors`, `focus-visible`, `.sr-only`) are present in the
+  standalone bundle. `styles.css` not hand-edited.
+- **Deviation:** none on the impl. RG-4 carries a single placeholder selector (`.sp-toggle-switch`);
+  T-AY-005 completes the concrete enumeration per SPEC-AY-006.

--- a/specs/accessibility/implementation-log.md
+++ b/specs/accessibility/implementation-log.md
@@ -115,7 +115,7 @@ registration + its RED-before-green file-read/registration tests.
   - `tests/ui/styles/accessibility.test.ts` — adds the TEST-AY-006 file-read leg asserting RG-4
     lists each enumerated control with a `currentColor` border (the coverage-table `006->T-AY-003(file)`
     leg; the mount leg is T-AY-006, Chunk 2).
-- **Commit:** _(recorded below at commit time)_
+- **Commit:** `e2a1c53d3c2db31e4e3f2fc2941c913d8d01c1c2`
 - **Outcome:** done. The TEST-AY-006 file-read leg passes (15 accessibility-css tests GREEN).
 - **Typecheck:** `npx vue-tsc -p tsconfig.lint.json --noEmit` -> **0**.
 - **Lint:** whole-project `npm run lint` -> **0 errors** (22 pre-existing warnings, none new).

--- a/specs/accessibility/parity-screenshots.md
+++ b/specs/accessibility/parity-screenshots.md
@@ -1,0 +1,91 @@
+---
+id: PARITY-AY-001
+title: Accessibility (P12, FINAL phase) — cross-surface parity-screenshot matrix (the human TEST-AY-017 sign-off artifact)
+stage: tasks
+feature: accessibility
+area: AY
+epic: claudian-reboot
+phase: P12
+status: scaffold        # baseline column noted from claudian; Specorator + a11y-condition columns filled at the human final gate
+owner: dev
+reference: D:\Projects\claudian-main   # MIT, read-only parity reference
+satisfies:
+  - REQ-AY-016          # parity-screenshots.md scaffold (the all-surfaces matrix)
+  - REQ-AY-017          # the single FINAL epic gate — the human sign-off (TEST-AY-017)
+  - NFR-AY-001          # cross-surface a11y judgment (visual forced-colors + reduced-motion)
+created: 2026-05-27
+updated: 2026-05-27
+---
+
+# Parity screenshots — Accessibility (P12, the FINAL phase)
+
+This is the **human TEST-AY-017 final-sign-off artifact** (the single FINAL epic gate, REQ-AY-017 —
+constitution Art. VII). It lists **every charter §3 surface** at the three charter widths
+(**320 / 520 / 720 px**) in **both themes** (light + dark), each side by side with its **claudian
+baseline**. The completeness of this matrix (every required row/cell slot) is what TEST-AY-016 checks
+deterministically; the **visual judgment** (forced-colors + reduced-motion rendering, parity with the
+claudian baseline) is the **human's** at T-AY-017 — **never** agent-self-claimed.
+
+> **This file is the baseline scaffold (T-AY-001).** The `Baseline (claudian)` column is captured
+> from `D:\Projects\claudian-main` at the matching width/theme; the `Specorator` columns and the
+> a11y-condition columns are filled at the human final gate (T-AY-017). The automatable suite
+> (TEST-AY-001..016) ships under the verify gate; this matrix is the human leg.
+
+Legend: ☐ = not yet captured. Each surface is captured **per theme × per width** for default render,
+plus the two a11y-condition columns (`prefers-reduced-motion: reduce` and `forced-colors: active`)
+that carry the visual judgment no automatable test replaces.
+
+## Surface × width × theme matrix (default render)
+
+| Charter surface (§3) | Baseline (claudian) | 320 L | 320 D | 520 L | 520 D | 720 L | 720 D |
+|---|---|---|---|---|---|---|---|
+| §3.1 Chat conversation surface (streaming messages, message renderers) | `MessageRenderer` | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.1 Tool-call rendering (collapsible input/result) | `ToolCallRenderer` | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.1 Write/Edit rendering (word-level diff) | `WriteEditRenderer` / `DiffRenderer` | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.1 Thinking blocks (collapsible) | `ThinkingBlockRenderer` | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.1 Todo list rendering | `TodoListRenderer` | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.1 Subagent rendering + lifecycle | `SubagentRenderer` | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.1 Inline interactive blocks (ask-user / exit-plan / plan-approval) | `InlineAskUserQuestion` etc. | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.2 Multi-tab strip + numbered badges | `TabBar` | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.2 History / resume drop-up | `ResumeSessionDropdown` | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.2 Fork-target modal | `ForkTargetModal` | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.2 Rewind / checkpoint menu | rewind menu | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.2 Compacted-boundary divider | `context_compacted` boundary | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.3 Composer / input + auto-resize textarea | `InputController` / `InputToolbar` | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.3 Slash `/` + Skills `$` dropdown | `SlashCommandDropdown` | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.3 `@mention` dropdown | `MentionDropdownController` | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.3 Instruction-mode `#` confirm | `InstructionConfirmModal` | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.3 Plan-mode toggle / bang-bash `!` | `plan-mode` / `BangBashModeManager` | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.4 File context / chips | `FileChipsView` | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.4 Image context / embed / modal | `ImageContext` / image-modal | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.4 External context + selection controllers | `SelectionHighlight` | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.4 Inline Edit modal (word-level diff) | `InlineEditModal` | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.5 Input toolbar widgets (model/mode/permission/thinking/tier/MCP/usage meter) | input toolbar strip | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.6 Provider consent modal | `ProviderConsentModal` | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.7 MCP server modal + test modal | `McpServerModal` / `McpTestModal` | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.8 Settings shell (provider tabs, env snippet manager) | settings shell | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| §3.9 Delete-confirm modal | `DeleteConfirmModal` | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+
+## A11y-condition columns (the visual judgment — the human T-AY-017 leg)
+
+For each surface above, the human reviewer also captures the two a11y-condition renderings that carry
+the judgment no automatable test replaces (NFR-AY-001):
+
+| Charter surface (§3) | reduced-motion (L) | reduced-motion (D) | forced-colors (L/HCM) | forced-colors (D/HCM) |
+|---|---|---|---|---|
+| §3.1 Chat conversation surface | ☐ | ☐ | ☐ | ☐ |
+| §3.1 Tool-call / Write-Edit / Thinking / Todo / Subagent renderers | ☐ | ☐ | ☐ | ☐ |
+| §3.1 Inline interactive blocks | ☐ | ☐ | ☐ | ☐ |
+| §3.2 Tab strip + history / fork / rewind / compact | ☐ | ☐ | ☐ | ☐ |
+| §3.3 Composer + slash / mention / instruction / plan / bang-bash | ☐ | ☐ | ☐ | ☐ |
+| §3.4 File / image chips + external context + inline edit | ☐ | ☐ | ☐ | ☐ |
+| §3.5 Input toolbar widgets (toggle / pills / usage meter) | ☐ | ☐ | ☐ | ☐ |
+| §3.6 / §3.7 Provider consent + MCP modals | ☐ | ☐ | ☐ | ☐ |
+| §3.8 / §3.9 Settings shell + delete-confirm modal | ☐ | ☐ | ☐ | ☐ |
+
+## Accumulated P5–P11 manual-Obsidian legs (converge here — charter §5.5)
+
+The per-phase manual-Obsidian screenshot legs (P5 modals, P7 providers, P8 MCP, P9 approvals, P10
+settings shell, P11 locales) converge at this final gate; the human reviewer confirms each at parity
+alongside the cross-surface a11y judgment above. T-AY-017 records the maintainer's recorded
+acceptance of the populated matrix + the accumulated manual legs as the close of the P0-P12 epic.

--- a/specs/accessibility/parity-screenshots.md
+++ b/specs/accessibility/parity-screenshots.md
@@ -6,7 +6,7 @@ feature: accessibility
 area: AY
 epic: claudian-reboot
 phase: P12
-status: scaffold        # baseline column noted from claudian; Specorator + a11y-condition columns filled at the human final gate
+status: complete        # matrix structurally complete (T-AY-016 / TEST-AY-016 green); Specorator + a11y-condition cells filled + judged at the human final gate (T-AY-017)
 owner: dev
 reference: D:\Projects\claudian-main   # MIT, read-only parity reference
 satisfies:
@@ -26,10 +26,15 @@ baseline**. The completeness of this matrix (every required row/cell slot) is wh
 deterministically; the **visual judgment** (forced-colors + reduced-motion rendering, parity with the
 claudian baseline) is the **human's** at T-AY-017 — **never** agent-self-claimed.
 
-> **This file is the baseline scaffold (T-AY-001).** The `Baseline (claudian)` column is captured
-> from `D:\Projects\claudian-main` at the matching width/theme; the `Specorator` columns and the
-> a11y-condition columns are filled at the human final gate (T-AY-017). The automatable suite
-> (TEST-AY-001..016) ships under the verify gate; this matrix is the human leg.
+> **This matrix is complete and structurally checked (T-AY-016 / TEST-AY-016).** Every charter §3
+> surface is listed at 320/520/720 px in light + dark, each paired with its `Baseline (claudian)`
+> reference (captured from `D:\Projects\claudian-main` at the matching width/theme). The `Specorator`
+> capture columns and the two a11y-condition columns (`reduced-motion` / `forced-colors`) are left for
+> the human reviewer to populate + judge at the final epic gate (T-AY-017) — the visual sign-off no
+> automatable test replaces (NFR-AY-001, constitution Art. VII). The automatable suite
+> (TEST-AY-001..016) ships under the verify gate; this matrix is the human leg. The completeness of the
+> row/cell structure (every surface × width × theme slot present) is what TEST-AY-016 asserts
+> deterministically.
 
 Legend: ☐ = not yet captured. Each surface is captured **per theme × per width** for default render,
 plus the two a11y-condition columns (`prefers-reduced-motion: reduce` and `forced-colors: active`)

--- a/specs/accessibility/requirements.md
+++ b/specs/accessibility/requirements.md
@@ -1,0 +1,536 @@
+---
+id: PRD-AY-001
+title: Accessibility — a11y stylesheet + WCAG 2.2 AA sweep + final parity sign-off
+stage: requirements
+feature: accessibility
+area: AY
+epic: claudian-reboot
+phase: P12
+status: accepted
+owner: pm
+integration_branch: next
+inputs:
+  - CHARTER-CLAUDIAN-REBOOT §1 (WCAG 2.2 AA bar; keyboard nav / focus management / forced-colors / reduced-motion — "meet or beat" claudian accessibility.css; lines 50-51)
+  - CHARTER-CLAUDIAN-REBOOT §3.9 (a11y stylesheet + behaviours) + §3.10 (accessibility.css in the 45-module visual system) + §4 P12 row (line 195) + §5.5 (program-done = P12 sign-off screenshots approved)
+  - specs/claudian-reboot/claudian-audit-frontend.md §"Motion/animation inventory" line 358 (claudian accessibility.css is minimal — focus-visible rings only; Specorator must beat it with reduced-motion + forced-colors) + §"Keyboard-shortcut map" (the parity interaction contract) + the per-surface ARIA/keyboard notes
+  - D:\Projects\claudian-main accessibility.css (the reference a11y layer to meet/beat — charter §3.10) + the a11y behaviours
+  - src/ui/styles/tokens.css (the --sp-* token layer + per-section prefers-reduced-motion overrides §4.6/§4.9/§4.10/§4.11) + src/ui/styles/animations.css (the five named keyframes + the existing spin reduced-motion guard CQ-AUX-14)
+  - src/plugin/main.ts + src/ui/main.ts (the CSS import pipeline — accessibility.css joins tokens.css/animations.css at both entry points) + vite.config.ts scopeBuiltCss() (auto-scopes selectors under .specorator-root :where(...), skips @keyframes)
+  - src/plugin/AgentSidebarView.ts (the .specorator-root host) + the P5/P7/P8/P10 modal seams (ProviderConsentModal/DeleteConfirmModal/ForkTargetModal/InstructionConfirmModal/InlineEditModal/ImagePreviewModal/McpServerModal/McpTestModal) + the P1-P11 components for the behaviour sweep
+created: 2026-05-27
+updated: 2026-05-27
+---
+
+# PRD — Accessibility (P12, final phase)
+
+## Summary
+
+P12 is the **final** phase of the claudian-reboot epic. P0–P11 are merged to `next`; every
+user-facing surface — chat, rich rendering, threads, composer, attachments, toolbar, approvals,
+MCP, providers, settings, ten locales — now exists. This phase adds the global **accessibility
+layer** and closes the accessibility gaps the per-phase work could not see in isolation.
+
+Two deliverables. First, a new `src/ui/styles/accessibility.css` stylesheet — the third CSS layer
+alongside `tokens.css` and `animations.css`, registered at both CSS import sites (`src/plugin/main.ts`
+and `src/ui/main.ts`) — that **meets or beats** Claudian's `accessibility.css` (charter §1, §3.10).
+The frontend audit (line 358) establishes the baseline: Claudian's layer is *minimal* — focus-visible
+rings only. Specorator beats it by adding the `prefers-reduced-motion` global guard, `forced-colors`
+/ high-contrast system-color mapping, a complete `:focus-visible` ring across every interactive
+`--sp-*` control, and an `.sr-only` screen-reader-only utility. Second, a **WCAG 2.2 AA behaviour
+sweep** across the P1–P11 surfaces: filling ARIA-role/label gaps, verifying modal focus trap +
+restore at the P5/P7/P8/P10 modal seams, adding live regions for streaming/notices where missing,
+and confirming the toolbar/settings/chat surfaces are keyboard-operable and labelled. The bar is
+**WCAG 2.2 AA** (charter §1).
+
+The automatable part — the stylesheet, the behaviour fixes, and the a11y tests — ships under the
+verify gate. The **final parity screenshot sign-off across all surfaces, light + dark, at the charter
+widths (320 / 520 / 720 px)** is a **human-owned** acceptance leg. The accumulated manual-Obsidian
+and parity-screenshot legs from P5–P11 converge here as the single final epic gate (charter §5.5,
+workflow-state line 64). After P12 merges to `next` with a green gate, opening the `next` → `develop`
+PR is the human's call.
+
+## Goals
+
+- G1 — Ship `src/ui/styles/accessibility.css` as a third global a11y CSS layer that meets-or-beats
+  claudian's `accessibility.css` and is registered in the build CSS pipeline at both entry points.
+- G2 — Add a global `prefers-reduced-motion: reduce` guard that disables or softens every animation
+  in `animations.css` (the five named keyframes) and every motion-carrying transition, covering the
+  gaps the per-section token overrides do not reach.
+- G3 — Add `forced-colors` / high-contrast handling: map surfaces to system colors with
+  `forced-color-adjust`, and guarantee a visible border on every interactive control so it stays
+  perceivable when the token palette is replaced.
+- G4 — Provide a `:focus-visible` keyboard-focus ring on every interactive `--sp-*` control across
+  all surfaces, and an `.sr-only` screen-reader-only utility for visually-hidden labels.
+- G5 — Sweep the P1–P11 surfaces for WCAG 2.2 AA behaviour gaps: ARIA roles/labels, modal focus
+  trap + restore (P5/P7/P8/P10 seams), live regions for streaming/notices, keyboard operability and
+  labelling of the toolbar / settings / chat surfaces — filling only the gaps, not re-building.
+- G6 — Keep the layer strictly **additive**: no surface regresses; en/de + all ten locales and the
+  P0–P11 behaviour stay unchanged except for the a11y improvements.
+- G7 — Surface the **human-owned** final parity screenshot sign-off (all surfaces, light + dark, the
+  charter widths) as the single final epic acceptance gate — never self-claimed.
+
+## Non-goals
+
+- NG1 — New visual design, layout, or microcopy. P12 polishes accessibility; it does not restyle or
+  re-word any surface. Forced-colors/high-contrast appearance is a system-driven fallback, not a new
+  theme.
+- NG2 — New `--sp-*` tokens or palette changes. The a11y layer consumes the existing token layer; the
+  only deliberate exception is the documented `forced-colors` system-color mapping (charter §3.10).
+- NG3 — WCAG levels beyond 2.2 AA (no AAA), and platform AT certification (e.g. formal NVDA/VoiceOver
+  conformance audit) beyond the automatable checks plus the human screenshot/manual sweep.
+- NG4 — New keyboard shortcuts or interaction patterns beyond the parity contract already built in
+  P1–P11 (audit "Keyboard-shortcut map"). P12 fills *gaps* in that contract; it does not extend it.
+- NG5 — Backwards compatibility / migration of any kind (CHARTER-REQ-FRESH).
+- NG6 — Changing the `next` → `develop` merge decision: that is the human's call after P12's gate is
+  green (workflow-state line 69-71).
+
+## Personas / stakeholders
+
+| Persona | Need | Why it matters |
+|---|---|---|
+| Keyboard-only Specorator user | Operate chat, composer, toolbar, settings, and every modal without a pointer | WCAG 2.2 AA (charter §1) requires full keyboard operability; the per-phase work built keyboard nav but P12 must prove no surface is a keyboard trap and every focus is visible. |
+| Screen-reader user (NVDA/VoiceOver) | Roles, labels, and live announcements for streaming text, tool calls, and notices | Imperative-DOM Claudian had ad-hoc ARIA; the Vue rebuild needs a deliberate sweep so the structure is announced and streaming output is announced via live regions. |
+| High-contrast / forced-colors user (Windows HCM) | Surfaces remain perceivable when the OS replaces the colour palette | The `--sp-*` token layer resolves to Obsidian theme colours; under forced-colors those are overridden, so borders/state cues must survive — a gap Claudian's minimal layer does not cover. |
+| Reduced-motion user | Streaming pulses, glows, spinners, and dropdown transitions calmed | The five named keyframes + transitions are motion sources; the token overrides cover most but P12 must guarantee a global guard so nothing animates against the user's stated preference. |
+| Maintainer / reviewer | Confidence the a11y layer is additive and token-disciplined | An a11y layer that leaks raw colour outside the documented forced-colors exception, or regresses a surface, would violate the epic constraints; deterministic guards make that a red build. |
+| Human acceptance owner | A complete, side-by-side parity screenshot set at the charter widths to approve | Charter §5.5 makes the P12 sign-off screenshots the program-done gate; this is human judgment that no automatable test replaces. |
+
+## Jobs to be done
+
+- When **I navigate Specorator with only the keyboard**, I want **a visible focus ring on every
+  control and no surface that traps or loses my focus**, so I can **reach and operate every feature
+  without a mouse**.
+- When **I use a screen reader**, I want **each surface's roles/labels announced and streaming
+  assistant output announced as it arrives**, so I can **follow the conversation and operate controls
+  without sighted feedback**.
+- When **I run Windows High Contrast / forced-colors**, I want **every control to keep a visible
+  border and state cue**, so I can **tell controls apart when the colour palette is replaced**.
+- When **I have set "reduce motion" in my OS**, I want **the thinking pulse, glows, spinners, and
+  dropdown transitions disabled or softened**, so I can **use the plugin without motion discomfort**.
+- When **the epic is feature-complete on `next`**, I want **a side-by-side parity screenshot set of
+  every surface at 320/520/720 px in light + dark to review**, so I can **approve the reboot as 1:1
+  before it merges to `develop`**.
+
+## Functional requirements (EARS)
+
+> Use [EARS notation](../../docs/ears-notation.md). One requirement per entry. Stable IDs. The 1:1
+> claudian reference is `accessibility.css` (charter §3.10), characterised by the frontend audit
+> (line 358) as a minimal focus-visible-rings layer that Specorator must *meet or beat*. Where the
+> requirement beats claudian (reduced-motion, forced-colors, sr-only, live regions), the path is
+> noted as `beat: claudian accessibility.css (minimal)`. Surface scope = the `.specorator-root`
+> subtree (the agent sidebar + every mounted modal seam).
+
+### Group A — accessibility.css layer & pipeline registration
+
+#### REQ-AY-001 — accessibility.css exists as the third global a11y layer
+
+- **Pattern:** ubiquitous
+- **Statement:** *The plugin shall provide a stylesheet `src/ui/styles/accessibility.css` containing
+  the global accessibility rules (reduced-motion guard, forced-colors mapping, focus-visible rings,
+  and the `.sr-only` utility), scoped to the `.specorator-root` subtree consistently with `tokens.css`
+  and `animations.css`.*
+- **Acceptance:**
+  - Given the source tree
+  - When `src/ui/styles/accessibility.css` is inspected
+  - Then it exists, declares the reduced-motion / forced-colors / focus-visible / `.sr-only` rule
+    groups, and contains no rule that targets outside the `.specorator-root` subtree (the build's
+    `scopeBuiltCss()` auto-scoping is honoured, not fought)
+- **Priority:** must
+- **Satisfies:** CHARTER-CLAUDIAN-REBOOT §3.9, §3.10, §1 — 1:1 path `accessibility.css` (meet/beat)
+- **Verified by:** TEST-AY-001
+
+#### REQ-AY-002 — accessibility.css registered at both CSS import sites
+
+- **Pattern:** ubiquitous
+- **Statement:** *The build CSS pipeline shall import `accessibility.css` at both entry points —
+  `src/plugin/main.ts` (the bundled `styles.css`) and `src/ui/main.ts` (the standalone build) —
+  alongside `tokens.css` and `animations.css`.*
+- **Acceptance:**
+  - Given the plugin build and the standalone build
+  - When each entry point's CSS imports are enumerated and the produced `styles.css` (plugin) /
+    standalone bundle is inspected
+  - Then `accessibility.css` is imported at both `src/plugin/main.ts` and `src/ui/main.ts`, and its
+    rules appear in both built outputs
+- **Priority:** must
+- **Satisfies:** CHARTER-CLAUDIAN-REBOOT §3.10 (accessibility.css in the visual system); workflow-state
+  scope "registered in the build's CSS pipeline" — 1:1 path `accessibility.css`
+- **Verified by:** TEST-AY-002
+
+### Group B — Reduced motion
+
+#### REQ-AY-003 — Reduced motion disables or softens every animation
+
+- **Pattern:** event-driven
+- **Statement:** *When the user agent reports `prefers-reduced-motion: reduce`, the accessibility layer
+  shall disable or reduce to a non-moving fallback every animation defined in `animations.css` (the
+  `thinking-pulse`, `streaming-cursor-blink`, `spin`, `mcp-glow`, and `external-context-glow`
+  keyframes) and every motion-carrying transition within `.specorator-root`.*
+- **Acceptance:**
+  - Given `prefers-reduced-motion: reduce` is active
+  - When any surface that would animate (live thinking pulse, streaming cursor, indeterminate spinner,
+    MCP/external-context glow, dropdown open, toggle knob, usage-meter fill) renders
+  - Then no element runs a perceptible looping or transitional animation (animation/transition
+    collapsed to `none`/`0s` or a static fallback), complementing — not duplicating-and-conflicting
+    with — the existing per-section token overrides in `tokens.css`
+- **Priority:** must
+- **Satisfies:** CHARTER-CLAUDIAN-REBOOT §1 (reduced-motion); audit line 358 — `beat: claudian
+  accessibility.css (minimal)`
+- **Verified by:** TEST-AY-003
+
+#### REQ-AY-004 — Indeterminate spinners are explicitly halted under reduced motion
+
+- **Pattern:** event-driven
+- **Statement:** *When `prefers-reduced-motion: reduce` is active, the accessibility layer shall set
+  `animation: none` on any element running the `spin` keyframe (title-gen loader, inline-edit spinner,
+  instruction-modal spinner), because an indeterminate loop is not stopped by zeroing a duration token
+  alone (CQ-AUX-14).*
+- **Acceptance:**
+  - Given `prefers-reduced-motion: reduce` is active and an element marked as a spinner
+  - When it renders
+  - Then its `spin` animation is `none` (not merely `0s`), so no spinner rotates
+- **Priority:** must
+- **Satisfies:** CHARTER-CLAUDIAN-REBOOT §1; animations.css CQ-AUX-14 (the existing spin guard,
+  consolidated/confirmed here) — `beat: claudian accessibility.css (minimal)`
+- **Verified by:** TEST-AY-004
+
+### Group C — Forced colors & contrast
+
+#### REQ-AY-005 — Forced-colors maps surfaces to system colors
+
+- **Pattern:** event-driven
+- **Statement:** *When the user agent reports `forced-colors: active`, the accessibility layer shall
+  apply `forced-color-adjust` and the documented system-color keywords (e.g. `CanvasText`, `Canvas`,
+  `Highlight`, `ButtonText`, `ButtonFace`) to the `.specorator-root` surfaces so the plugin remains
+  legible when the user's colour palette is replaced.*
+- **Acceptance:**
+  - Given `forced-colors: active`
+  - When any P1–P11 surface renders
+  - Then text, backgrounds, and interactive controls resolve to system colours (the documented
+    forced-colors/system-colors exception to the token-only rule), and no surface becomes invisible or
+    unreadable
+- **Priority:** must
+- **Satisfies:** CHARTER-CLAUDIAN-REBOOT §1 (forced-colors), §3.10 — `beat: claudian accessibility.css
+  (minimal)`
+- **Verified by:** TEST-AY-005
+
+#### REQ-AY-006 — Interactive controls keep a visible border under forced-colors
+
+- **Pattern:** event-driven
+- **Statement:** *When `forced-colors: active`, the accessibility layer shall guarantee a visible
+  (non-transparent, non-`currentColor`-collapsing) border on every interactive `--sp-*` control whose
+  normal affordance is conveyed only by a background fill or wash (toggles, pills, chips, tabs,
+  dropdown options, buttons).*
+- **Acceptance:**
+  - Given `forced-colors: active`
+  - When a control that normally relies on a background-only cue renders (e.g. a `SpToggleSwitch`, a
+    tab badge, a selected dropdown option, a context chip)
+  - Then the control shows a perceivable border so it is distinguishable from its surroundings and from
+    its sibling controls
+- **Priority:** must
+- **Satisfies:** CHARTER-CLAUDIAN-REBOOT §1 (forced-colors / non-colour cue); audit §"Composer power"
+  NFR-CP-008 (non-colour cue for forced-colors) — `beat: claudian accessibility.css (minimal)`
+- **Verified by:** TEST-AY-006
+
+### Group D — Focus-visible & keyboard operability
+
+#### REQ-AY-007 — Focus-visible ring on every interactive control
+
+- **Pattern:** event-driven
+- **Statement:** *When an interactive `--sp-*` control receives keyboard focus (`:focus-visible`), the
+  accessibility layer shall render a visible focus ring (using `--sp-focus-ring` / `--sp-shadow-focus-ring`)
+  on that control across every P1–P11 surface — buttons, toggles, tab badges, dropdown options, chips,
+  textarea, collapsible headers, and modal controls.*
+- **Acceptance:**
+  - Given keyboard focus moves to an interactive control via Tab / arrow navigation
+  - When the control is focused
+  - Then a visible focus ring is present (and it is not suppressed for mouse-only `:focus`, i.e.
+    `:focus-visible` is used so pointer interaction does not show a stray ring), matching or exceeding
+    claudian's focus-visible rings
+- **Priority:** must
+- **Satisfies:** CHARTER-CLAUDIAN-REBOOT §1 (focus management) — 1:1 path `accessibility.css`
+  (focus-visible rings, the part claudian *does* ship) — meet
+- **Verified by:** TEST-AY-007
+
+#### REQ-AY-008 — Toolbar, settings, and chat surfaces are keyboard-operable and labelled
+
+- **Pattern:** ubiquitous
+- **Statement:** *Every interactive control in the toolbar strip, the settings shell, and the chat
+  surface (composer, message actions, dropdowns) shall be reachable and operable by keyboard and shall
+  expose an accessible name (visible label, `aria-label`, or an associated `.sr-only` label).*
+- **Acceptance:**
+  - Given a surface rendered with no pointer device
+  - When the user tabs/arrows through its controls and activates them via Enter/Space (per the audit
+    keyboard contract)
+  - Then every control is focusable in a sensible order, is operable from the keyboard, and reports a
+    non-empty accessible name to the accessibility tree
+- **Priority:** must
+- **Satisfies:** CHARTER-CLAUDIAN-REBOOT §1 (keyboard nav); audit §"Keyboard-shortcut map"
+- **Verified by:** TEST-AY-008
+
+### Group E — ARIA & screen-reader support
+
+#### REQ-AY-009 — `.sr-only` utility for screen-reader-only labels
+
+- **Pattern:** ubiquitous
+- **Statement:** *The accessibility layer shall provide an `.sr-only` utility class that visually hides
+  its element while keeping it in the accessibility tree (the standard clip/size technique), for
+  labelling icon-only controls and providing screen-reader-only context.*
+- **Acceptance:**
+  - Given an element with the `.sr-only` class
+  - When the surface is rendered
+  - Then the element is not visually perceivable (zero visible footprint) yet remains exposed to the
+    accessibility tree (not `display:none` / not `visibility:hidden`)
+- **Priority:** must
+- **Satisfies:** CHARTER-CLAUDIAN-REBOOT §3.9 — `beat: claudian accessibility.css (minimal)`
+- **Verified by:** TEST-AY-009
+
+#### REQ-AY-010 — Streaming and notice output is announced via a live region
+
+- **Pattern:** event-driven
+- **Statement:** *When the assistant streams a turn or a non-blocking notice is shown, the chat surface
+  shall announce the change through an ARIA live region (`aria-live` polite for streaming/notices,
+  assertive only for errors) so a screen-reader user is informed without moving focus.*
+- **Acceptance:**
+  - Given a screen reader and an active surface
+  - When the assistant begins/continues streaming or a notice appears
+  - Then the new text is conveyed through an `aria-live` region (polite for streaming/info,
+    assertive for errors), and focus is not stolen
+- **Priority:** must
+- **Satisfies:** CHARTER-CLAUDIAN-REBOOT §1 (WCAG 2.2 AA status messages, SC 4.1.3); audit §3.1
+  (streaming) — `beat: claudian accessibility.css (minimal)`
+- **Verified by:** TEST-AY-010
+
+#### REQ-AY-011 — Collapsible and tool-call structure exposes ARIA state
+
+- **Pattern:** event-driven
+- **Statement:** *When a collapsible region (tool call, thinking block, subagent, write/edit) is
+  rendered or toggled, its header control shall expose `aria-expanded` reflecting the open/closed
+  state and an accessible name describing the region, filling any per-phase gap.*
+- **Acceptance:**
+  - Given a collapsible header
+  - When it is rendered and when it is toggled by Enter/Space/click
+  - Then `aria-expanded` is present and updates to match the visible state, and the control reports an
+    accessible name
+- **Priority:** should
+- **Satisfies:** CHARTER-CLAUDIAN-REBOOT §1; audit cross-cutting "Collapsible" (`aria-expanded` +
+  dynamic `aria-label`)
+- **Verified by:** TEST-AY-011
+
+### Group F — Modal focus management (P5/P7/P8/P10 seams)
+
+#### REQ-AY-012 — Modals trap focus while open
+
+- **Pattern:** state-driven
+- **Statement:** *While a Specorator-launched modal is open (ProviderConsent, DeleteConfirm,
+  ForkTarget, InstructionConfirm, InlineEdit, ImagePreview, McpServer, McpTest), keyboard focus shall
+  remain within that modal — Tab/Shift+Tab cycle through the modal's controls and do not escape to the
+  surface behind it.*
+- **Acceptance:**
+  - Given a modal launched through a P5/P7/P8/P10 modal seam is open
+  - When the user tabs forward past the last control or shift-tabs before the first
+  - Then focus wraps within the modal and never lands on a control in the obscured surface behind it
+- **Priority:** must
+- **Satisfies:** CHARTER-CLAUDIAN-REBOOT §1 (focus management); WCAG 2.2 AA SC 2.4.3 / 2.1.2 —
+  verify the P5/P7/P8/P10 modal seams
+- **Verified by:** TEST-AY-012
+
+#### REQ-AY-013 — Modals restore focus on close
+
+- **Pattern:** event-driven
+- **Statement:** *When a Specorator-launched modal closes (confirm, cancel, or Esc), focus shall return
+  to the control that opened it (or a sensible fallback within the originating surface).*
+- **Acceptance:**
+  - Given a modal was opened from a known trigger control
+  - When the modal closes by any path (accept / reject / Esc / overlay dismiss)
+  - Then focus returns to the originating trigger (or its nearest still-present sibling), not to the
+    document body
+- **Priority:** must
+- **Satisfies:** CHARTER-CLAUDIAN-REBOOT §1 (focus management); WCAG 2.2 AA SC 2.4.3 — verify the
+  P5/P7/P8/P10 modal seams
+- **Verified by:** TEST-AY-013
+
+### Group G — Additivity guard
+
+#### REQ-AY-014 — The a11y layer is additive — no surface regresses
+
+- **Pattern:** unwanted behaviour
+- **Statement:** *The accessibility layer shall not alter the default (no-media-query) appearance,
+  layout, microcopy, locale output, or behaviour of any P0–P11 surface; its rules shall take effect
+  only inside `:focus-visible`, `prefers-reduced-motion`, `forced-colors`, `.sr-only`, or additive
+  ARIA — never the base render.*
+- **Acceptance:**
+  - Given the `next` baseline at branch cut with no a11y media query active and no `.sr-only` applied
+  - When a surface is rendered after the P12 change
+  - Then its default visual output and behaviour are unchanged from baseline (the a11y rules are inert
+    until a focus-visible / reduced-motion / forced-colors / sr-only condition applies)
+- **Priority:** must
+- **Satisfies:** CHARTER-CLAUDIAN-REBOOT (additive phase); constitution Art. III; workflow-state
+  "additivity"
+- **Verified by:** TEST-AY-014
+
+#### REQ-AY-015 — No raw HTML injection and no token-discipline leak in the a11y layer
+
+- **Pattern:** unwanted behaviour
+- **Statement:** *The P12 change shall introduce no `innerHTML` / `outerHTML` / `insertAdjacentHTML`
+  assignment and no `v-html`, and `accessibility.css` shall carry no hex or raw Obsidian colour var
+  outside the single documented `forced-colors` system-color exception.*
+- **Acceptance:**
+  - Given the P12 diff and `accessibility.css`
+  - When scanned for raw-HTML sinks and for colour literals / raw Obsidian vars
+  - Then no raw-HTML sink is added, and the only colour keywords in `accessibility.css` are CSS
+    system-color keywords inside a `forced-colors` block (no hex, no `var(--text-*)` etc. outside the
+    `--sp-*` token consumption)
+- **Priority:** must
+- **Satisfies:** CHARTER-CLAUDIAN-REBOOT epic constraints (no innerHTML/v-html; token discipline +
+  documented forced-colors exception); CLAUDE.md DOM/security rules
+- **Verified by:** TEST-AY-015
+
+### Group H — Final parity sign-off (human-owned)
+
+#### REQ-AY-016 — Final cross-surface parity screenshot set captured
+
+- **Pattern:** ubiquitous
+- **Statement:** *The phase shall produce a side-by-side parity screenshot set covering every P1–P11
+  surface at the charter widths (320 / 520 / 720 px) in both light and dark theme, stored under
+  `specs/accessibility/parity-screenshots.md`.*
+- **Acceptance:**
+  - Given the feature-complete `next` build with the a11y layer applied
+  - When the screenshot set is assembled
+  - Then every charter §3 surface appears at all three widths in both themes, side by side with its
+    claudian reference, in `specs/accessibility/parity-screenshots.md`
+- **Priority:** must
+- **Satisfies:** CHARTER-CLAUDIAN-REBOOT §4 P12 row (line 195), §5.1, §5.5
+- **Verified by:** TEST-AY-016 (artifact-completeness check; the visual judgment is REQ-AY-017)
+
+#### REQ-AY-017 — Human sign-off is the final epic acceptance gate
+
+- **Pattern:** state-driven
+- **Statement:** *While the P12 automatable gate is green, the program shall remain unaccepted until a
+  **human** reviewer approves the final parity screenshot set and the accumulated P5–P11 manual-Obsidian
+  legs; the agent shall surface this gate and shall not self-claim the sign-off.*
+- **Acceptance:**
+  - Given the verify gate is green and the screenshot set (REQ-AY-016) is complete
+  - When acceptance is evaluated
+  - Then the phase status records the human approval as the outstanding final gate, the agent presents
+    (does not merge) the `next` → `develop` PR, and program-done is asserted only after the human's
+    approval (owner: human — charter §5.5, workflow-state line 64-71)
+- **Priority:** must
+- **Satisfies:** CHARTER-CLAUDIAN-REBOOT §5.5 (program-done = sign-off approved); constitution Art. VII
+  (human owns acceptance) — owner: **human**
+- **Verified by:** human review (not an automatable test); evidenced by the approved
+  `parity-screenshots.md` + the maintainer's recorded acceptance
+
+## Non-functional requirements
+
+> Targets inherit from the epic constraints (`specs/accessibility/workflow-state.md`) and the parity
+> charter; none introduces a new threshold beyond what those documents fix. The single deliberate new
+> CSS allowance — system-color keywords inside a `forced-colors` block — is documented in NFR-AY-002.
+
+| ID | Category | Requirement | Target |
+|---|---|---|---|
+| NFR-AY-001 | accessibility | WCAG conformance level across all P1–P11 surfaces | 2.2 AA |
+| NFR-AY-002 | maintainability | a11y layer consumes `--sp-*` tokens + standard a11y media queries; colour literals only as system-color keywords inside a `forced-colors` block | 0 hex / 0 raw Obsidian var outside the documented forced-colors exception |
+| NFR-AY-003 | security | No raw-HTML sink introduced | 0 added `innerHTML`/`outerHTML`/`insertAdjacentHTML`/`v-html` |
+| NFR-AY-004 | maintainability | Additivity — no surface's default render/behaviour/locale output regresses; en/de + all ten locales and P0–P11 behaviour unchanged except a11y improvements | 0 default-state regression; locale output byte-identical |
+| NFR-AY-005 | build | lightningcss-safe CSS (ASCII comment markers; minifier-accepted at-rules) in `accessibility.css` | `npm run build` + `npm run build:web` green; no CSS minify error |
+| NFR-AY-006 | build | accessibility.css registered + present in both built outputs | rule group present in plugin `styles.css` and standalone bundle |
+| NFR-AY-007 | quality | Test-coverage gate holds | 80 / 70 / 80 / 80 statements/branches/functions/lines |
+| NFR-AY-008 | release | `manifest.json` untouched | identical `id` / `version` / `minAppVersion` to baseline |
+| NFR-AY-009 | reliability | Reduced-motion / forced-colors handling never breaks a surface (no layout collapse, no invisible control) | every surface remains operable + perceivable under each media query |
+| NFR-AY-010 | gate | Full verify gate + storybook/unit suite | `npm run verify` + `npm run test:all` zero failures on `next` |
+
+## Success metrics
+
+- **North star:** WCAG 2.2 AA met across every P1–P11 surface with `accessibility.css` shipped and
+  registered, the automatable a11y tests (TEST-AY-001..016) green, and the full verify gate green on
+  `next` — followed by the **human** final parity screenshot sign-off (REQ-AY-017) that closes the
+  epic.
+- **Supporting:** reduced-motion guard verified across all five keyframes + transitions;
+  forced-colors mapping verified with a visible border on every background-cue-only control;
+  focus-visible ring present on every interactive control; modal focus trap + restore verified at the
+  P5/P7/P8/P10 seams; live regions announce streaming + notices.
+- **Counter-metric:** number of P0–P11 surfaces whose **default** (no-a11y-media-query) appearance or
+  behaviour regresses, or whose locale output changes, because of the a11y layer — target **0** (a
+  non-zero value means the layer stopped being additive, the cardinal P12 failure). Secondary watch:
+  controls that gain a focus ring under mouse-only `:focus` (stray rings from using `:focus` instead
+  of `:focus-visible`) — target 0.
+
+## Release criteria
+
+What must be true to ship P12 (and thereby the epic).
+
+- [ ] All `must` requirements (REQ-AY-001..010, 012..017) pass acceptance.
+- [ ] REQ-AY-011 (collapsible ARIA `should`) addressed or explicitly deferred with a note.
+- [ ] NFR-AY-001..010 met (or explicitly waived with an ADR/note).
+- [ ] `accessibility.css` shipped, registered at both entry points, and present in both built outputs.
+- [ ] The automatable a11y tests (TEST-AY-001..016) green; reduced-motion / forced-colors /
+      focus-visible / sr-only / live-region / modal-focus behaviours verified.
+- [ ] `npm run verify` + `npm run test:all` zero failures on `next`; `manifest.json` byte-identical to
+      baseline; en/de + all ten locales unchanged.
+- [ ] The final parity screenshot set (REQ-AY-016) captured under
+      `specs/accessibility/parity-screenshots.md` at 320/520/720 px, light + dark, all surfaces.
+- [ ] **Human** final parity screenshot sign-off + the accumulated P5–P11 manual-Obsidian legs
+      approved (REQ-AY-017 — the single final epic gate; owner: human). The agent presents, does not
+      self-claim, this gate.
+- [ ] After the gate is green, the `next` → `develop` PR is **opened (not merged)** — the merge is the
+      human's call (workflow-state line 69-71).
+
+## Open questions / clarifications
+
+- See CLAR-AY-001 and CLAR-AY-002 below — both resolved with a recommended resolution recorded for the
+  design stage. None blocks acceptance of these requirements.
+
+### CLAR-AY-001 — Reference accessibility.css not directly readable from the worktree
+
+- **Question:** The exact `D:\Projects\claudian-main` `accessibility.css` file was not directly
+  readable from this worktree's working directory during requirements authoring. What is the
+  authoritative 1:1 reference for the "meet or beat" bar?
+- **Recommended resolution (PM):** Use the frontend audit's authoritative characterisation as the
+  reference until the design stage reads the file directly: `claudian-audit-frontend.md` line 358
+  states claudian's `accessibility.css` is **minimal — focus-visible rings only** — and explicitly
+  mandates that Specorator *beat* it by adding `prefers-reduced-motion` + `forced-colors` handling.
+  REQ-AY-007 (focus-visible) is the *meet* leg (the part claudian ships); REQ-AY-003..006, 009, 010
+  are the *beat* legs. The design stage must open the actual `accessibility.css` (charter §3.10 lists
+  it in the visual system) to confirm no claudian rule is missed; if it carries more than focus-visible
+  rings, the design stage adds the corresponding `--sp-*` mapping. This is a design-input note, not a
+  scope change.
+
+### CLAR-AY-002 — Reduced-motion: per-section token overrides vs a single global guard
+
+- **Question:** `tokens.css` already zeroes several `--sp-duration-*` tokens per section under
+  `prefers-reduced-motion` (§4.6/§4.9/§4.10/§4.11), and `animations.css` already halts `spin`
+  (CQ-AUX-14). Should `accessibility.css` *replace* those, or *complement* them?
+- **Recommended resolution (PM):** Complement, not replace. REQ-AY-003/004 require a single global
+  reduced-motion guard that catches every animation/transition (including any a per-section override
+  missed), while leaving the existing token overrides in place so no surface double-defines a conflict.
+  The design stage decides the exact selector strategy (e.g. a broad `animation/transition: none` guard
+  scoped to `.specorator-root` with explicit `spin` halting), keeping the existing token-driven
+  collapse as the primary path and the global guard as the safety net. Recorded so the design stage
+  does not silently drop the existing per-section overrides.
+
+## Out of scope
+
+- New visual design, layout, microcopy, or `--sp-*` tokens (forced-colors system-color mapping is the
+  only deliberate colour exception).
+- WCAG AAA, and formal third-party AT-conformance certification beyond the automatable checks + the
+  human screenshot/manual sweep.
+- New keyboard shortcuts or interaction patterns beyond the P1–P11 parity contract (audit
+  "Keyboard-shortcut map").
+- Backwards compatibility / migration (CHARTER-REQ-FRESH).
+- The `next` → `develop` merge itself — opened (not merged) after a green gate; the merge is the
+  human's call.
+
+---
+
+## Quality gate
+
+- [x] Goals and non-goals explicit.
+- [x] Personas / stakeholders named.
+- [x] Jobs to be done captured.
+- [x] Every functional requirement uses EARS and has an ID.
+- [x] Acceptance criteria testable.
+- [x] NFRs listed with targets.
+- [x] Success metrics defined (including a counter-metric).
+- [x] Release criteria stated.
+- [x] `/spec:clarify` self-check complete — CLAR-AY-001 and CLAR-AY-002 resolved (recommended
+      resolutions recorded for the design stage); no blocking open question.

--- a/specs/accessibility/review.md
+++ b/specs/accessibility/review.md
@@ -1,0 +1,181 @@
+---
+id: REVIEW-AY-001
+title: Accessibility (P12, FINAL phase) — Stage-9 review
+stage: review
+feature: accessibility
+area: AY
+epic: claudian-reboot
+phase: P12
+status: complete
+owner: reviewer
+integration_branch: next
+created: 2026-05-27
+updated: 2026-05-27
+verdict: approve-with-nits
+inputs:
+  - PRD-AY-001, DESIGN-AY-001, SPEC-AY-001, TASKS-AY-001, IMPL-LOG-AY-001, TEST-PLAN-AY-001
+  - git diff next..HEAD (base next @ d4733464, not advanced — the diff is the whole P12 feature)
+  - D:\Projects\claudian-main\src\style\accessibility.css (the 41-line focus-ring reference)
+  - memory/constitution.md; CLAUDE.md DOM/security + architecture rules
+---
+
+# Stage-9 review — Accessibility (P12, the FINAL phase)
+
+## Verdict: APPROVE WITH NITS
+
+P12 is a genuinely additive, presentation-only CSS-layer + ARIA-sweep phase that meets-and-beats the
+claudian reference and the WCAG 2.2 AA bar at the automatable level. The cardinal P12 constraint —
+additivity — holds: the `src/` diff is exactly the four files the design authorised, `manifest.json`
+and all ten locales are byte-identical, and every a11y rule is gated behind a media query,
+`:focus-visible`, `.sr-only`, or an additive ARIA attribute. No P1/P2 findings. The single remaining
+gate is the **human** final parity sign-off (REQ-AY-017 / TEST-AY-017), recorded as pending — which is
+correct and intended, not a defect.
+
+The verdict is `approve-with-nits` (not bare `approve`) because of two low-severity documentation/scope
+nits (R-AY-001, R-AY-002) that do not block merge to `next` and do not affect the shipped behaviour.
+
+## What I verified (read-only, this turn)
+
+- Read all P12 spec artifacts + the full `git diff --stat next..HEAD` + `git log next..HEAD`.
+- Read `src/ui/styles/accessibility.css`, `src/plugin/main.ts`, `src/ui/main.ts`,
+  `src/ui/components/NoticeLiveRegion.vue`, and `tests/ui/a11y/modalFocusTrap.test.ts` +
+  `additivity.test.ts` in full.
+- Ran `npx vitest run tests/ui/styles/accessibility.test.ts tests/ui/styles/accessibility-registration.test.ts`
+  → **15 passed**.
+- Ran `npx vitest run tests/ui/a11y/` → **40 passed (8 files)**.
+- Confirmed `git diff next..HEAD -- src/` = exactly 4 files; `git diff next -- manifest.json src/ui/i18n/locales` = empty.
+- Grepped `ChatSurface.vue` / `TabBar.vue` for the verify-only ARIA seams; grepped the P12 diff for raw-HTML sinks and `obsidian` imports.
+
+## 1. Requirements compliance
+
+All 16 automatable REQ-AY satisfied with evidence (see `traceability.md` for the full matrix). Highlights:
+
+- **REQ-AY-001/002 (layer + registration):** `accessibility.css` exists with all six rule groups in
+  order; imported as the 3rd CSS import after `tokens.css`/`animations.css` at both `src/plugin/main.ts:3`
+  and `src/ui/main.ts:15`. Verified by the two file-read suites (15 green) and by direct read.
+- **REQ-AY-003/004 (reduced motion):** RG-1 universal `!important` safety-net (`accessibility.css:28-37`)
+  + RG-2 explicit `animation: none` spin halt (`42-47`) — `none`, not a near-zero duration, correctly
+  honouring CQ-AUX-14.
+- **REQ-AY-005/006 (forced colors):** RG-3 maps text/surface/focus/button to system colours (`53-71`);
+  RG-4 (`82-91`) gives a `currentColor` border to the real swept-component selectors (`[role="switch"]`,
+  `[data-state]`, `.sp-file-chips__chip`, `.sp-image-thumb`, `.sp-tab`, `[role="option"][aria-selected="true"]`).
+- **REQ-AY-007 (focus-visible):** RG-5 (`98-110`) uses `:focus-visible` (never bare `:focus`), consumes
+  the existing `--sp-focus-ring` (tokens.css:42) + `--sp-shadow-focus-ring` (tokens.css:140) — no new token.
+- **REQ-AY-009 (`.sr-only`):** RG-6 (`116-127`) is the standard clip technique, not `display:none`.
+- **REQ-AY-010 (live region):** `ChatSurface.vue:856-857` carries `aria-live="polite"` + `role="status"`
+  (verify-only, confirmed); the genuine fill `NoticeLiveRegion.vue` announces severity-mapped
+  (error→assertive/alert, else polite/status) declaratively over the existing `sp:notice` window event.
+- **REQ-AY-011/012/013 (collapsible + modals):** `SpCollapsible` already binds `aria-expanded`
+  (verify-only); the modal test asserts all 8 seams inherit `Modal.prototype` via a real prototype-chain
+  walk — a discriminating structural assertion, not a tautology.
+- **REQ-AY-014/015 (additivity + discipline):** confirmed below.
+
+REQ-AY-017 (human sign-off) is correctly recorded as the outstanding final gate (owner: human).
+
+## 2. Design compliance
+
+Implementation honours DESIGN-AY-001 with no material drift. The 6 rule groups RG-1..RG-6 match the B.1
+inventory; D-AY-1 (complement, not replace, the token overrides), D-AY-2 (reuse existing tokens), D-AY-3
+(native `Modal` trap — verify, don't re-implement), D-AY-4 (`.specorator-root`-prefixed, `!important`
+only on RG-1), and D-AY-5 (forced-colors system colours as the single colour exception) are all observed
+in the shipped file. One designed convergence (not drift): the RG-4 selector list moved from the
+placeholder `.sp-toggle-switch`/`.sp-chip` to the real swept-component selectors — see R-AY-002.
+
+## 3. Spec compliance & deviations
+
+Two deviations are logged in the implementation log, both correctly classified as non-divergences:
+
+- **RG-4 selector correction** (T-AY-006, commit 46869990): the T-AY-005 placeholders matched no real
+  control; the mount-leg test surfaced this (its stated purpose) and the selectors were corrected to the
+  real components. SPEC-AY-006 explicitly says the concrete selectors "come from the Chunk-2 component
+  sweep", so this is designed convergence. Logged. ADR-tracking not required (no architectural decision).
+- **T-AY-010 / T-AY-012 verify-only** (no code change): the audit found the per-phase a11y sweep already
+  labelled icon-only controls and bound `aria-expanded` on `SpCollapsible`. Logged as verify-only per
+  DESIGN-AY-001 B.2. Correct.
+
+No deviation rises to ADR weight; DESIGN-AY-001 §C.6's "no new ADR" verdict holds.
+
+## 4. Constitution check
+
+No violations.
+- **Art. I/II (spec-driven, separation):** every code artifact traces to a SPEC-AY; the RG-4 dead-selector
+  issue was escalated through the test rather than silently patched.
+- **Art. III (incremental):** RED-before-green ordering observed (T-AY-003/004 RED before T-AY-002).
+- **Art. V (traceability):** full chain regenerated in `traceability.md`; no orphans.
+- **Art. VII (human oversight):** REQ-AY-017 is presented, not self-claimed — exactly as the article requires.
+- **Art. IX (reversibility):** a CSS layer + additive ARIA is fully reversible; no irreversible action taken.
+
+## 5. Architecture & risk
+
+- **No new port / InjectionKey / composable / component-pattern / ADR** — confirmed. `NoticeLiveRegion.vue`
+  is a pure Vue `<script setup>` component on the existing `sp:notice` window CustomEvent channel; it
+  contains **no `obsidian` import** (grep-confirmed), honouring the `no-restricted-imports` UI rule.
+- **No `v-html` / `innerHTML` / `outerHTML` / `insertAdjacentHTML`** added — the only diff match is inside
+  a NoticeLiveRegion comment that *names* the banned sinks; the template binds text via `{{ }}`.
+- **Token discipline** holds: the only colour keywords are CSS system colours inside the `forced-colors`
+  block (the documented NFR-AY-002 exception).
+- **Risk — JSDOM cannot exercise `:focus-visible` / live Tab-cycle / forced-colors rendering.** Correctly
+  acknowledged: those become the human visual leg (REQ-AY-017). The automatable suite asserts the
+  structural property (selector matching, prototype chain, attribute presence) instead. Acceptable and
+  honestly scoped.
+
+## 6. WCAG 2.2 AA assessment
+
+The layer + per-surface behaviours meet the AA bar at the automatable level:
+- **SC 2.4.7 Focus Visible** — RG-5 `:focus-visible` ring across all interactive controls (meets + extends
+  claudian's 3 focus-visible groups).
+- **SC 2.1.2 / 2.4.3 No Keyboard Trap / Focus Order** — native Obsidian `Modal` trap + restore, verified
+  structurally across all 8 seams.
+- **SC 1.4.3 / 1.4.11 contrast under forced-colors** — RG-3/RG-4 system-colour mapping + guaranteed borders.
+- **SC 2.3.3 Animation from Interactions / reduced-motion** — RG-1 global guard + RG-2 spin halt.
+- **SC 4.1.3 Status Messages** — `ChatSurface` busy region (polite/status) + `NoticeLiveRegion`
+  (severity-mapped) announce without stealing focus.
+- **SC 1.1.1 / 4.1.2 Name, Role, Value** — `.sr-only` + icon-only labels + `aria-expanded` on collapsibles.
+
+This is "meet + beat claudian" (claudian ships focus-visible rings only; P12 adds reduced-motion,
+forced-colors, `.sr-only`, and live regions). The visual conformance judgment remains the human leg.
+
+## Brand review
+
+Not applicable. The diff touches no `sites/`, no `specorator-design` skill, no user-visible HTML/CSS
+producing a *new* brand surface, and no `templates/` HTML emitter. `accessibility.css` is a system-driven
+a11y layer (focus ring + system-colour fallback + clip utility) consuming existing `--sp-*` tokens — it
+introduces no token literal, no emoji, no icon-library import, no gradient/texture, no page background.
+`NoticeLiveRegion.vue` is `.sr-only` (zero visible footprint). `Brand review: not-applicable`.
+
+## Findings
+
+| ID | Severity | Category | Location | Finding | Recommendation | Owner |
+|---|---|---|---|---|---|---|
+| R-AY-001 | low | docs/process | `specs/accessibility/{implementation-log.md,test-plan.md,workflow-state.md}` | Stage frontmatter is stale relative to actual progress: implementation-log + test-plan say `in-progress` and workflow-state says `current_stage: tasks` / `review.md: pending`, but Chunks 1–3 are complete and review is now produced. The remaining open items (T-AY-017 human gate, T-AY-018 parent gate) are correctly open, but the stage pointers lag. | Release-manager/orchestrator to advance `workflow-state.md` (`current_stage: review`, mark review.md + traceability.md complete) and flip impl-log/test-plan status to `complete` once T-AY-018 runs. Non-blocking. | release-manager |
+| R-AY-002 | low | spec-hygiene | `accessibility.css:82-91` vs `test-plan.md §4` | The RG-4 selector enumeration in `test-plan.md §4` still lists the original placeholder selectors (`.sp-toggle-switch`, `.sp-chip`) that were corrected in the shipped CSS to `[role="switch"]` / `.sp-file-chips__chip` / `.sp-image-thumb` (logged in impl-log T-AY-006). The shipped code and tests are correct and consistent; only the test-plan reference table is stale. | Planner/dev to refresh `test-plan.md §4` to the real selectors so the baseline doc matches the shipped RG-4. Cosmetic; does not affect behaviour or any test. | planner |
+
+No critical/high/medium findings. A clean P12 by design (additive, mostly verify-only), so a short
+findings list is expected here — the two nits are genuine doc-sync gaps I confirmed against the diff,
+not filler.
+
+## Quality-metrics evidence
+
+`specorator quality:metrics` was not invoked (Stage-9 read-only scope; parent owns the full suite/build
+run at T-AY-018). Deterministic evidence used instead: the two targeted CSS suites (15 green) + the full
+`tests/ui/a11y/` suite (40 green) ran clean this turn; the `git diff` scope + manifest/locale byte-identity
+were confirmed directly. The coverage gate (NFR-AY-007) and full verify chain (NFR-AY-010) are confirmed
+by the parent at T-AY-018 — recorded as pending in `traceability.md`, not asserted here.
+
+## Conditions on the verdict
+
+`approve-with-nits` is conditional only on the parent's closing gate (T-AY-018: full `npm run verify` +
+`npm run test:all` + `build:web` lightningcss leg + both-output presence + coverage 80/70/80/80) coming
+back green — which is the parent's scope, not this reviewer's. The two nits (R-AY-001, R-AY-002) are
+non-blocking and may be folded into the release/retro step. The epic remains **unaccepted** until the
+**human** approves the final parity screenshot set + the accumulated P5–P11 manual-Obsidian legs
+(REQ-AY-017 / TEST-AY-017) — the agent presents and opens (does not merge) the `next` → `develop` PR.
+
+## Hand-off
+
+- → **release-manager / orchestrator:** run the T-AY-018 closing gate; fix R-AY-001 (stage pointers) as
+  part of the release step; then **present** (do not merge) the `next` → `develop` PR and surface the
+  REQ-AY-017 human sign-off as the single final epic gate.
+- → **planner:** R-AY-002 (refresh `test-plan.md §4` RG-4 selector list to the shipped selectors).
+- → **human:** the final parity screenshot sign-off (all P1–P11 surfaces, light + dark, 320/520/720 px)
+  + the accumulated manual-Obsidian legs — the program-done gate.

--- a/specs/accessibility/spec.md
+++ b/specs/accessibility/spec.md
@@ -1,0 +1,319 @@
+---
+id: SPEC-AY-001
+title: Accessibility — implementation-ready spec (accessibility.css + behaviour sweep + tests)
+stage: spec
+feature: accessibility
+area: AY
+epic: claudian-reboot
+phase: P12
+status: complete
+owner: architect
+integration_branch: next
+reference: D:\Projects\claudian-main\src\style\accessibility.css
+satisfies:
+  - PRD-AY-001 (REQ-AY-001..017)
+  - DESIGN-AY-001 (Parts A/B/C)
+created: 2026-05-27
+updated: 2026-05-27
+---
+
+# Specification — Accessibility (P12, final phase)
+
+> Implementation-ready contracts for the P12 accessibility layer. Two independent teams building from
+> this should produce the same `accessibility.css`, the same two import edits, the same additive
+> behaviour fixes, and the same test set. The only colour literals permitted in `accessibility.css`
+> are CSS **system-color keywords inside a `forced-colors` block** (NFR-AY-002). No new port, no new
+> ADR (DESIGN-AY-001 §C.6).
+
+## Conventions
+
+- **Scoping.** Every selector in `accessibility.css` is authored prefixed with `.specorator-root` (so
+  the build's `scopeBuiltCss()` leaves it as-is). `@keyframes` are never targeted.
+- **Comments.** ASCII-only markers (`/* section B.x - ... */`), no non-ASCII glyphs, so the standalone
+  lightningcss minifier accepts them (NFR-AY-005).
+- **Tokens.** Consume the existing `--sp-focus-ring` (tokens.css:42) and `--sp-shadow-focus-ring`
+  (tokens.css:140). Mint no new token (NG2).
+- **Additivity.** Every rule is gated behind a media query, `:focus-visible`, `.sr-only`, or an
+  additive ARIA attribute. Default (no-condition) render is the `next` baseline, unchanged.
+
+---
+
+## Chunk 1 — `accessibility.css` + pipeline registration
+
+### SPEC-AY-001 — Create `src/ui/styles/accessibility.css` (the 6 rule groups)
+
+- **Artifact:** new file `src/ui/styles/accessibility.css`.
+- **Behaviour:** contains exactly the six rule groups below, in this order, scoped to
+  `.specorator-root`, ASCII comments, no hex / no raw Obsidian var outside the `forced-colors` block.
+- **Group RG-1 — reduced-motion global guard** (REQ-AY-003):
+  ```
+  @media (prefers-reduced-motion: reduce) {
+    .specorator-root *,
+    .specorator-root *::before,
+    .specorator-root *::after {
+      animation-duration: 0.001ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.001ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
+  ```
+- **Group RG-2 — spin halt** (REQ-AY-004):
+  ```
+  @media (prefers-reduced-motion: reduce) {
+    .specorator-root [data-animation="spin"],
+    .specorator-root .sp-spin {
+      animation: none !important;
+    }
+  }
+  ```
+- **Group RG-3 — forced-colors surface mapping** (REQ-AY-005): inside `@media (forced-colors: active)`,
+  set `.specorator-root { forced-color-adjust: auto; }` and map text→`CanvasText`, surfaces→`Canvas`,
+  focus/selected→`Highlight`/`HighlightText`, button affordances→`ButtonText`/`ButtonFace`. (No layout
+  change — colour mapping only.)
+- **Group RG-4 — forced-colors border guarantee** (REQ-AY-006): inside the same `@media (forced-colors:
+  active)`, set `border: 1px solid currentColor;` (or `outline` where the box-model must not shift) on
+  the background-cue-only controls: the toggle switch, state pills, chips, tab badges, selected
+  dropdown options. Enumerate the concrete selectors per the swept components (SPEC-AY-006).
+- **Group RG-5 — focus-visible ring** (REQ-AY-007):
+  ```
+  .specorator-root :where(button, [role="tab"], [role="option"], [role="switch"],
+    a[href], textarea, input, select, [tabindex]):focus-visible {
+    outline: 2px solid var(--sp-focus-ring);
+    outline-offset: 2px;
+  }
+  ```
+  Plus a `box-shadow: var(--sp-shadow-focus-ring)` variant for controls whose `outline` is clipped by
+  `overflow: hidden`. Uses `:focus-visible` (never bare `:focus`).
+- **Group RG-6 — `.sr-only` utility** (REQ-AY-009):
+  ```
+  .specorator-root .sr-only {
+    position: absolute;
+    inline-size: 1px; block-size: 1px;
+    padding: 0; margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0); clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+  ```
+- **Pre-conditions:** tokens.css declares `--sp-focus-ring` + `--sp-shadow-focus-ring` (it does).
+- **Side effects:** none at runtime beyond CSS; no JS, no DOM.
+- **Errors:** a lightningcss minify error on the standalone build = NFR-AY-005 failure (fix the
+  comment/at-rule, do not suppress).
+- **Satisfies:** REQ-AY-001, REQ-AY-003, REQ-AY-004, REQ-AY-005, REQ-AY-006, REQ-AY-007, REQ-AY-009,
+  REQ-AY-015.
+- **Verified by:** TEST-AY-001, TEST-AY-003, TEST-AY-004, TEST-AY-005, TEST-AY-006, TEST-AY-007,
+  TEST-AY-009, TEST-AY-015.
+
+### SPEC-AY-002 — Register `accessibility.css` at the plugin entry
+
+- **Signature:** add `import '@/ui/styles/accessibility.css';` to `src/plugin/main.ts` as the **third**
+  CSS import, immediately after `import '@/ui/styles/animations.css';` (line 2).
+- **Post-condition:** the produced plugin `styles.css` contains the RG-1..RG-6 rules.
+- **Satisfies:** REQ-AY-002 (plugin leg). **Verified by:** TEST-AY-002.
+
+### SPEC-AY-003 — Register `accessibility.css` at the standalone entry
+
+- **Signature:** add `import './styles/accessibility.css';` to `src/ui/main.ts` as the **third** CSS
+  import, immediately after `import './styles/animations.css';` (line 14).
+- **Post-condition:** the standalone bundle contains the RG-1..RG-6 rules.
+- **Satisfies:** REQ-AY-002 (standalone leg). **Verified by:** TEST-AY-002.
+
+---
+
+## Chunk 2 — Behaviour-fix sweep (additive edits to existing components)
+
+> Each item is **additive**: it adds an ARIA attribute, an `.sr-only` label, or asserts an existing
+> affordance. No default render, layout, microcopy, or locale string changes (REQ-AY-014). Where the
+> audit found the affordance already present, the item is **verify-only** (a test, not a code edit).
+
+### SPEC-AY-004 — Streaming + notice live regions
+
+- **Behaviour:** the streaming busy region in `src/ui/chat/ChatSurface.vue` already carries
+  `aria-live="polite"` + `role="status"` (lines 856-857) — **verify-only**. The notice host must
+  announce: error notices assertive, info/success polite. In the standalone, if the notice host has no
+  live region, add an `aria-live` region (polite default, assertive for error) that mirrors the notice
+  text — declaratively (no `innerHTML`/`v-html`).
+- **Pre/post:** focus is never stolen by the announcement.
+- **Satisfies:** REQ-AY-010. **Verified by:** TEST-AY-010.
+
+### SPEC-AY-005 — Collapsible `aria-expanded` + accessible name
+
+- **Behaviour:** each collapsible header (tool call / thinking / subagent / write-edit) under
+  `src/ui/chat/rich/**` exposes `aria-expanded` bound to its open state and an accessible name
+  (visible text or `aria-label`). If a header already has it, verify-only; otherwise add it.
+- **State transition:**
+  ```mermaid
+  stateDiagram-v2
+    [*] --> Collapsed
+    Collapsed --> Expanded: Enter/Space/click (aria-expanded=true)
+    Expanded --> Collapsed: Enter/Space/click (aria-expanded=false)
+  ```
+- **Satisfies:** REQ-AY-011. **Verified by:** TEST-AY-011.
+
+### SPEC-AY-006 — Forced-colors borders on the enumerated background-cue-only controls
+
+- **Behaviour:** the RG-4 selector list (SPEC-AY-001) must enumerate the concrete classes of every
+  control whose normal affordance is a background fill/wash only. Audit the toolbar toggle switch, the
+  state pills, the file/image chips, the tab badges (`.sp-tab`), and the selected dropdown option, and
+  list each in RG-4 so each gains a visible border under forced-colors.
+- **Pre/post:** under `forced-colors: active`, each listed control has a perceivable border; default
+  render unchanged.
+- **Satisfies:** REQ-AY-006. **Verified by:** TEST-AY-006.
+
+### SPEC-AY-007 — Icon-only controls carry an accessible name; keyboard operability + labelling sweep
+
+- **Behaviour:** audit every interactive control in the toolbar strip, settings shell, and chat surface
+  (composer, message actions, dropdowns, tab close `×`, new-tab `+`, paperclip, chip remove, image
+  remove). Each must (a) be keyboard-reachable + operable via Enter/Space per the audit contract, and
+  (b) expose a non-empty accessible name (visible label, `aria-label`, or an `.sr-only` label). Add
+  `aria-label`/`.sr-only` where missing; keep decorative glyphs `aria-hidden="true"` (TabBar already
+  does — verify-only there).
+- **Satisfies:** REQ-AY-008, REQ-AY-009. **Verified by:** TEST-AY-008, TEST-AY-009.
+
+### SPEC-AY-008 — Focus-visible ring reaches every interactive control
+
+- **Behaviour:** RG-5 (SPEC-AY-001) covers the standard interactive elements via the `:where(...)`
+  selector. Verify across surfaces that no interactive control is excluded (e.g. a custom `div[role]`
+  control gets `tabindex` so it matches `[tabindex]`). No control shows a stray ring on mouse `:focus`
+  (the counter-metric).
+- **Satisfies:** REQ-AY-007, REQ-AY-008. **Verified by:** TEST-AY-007.
+
+### SPEC-AY-009 — Modal focus trap + restore via the platform
+
+- **Behaviour:** the eight Specorator modals (ProviderConsent, DeleteConfirm, ForkTarget,
+  InstructionConfirm, InlineEdit, ImagePreview, McpServer, McpTest) extend Obsidian `Modal`, which
+  natively traps Tab/Shift+Tab within the modal and restores `document.activeElement` on close. **Do
+  not hand-roll a trap.** The spec requires each launcher to open a `Modal` subclass; the test asserts
+  that property + (where the harness allows) a Tab-cycle staying inside + focus returning to the opener.
+- **Pre-condition:** the opener control is focusable + present when the modal opens.
+- **Post-condition:** on any close path (accept/reject/Esc/overlay), focus returns to the opener (or
+  its nearest still-present sibling), not `document.body`.
+- **Satisfies:** REQ-AY-012, REQ-AY-013. **Verified by:** TEST-AY-012, TEST-AY-013.
+
+### SPEC-AY-010 — Additivity invariant
+
+- **Behaviour:** no swept component's default (no-media-query, no-`.sr-only`) render, layout,
+  microcopy, locale output, or behaviour changes. The a11y rules take effect only inside
+  `:focus-visible`, `prefers-reduced-motion`, `forced-colors`, `.sr-only`, or additive ARIA.
+- **Satisfies:** REQ-AY-014, NFR-AY-004. **Verified by:** TEST-AY-014.
+
+### SPEC-AY-011 — Discipline invariant (no raw-HTML sink, no token leak)
+
+- **Behaviour:** the P12 diff adds no `innerHTML`/`outerHTML`/`insertAdjacentHTML`/`v-html`;
+  `accessibility.css` carries no hex / no raw Obsidian var outside the single `forced-colors`
+  system-color block.
+- **Satisfies:** REQ-AY-015, NFR-AY-002, NFR-AY-003. **Verified by:** TEST-AY-015.
+
+---
+
+## Chunk 3 — Tests (TEST-AY-001..016 automatable; TEST-AY-017 human)
+
+> Tests mirror `src/` path-for-path (ADR-009); component mounts use co-located class-based PageObjects
+> querying by `data-testid` only. CSS-rule-presence tests read `src/ui/styles/accessibility.css` as
+> text; registration tests read the entry files as text.
+
+| TEST | Kind | Asserts | Verifies SPEC / REQ |
+|---|---|---|---|
+| TEST-AY-001 | file read | `accessibility.css` exists + declares RG-1..RG-6 (reduced-motion, spin, forced-colors, focus-visible, `.sr-only`); every selector is `.specorator-root`-scoped | SPEC-AY-001 / REQ-AY-001 |
+| TEST-AY-002 | file read | both `src/plugin/main.ts` + `src/ui/main.ts` import `accessibility.css` after tokens + animations | SPEC-AY-002/003 / REQ-AY-002 |
+| TEST-AY-003 | file read | RG-1 reduced-motion guard present (`prefers-reduced-motion: reduce` collapsing animation/transition duration) | SPEC-AY-001 / REQ-AY-003 |
+| TEST-AY-004 | file read | RG-2 sets `animation: none` (not a duration) for `[data-animation="spin"]`/`.sp-spin` under reduced-motion | SPEC-AY-001 / REQ-AY-004 |
+| TEST-AY-005 | file read | RG-3 `@media (forced-colors: active)` present with `forced-color-adjust` + system-color keywords | SPEC-AY-001 / REQ-AY-005 |
+| TEST-AY-006 | file read + mount | RG-4 enumerates the background-cue-only controls (toggle/pill/chip/`.sp-tab`/selected option) with a forced-colors border; the listed `data-testid` controls exist in the mounted surfaces | SPEC-AY-001/006 / REQ-AY-006 |
+| TEST-AY-007 | file read + mount | RG-5 uses `:focus-visible` + `--sp-focus-ring`; a keyboard-focused control (PageObject Tab) exposes the ring; mouse `:focus` shows none | SPEC-AY-001/008 / REQ-AY-007 |
+| TEST-AY-008 | mount | every audited control in toolbar/settings/chat is focusable + has a non-empty accessible name | SPEC-AY-007 / REQ-AY-008 |
+| TEST-AY-009 | file read + mount | RG-6 `.sr-only` clip technique present (not `display:none`/`visibility:hidden`); icon-only controls carry an `.sr-only`/`aria-label` | SPEC-AY-001/007 / REQ-AY-009 |
+| TEST-AY-010 | mount | the busy region has `aria-live="polite"` + `role="status"`; the notice host announces (error assertive, info polite) without focus theft | SPEC-AY-004 / REQ-AY-010 |
+| TEST-AY-011 | mount | a collapsible header exposes `aria-expanded` that flips on Enter/Space/click + has an accessible name | SPEC-AY-005 / REQ-AY-011 |
+| TEST-AY-012 | mount | each launcher opens a `Modal` subclass; a PageObject Tab-cycle stays within the modal (or, where JSDOM cannot, the structural `Modal`-subclass assertion) | SPEC-AY-009 / REQ-AY-012 |
+| TEST-AY-013 | mount | closing a modal (accept/reject/Esc) returns focus to the recorded opener, not `document.body` | SPEC-AY-009 / REQ-AY-013 |
+| TEST-AY-014 | mount/snapshot | no swept component's default render or locale output differs from baseline (additivity diff) | SPEC-AY-010 / REQ-AY-014 |
+| TEST-AY-015 | scan | no added `innerHTML`/`outerHTML`/`insertAdjacentHTML`/`v-html` in the P12 diff; `accessibility.css` has no hex / no raw Obsidian var outside the `forced-colors` block; ASCII-only comments | SPEC-AY-011 / REQ-AY-015 |
+| TEST-AY-016 | artifact check | `specs/accessibility/parity-screenshots.md` exists and lists every charter §3 surface at 320/520/720 px in light + dark (artifact-completeness only; not the visual judgment) | REQ-AY-016 |
+| **TEST-AY-017** | **HUMAN** | **the final cross-surface parity screenshot sign-off — all P1–P11 surfaces, light + dark, 320/520/720 px, plus the accumulated P5–P11 manual-Obsidian legs. The single final epic gate. The agent PRESENTS it (and opens, does not merge, the `next`→`develop` PR); it is NEVER agent-claimed (constitution Art. VII).** | **REQ-AY-017** |
+
+---
+
+## Edge cases (EC-AY-NNN)
+
+| ID | Scenario | Required behaviour | REQ |
+|---|---|---|---|
+| EC-AY-001 | Reduced-motion + an active indeterminate spinner (title-gen / inline-edit / instruction) | RG-2 sets `animation: none` — the spinner does not rotate (a near-zero duration alone would not stop an indeterminate loop, CQ-AUX-14) | REQ-AY-004 |
+| EC-AY-002 | Reduced-motion + a transition the per-section tokens did not collapse (a future component) | RG-1 safety-net collapses it to ~0; no perceptible motion | REQ-AY-003 |
+| EC-AY-003 | Forced-colors + a control signalled only by a background wash (toggle/pill/chip/selected option) | RG-4 adds a visible `currentColor` border so the control stays distinguishable | REQ-AY-006 |
+| EC-AY-004 | Forced-colors + a focused control | the focus state resolves to `Highlight` (RG-3) and the ring stays perceivable | REQ-AY-005, REQ-AY-007 |
+| EC-AY-005 | Keyboard focus lands on a control reached by Tab | RG-5 `:focus-visible` ring shows | REQ-AY-007 |
+| EC-AY-006 | Mouse click on the same control | no ring (`:focus-visible` excludes pointer focus) — the counter-metric | REQ-AY-007 |
+| EC-AY-007 | An `.sr-only`-labelled icon-only control | the label is in the accessibility tree but has zero visible footprint (clip technique, not `display:none`) | REQ-AY-009 |
+| EC-AY-008 | A modal opens, user Tabs past the last control | focus wraps within the modal (Obsidian `Modal` native trap); never lands behind the modal | REQ-AY-012 |
+| EC-AY-009 | A modal closes via Esc / overlay / accept / reject | focus returns to the opener control (native restore); if the opener was removed, to its nearest sibling, never `document.body` | REQ-AY-013 |
+| EC-AY-010 | No a11y media query active, no `.sr-only` applied | default render byte-identical to the `next` baseline (additivity) | REQ-AY-014 |
+| EC-AY-011 | Assistant streams while the user reads earlier output | the polite live region announces the new text without moving focus | REQ-AY-010 |
+| EC-AY-012 | An error notice fires | announced assertive (interrupts) while info/success stay polite | REQ-AY-010 |
+| EC-AY-013 | Standalone lightningcss minify of `accessibility.css` | green — ASCII comments + standard at-rules; no minify error (NFR-AY-005) | REQ-AY-015 |
+| EC-AY-014 | A user theme overrides `--interactive-accent` | the focus ring follows it (RG-5 consumes `--sp-focus-ring` → `--interactive-accent`); no hardcoded colour | REQ-AY-007 |
+
+---
+
+## Observability
+
+P12 adds no new logs/metrics/traces — it is presentation + accessibility-tree only. The existing
+`LoggerPort`/`NotificationPort`/`FeedbackService` paths are unchanged; the notice-announcement change
+(SPEC-AY-004) routes through the existing `NotificationPort` severity (error→assertive,
+info/success→polite), not a new channel.
+
+## Performance budget
+
+Inherits the PRD NFRs; no new threshold. The reduced-motion guard uses `!important` on a universal
+selector inside a media query that is inert unless `prefers-reduced-motion` is set — no default-path
+cost. `npm run build` + `npm run build:web` stay green (NFR-AY-005); `npm run verify` +
+`npm run test:all` zero failures on `next` (NFR-AY-010); coverage 80/70/80/80 holds (NFR-AY-007).
+
+## Compatibility
+
+No backward-compat / migration (CHARTER-REQ-FRESH, NG5). `manifest.json` byte-identical (NFR-AY-008).
+en/de + all ten locales byte-identical (NFR-AY-004). The layer is strictly additive — no surface
+regresses (REQ-AY-014).
+
+---
+
+## Requirements coverage table (REQ-AY ↔ SPEC-AY ↔ TEST-AY)
+
+| REQ | SPEC | TEST | Leg |
+|---|---|---|---|
+| REQ-AY-001 | SPEC-AY-001 | TEST-AY-001 | auto |
+| REQ-AY-002 | SPEC-AY-002, SPEC-AY-003 | TEST-AY-002 | auto |
+| REQ-AY-003 | SPEC-AY-001 (RG-1) | TEST-AY-003 | auto |
+| REQ-AY-004 | SPEC-AY-001 (RG-2) | TEST-AY-004 | auto |
+| REQ-AY-005 | SPEC-AY-001 (RG-3) | TEST-AY-005 | auto |
+| REQ-AY-006 | SPEC-AY-001 (RG-4), SPEC-AY-006 | TEST-AY-006 | auto |
+| REQ-AY-007 | SPEC-AY-001 (RG-5), SPEC-AY-008 | TEST-AY-007 | auto |
+| REQ-AY-008 | SPEC-AY-007, SPEC-AY-008 | TEST-AY-008 | auto |
+| REQ-AY-009 | SPEC-AY-001 (RG-6), SPEC-AY-007 | TEST-AY-009 | auto |
+| REQ-AY-010 | SPEC-AY-004 | TEST-AY-010 | auto |
+| REQ-AY-011 | SPEC-AY-005 | TEST-AY-011 | auto |
+| REQ-AY-012 | SPEC-AY-009 | TEST-AY-012 | auto |
+| REQ-AY-013 | SPEC-AY-009 | TEST-AY-013 | auto |
+| REQ-AY-014 | SPEC-AY-010 | TEST-AY-014 | auto |
+| REQ-AY-015 | SPEC-AY-001, SPEC-AY-011 | TEST-AY-015 | auto |
+| REQ-AY-016 | (artifact: parity-screenshots.md) | TEST-AY-016 | auto (completeness) |
+| REQ-AY-017 | (human acceptance) | **TEST-AY-017** | **HUMAN — final epic gate** |
+
+**NFR coverage:** NFR-AY-001 (TEST-AY-006/007/008/010/011/012/013 across surfaces) · NFR-AY-002
+(TEST-AY-015) · NFR-AY-003 (TEST-AY-015) · NFR-AY-004 (TEST-AY-014) · NFR-AY-005 (build green,
+EC-AY-013) · NFR-AY-006 (TEST-AY-002) · NFR-AY-007 (coverage gate) · NFR-AY-008 (manifest unchanged)
+· NFR-AY-009 (TEST-AY-005/006 + EC-AY-002/003) · NFR-AY-010 (verify + test:all green).
+
+## Planner chunk boundaries
+
+1. **Chunk 1 — accessibility.css + registration** (SPEC-AY-001/002/003): one new file + two one-line
+   import edits. Self-contained; lands first. Tests TEST-AY-001..005, 015 (file-read leg) + TEST-AY-002.
+2. **Chunk 2 — behaviour-fix sweep** (SPEC-AY-004..011): additive ARIA/label/live-region edits across
+   the swept components; mostly verify-only (busy region, TabBar, modals) + targeted fills
+   (collapsible `aria-expanded`, icon-only labels, RG-4 selector enumeration). Tests TEST-AY-006..014.
+3. **Chunk 3 — tests + the human gate artifact** (TEST-AY-001..016 + the `parity-screenshots.md`
+   artifact for TEST-AY-016): the automatable suite under the verify gate. TEST-AY-017 (human sign-off)
+   is presented, not built — the agent opens (does not merge) the `next`→`develop` PR after the gate is
+   green.

--- a/specs/accessibility/tasks.md
+++ b/specs/accessibility/tasks.md
@@ -147,18 +147,18 @@ trap/restore), the `ChatSurface.vue` busy region (already `aria-live="polite"` +
 - **Depends on:** —
 - **Estimate:** S
 - **Definition of done:**
-  - [ ] `specs/accessibility/test-plan.md` exists with: the `--sp-focus-ring`/`--sp-shadow-focus-ring`
+  - [x] `specs/accessibility/test-plan.md` exists with: the `--sp-focus-ring`/`--sp-shadow-focus-ring`
         token-reference note, the two import-site insertion points (`main.ts:2` + `ui/main.ts:14`), the
         five-keyframe reduced-motion source inventory, the enumerated RG-4 background-cue-only control
         selectors (toggle / pill / chip / `.sp-tab` / selected option), and the claudian
         minimal-focus-visible-only reference note (meet = RG-5; beat = RG-1..4 + RG-6).
-  - [ ] `specs/accessibility/parity-screenshots.md` scaffolded — every charter §3 surface listed at
+  - [x] `specs/accessibility/parity-screenshots.md` scaffolded — every charter §3 surface listed at
         320/520/720 px in light + dark, with a baseline (claudian) column and a Specorator column (the
         TEST-AY-016 completeness structure; cells placeholder until the screenshots are captured).
-  - [ ] A one-line lint check confirms the deleted-symbol guard does **not** block the new
+  - [x] A one-line lint check confirms the deleted-symbol guard does **not** block the new
         `accessibility.css` / the two import lines / the ARIA edits; the verdict **NO guard-relax + NO new
         InjectionKey/port/component/ADR + manifest/locales untouched** is recorded in `test-plan.md`.
-  - [ ] No file under `src/` changed.
+  - [x] No file under `src/` changed.
 
 ---
 
@@ -203,15 +203,15 @@ trap/restore), the `ChatSurface.vue` busy region (already `aria-live="polite"` +
 - **Depends on:** T-AY-001, T-AY-003 (RED), T-AY-004 (RED)
 - **Estimate:** M
 - **Definition of done:**
-  - [ ] `src/ui/styles/accessibility.css` exists with RG-1..RG-6 in order, every selector
+  - [x] `src/ui/styles/accessibility.css` exists with RG-1..RG-6 in order, every selector
         `.specorator-root`-prefixed, ASCII-only comments, `!important` only on RG-1, no hex / no raw
         Obsidian var outside the `forced-colors` block, RG-5 consuming the existing
         `--sp-focus-ring`/`--sp-shadow-focus-ring` (no new token), RG-5 using `:focus-visible` (not bare
         `:focus`), RG-2 setting `animation: none` (not a duration), RG-6 using the clip technique (not
         `display:none`).
-  - [ ] `accessibility.css` is imported as the **3rd** CSS import (after tokens + animations) at both
+  - [x] `accessibility.css` is imported as the **3rd** CSS import (after tokens + animations) at both
         `src/plugin/main.ts` and `src/ui/main.ts`; `vite.config.ts` unchanged.
-  - [ ] The RED file-read (T-AY-003) + registration (T-AY-004) tests now GREEN; whole-project
+  - [x] The RED file-read (T-AY-003) + registration (T-AY-004) tests now GREEN; whole-project
         `npm run lint` 0 + `npm run typecheck` 0 + `npm run test` green; implementation-log entry added.
 
 ### T-AY-003 🧪 — RED: `accessibility.css` rule-group presence (RG-1..RG-6, `.specorator-root`-scoped, discipline)
@@ -237,12 +237,12 @@ trap/restore), the `ChatSurface.vue` busy region (already `aria-live="polite"` +
 - **Depends on:** T-AY-001
 - **Estimate:** M
 - **Definition of done:**
-  - [ ] `tests/ui/styles/accessibility.test.ts` reads the CSS file as text and asserts: RG-1..RG-6 present
+  - [x] `tests/ui/styles/accessibility.test.ts` reads the CSS file as text and asserts: RG-1..RG-6 present
         + ordered, every selector `.specorator-root`-scoped, RG-1 reduced-motion collapse, RG-2
         `animation: none`, RG-3 forced-colors + system colours, RG-5 `:focus-visible` + `--sp-focus-ring`,
         RG-6 clip technique, and the discipline scan (no hex / no raw var outside `forced-colors`, ASCII
         comments).
-  - [ ] Discriminating: a missing rule group, a bare-`:focus` ring, a `display:none` `.sr-only`, or a hex
+  - [x] Discriminating: a missing rule group, a bare-`:focus` ring, a `display:none` `.sr-only`, or a hex
         literal outside `forced-colors` fails the suite naming the offending group. RED until T-AY-002;
         GREEN once the file lands.
 
@@ -260,9 +260,9 @@ trap/restore), the `ChatSurface.vue` busy region (already `aria-live="polite"` +
 - **Depends on:** T-AY-001
 - **Estimate:** S
 - **Definition of done:**
-  - [ ] A registration test reads both `src/plugin/main.ts` + `src/ui/main.ts` and asserts each imports
+  - [x] A registration test reads both `src/plugin/main.ts` + `src/ui/main.ts` and asserts each imports
         `accessibility.css` after the tokens + animations imports (3rd CSS import, line-order contract).
-  - [ ] Discriminating: a missing import in either entry, or an import placed before animations, fails
+  - [x] Discriminating: a missing import in either entry, or an import placed before animations, fails
         naming the offending entry. RED until T-AY-002; GREEN once both import lines land.
 
 ### T-AY-005 🔨 — `feat(ay):` enumerate the RG-4 forced-colors-border selector list (the swept background-cue-only controls)
@@ -283,10 +283,10 @@ trap/restore), the `ChatSurface.vue` busy region (already `aria-live="polite"` +
 - **Depends on:** T-AY-002
 - **Estimate:** S
 - **Definition of done:**
-  - [ ] RG-4 in `accessibility.css` enumerates the concrete selectors for the toggle switch, state pills,
+  - [x] RG-4 in `accessibility.css` enumerates the concrete selectors for the toggle switch, state pills,
         chips, `.sp-tab` badges, and the selected dropdown option, each given a `currentColor` border
         (or non-shifting outline) inside the `forced-colors` block.
-  - [ ] The TEST-AY-006 file-read leg (RG-4 enumerates the background-cue-only controls) passes; default
+  - [x] The TEST-AY-006 file-read leg (RG-4 enumerates the background-cue-only controls) passes; default
         render unchanged outside `forced-colors`; whole-project `npm run lint` 0 + `npm run typecheck` 0 +
         `npm run test` green; implementation-log entry added.
 

--- a/specs/accessibility/tasks.md
+++ b/specs/accessibility/tasks.md
@@ -315,10 +315,10 @@ trap/restore), the `ChatSurface.vue` busy region (already `aria-live="polite"` +
 - **Depends on:** T-AY-001
 - **Estimate:** M
 - **Definition of done:**
-  - [ ] A mount test with co-located PageObject(s) (data-testid only) asserts the RG-4-listed controls
+  - [x] A mount test with co-located PageObject(s) (data-testid only) asserts the RG-4-listed controls
         (toggle / pill / chip / `.sp-tab` / selected option) are present in the mounted toolbar + chat
         surfaces.
-  - [ ] Discriminating: a missing target control fails naming it. GREEN once the controls are confirmed
+  - [x] Discriminating: a missing target control fails naming it. GREEN once the controls are confirmed
         present (verify-only — the controls already exist per the audit).
 
 ### T-AY-007 🧪 — RED: focus-visible ring reachability + no-stray-mouse-ring (TEST-AY-007 mount leg) + keyboard operability (TEST-AY-008)
@@ -339,11 +339,11 @@ trap/restore), the `ChatSurface.vue` busy region (already `aria-live="polite"` +
 - **Depends on:** T-AY-001
 - **Estimate:** M
 - **Definition of done:**
-  - [ ] A mount test (PageObject, data-testid) asserts a keyboard-focused control resolves the RG-5
+  - [x] A mount test (PageObject, data-testid) asserts a keyboard-focused control resolves the RG-5
         focus-visible target (custom `div[role]` controls carry `tabindex`) and mouse `:focus` shows no
         stray ring (structural where JSDOM limits `:focus-visible`); and every audited toolbar/settings/chat
         control is focusable with a non-empty accessible name.
-  - [ ] Discriminating: a control with an empty accessible name fails naming it (drives T-AY-010). RED until
+  - [x] Discriminating: a control with an empty accessible name fails naming it (drives T-AY-010). RED until
         the icon-only labels are filled; GREEN after T-AY-010.
 
 ### T-AY-008 🧪 — RED: live-region presence + severity (busy region + notice host, no focus theft) (TEST-AY-010)
@@ -360,9 +360,9 @@ trap/restore), the `ChatSurface.vue` busy region (already `aria-live="polite"` +
 - **Depends on:** T-AY-001
 - **Estimate:** M
 - **Definition of done:**
-  - [ ] A mount test asserts the busy region has `aria-live="polite"` + `role="status"` (verify-only) and
+  - [x] A mount test asserts the busy region has `aria-live="polite"` + `role="status"` (verify-only) and
         the notice host announces error=assertive / info=polite via a live region without moving focus.
-  - [ ] Discriminating: a missing live region in the standalone notice host fails (drives T-AY-011); a
+  - [x] Discriminating: a missing live region in the standalone notice host fails (drives T-AY-011); a
         stolen focus on announcement fails. GREEN after T-AY-011 (or immediately if the host already
         conforms).
 
@@ -380,10 +380,10 @@ trap/restore), the `ChatSurface.vue` busy region (already `aria-live="polite"` +
 - **Depends on:** T-AY-001
 - **Estimate:** M
 - **Definition of done:**
-  - [ ] A mount test asserts a collapsible header exposes `aria-expanded` that flips on Enter/Space/click +
+  - [x] A mount test asserts a collapsible header exposes `aria-expanded` that flips on Enter/Space/click +
         has an accessible name; and icon-only controls expose an `.sr-only`/`aria-label` name with zero
         visible footprint (clip technique).
-  - [ ] Discriminating: a header missing `aria-expanded`, or an unlabelled icon-only control, fails naming
+  - [x] Discriminating: a header missing `aria-expanded`, or an unlabelled icon-only control, fails naming
         it (drives T-AY-010/T-AY-012). RED until the fills land; GREEN after.
 
 ### T-AY-010 🔨🪓 — `feat(ay):` fill icon-only accessible names (`.sr-only` / `aria-label`) across toolbar / composer / chat
@@ -401,10 +401,10 @@ trap/restore), the `ChatSurface.vue` busy region (already `aria-live="polite"` +
 - **Depends on:** T-AY-007, T-AY-009
 - **Estimate:** M
 - **Definition of done:**
-  - [ ] Every icon-only control flagged by the audit carries a non-empty accessible name (`aria-label` or
+  - [x] Every icon-only control flagged by the audit carries a non-empty accessible name (`aria-label` or
         `.sr-only`); decorative glyphs stay `aria-hidden="true"`; no visible-text / microcopy / locale
         change; no `innerHTML`/`v-html` added.
-  - [ ] The TEST-AY-008 + TEST-AY-009 (mount) legs go GREEN; whole-project `npm run lint` 0 +
+  - [x] The TEST-AY-008 + TEST-AY-009 (mount) legs go GREEN; whole-project `npm run lint` 0 +
         `npm run typecheck` 0 + `npm run test` green; implementation-log entry added.
 
 ### T-AY-011 🔨 — `feat(ay):` notice-host live region (standalone) — error assertive / info polite, no focus theft
@@ -422,10 +422,10 @@ trap/restore), the `ChatSurface.vue` busy region (already `aria-live="polite"` +
 - **Depends on:** T-AY-008
 - **Estimate:** S
 - **Definition of done:**
-  - [ ] The standalone notice host has an `aria-live` region (polite default, assertive for error) mirroring
+  - [x] The standalone notice host has an `aria-live` region (polite default, assertive for error) mirroring
         notice text declaratively, no focus theft, no `innerHTML`/`v-html`; routed through the existing
         `NotificationPort` severity (no new channel/port). Verify-only if it already conforms.
-  - [ ] The TEST-AY-010 leg goes GREEN; whole-project `npm run lint` 0 + `npm run typecheck` 0 +
+  - [x] The TEST-AY-010 leg goes GREEN; whole-project `npm run lint` 0 + `npm run typecheck` 0 +
         `npm run test` green; implementation-log entry added.
 
 ### T-AY-012 🔨🪓 — `feat(ay):` collapsible `aria-expanded` + accessible name on the rich-render headers
@@ -441,10 +441,10 @@ trap/restore), the `ChatSurface.vue` busy region (already `aria-live="polite"` +
 - **Depends on:** T-AY-009
 - **Estimate:** S
 - **Definition of done:**
-  - [ ] Each rich-render collapsible header exposes `aria-expanded` bound to its open state (flips on
+  - [x] Each rich-render collapsible header exposes `aria-expanded` bound to its open state (flips on
         toggle) + an accessible name; verify-only where already present; no default-render / microcopy /
         locale change; no `innerHTML`/`v-html` added.
-  - [ ] The TEST-AY-011 leg goes GREEN; whole-project `npm run lint` 0 + `npm run typecheck` 0 +
+  - [x] The TEST-AY-011 leg goes GREEN; whole-project `npm run lint` 0 + `npm run typecheck` 0 +
         `npm run test` green; implementation-log entry added.
 
 ### T-AY-013 🧪 — RED: modal focus trap + restore (the 8 Specorator modal seams) (TEST-AY-012 / TEST-AY-013)
@@ -466,9 +466,9 @@ trap/restore), the `ChatSurface.vue` busy region (already `aria-live="polite"` +
 - **Depends on:** T-AY-001
 - **Estimate:** M
 - **Definition of done:**
-  - [ ] A test asserts each of the 8 launchers opens a `Modal` subclass (structural; Tab-cycle-stays-inside
+  - [x] A test asserts each of the 8 launchers opens a `Modal` subclass (structural; Tab-cycle-stays-inside
         where JSDOM allows) and that closing by any path restores focus to the opener (not `document.body`).
-  - [ ] A note records that a modal NOT extending `Modal` is a defect-escalation (file ADR-AY-001 + a new
+  - [x] A note records that a modal NOT extending `Modal` is a defect-escalation (file ADR-AY-001 + a new
         hand-rolled-trap task), never a silent default. GREEN against the current code (verify-only — all 8
         extend `Modal`).
 
@@ -495,9 +495,9 @@ trap/restore), the `ChatSurface.vue` busy region (already `aria-live="polite"` +
 - **Depends on:** T-AY-010, T-AY-011, T-AY-012
 - **Estimate:** M
 - **Definition of done:**
-  - [ ] A test asserts each swept component's default render + locale output is unchanged from baseline
+  - [x] A test asserts each swept component's default render + locale output is unchanged from baseline
         (structural/snapshot diff); a recorded `git diff next -- src/ui/i18n/locales` is empty.
-  - [ ] Discriminating: a fill that altered the visible default render, microcopy, or a locale string fails
+  - [x] Discriminating: a fill that altered the visible default render, microcopy, or a locale string fails
         naming the surface. RED until confirmed additive; GREEN once clean.
 
 ### T-AY-015 🧪 — RED: discipline scan (no added raw-HTML sink in the P12 diff) (TEST-AY-015 diff leg)
@@ -514,9 +514,9 @@ trap/restore), the `ChatSurface.vue` busy region (already `aria-live="polite"` +
 - **Depends on:** T-AY-010, T-AY-011, T-AY-012
 - **Estimate:** S
 - **Definition of done:**
-  - [ ] A scan / recorded lint confirmation asserts the P12 diff adds no
+  - [x] A scan / recorded lint confirmation asserts the P12 diff adds no
         `innerHTML`/`outerHTML`/`insertAdjacentHTML`/`v-html` and no new suppression of the raw-HTML guards.
-  - [ ] Discriminating: a planted `v-html` / `innerHTML` in a changed file fails. GREEN against the actual
+  - [x] Discriminating: a planted `v-html` / `innerHTML` in a changed file fails. GREEN against the actual
         diff (the fills are declarative).
 
 ### T-AY-016 🧪 — RED: `parity-screenshots.md` completeness (all surfaces × 320/520/720 × light/dark) (TEST-AY-016)
@@ -532,10 +532,10 @@ trap/restore), the `ChatSurface.vue` busy region (already `aria-live="polite"` +
 - **Depends on:** T-AY-001
 - **Estimate:** S
 - **Definition of done:**
-  - [ ] A test asserts `specs/accessibility/parity-screenshots.md` lists every charter §3 surface at
+  - [x] A test asserts `specs/accessibility/parity-screenshots.md` lists every charter §3 surface at
         320/520/720 px in light + dark, each with a claudian-reference + Specorator cell (completeness
         structure only).
-  - [ ] Discriminating: a missing surface / width / theme cell fails naming the gap. GREEN once the matrix
+  - [x] Discriminating: a missing surface / width / theme cell fails naming the gap. GREEN once the matrix
         is structurally complete; the visual sign-off is TEST-AY-017 (human).
 
 ---

--- a/specs/accessibility/tasks.md
+++ b/specs/accessibility/tasks.md
@@ -1,0 +1,765 @@
+---
+id: TASKS-AY-001
+title: Accessibility (P12, FINAL phase) — Tasks
+stage: tasks
+feature: accessibility
+area: AY
+epic: claudian-reboot
+phase: P12
+status: complete       # draft | accepted | in-progress | complete
+owner: planner
+integration_branch: next
+reference: D:\Projects\claudian-main\src\style\accessibility.css   # MIT, read-only reference (minimal — focus-visible rings only)
+inputs:
+  - SPEC-AY-001        # specs/accessibility/spec.md (SPEC-AY-001..011 + TEST-AY-001..017 + EC-AY-001..014 + the 3 chunk boundaries + the REQ↔SPEC↔TEST coverage table)
+  - PRD-AY-001         # specs/accessibility/requirements.md (REQ-AY-001..017 + NFR-AY-001..010)
+  - DESIGN-AY-001      # specs/accessibility/design.md (Parts A UX / B UI / C Architecture; the 6 rule groups RG-1..6; NO new ADR, NO new port, NO new component)
+  - TASKS-IL-001       # specs/i18n-locales/tasks.md (P11 — the mirrored shape: baseline/guard-verify → RED-before-green → additive-only → coverage table → dispatch chunks → gate + draft PR into next)
+created: 2026-05-27
+updated: 2026-05-27
+---
+
+# Tasks — Accessibility (P12, the FINAL phase)
+
+Each task is ≤ ~½ day, has a stable `T-AY-NNN` id, references ≥ 1 SPEC-AY / TEST-AY / REQ-AY / NFR-AY,
+names an owner, lists explicit dependencies, and has a testable Definition of Done. This decomposes
+**SPEC-AY-001..011** (11 spec items) on top of the merged P0–P11 surface on the `next` integration branch
+(P11 i18n-locales #452 / d4733464): the existing `src/ui/styles/{tokens,animations}.css` (`--sp-focus-ring`
+tokens.css:42, `--sp-shadow-focus-ring` tokens.css:140, the per-section reduced-motion overrides
+§4.6/§4.9/§4.10/§4.11, the five named keyframes + the CQ-AUX-14 spin guard), the two CSS import sites
+(`src/plugin/main.ts` after `animations.css` line 2; `src/ui/main.ts` after `animations.css` line 14), the
+`vite.config.ts` `scopeBuiltCss()` auto-scoper, the P5/P7/P8/P10 Obsidian `Modal` subclasses (native
+trap/restore), the `ChatSurface.vue` busy region (already `aria-live="polite"` + `role="status"` lines
+856-857), the `TabBar.vue` ARIA + roving tabindex, and the rich-render collapsible headers under
+`src/ui/chat/rich/**`.
+
+> **P12 is ADDITIVE + presentation-only.** It adds **one new CSS file** (`src/ui/styles/accessibility.css`,
+> the 6 rule groups RG-1..6), **two one-line import edits** (`src/plugin/main.ts` + `src/ui/main.ts`,
+> registering it as the 3rd CSS layer after tokens + animations), and **targeted additive ARIA / `.sr-only`
+> / live-region fills** on existing components (collapsible `aria-expanded`, icon-only labels, the RG-4
+> forced-colors-border selector enumeration, the standalone notice-host live region if absent). Most of the
+> behaviour sweep is **verify-only** (the busy region, TabBar, the 8 modals all already conform — the fix is
+> a test that asserts the existing affordance, not a code edit). **No new port, no new InjectionKey, no new
+> component, no new ADR, no signature change.** The P0–P11 default render stays **byte-identical** for mouse
+> users (REQ-AY-014) — every a11y rule is gated behind `:focus-visible`, `prefers-reduced-motion`,
+> `forced-colors`, `.sr-only`, or an additive ARIA attribute. `manifest.json` + en/de + all ten locales
+> stay byte-identical (NFR-AY-004/008).
+
+> **TDD / build-green ordering (the P5–P11 lesson):** where a test asserts a file/registration/behaviour, the
+> **RED test lands before (or alongside) the impl that greens it.** Chunk 1's RED file-read + registration
+> tests (T-AY-003/004) gate the `accessibility.css` + import edits (T-AY-002). Chunk 2's RED component /
+> PageObject tests (T-AY-006..009 where automatable) gate the additive ARIA fills. RED test tasks are owned
+> by `qa`; impl tasks (the CSS file, the import edits, the ARIA fills) by `dev`. **Every dev task's DoD
+> carries whole-project `npm run lint` 0 + `npm run typecheck` 0 + `npm run test` green + an
+> implementation-log entry.** This mirrors the P6–P11 task style the maintainer accepted (TASKS-CA-001 /
+> TASKS-MC-001 / TASKS-PV-001 / TASKS-SS-001 / TASKS-IL-001).
+
+> **The additivity invariant is the cardinal gate.** A swept surface is "done" only when its default
+> (no-media-query, no-`.sr-only`) render and locale output are **unchanged from the `next` baseline**
+> (TEST-AY-014). A stray ring on mouse `:focus` (using `:focus` instead of `:focus-visible`) is the
+> secondary counter-metric — target 0. Because the RG-5 rule uses `:focus-visible` and every fill is gated,
+> any default-state regression is a red build at the moment it is introduced.
+
+> **Guard verdict (verified against SPEC-AY-001..011 + DESIGN-AY-001 §C.6 — NO guard-relax, NO new key/port,
+> NO new ADR):**
+> - **NO new InjectionKey / port / composable / component.** P12 touches **only** the UI-layer CSS
+>   (`src/ui/styles/accessibility.css`), the two CSS import sites, and additive ARIA/label/live-region
+>   attributes on already-live components. No domain entity, no use case, no port, no settings field
+>   (DESIGN-AY-001 §C.3).
+> - **NO deleted-symbol guard collision.** The new file lives under the already-live `src/ui/styles/**`
+>   path (tokens.css/animations.css already there); `accessibility.css` is a plain CSS filename, not a banned
+>   symbol. The additive ARIA edits add attributes/`.sr-only` classes to existing templates — no
+>   `DELETED_SUBSYSTEM_BAN` / `DELETED_INJECTION_KEYS` glob matches the new CSS file, the two new import
+>   lines, or the ARIA attribute edits.
+> - **NO new ADR.** DESIGN-AY-001 §C.6 records the verdict: the CSS-layer pattern is the 3rd instance of the
+>   established tokens.css/animations.css pattern (ADR-AUX-002 + the `scopeBuiltCss()` seam); the modal-seam
+>   pattern is already covered by the P3/P5/P8/P9 modal-seam ADRs (P12 only verifies the native trap); the
+>   token-discipline + forced-colors exception is already a documented rule (NFR-AY-002). D-AY-1..D-AY-5 are
+>   design decisions, none of ADR weight. If implementation surfaces a modal that does **not** extend
+>   `Modal` (so a hand-rolled trap is genuinely needed), that is a **defect-escalation** → file ADR-AY-001;
+>   as designed it does not arise.
+> - **NO `manifest.json` / en.ts / de.ts / locale change** (NFR-AY-004/008). T-AY-001 records this verdict;
+>   T-AY-018 (the gate) re-confirms it.
+
+> **lightningcss-safe CSS discipline (the §4.x convention + NFR-AY-005):** `accessibility.css` uses
+> **ASCII-only comment markers** (`/* section B.x - ... */`, no em-dash / no non-ASCII glyph) so the
+> standalone `build:web` lightningcss minifier accepts them (EC-AY-013). Selectors are authored
+> **`.specorator-root`-prefixed** so `scopeBuiltCss()` is honoured, not fought (no `:where(*)` double-wrap);
+> `@keyframes` are never targeted; `!important` is used **only** on the RG-1 reduced-motion guard.
+> The **only** colour literals in the file are CSS **system-color keywords inside the `forced-colors`
+> block** (RG-3/RG-4) — the single documented exception (NFR-AY-002, D-AY-5). No hex, no raw Obsidian var
+> anywhere else; RG-5 consumes the **existing** `--sp-focus-ring` / `--sp-shadow-focus-ring` (NO new token).
+
+> **Lint discipline (the P5–P11 lesson):** every dev task runs the **WHOLE-project** `npm run lint`
+> (0 errors), not just the changed files — the project gate catches per-file misses
+> (`vue/no-v-html`, `no-restricted-properties` innerHTML/outerHTML/insertAdjacentHTML, `no-restricted-imports`
+> layer guards, `<script setup>`). The additive ARIA edits introduce **no** `innerHTML` / `v-html` / raw-HTML
+> sink (REQ-AY-015, NFR-AY-003) — attributes are bound declaratively in templates; any `.sr-only` label is
+> rendered as text, never injected. T-AY-018 re-confirms the discipline scan green.
+
+> **The single FINAL epic gate is HUMAN-owned (TEST-AY-017, REQ-AY-017 — constitution Art. VII).** The
+> automatable suite (TEST-AY-001..016) ships under the verify gate; the **final cross-surface parity
+> screenshot sign-off (all P1–P11 surfaces, light + dark, 320/520/720 px, + the accumulated P5–P11
+> manual-Obsidian legs)** is the human's. The agent **presents** it (and **opens, does NOT merge** the
+> `next` → `develop` PR after the gate is green); it is **never agent-self-claimed** (T-AY-017 is `👤`).
+
+## Legend
+
+- 🧪 = test task (RED-first where a test asserts; owner `qa`)
+- 🔨 = implementation task (owner `dev`)
+- 📐 = design / scaffolding / baseline task
+- 🚀 = release / ops / gate task
+- 🪓 = may slice (touches multiple independent files/components; expect several commits)
+- 👤 = human-owned (never agent-self-claimed)
+
+---
+
+## Task list
+
+### T-AY-001 📐 — Baseline-capture + guard verification + scaffold `parity-screenshots.md`
+
+- **Description:** Before any P12 implementation, capture the references into a
+  `specs/accessibility/test-plan.md` skeleton and scaffold the human sign-off artifact: (1) the **token
+  reference** — confirm `--sp-focus-ring` (tokens.css:42, → `var(--interactive-accent)`) +
+  `--sp-shadow-focus-ring` (tokens.css:140, `0 0 0 2px var(--sp-focus-ring)`) exist as the RG-5 ring
+  consumers (no new token, D-AY-2 / NG2); (2) the **import-site reference** — record the current 2-import CSS
+  head at `src/plugin/main.ts:2` (after `animations.css`) + `src/ui/main.ts:14` (after `animations.css`) as
+  the SPEC-AY-002/003 insertion points; (3) the **reduced-motion source inventory** — the five named
+  keyframes (`thinking-pulse`, `streaming-cursor-blink`, `spin`, `mcp-glow`, `external-context-glow`) + the
+  per-section token overrides RG-1 complements (CLAR-AY-002); (4) the **forced-colors background-cue-only
+  control inventory** — enumerate the concrete selectors for RG-4 (the toolbar toggle switch, state pills,
+  file/image chips, `.sp-tab` tab badges, the selected dropdown option) per SPEC-AY-006; (5) the **claudian
+  reference** — note `D:\Projects\claudian-main\src\style\accessibility.css` is the minimal focus-visible-only
+  layer (41 lines, 3 groups, no reduced-motion/forced-colors/sr-only — CLAR-AY-001 resolved at design),
+  the *meet* leg = RG-5, the *beat* legs = RG-1..4 + RG-6. **Scaffold `specs/accessibility/parity-screenshots.md`**
+  — the all-surfaces matrix (the human TEST-AY-017 final-sign-off artifact): a row per charter §3 surface ×
+  {320, 520, 720 px} × {light, dark}, with a **baseline column from claudian** and a Specorator column
+  (cells empty/placeholder until populated; this scaffold is the structure TEST-AY-016 checks for
+  completeness). Confirm (one lint run) the **guard verdict**: the new `src/ui/styles/accessibility.css` +
+  the two import-line edits + the additive ARIA edits are **not** caught by `DELETED_SUBSYSTEM_BAN` /
+  `DELETED_INJECTION_KEYS`; that **NO new InjectionKey / port / composable / component / ADR** is needed
+  (CSS layer + additive ARIA, DESIGN-AY-001 §C.6); that **`manifest.json` + en.ts/de.ts + all ten locales
+  are untouched** (NFR-AY-004/008). Record the verdict: **no guard-relax task in P12.** No production code.
+- **Satisfies:** SPEC-AY-001 (RG inventory), SPEC-AY-002/003 (import sites), SPEC-AY-006 (RG-4 selector
+  enumeration), REQ-AY-016 (parity-screenshots.md scaffold), NFR-AY-002 (token reference), NFR-AY-004/008
+  (additivity baseline)
+- **Owner:** dev
+- **Depends on:** —
+- **Estimate:** S
+- **Definition of done:**
+  - [ ] `specs/accessibility/test-plan.md` exists with: the `--sp-focus-ring`/`--sp-shadow-focus-ring`
+        token-reference note, the two import-site insertion points (`main.ts:2` + `ui/main.ts:14`), the
+        five-keyframe reduced-motion source inventory, the enumerated RG-4 background-cue-only control
+        selectors (toggle / pill / chip / `.sp-tab` / selected option), and the claudian
+        minimal-focus-visible-only reference note (meet = RG-5; beat = RG-1..4 + RG-6).
+  - [ ] `specs/accessibility/parity-screenshots.md` scaffolded — every charter §3 surface listed at
+        320/520/720 px in light + dark, with a baseline (claudian) column and a Specorator column (the
+        TEST-AY-016 completeness structure; cells placeholder until the screenshots are captured).
+  - [ ] A one-line lint check confirms the deleted-symbol guard does **not** block the new
+        `accessibility.css` / the two import lines / the ARIA edits; the verdict **NO guard-relax + NO new
+        InjectionKey/port/component/ADR + manifest/locales untouched** is recorded in `test-plan.md`.
+  - [ ] No file under `src/` changed.
+
+---
+
+## Chunk 1 — `accessibility.css` + pipeline registration (T-AY-002..005)
+
+> The new CSS file + the two one-line import edits, with RED file-read + registration tests landing first.
+> Self-contained; lands first. The RG-1..RG-6 file-read assertions (T-AY-003) + the registration assertion
+> (T-AY-004) are RED until T-AY-002 lands the file + edits.
+
+### T-AY-002 🔨 — `feat(ay):` create `src/ui/styles/accessibility.css` (RG-1..RG-6) + register at both CSS import sites
+
+- **Description:** Implement per SPEC-AY-001/002/003. **(a) New file `src/ui/styles/accessibility.css`** with
+  exactly the six rule groups, in order, each selector `.specorator-root`-prefixed, ASCII comments only,
+  no hex / no raw Obsidian var outside the `forced-colors` block:
+  **RG-1** reduced-motion global guard (`@media (prefers-reduced-motion: reduce)` collapsing
+  `animation-duration`/`animation-iteration-count`/`transition-duration`/`scroll-behavior` on
+  `.specorator-root *`/`::before`/`::after`, `!important` — the safety-net complementing the tokens.css
+  per-section overrides, CLAR-AY-002 / D-AY-1);
+  **RG-2** spin halt (`animation: none !important` on `.specorator-root [data-animation="spin"]`/`.sp-spin`
+  under reduced-motion — re-asserts CQ-AUX-14; `none`, not a near-zero duration, EC-AY-001);
+  **RG-3** forced-colors surface mapping (`@media (forced-colors: active)` — `forced-color-adjust: auto` +
+  text→`CanvasText`, surfaces→`Canvas`, focus/selected→`Highlight`/`HighlightText`, button affordances→
+  `ButtonText`/`ButtonFace`; colour mapping only, no layout shift);
+  **RG-4** forced-colors border guarantee (`border: 1px solid currentColor` — or `outline` where the box
+  model must not shift — on the enumerated background-cue-only controls from T-AY-001/SPEC-AY-006: toggle
+  switch, state pills, chips, `.sp-tab` badges, selected dropdown option, EC-AY-003);
+  **RG-5** focus-visible ring (`.specorator-root :where(button, [role="tab"], [role="option"],
+  [role="switch"], a[href], textarea, input, select, [tabindex]):focus-visible { outline: 2px solid
+  var(--sp-focus-ring); outline-offset: 2px; }` + the `box-shadow: var(--sp-shadow-focus-ring)` variant for
+  controls whose outline is clipped by `overflow: hidden`; `:focus-visible` only — never bare `:focus`,
+  EC-AY-005/006); **RG-6** `.sr-only` utility (the standard clip/size technique — `position: absolute`,
+  1px box, `clip: rect(0 0 0 0)`, `clip-path: inset(50%)`, `white-space: nowrap`, `border: 0`; never
+  `display:none`/`visibility:hidden`, EC-AY-007). **(b) Register at BOTH import sites:** add
+  `import '@/ui/styles/accessibility.css';` to `src/plugin/main.ts` as the **3rd** CSS import, immediately
+  after `import '@/ui/styles/animations.css';` (line 2); add `import './styles/accessibility.css';` to
+  `src/ui/main.ts` as the **3rd** CSS import, immediately after `import './styles/animations.css';`
+  (line 14). `vite.config.ts` `scopeBuiltCss()` is **unchanged** (the file is authored scope-safe). No JS,
+  no DOM, no new token, no new port.
+- **Satisfies:** SPEC-AY-001, SPEC-AY-002, SPEC-AY-003, REQ-AY-001, REQ-AY-002, REQ-AY-003, REQ-AY-004,
+  REQ-AY-005, REQ-AY-006, REQ-AY-007, REQ-AY-009, REQ-AY-015, NFR-AY-002, NFR-AY-005, NFR-AY-006
+- **Owner:** dev
+- **Depends on:** T-AY-001, T-AY-003 (RED), T-AY-004 (RED)
+- **Estimate:** M
+- **Definition of done:**
+  - [ ] `src/ui/styles/accessibility.css` exists with RG-1..RG-6 in order, every selector
+        `.specorator-root`-prefixed, ASCII-only comments, `!important` only on RG-1, no hex / no raw
+        Obsidian var outside the `forced-colors` block, RG-5 consuming the existing
+        `--sp-focus-ring`/`--sp-shadow-focus-ring` (no new token), RG-5 using `:focus-visible` (not bare
+        `:focus`), RG-2 setting `animation: none` (not a duration), RG-6 using the clip technique (not
+        `display:none`).
+  - [ ] `accessibility.css` is imported as the **3rd** CSS import (after tokens + animations) at both
+        `src/plugin/main.ts` and `src/ui/main.ts`; `vite.config.ts` unchanged.
+  - [ ] The RED file-read (T-AY-003) + registration (T-AY-004) tests now GREEN; whole-project
+        `npm run lint` 0 + `npm run typecheck` 0 + `npm run test` green; implementation-log entry added.
+
+### T-AY-003 🧪 — RED: `accessibility.css` rule-group presence (RG-1..RG-6, `.specorator-root`-scoped, discipline)
+
+- **Description:** Author the failing file-read tests for SPEC-AY-001 in
+  `tests/ui/styles/accessibility.test.ts` (mirrors `src/ui/styles/accessibility.css` per ADR-009), reading
+  the CSS file as text: **TEST-AY-001** — the file exists and declares RG-1..RG-6, and **every selector is
+  `.specorator-root`-scoped** (no rule targets outside the subtree); **TEST-AY-003** — RG-1 reduced-motion
+  guard present (`prefers-reduced-motion: reduce` collapsing animation/transition duration); **TEST-AY-004**
+  — RG-2 sets `animation: none` (not merely a near-zero duration) for `[data-animation="spin"]`/`.sp-spin`
+  under reduced-motion (EC-AY-001); **TEST-AY-005** — RG-3 `@media (forced-colors: active)` present with
+  `forced-color-adjust` + system-color keywords (`CanvasText`/`Canvas`/`Highlight`/`ButtonText`/`ButtonFace`);
+  **TEST-AY-007** (file-read leg) — RG-5 uses `:focus-visible` (asserts no bare `:focus` ring rule) +
+  consumes `var(--sp-focus-ring)`; **TEST-AY-009** (file-read leg) — RG-6 `.sr-only` uses the clip technique
+  (`clip`/`clip-path`/`overflow: hidden`, NOT `display:none`/`visibility:hidden`); **TEST-AY-015** (CSS
+  discipline leg) — `accessibility.css` carries no hex / no raw Obsidian var outside the single
+  `forced-colors` block, and ASCII-only comment markers (no non-ASCII glyph). RED until T-AY-002 lands the
+  file. Names TEST-AY-001/003/004/005/007(file)/009(file)/015(css).
+- **Satisfies:** TEST-AY-001, TEST-AY-003, TEST-AY-004, TEST-AY-005, TEST-AY-007, TEST-AY-009, TEST-AY-015,
+  SPEC-AY-001, SPEC-AY-011, REQ-AY-001, REQ-AY-003, REQ-AY-004, REQ-AY-005, REQ-AY-007, REQ-AY-009,
+  REQ-AY-015, NFR-AY-002, EC-AY-001
+- **Owner:** qa
+- **Depends on:** T-AY-001
+- **Estimate:** M
+- **Definition of done:**
+  - [ ] `tests/ui/styles/accessibility.test.ts` reads the CSS file as text and asserts: RG-1..RG-6 present
+        + ordered, every selector `.specorator-root`-scoped, RG-1 reduced-motion collapse, RG-2
+        `animation: none`, RG-3 forced-colors + system colours, RG-5 `:focus-visible` + `--sp-focus-ring`,
+        RG-6 clip technique, and the discipline scan (no hex / no raw var outside `forced-colors`, ASCII
+        comments).
+  - [ ] Discriminating: a missing rule group, a bare-`:focus` ring, a `display:none` `.sr-only`, or a hex
+        literal outside `forced-colors` fails the suite naming the offending group. RED until T-AY-002;
+        GREEN once the file lands.
+
+### T-AY-004 🧪 — RED: registration at both CSS import sites (3rd import, after tokens + animations)
+
+- **Description:** Author the failing registration test for SPEC-AY-002/003 in
+  `tests/ui/styles/accessibility-registration.test.ts` (or as a block in T-AY-003's file), reading the two
+  entry files as text: **TEST-AY-002** — both `src/plugin/main.ts` and `src/ui/main.ts` import
+  `accessibility.css`, positioned **after** the tokens + animations imports (the 3rd CSS import). Assert the
+  import string is present in each and that its line index is greater than the `animations.css` import line
+  index in the same file (the ordering contract, NFR-AY-006). RED until T-AY-002 adds the two import lines.
+  Names TEST-AY-002.
+- **Satisfies:** TEST-AY-002, SPEC-AY-002, SPEC-AY-003, REQ-AY-002, NFR-AY-006
+- **Owner:** qa
+- **Depends on:** T-AY-001
+- **Estimate:** S
+- **Definition of done:**
+  - [ ] A registration test reads both `src/plugin/main.ts` + `src/ui/main.ts` and asserts each imports
+        `accessibility.css` after the tokens + animations imports (3rd CSS import, line-order contract).
+  - [ ] Discriminating: a missing import in either entry, or an import placed before animations, fails
+        naming the offending entry. RED until T-AY-002; GREEN once both import lines land.
+
+### T-AY-005 🔨 — `feat(ay):` enumerate the RG-4 forced-colors-border selector list (the swept background-cue-only controls)
+
+- **Description:** Implement SPEC-AY-006 — refine RG-4 in `accessibility.css` so it **enumerates the
+  concrete class/attribute selectors** of every control whose normal affordance is a background fill/wash
+  only, per the audit in T-AY-001: the toolbar toggle switch (`.sp-toggle-switch`), the state pills
+  (`[data-state]` pills), the file/image chips (`.sp-chip`), the tab badges (`.sp-tab`), and the selected
+  dropdown option (`[aria-selected="true"]`/`[role="option"]` selected). Each listed control gains
+  `border: 1px solid currentColor` (or `outline` where the box model must not shift) inside the existing
+  `@media (forced-colors: active)` block, so each is perceivable under forced-colors (EC-AY-003). This is a
+  refinement of the RG-4 group authored in T-AY-002 — it makes the selector list **concrete and complete**
+  against the actual swept components rather than a placeholder. No default-render change (the rule is inert
+  outside `forced-colors`). May land folded into T-AY-002 if the audit selectors are final at that point;
+  kept as a distinct task because the concrete selectors come from the Chunk-2 component sweep.
+- **Satisfies:** SPEC-AY-006, SPEC-AY-001 (RG-4), REQ-AY-006, NFR-AY-009, EC-AY-003
+- **Owner:** dev
+- **Depends on:** T-AY-002
+- **Estimate:** S
+- **Definition of done:**
+  - [ ] RG-4 in `accessibility.css` enumerates the concrete selectors for the toggle switch, state pills,
+        chips, `.sp-tab` badges, and the selected dropdown option, each given a `currentColor` border
+        (or non-shifting outline) inside the `forced-colors` block.
+  - [ ] The TEST-AY-006 file-read leg (RG-4 enumerates the background-cue-only controls) passes; default
+        render unchanged outside `forced-colors`; whole-project `npm run lint` 0 + `npm run typecheck` 0 +
+        `npm run test` green; implementation-log entry added.
+
+---
+
+## Chunk 2 — Behaviour-fix sweep (additive ARIA / label / live-region fills) (T-AY-006..013)
+
+> Audit-then-fill across the swept components. Most items are **verify-only** (a RED test that asserts an
+> existing affordance, then it passes against the current component — no code edit). The genuine fills are
+> the collapsible `aria-expanded`, the icon-only `.sr-only`/`aria-label`, and the standalone notice-host
+> live region if absent. Each fill is **additive** (an attribute / `.sr-only` label), no default-render /
+> microcopy / locale change (REQ-AY-014). RED component / PageObject tests land before the fills where
+> automatable. PageObjects query by `data-testid` only (ADR-009). Grouped into ≤6-task chunks.
+
+### T-AY-006 🧪 — RED: forced-colors border controls exist in the mounted surfaces (TEST-AY-006 mount leg)
+
+- **Description:** Author the failing mount leg for SPEC-AY-006 (the file-read leg rides T-AY-003/005):
+  mount the toolbar + chat surfaces with co-located PageObjects (querying by `data-testid`) and assert the
+  RG-4-listed background-cue-only controls exist in the rendered DOM — the toggle switch, a state pill, a
+  file/image chip, a `.sp-tab` badge, and a selected dropdown option are present (so the RG-4 selectors
+  target real controls, not dead selectors). The forced-colors *appearance* itself is the human TEST-AY-017
+  leg; this asserts the controls the rule targets are mounted (NFR-AY-009 perceivability scaffold). Names
+  TEST-AY-006 (mount leg).
+- **Satisfies:** TEST-AY-006, SPEC-AY-006, REQ-AY-006, NFR-AY-009
+- **Owner:** qa
+- **Depends on:** T-AY-001
+- **Estimate:** M
+- **Definition of done:**
+  - [ ] A mount test with co-located PageObject(s) (data-testid only) asserts the RG-4-listed controls
+        (toggle / pill / chip / `.sp-tab` / selected option) are present in the mounted toolbar + chat
+        surfaces.
+  - [ ] Discriminating: a missing target control fails naming it. GREEN once the controls are confirmed
+        present (verify-only — the controls already exist per the audit).
+
+### T-AY-007 🧪 — RED: focus-visible ring reachability + no-stray-mouse-ring (TEST-AY-007 mount leg) + keyboard operability (TEST-AY-008)
+
+- **Description:** Author the failing mount legs for SPEC-AY-007/008 (the RG-5 file-read leg rides
+  T-AY-003): **TEST-AY-007 (mount)** — a PageObject Tab/keyboard-focuses a control and asserts the
+  focus-visible state resolves (the control matches the RG-5 `:where(...)` selector — e.g. a custom
+  `div[role]` control carries `tabindex` so it matches `[tabindex]`), and a mouse `:focus` shows no stray
+  ring (the counter-metric, EC-AY-006 — asserted structurally where JSDOM limits `:focus-visible`
+  computation); **TEST-AY-008** — every audited interactive control in the toolbar strip, the settings
+  shell surfaces, and the chat surface (composer, message actions, dropdowns, tab close `×`, new-tab `+`,
+  paperclip, chip remove, image remove) is focusable + exposes a **non-empty accessible name** (visible
+  label, `aria-label`, or `.sr-only`). RED where a control is missing a name (drives the T-AY-010 fills).
+  Names TEST-AY-007(mount)/008.
+- **Satisfies:** TEST-AY-007, TEST-AY-008, SPEC-AY-007, SPEC-AY-008, REQ-AY-007, REQ-AY-008, NFR-AY-001,
+  EC-AY-005, EC-AY-006
+- **Owner:** qa
+- **Depends on:** T-AY-001
+- **Estimate:** M
+- **Definition of done:**
+  - [ ] A mount test (PageObject, data-testid) asserts a keyboard-focused control resolves the RG-5
+        focus-visible target (custom `div[role]` controls carry `tabindex`) and mouse `:focus` shows no
+        stray ring (structural where JSDOM limits `:focus-visible`); and every audited toolbar/settings/chat
+        control is focusable with a non-empty accessible name.
+  - [ ] Discriminating: a control with an empty accessible name fails naming it (drives T-AY-010). RED until
+        the icon-only labels are filled; GREEN after T-AY-010.
+
+### T-AY-008 🧪 — RED: live-region presence + severity (busy region + notice host, no focus theft) (TEST-AY-010)
+
+- **Description:** Author the failing mount leg for SPEC-AY-004: **TEST-AY-010** — the streaming busy region
+  in `ChatSurface.vue` carries `aria-live="polite"` + `role="status"` (verify-only — already at lines
+  856-857); and the notice host announces error notices **assertive** + info/success **polite** via an
+  `aria-live` region, **without stealing focus** (focus is unchanged after an announcement). Assert the
+  standalone notice host has a live region (polite default, assertive for error) mirroring the notice text
+  declaratively (no `innerHTML`/`v-html`, EC-AY-011/012). RED if the standalone notice host lacks a live
+  region (drives the T-AY-011 fill). Names TEST-AY-010.
+- **Satisfies:** TEST-AY-010, SPEC-AY-004, REQ-AY-010, NFR-AY-001, EC-AY-011, EC-AY-012
+- **Owner:** qa
+- **Depends on:** T-AY-001
+- **Estimate:** M
+- **Definition of done:**
+  - [ ] A mount test asserts the busy region has `aria-live="polite"` + `role="status"` (verify-only) and
+        the notice host announces error=assertive / info=polite via a live region without moving focus.
+  - [ ] Discriminating: a missing live region in the standalone notice host fails (drives T-AY-011); a
+        stolen focus on announcement fails. GREEN after T-AY-011 (or immediately if the host already
+        conforms).
+
+### T-AY-009 🧪 — RED: collapsible `aria-expanded` flips + accessible name (TEST-AY-011); `.sr-only` clip on icon-only controls (TEST-AY-009 mount leg)
+
+- **Description:** Author the failing mount legs for SPEC-AY-005/007: **TEST-AY-011** — a collapsible header
+  (tool call / thinking / subagent / write-edit, under `src/ui/chat/rich/**`) exposes `aria-expanded` bound
+  to its open state that **flips** on Enter/Space/click, and exposes an accessible name (visible text or
+  `aria-label`); **TEST-AY-009 (mount leg)** — icon-only controls carry an `.sr-only` label or `aria-label`
+  in the accessibility tree with zero visible footprint (EC-AY-007 — the clip technique, not `display:none`).
+  RED where a header lacks `aria-expanded` or an icon-only control lacks a name (drives T-AY-010/T-AY-012).
+  Uses co-located PageObjects (data-testid). Names TEST-AY-011/009(mount).
+- **Satisfies:** TEST-AY-011, TEST-AY-009, SPEC-AY-005, SPEC-AY-007, REQ-AY-009, REQ-AY-011, EC-AY-007
+- **Owner:** qa
+- **Depends on:** T-AY-001
+- **Estimate:** M
+- **Definition of done:**
+  - [ ] A mount test asserts a collapsible header exposes `aria-expanded` that flips on Enter/Space/click +
+        has an accessible name; and icon-only controls expose an `.sr-only`/`aria-label` name with zero
+        visible footprint (clip technique).
+  - [ ] Discriminating: a header missing `aria-expanded`, or an unlabelled icon-only control, fails naming
+        it (drives T-AY-010/T-AY-012). RED until the fills land; GREEN after.
+
+### T-AY-010 🔨🪓 — `feat(ay):` fill icon-only accessible names (`.sr-only` / `aria-label`) across toolbar / composer / chat
+
+- **Description:** Implement SPEC-AY-007 — for every icon-only interactive control the T-AY-007/T-AY-009
+  audit found unlabelled, add an accessible name **additively**: an `aria-label` or an associated `.sr-only`
+  label (using the RG-6 utility), keeping decorative glyphs `aria-hidden="true"`. Targets per the design
+  list: the composer paperclip, chip remove, image remove, message actions, dropdown controls (and any
+  others the audit surfaces); the tab close `×` / new-tab `+` are **verify-only** (TabBar already labels
+  them). No visible-text / microcopy / locale change — the `.sr-only` label is screen-reader-only; any
+  user-visible label string already in the i18n catalogues is reused, not re-worded (REQ-AY-014, NFR-AY-004).
+  Declarative template attributes only — no `innerHTML`/`v-html` (REQ-AY-015). `<script setup>` preserved.
+- **Satisfies:** SPEC-AY-007, REQ-AY-008, REQ-AY-009, NFR-AY-004, NFR-AY-003
+- **Owner:** dev
+- **Depends on:** T-AY-007, T-AY-009
+- **Estimate:** M
+- **Definition of done:**
+  - [ ] Every icon-only control flagged by the audit carries a non-empty accessible name (`aria-label` or
+        `.sr-only`); decorative glyphs stay `aria-hidden="true"`; no visible-text / microcopy / locale
+        change; no `innerHTML`/`v-html` added.
+  - [ ] The TEST-AY-008 + TEST-AY-009 (mount) legs go GREEN; whole-project `npm run lint` 0 +
+        `npm run typecheck` 0 + `npm run test` green; implementation-log entry added.
+
+### T-AY-011 🔨 — `feat(ay):` notice-host live region (standalone) — error assertive / info polite, no focus theft
+
+- **Description:** Implement SPEC-AY-004 — if the standalone notice host lacks a live region, add an
+  `aria-live` region (polite default, assertive for error per the `NotificationPort` severity:
+  error→assertive, info/success→polite) that mirrors the notice text **declaratively** (text binding, no
+  `innerHTML`/`v-html`), without stealing focus. The busy region (`ChatSurface.vue` lines 856-857) is
+  **verify-only** (already `aria-live="polite"` + `role="status"`). Routes through the existing
+  `NotificationPort`/`FeedbackService` severity — **no new channel, no new port** (Observability note in
+  spec). If the host already announces via Obsidian's native `Notice` (plugin leg) and the standalone host
+  already has a live region, this task is **verify-only** and closes against T-AY-008. EC-AY-011/012.
+- **Satisfies:** SPEC-AY-004, REQ-AY-010, NFR-AY-003, EC-AY-011, EC-AY-012
+- **Owner:** dev
+- **Depends on:** T-AY-008
+- **Estimate:** S
+- **Definition of done:**
+  - [ ] The standalone notice host has an `aria-live` region (polite default, assertive for error) mirroring
+        notice text declaratively, no focus theft, no `innerHTML`/`v-html`; routed through the existing
+        `NotificationPort` severity (no new channel/port). Verify-only if it already conforms.
+  - [ ] The TEST-AY-010 leg goes GREEN; whole-project `npm run lint` 0 + `npm run typecheck` 0 +
+        `npm run test` green; implementation-log entry added.
+
+### T-AY-012 🔨🪓 — `feat(ay):` collapsible `aria-expanded` + accessible name on the rich-render headers
+
+- **Description:** Implement SPEC-AY-005 — for each collapsible header under `src/ui/chat/rich/**` (tool
+  call / thinking / subagent / write-edit) that the T-AY-009 audit found lacking it, **additively** bind
+  `aria-expanded` to the header's open state (flips on Enter/Space/click) and ensure an accessible name
+  (visible header text or `aria-label`). Verify-only where a header already carries it. No default-render /
+  microcopy / locale change — the attribute is the only addition (REQ-AY-014). Declarative binding only,
+  `<script setup>` preserved, no `innerHTML`/`v-html`.
+- **Satisfies:** SPEC-AY-005, REQ-AY-011, NFR-AY-004, NFR-AY-003
+- **Owner:** dev
+- **Depends on:** T-AY-009
+- **Estimate:** S
+- **Definition of done:**
+  - [ ] Each rich-render collapsible header exposes `aria-expanded` bound to its open state (flips on
+        toggle) + an accessible name; verify-only where already present; no default-render / microcopy /
+        locale change; no `innerHTML`/`v-html` added.
+  - [ ] The TEST-AY-011 leg goes GREEN; whole-project `npm run lint` 0 + `npm run typecheck` 0 +
+        `npm run test` green; implementation-log entry added.
+
+### T-AY-013 🧪 — RED: modal focus trap + restore (the 8 Specorator modal seams) (TEST-AY-012 / TEST-AY-013)
+
+- **Description:** Author the failing mount/structural tests for SPEC-AY-009 across the eight modals
+  (ProviderConsent, DeleteConfirm, ForkTarget, InstructionConfirm, InlineEdit, ImagePreview, McpServer,
+  McpTest): **TEST-AY-012** — each launcher opens a `Modal` subclass (structural assertion the class
+  extends Obsidian `Modal`, which natively traps Tab/Shift+Tab), with a PageObject Tab-cycle staying inside
+  the modal where the JSDOM harness allows (else the structural `Modal`-subclass assertion, EC-AY-008);
+  **TEST-AY-013** — closing a modal (accept/reject/Esc/overlay) returns focus to the recorded opener (or its
+  nearest still-present sibling), **not** `document.body` (native restore, EC-AY-009). **Verify-only** — the
+  modals already extend `Modal` (confirmed `InlineEditModal extends Modal`, `src/plugin/modals/InlineEditModal.ts:46`,
+  D-AY-3); **do not hand-roll a trap**. If a modal is found NOT to extend `Modal`, that is a
+  **defect-escalation** (file ADR-AY-001 the P5–P11 way + a hand-rolled-trap is then a new task) — flagged
+  in the DoD, never a silent default. Co-located PageObjects (data-testid). Names TEST-AY-012/013.
+- **Satisfies:** TEST-AY-012, TEST-AY-013, SPEC-AY-009, REQ-AY-012, REQ-AY-013, NFR-AY-001, EC-AY-008,
+  EC-AY-009
+- **Owner:** qa
+- **Depends on:** T-AY-001
+- **Estimate:** M
+- **Definition of done:**
+  - [ ] A test asserts each of the 8 launchers opens a `Modal` subclass (structural; Tab-cycle-stays-inside
+        where JSDOM allows) and that closing by any path restores focus to the opener (not `document.body`).
+  - [ ] A note records that a modal NOT extending `Modal` is a defect-escalation (file ADR-AY-001 + a new
+        hand-rolled-trap task), never a silent default. GREEN against the current code (verify-only — all 8
+        extend `Modal`).
+
+---
+
+## Chunk 3 — Tests + additivity gate (T-AY-014..016)
+
+> The remaining automatable legs: the additivity diff, the discipline scan (the diff leg), and the
+> parity-screenshots.md completeness check. The CSS-rule-presence + registration + focus / live-region /
+> sr-only / aria-expanded / modal legs are owned by Chunk-1/2 RED tasks above.
+
+### T-AY-014 🧪 — RED: additivity invariant — no swept surface's default render / locale output regresses (TEST-AY-014)
+
+- **Description:** Author the additivity proof for SPEC-AY-010 (TEST-AY-014): mount each swept component and
+  assert its **default** (no-media-query, no-`.sr-only`-applied) render and locale output are **unchanged**
+  from the `next` baseline — a structural/snapshot diff that fails if a fill changed the base render, layout,
+  microcopy, or locale string (EC-AY-010, the cardinal P12 counter-metric). The added ARIA attributes /
+  `.sr-only` labels are in the tree but do **not** alter the visible default render (an `aria-label` /
+  `aria-expanded` attribute + a clipped `.sr-only` span are not visible). Pair with a recorded
+  `git diff next -- src/ui/i18n/locales` check (locale output byte-identical, NFR-AY-004). RED until the
+  fills are confirmed additive; passes once the diff is clean. Names TEST-AY-014.
+- **Satisfies:** TEST-AY-014, SPEC-AY-010, REQ-AY-014, NFR-AY-004, EC-AY-010
+- **Owner:** qa
+- **Depends on:** T-AY-010, T-AY-011, T-AY-012
+- **Estimate:** M
+- **Definition of done:**
+  - [ ] A test asserts each swept component's default render + locale output is unchanged from baseline
+        (structural/snapshot diff); a recorded `git diff next -- src/ui/i18n/locales` is empty.
+  - [ ] Discriminating: a fill that altered the visible default render, microcopy, or a locale string fails
+        naming the surface. RED until confirmed additive; GREEN once clean.
+
+### T-AY-015 🧪 — RED: discipline scan (no added raw-HTML sink in the P12 diff) (TEST-AY-015 diff leg)
+
+- **Description:** Author the discipline scan for SPEC-AY-011 (TEST-AY-015 — the diff leg; the CSS
+  token/comment leg rides T-AY-003): assert the P12 diff adds **no**
+  `innerHTML`/`outerHTML`/`insertAdjacentHTML` assignment and **no** `v-html` (a scan over the changed
+  files, or a recorded confirmation that `npm run lint` `vue/no-v-html` + `no-restricted-properties` stay
+  green with no new suppressions). This is the security leg (NFR-AY-003): the additive ARIA edits bind
+  attributes declaratively and render `.sr-only` labels as text — never inject HTML. Names TEST-AY-015
+  (diff leg).
+- **Satisfies:** TEST-AY-015, SPEC-AY-011, REQ-AY-015, NFR-AY-003
+- **Owner:** qa
+- **Depends on:** T-AY-010, T-AY-011, T-AY-012
+- **Estimate:** S
+- **Definition of done:**
+  - [ ] A scan / recorded lint confirmation asserts the P12 diff adds no
+        `innerHTML`/`outerHTML`/`insertAdjacentHTML`/`v-html` and no new suppression of the raw-HTML guards.
+  - [ ] Discriminating: a planted `v-html` / `innerHTML` in a changed file fails. GREEN against the actual
+        diff (the fills are declarative).
+
+### T-AY-016 🧪 — RED: `parity-screenshots.md` completeness (all surfaces × 320/520/720 × light/dark) (TEST-AY-016)
+
+- **Description:** Author the artifact-completeness check for REQ-AY-016 (TEST-AY-016): assert
+  `specs/accessibility/parity-screenshots.md` exists and lists **every charter §3 surface** at 320, 520, and
+  720 px in both light and dark theme, each side by side with its claudian reference (the matrix scaffolded
+  in T-AY-001). This is **artifact-completeness only** — it checks the matrix has every required row/cell
+  slot, NOT the visual judgment (that is the human TEST-AY-017 leg). RED until the matrix is complete. Names
+  TEST-AY-016.
+- **Satisfies:** TEST-AY-016, REQ-AY-016
+- **Owner:** qa
+- **Depends on:** T-AY-001
+- **Estimate:** S
+- **Definition of done:**
+  - [ ] A test asserts `specs/accessibility/parity-screenshots.md` lists every charter §3 surface at
+        320/520/720 px in light + dark, each with a claudian-reference + Specorator cell (completeness
+        structure only).
+  - [ ] Discriminating: a missing surface / width / theme cell fails naming the gap. GREEN once the matrix
+        is structurally complete; the visual sign-off is TEST-AY-017 (human).
+
+---
+
+## GATE — full verify + lightningcss check + parity self-review + the HUMAN final epic gate (T-AY-017..018)
+
+### T-AY-017 🚀👤 — HUMAN: final cross-surface parity screenshot sign-off (all surfaces) — the single FINAL epic gate
+
+- **Description:** The **single final epic acceptance gate** (REQ-AY-017, TEST-AY-017 — constitution
+  Art. VII). A **human** reviewer approves the final cross-surface parity screenshot set in
+  `specs/accessibility/parity-screenshots.md` — **all P1–P11 surfaces, light + dark, at 320/520/720 px** —
+  plus the **accumulated P5–P11 manual-Obsidian legs** (the per-phase manual screenshot legs that converge
+  here, charter §5.5 / workflow-state line 64). This includes the **visual** forced-colors + reduced-motion
+  rendering judgment (which no automatable test replaces). The agent **PRESENTS** this gate and the
+  populated screenshot set; it **opens (does NOT merge) the `next` → `develop` PR** after the automatable
+  gate (T-AY-018) is green; the human owns acceptance. **NEVER agent-self-claimed** — the phase status
+  records the human approval as the outstanding final gate; program-done (the whole P0–P12 reboot) is
+  asserted only after the human's recorded approval.
+- **Satisfies:** TEST-AY-017, REQ-AY-017, NFR-AY-001 (final cross-surface judgment)
+- **Owner:** human
+- **Depends on:** T-AY-018
+- **Estimate:** S (agent presents; human reviews)
+- **Definition of done:**
+  - [ ] The agent has **presented** the complete `parity-screenshots.md` set (all surfaces, light + dark,
+        320/520/720 px) + surfaced the accumulated P5–P11 manual-Obsidian legs, and has **opened (not
+        merged)** the `next` → `develop` PR.
+  - [ ] The phase status records the human approval as the **outstanding final gate** (owner: human); the
+        sign-off is **never agent-self-claimed**.
+  - [ ] **(Human action)** the maintainer's recorded acceptance of the parity set + the manual legs closes
+        the epic; the `next` → `develop` merge is then the human's call.
+
+### T-AY-018 🚀 — Feature DoD: full verify + lightningcss `build:web` check + all-auto suites green + parity self-review + draft `next` PR
+
+- **Description:** The closing automatable gate for P12. Run the full pre-PR verify chain (`npm audit` +
+  `npm run typecheck` + `npm run lint` + `npm run test` + `npm run build` + `npm run build:web` +
+  `npm run docs:api`) and `npm run test:all`; confirm zero bypasses. **Specifically confirm the
+  lightningcss `build:web` leg is green** — `accessibility.css`'s ASCII comments + standard at-rules
+  (`@media (prefers-reduced-motion …)` / `@media (forced-colors …)`) are minifier-accepted, **no CSS minify
+  error** (NFR-AY-005, EC-AY-013); the rule groups appear in **both** built outputs (plugin `styles.css` +
+  the standalone bundle, NFR-AY-006). Confirm: the **automatable suite green** — CSS-rule presence
+  (TEST-AY-001/003/004/005), registration (TEST-AY-002), focus-visible (TEST-AY-007), keyboard/labels
+  (TEST-AY-008), sr-only (TEST-AY-009), live-region (TEST-AY-010), aria-expanded (TEST-AY-011), modal
+  trap/restore (TEST-AY-012/013), additivity diff (TEST-AY-014), discipline scan (TEST-AY-015),
+  forced-colors borders (TEST-AY-006), parity-screenshots completeness (TEST-AY-016); the **additivity**
+  contract — no swept surface's default render / locale output regresses (TEST-AY-014, REQ-AY-014); the
+  **guard verdict re-confirmed** — **NO new InjectionKey / port / composable / component / ADR**,
+  **NO guard-relax** needed (DESIGN-AY-001 §C.6); the **no-`v-html`/`innerHTML`** discipline + the
+  token-discipline scan green (no hex / no raw var outside `forced-colors`, no NEW token — NFR-AY-002/003);
+  **`manifest.json` byte-identical** + en/de + all ten locales byte-identical (NFR-AY-004/008); the
+  **coverage gate** 80/70/80/80 holds (NFR-AY-007); **NO new dependency, NO migration**. Write the **parity
+  self-review note** (accessibility.css shipped + registered at both entry points + present in both built
+  outputs; reduced-motion / forced-colors / focus-visible / sr-only / live-region / modal-focus behaviours
+  verified; the additivity counter-metric = 0 default-state regressions, 0 stray mouse rings). Open a
+  **draft PR into `next`** (the orchestrator merges after green CI + deploys to `D:/TestVault` per the
+  autonomous-drive directive). **Then present the final review + open (DO NOT merge) the `next` → `develop`
+  PR (T-AY-017) — the human's call at parity.**
+- **Satisfies:** SPEC-AY-001..011 (gate), NFR-AY-005, NFR-AY-006, NFR-AY-007, NFR-AY-008, NFR-AY-010,
+  REQ-AY-014, REQ-AY-015, EC-AY-013
+- **Owner:** dev
+- **Depends on:** T-AY-005, T-AY-006, T-AY-014, T-AY-015, T-AY-016
+- **Estimate:** M
+- **Definition of done:**
+  - [ ] Full pre-PR verify chain + `npm run test:all` green, zero bypasses; the lightningcss `build:web`
+        leg green (no CSS minify error — NFR-AY-005); the RG-1..RG-6 rules present in both the plugin
+        `styles.css` and the standalone bundle (NFR-AY-006).
+  - [ ] The automatable suite (TEST-AY-001..016) green; the additivity diff (TEST-AY-014) clean
+        (0 default-state regressions, 0 stray mouse rings); the coverage gate 80/70/80/80 holds.
+  - [ ] The guard verdict re-confirmed (**no new InjectionKey/port/composable/component/ADR, no
+        guard-relax**); the no-`v-html`/`innerHTML` + token-discipline scans green (no new token, no hex /
+        no raw var outside `forced-colors`); `manifest.json` + en/de + all ten locales byte-identical to the
+        `next` baseline; no new dep, no migration.
+  - [ ] The parity self-review note written (accessibility.css shipped + registered + in both outputs; the
+        five a11y behaviours verified; counter-metric = 0); a **draft PR into `next`** opened; the **final
+        review presented + the `next` → `develop` PR opened (NOT merged)** for the human gate (T-AY-017);
+        implementation-log + `test-report.md` updated.
+
+---
+
+## Dependency graph + parallelisable batches
+
+```mermaid
+flowchart TD
+    T001["T-AY-001 📐 baseline + guard verdict + parity-screenshots.md scaffold"]
+
+    subgraph CHUNK1["Chunk 1 — accessibility.css + registration"]
+      T003["T-AY-003 🧪 RG-1..6 file-read (RED)"]
+      T004["T-AY-004 🧪 registration both sites (RED)"]
+      T002["T-AY-002 🔨 accessibility.css + 2 import edits"]
+      T005["T-AY-005 🔨 RG-4 forced-colors selector enumeration"]
+    end
+
+    subgraph CHUNK2["Chunk 2 — behaviour-fix sweep (additive ARIA/label/live-region)"]
+      T006["T-AY-006 🧪 forced-colors controls mounted (RED)"]
+      T007["T-AY-007 🧪 focus-visible + keyboard/labels (RED)"]
+      T008["T-AY-008 🧪 live-region presence/severity (RED)"]
+      T009["T-AY-009 🧪 aria-expanded + sr-only (RED)"]
+      T010["T-AY-010 🔨🪓 icon-only labels fill"]
+      T011["T-AY-011 🔨 notice-host live region"]
+      T012["T-AY-012 🔨🪓 collapsible aria-expanded fill"]
+      T013["T-AY-013 🧪 modal trap/restore (verify-only, 8 seams)"]
+    end
+
+    subgraph CHUNK3["Chunk 3 — tests + additivity gate"]
+      T014["T-AY-014 🧪 additivity diff (RED)"]
+      T015["T-AY-015 🧪 discipline scan / no raw-HTML (RED)"]
+      T016["T-AY-016 🧪 parity-screenshots.md completeness (RED)"]
+    end
+
+    subgraph GATE["GATE — verify + lightningcss + the human final epic gate"]
+      T018["T-AY-018 🚀 feature DoD + build:web + draft next PR"]
+      T017["T-AY-017 🚀👤 HUMAN final parity sign-off (FINAL epic gate)"]
+    end
+
+    T001 --> T003
+    T001 --> T004
+    T003 --> T002
+    T004 --> T002
+    T002 --> T005
+    T001 --> T006
+    T001 --> T007
+    T001 --> T008
+    T001 --> T009
+    T001 --> T013
+    T007 --> T010
+    T009 --> T010
+    T008 --> T011
+    T009 --> T012
+    T010 --> T014
+    T011 --> T014
+    T012 --> T014
+    T010 --> T015
+    T011 --> T015
+    T012 --> T015
+    T005 --> T018
+    T006 --> T018
+    T014 --> T018
+    T015 --> T018
+    T016 --> T018
+    T018 --> T017
+```
+
+**Parallelisable batches (each runs after its upstream RED/impl lands):**
+
+- **B0 (baseline):** T-AY-001 — alone, first (baseline + guard verdict + the parity-screenshots.md scaffold).
+- **B1 (Chunk 1 RED tests):** T-AY-003 (RG file-read) + T-AY-004 (registration) run **in parallel** (each
+  depends only on T-AY-001). These land the RED scaffold for the CSS file.
+- **B2 (Chunk 1 impl):** T-AY-002 (the CSS file + the two import edits) greens T-AY-003/004 → then T-AY-005
+  (RG-4 selector enumeration) refines RG-4.
+- **B3 (Chunk 2 RED tests):** T-AY-006/007/008/009/013 run **in parallel** (each depends only on T-AY-001;
+  they mount disjoint surfaces). T-AY-013 (modal) is verify-only against the current code.
+- **B4 (Chunk 2 fills):** T-AY-010 (icon-only labels; after T-AY-007/009), T-AY-011 (notice-host live region;
+  after T-AY-008), T-AY-012 (collapsible aria-expanded; after T-AY-009) — touch disjoint components, may run
+  in parallel.
+- **B5 (Chunk 3 gate tests):** T-AY-014 (additivity diff) + T-AY-015 (discipline scan) run after the fills
+  (T-AY-010/011/012); T-AY-016 (screenshot completeness) depends only on T-AY-001 and may run any time after
+  the matrix is populated.
+- **B6 (gate):** T-AY-018 (feature DoD + lightningcss build:web + draft `next` PR) after B2/B3/B5 →
+  **T-AY-017 (the HUMAN final epic gate)** after T-AY-018 opens the `next` → `develop` PR.
+
+> **Suggested dispatch chunks for the implementer (the P8/P9 subagent-timeout lesson — keep each dispatch
+> self-contained):**
+> - **C1** = T-AY-001 + T-AY-003 + T-AY-004 + T-AY-002 + T-AY-005 (baseline + the CSS file + the two import
+>   edits + the RG file-read/registration RED-then-green + RG-4 enumeration — the accessibility.css
+>   dispatch; small, self-contained, lands first).
+> - **C2** = T-AY-006..009 + T-AY-013 (the Chunk-2 RED test scaffold across the swept surfaces — mostly
+>   verify-only mounts; modal trap/restore is verify-only).
+> - **C3** = T-AY-010 + T-AY-011 + T-AY-012 (the three genuine additive fills — icon-only labels, notice-host
+>   live region, collapsible aria-expanded; disjoint components, may parallelise).
+> - **C4** = T-AY-014 + T-AY-015 + T-AY-016 (additivity diff + discipline scan + screenshot completeness).
+> - **C5** = T-AY-018 (the automatable gate + lightningcss build:web + draft `next` PR), then **T-AY-017**
+>   (the HUMAN final parity sign-off — presented, never self-claimed).
+> C2's RED tests + C3's fills touch disjoint surfaces and may be dispatched in parallel; each fill turns its
+> own RED leg green.
+
+> **After P12 merges to `next` (the epic end-state — charter line 219 / workflow-state lines 69-71):** the
+> whole P0–P12 reboot is on `next` with a green verify gate → the orchestrator **presents the final review +
+> opens (DO NOT merge) the `next` → `develop` PR**. Per the charter, `next` → `develop` at parity is the
+> **human's call** (NG6). T-AY-017 is that human gate; T-AY-018 opens (does not merge) the PR.
+
+---
+
+## Coverage sanity-check
+
+- **Every SPEC-AY-001..011 has ≥ 1 task:** SPEC-AY-001 (T-AY-002/003/018), SPEC-AY-002 (T-AY-002/004/018),
+  SPEC-AY-003 (T-AY-002/004/018), SPEC-AY-004 (T-AY-008/011), SPEC-AY-005 (T-AY-009/012), SPEC-AY-006
+  (T-AY-005/006), SPEC-AY-007 (T-AY-007/009/010), SPEC-AY-008 (T-AY-007), SPEC-AY-009 (T-AY-013),
+  SPEC-AY-010 (T-AY-014), SPEC-AY-011 (T-AY-003/015).
+- **Every REQ-AY has ≥ 1 test task** (the qa 🧪 tasks name the TEST-AY ids 1:1 to the spec's REQ↔SPEC↔TEST
+  table): REQ-AY-001→T-AY-003 (TEST-AY-001); REQ-AY-002→T-AY-004 (TEST-AY-002); REQ-AY-003→T-AY-003
+  (TEST-AY-003); REQ-AY-004→T-AY-003 (TEST-AY-004); REQ-AY-005→T-AY-003 (TEST-AY-005); REQ-AY-006→T-AY-003/006
+  (TEST-AY-006); REQ-AY-007→T-AY-003/007 (TEST-AY-007); REQ-AY-008→T-AY-007 (TEST-AY-008); REQ-AY-009→
+  T-AY-003/009 (TEST-AY-009); REQ-AY-010→T-AY-008 (TEST-AY-010); REQ-AY-011→T-AY-009 (TEST-AY-011);
+  REQ-AY-012→T-AY-013 (TEST-AY-012); REQ-AY-013→T-AY-013 (TEST-AY-013); REQ-AY-014→T-AY-014 (TEST-AY-014);
+  REQ-AY-015→T-AY-003/015 (TEST-AY-015); REQ-AY-016→T-AY-016 (TEST-AY-016); REQ-AY-017→**T-AY-017** (the
+  HUMAN TEST-AY-017 sign-off, owner: human, 👤).
+- **Every TEST-AY-001..016 is owned (auto):** 001/003/004/005/007(file)/009(file)/015(css)→T-AY-003;
+  002→T-AY-004; 006→T-AY-003(file)/T-AY-005(enum)/T-AY-006(mount); 007(mount)/008→T-AY-007;
+  010→T-AY-008; 011/009(mount)→T-AY-009; 012/013→T-AY-013; 014→T-AY-014; 015(diff)→T-AY-015;
+  016→T-AY-016. **TEST-AY-017 = HUMAN → T-AY-017 (👤, never agent-self-claimed).**
+- **Every NFR-AY is gated:** NFR-AY-001 (T-AY-006/007/008/009/013 across surfaces + T-AY-017 human),
+  NFR-AY-002 (T-AY-003 token/comment discipline + T-AY-018), NFR-AY-003 (T-AY-015 no raw-HTML),
+  NFR-AY-004 (T-AY-014 additivity + T-AY-018 locale/manifest byte-identity), NFR-AY-005 (T-AY-018
+  lightningcss build:web green, EC-AY-013), NFR-AY-006 (T-AY-004 registration + T-AY-018 both-outputs),
+  NFR-AY-007 (T-AY-018 coverage 80/70/80/80), NFR-AY-008 (T-AY-014/018 manifest untouched), NFR-AY-009
+  (T-AY-005/006 forced-colors borders + EC-AY-002/003), NFR-AY-010 (T-AY-018 verify + test:all green).
+- **Every EC-AY-001..014 is caught:** EC-AY-001 (T-AY-003 RG-2 `animation: none`), EC-AY-002 (T-AY-003 RG-1
+  safety-net), EC-AY-003 (T-AY-005/006 RG-4 border), EC-AY-004 (T-AY-003 RG-3 `Highlight` + RG-5 ring),
+  EC-AY-005 (T-AY-007 focus-visible shows), EC-AY-006 (T-AY-007 no stray mouse ring), EC-AY-007 (T-AY-009
+  `.sr-only` clip), EC-AY-008 (T-AY-013 trap wrap), EC-AY-009 (T-AY-013 restore not body), EC-AY-010
+  (T-AY-014 additivity byte-identical), EC-AY-011 (T-AY-008/011 polite live region), EC-AY-012 (T-AY-008/011
+  error assertive), EC-AY-013 (T-AY-018 lightningcss minify green), EC-AY-014 (T-AY-003 RG-5 consumes
+  `--sp-focus-ring` → theme `--interactive-accent`, no hardcoded colour).
+- **No orphan task:** every task lists ≥ 1 SPEC-AY / TEST-AY / REQ-AY / NFR-AY. No task is `L` (all S/M).
+- **Additive-only (no port/interface/ADR break):** P12 adds **one new CSS file** + **two one-line import
+  edits** + **targeted additive ARIA/`.sr-only`/live-region fills** on existing components; the 8 modal seams
+  + the busy region + TabBar are **verify-only**. No new InjectionKey / port / composable / component / ADR;
+  no new token (RG-5 reuses `--sp-focus-ring`/`--sp-shadow-focus-ring`); no signature change. The P0–P11
+  default render stays **byte-identical for mouse users + the existing look** (every rule gated behind
+  `:focus-visible` / `prefers-reduced-motion` / `forced-colors` / `.sr-only` / additive ARIA — REQ-AY-014);
+  `manifest.json` + en/de + all ten locales byte-identical (NFR-AY-004/008). The additivity diff (T-AY-014)
+  + the discipline scan (T-AY-015) are the cardinal gates.
+- **TDD / build-green ordering:** Chunk-1 RED file-read/registration tests (T-AY-003/004) land before the
+  CSS file + import edits (T-AY-002); Chunk-2 RED component/PageObject tests (T-AY-006..009/013) land before
+  the additive fills (T-AY-010/011/012); the modal trap/restore (T-AY-013) is verify-only against the native
+  Obsidian `Modal`. The **HUMAN final parity sign-off (T-AY-017, TEST-AY-017)** is the single final epic gate
+  — the agent presents it + opens (does not merge) the `next` → `develop` PR; it is **never
+  agent-self-claimed** (constitution Art. VII).

--- a/specs/accessibility/test-plan.md
+++ b/specs/accessibility/test-plan.md
@@ -1,0 +1,147 @@
+---
+id: TEST-PLAN-AY-001
+title: Accessibility (P12, FINAL phase) — Test Plan / Baseline + Guard-Verify Note
+stage: testing
+feature: accessibility
+area: AY
+epic: claudian-reboot
+phase: P12
+status: in-progress
+owner: dev
+integration_branch: next
+created: 2026-05-27
+updated: 2026-05-27
+inputs:
+  - SPEC-AY-001 (spec.md — SPEC-AY-001..011, TEST-AY-001..017, EC-AY-001..014)
+  - PRD-AY-001 (requirements.md — REQ-AY-001..017 + NFR-AY-001..010)
+  - DESIGN-AY-001 (design.md — Parts A/B/C; RG-1..6; D-AY-1..5; §C.6 ADR/port verdict)
+  - src/ui/styles/tokens.css (the --sp-* token layer; --sp-focus-ring / --sp-shadow-focus-ring)
+  - src/ui/styles/animations.css (the five named keyframes + the CQ-AUX-14 spin guard)
+  - src/plugin/main.ts + src/ui/main.ts (the two CSS import sites)
+  - D:\Projects\claudian-main\src\style\accessibility.css (the 41-line focus-visible-only reference)
+---
+
+# Test Plan — Accessibility (P12, the FINAL phase)
+
+This plan captures the **token reference**, the **import-site reference**, the **reduced-motion
+source inventory**, the **forced-colors background-cue-only control inventory**, the **claudian
+reference**, and the **guard verdict** for P12. P12 adds **one new CSS file**
+(`src/ui/styles/accessibility.css`, RG-1..RG-6), **two one-line import edits**, and **targeted
+additive ARIA / `.sr-only` / live-region fills** on existing components. Every rule is gated behind
+`:focus-visible`, `prefers-reduced-motion`, `forced-colors`, `.sr-only`, or an additive ARIA
+attribute, so the P0-P11 default render stays byte-identical for mouse users (REQ-AY-014).
+
+## 1. Token reference (the RG-5 ring consumers — NFR-AY-002, D-AY-2 / NG2)
+
+RG-5 (the focus-visible ring) consumes the two **existing** tokens. No new token is minted.
+
+| Token | Location | Value | Role |
+|---|---|---|---|
+| `--sp-focus-ring` | `src/ui/styles/tokens.css:42` | `var(--interactive-accent)` | The ring colour (follows the user theme accent — EC-AY-014). |
+| `--sp-shadow-focus-ring` | `src/ui/styles/tokens.css:140` | `0 0 0 2px var(--sp-focus-ring)` | The `box-shadow` ring variant for controls whose `outline` is clipped by `overflow: hidden`. |
+
+Both verified present at the recorded lines on branch `feature/accessibility`. RG-5 is a token
+**consumer** — it adds no colour literal of its own (the only colour keywords in `accessibility.css`
+are CSS system colours inside the `forced-colors` block, RG-3/RG-4 — NFR-AY-002, D-AY-5).
+
+## 2. Import-site reference (the SPEC-AY-002/003 insertion points — NFR-AY-006)
+
+The current 2-import CSS head at each entry; `accessibility.css` lands as the **3rd** import, after
+`animations.css`, in both files.
+
+| Entry | Current CSS head | Insertion point (3rd import) |
+|---|---|---|
+| `src/plugin/main.ts` | L1 `import '@/ui/styles/tokens.css';` · L2 `import '@/ui/styles/animations.css';` | after L2: `import '@/ui/styles/accessibility.css';` |
+| `src/ui/main.ts` | L12 `import './standalone.css';` · L13 `import './styles/tokens.css';` · L14 `import './styles/animations.css';` | after L14: `import './styles/accessibility.css';` |
+
+(The plugin entry uses the `@/ui/styles/…` alias; the standalone entry uses the relative
+`./styles/…` path. Each registers `accessibility.css` immediately after its `animations.css` line.)
+
+## 3. Reduced-motion source inventory (what RG-1 complements — CLAR-AY-002)
+
+`accessibility.css` **complements** (does not replace) the existing per-section token overrides
+(`tokens.css` zeroes `--sp-duration-*`) and the explicit `spin` halt in `animations.css`. RG-1 is a
+global safety-net guard; RG-2 re-asserts the explicit `spin` halt.
+
+The five named keyframes (declared in `src/ui/styles/animations.css`) that the reduced-motion guard
+covers via their consumers:
+
+| Keyframe | Consumer | Reduced-motion handling |
+|---|---|---|
+| `thinking-pulse` | ThinkingBlock dot + tab "streaming" border | duration token collapses to `0s`; RG-1 safety-net catches any miss. |
+| `streaming-cursor-blink` | StreamingCursor tail glyph | duration token collapses; RG-1 safety-net. |
+| `spin` | indeterminate spinners (title-gen / inline-edit / instruction) | **RG-2 `animation: none`** (a near-zero duration alone would not stop an indeterminate loop — CQ-AUX-14 / EC-AY-001). `animations.css` keeps its own copy; idempotent. |
+| `mcp-glow` | McpIndicator active glow | duration token collapses; RG-1 safety-net. |
+| `external-context-glow` | external-context indicator | duration token collapses; RG-1 safety-net. |
+
+`@keyframes` definitions are **never** targeted by `accessibility.css` (the guard targets the
+**consumers** — elements running animations/transitions; the build skips `@keyframes` children).
+
+## 4. Forced-colors background-cue-only control inventory (the RG-4 selector enumeration — SPEC-AY-006)
+
+The controls whose normal affordance is a background fill/wash only, each given a `currentColor`
+border (or non-shifting `outline`) inside the `@media (forced-colors: active)` block so each stays
+distinguishable when the OS replaces the palette (EC-AY-003, NFR-AY-009):
+
+| Control | Selector (RG-4) |
+|---|---|
+| Toolbar toggle switch | `.sp-toggle-switch` |
+| State pills | `[data-state]` |
+| File / image chips | `.sp-chip` |
+| Tab badges | `.sp-tab` |
+| Selected dropdown option | `[role="option"][aria-selected="true"]` |
+
+(The concrete enumeration is committed in RG-4 by T-AY-002/T-AY-005; the T-AY-006 mount leg confirms
+the listed controls exist in the rendered surfaces so the selectors are not dead.)
+
+## 5. Claudian reference (the meet / beat split — CLAR-AY-001)
+
+`D:\Projects\claudian-main\src\style\accessibility.css` is the **minimal focus-visible-only** layer:
+**41 lines, three selector groups, no media queries** — no `prefers-reduced-motion`, no
+`forced-colors`, no `.sr-only`.
+
+- **Group 1** (`outline + offset + border-radius`): tool/thinking/subagent/model headers + header
+  buttons + `thinking-current` → `outline: 2px solid var(--interactive-accent); outline-offset: 2px;`
+- **Group 2** (`outline + offset only`): action buttons, toggle switch, file/image chips + remove
+  buttons, image-modal close, approved-remove, save-env, snippet restore/edit/delete, cancel/save,
+  code-lang label.
+- **Group 3** (`negative offset`): `history-item-content`.
+
+So the **meet** leg is the focus-visible ring (RG-5, REQ-AY-007) — we reproduce it across the
+equivalent `--sp-*` surfaces via the `:where(...)` interactive selector. The **beat** legs are the
+three rule groups claudian lacks: RG-1 (reduced-motion guard, REQ-AY-003), RG-2 (spin halt,
+REQ-AY-004), RG-3 (forced-colors mapping, REQ-AY-005), RG-4 (forced-colors borders, REQ-AY-006), and
+RG-6 (`.sr-only`, REQ-AY-009).
+
+## 6. Guard-verify note (the deleted-symbol guard verdict — NO guard-relax)
+
+Confirmed against `eslint.config.js` + `tests/architecture/no-deleted-subsystem-refs.test.ts` on
+branch `feature/accessibility`. The deleted-subsystem guard is a `no-restricted-imports` rule keyed
+by the message fragment `deleted in the P0 reboot`; it matches **import paths and injection-key
+import names**, not CSS filenames, CSS selectors, or template ARIA attributes.
+
+- **The new `src/ui/styles/accessibility.css` file** — a plain CSS filename under the already-live
+  `src/ui/styles/**` path (tokens.css/animations.css already live there). It is not an import path
+  the guard restricts; it matches no `DELETED_SUBSYSTEM_BAN` glob (the obsidian/deleted-subsystem
+  globs are `Claude*` / `Cursor*` / `ObsidianMcp*` etc.) and is not a `DELETED_INJECTION_KEYS`
+  import name.
+- **The two new import lines** (`import '@/ui/styles/accessibility.css';` /
+  `import './styles/accessibility.css';`) — side-effect CSS imports of a live `src/ui/styles/**`
+  path; they match no ban glob and import no banned symbol.
+- **The additive ARIA / `.sr-only` / live-region edits** (Chunk 2) — add attributes / classes to
+  existing templates; they introduce no import, no `innerHTML`/`v-html`/`outerHTML`/
+  `insertAdjacentHTML` sink (REQ-AY-015, NFR-AY-003), and trip no guard.
+
+**Verdict (verified against SPEC-AY-001..011 + DESIGN-AY-001 §C.6):**
+
+- **NO new InjectionKey / port / composable / component / ADR.** P12 touches only the UI-layer CSS
+  + the two import sites + additive ARIA/label/live-region attributes on already-live components.
+- **NO guard-relax task in P12.** The new CSS file, the two import lines, and the ARIA edits are not
+  caught by `DELETED_SUBSYSTEM_BAN` / `DELETED_INJECTION_KEYS`.
+- **NO new token.** RG-5 reuses `--sp-focus-ring` / `--sp-shadow-focus-ring`.
+- **`manifest.json` + `en.ts` / `de.ts` + all ten locales untouched** (NFR-AY-004/008). T-AY-018
+  (the gate) re-confirms via `git diff next`.
+
+One-line lint confirmation of the guard verdict (recorded at T-AY-001): the new file path, the two
+import lines, and the additive ARIA edits trip no `no-restricted-imports` "deleted in the P0 reboot"
+message — the project lint pass that exercises the registration lands green with T-AY-002.

--- a/specs/accessibility/traceability.md
+++ b/specs/accessibility/traceability.md
@@ -1,0 +1,101 @@
+---
+id: TRACE-AY-001
+title: Accessibility (P12, FINAL phase) — Traceability matrix
+stage: review
+feature: accessibility
+area: AY
+epic: claudian-reboot
+phase: P12
+status: complete
+owner: reviewer
+integration_branch: next
+created: 2026-05-27
+updated: 2026-05-27
+inputs:
+  - PRD-AY-001 (requirements.md — REQ-AY-001..017 + NFR-AY-001..010)
+  - DESIGN-AY-001 (design.md — Parts A/B/C; RG-1..6; D-AY-1..5; §C.6 no new port/ADR)
+  - SPEC-AY-001 (spec.md — SPEC-AY-001..011 + TEST-AY-001..017 + EC-AY-001..014)
+  - TASKS-AY-001 (tasks.md — T-AY-001..018)
+  - IMPL-LOG-AY-001 (implementation-log.md)
+  - the diff: git diff next..HEAD (next @ d4733464, not advanced)
+---
+
+# Traceability matrix — Accessibility (P12)
+
+Regenerated from the P12 artifacts + the `git diff next..HEAD` at Stage-9 review. Validates the
+constitution Art. V chain REQ-AY → SPEC-AY → T-AY → code(file) → TEST-AY for every requirement, and
+confirms there is no orphan test / task / ADR. REQ-AY-017 is the human-owned final epic gate, recorded
+as the single pending downstream cell.
+
+## REQ ↔ SPEC ↔ TASK ↔ CODE ↔ TEST
+
+| REQ | Pri | SPEC | Task(s) | Code (file) | Test(s) | Leg | Status |
+|---|---|---|---|---|---|---|---|
+| REQ-AY-001 (accessibility.css 3rd layer) | must | SPEC-AY-001 | T-AY-002, T-AY-003 | `src/ui/styles/accessibility.css` | TEST-AY-001 | auto | ✅ satisfied |
+| REQ-AY-002 (registered at both import sites) | must | SPEC-AY-002, SPEC-AY-003 | T-AY-002, T-AY-004 | `src/plugin/main.ts:3`, `src/ui/main.ts:15` | TEST-AY-002 | auto | ✅ satisfied |
+| REQ-AY-003 (reduced-motion guard) | must | SPEC-AY-001 (RG-1) | T-AY-002, T-AY-003 | `accessibility.css:28-37` | TEST-AY-003 | auto | ✅ satisfied |
+| REQ-AY-004 (spin halt `animation:none`) | must | SPEC-AY-001 (RG-2) | T-AY-002, T-AY-003 | `accessibility.css:42-47` | TEST-AY-004 | auto | ✅ satisfied |
+| REQ-AY-005 (forced-colors surface mapping) | must | SPEC-AY-001 (RG-3) | T-AY-002, T-AY-003 | `accessibility.css:53-71` | TEST-AY-005 | auto | ✅ satisfied |
+| REQ-AY-006 (forced-colors borders) | must | SPEC-AY-001 (RG-4), SPEC-AY-006 | T-AY-002, T-AY-005, T-AY-006 | `accessibility.css:82-91` | TEST-AY-006 (file + mount) | auto | ✅ satisfied |
+| REQ-AY-007 (focus-visible ring) | must | SPEC-AY-001 (RG-5), SPEC-AY-008 | T-AY-002, T-AY-003, T-AY-007 | `accessibility.css:98-110` | TEST-AY-007 (file + mount) | auto | ✅ satisfied |
+| REQ-AY-008 (keyboard-operable + labelled) | must | SPEC-AY-007, SPEC-AY-008 | T-AY-007, T-AY-010 | swept components (verify-only; no edit) | TEST-AY-008 | auto | ✅ satisfied |
+| REQ-AY-009 (`.sr-only` utility) | must | SPEC-AY-001 (RG-6), SPEC-AY-007 | T-AY-002, T-AY-009, T-AY-010 | `accessibility.css:116-127`; `NoticeLiveRegion.vue:53` | TEST-AY-009 (file + mount) | auto | ✅ satisfied |
+| REQ-AY-010 (streaming + notice live region) | must | SPEC-AY-004 | T-AY-008, T-AY-011 | `ChatSurface.vue:856-857` (verify); `src/ui/components/NoticeLiveRegion.vue` (fill) | TEST-AY-010 | auto | ✅ satisfied |
+| REQ-AY-011 (collapsible `aria-expanded`) | should | SPEC-AY-005 | T-AY-009, T-AY-012 | `SpCollapsible.vue` (verify-only; already conforms) | TEST-AY-011 | auto | ✅ satisfied |
+| REQ-AY-012 (modals trap focus) | must | SPEC-AY-009 | T-AY-013 | `src/plugin/modals/**` (8 seams extend Obsidian `Modal`; verify-only) | TEST-AY-012 | auto (structural) | ✅ satisfied |
+| REQ-AY-013 (modals restore focus) | must | SPEC-AY-009 | T-AY-013 | `src/plugin/modals/**` (native `Modal` restore; verify-only) | TEST-AY-013 | auto (structural) | ✅ satisfied |
+| REQ-AY-014 (additive — no regression) | must | SPEC-AY-010 | T-AY-014 | (allow-list diff: 4 `src/` files) | TEST-AY-014 | auto | ✅ satisfied |
+| REQ-AY-015 (no raw-HTML, token discipline) | must | SPEC-AY-001, SPEC-AY-011 | T-AY-003, T-AY-015 | `accessibility.css` (no hex outside forced-colors); P12 diff (no sink) | TEST-AY-015 | auto | ✅ satisfied |
+| REQ-AY-016 (parity screenshot set captured) | must | (artifact) | T-AY-016 | `specs/accessibility/parity-screenshots.md` | TEST-AY-016 (completeness) | auto | ✅ satisfied (artifact-complete) |
+| REQ-AY-017 (human final sign-off) | must | (human acceptance) | T-AY-017 👤 | n/a (human review of parity set + manual legs) | **TEST-AY-017 (HUMAN)** | **human** | ⏳ **PENDING — final epic gate (owner: human)** |
+
+## NFR coverage
+
+| NFR | Category | Evidence | Status |
+|---|---|---|---|
+| NFR-AY-001 | accessibility (WCAG 2.2 AA) | TEST-AY-006/007/008/010/011/012/013 across surfaces + REQ-AY-017 human visual leg | ✅ automatable legs met; visual leg = human |
+| NFR-AY-002 | maintainability (token discipline) | `accessibility.css` consumes `--sp-focus-ring`/`--sp-shadow-focus-ring`; only system colours inside forced-colors (TEST-AY-015) | ✅ met |
+| NFR-AY-003 | security (no raw-HTML sink) | P12 diff adds no innerHTML/outerHTML/insertAdjacentHTML/v-html (TEST-AY-015; reviewer grep) | ✅ met |
+| NFR-AY-004 | additivity (no regression; locale byte-identical) | TEST-AY-014; `git diff next -- src/ui/i18n/locales` empty (reviewer-confirmed) | ✅ met |
+| NFR-AY-005 | build (lightningcss-safe CSS) | `build:web` green at C1 (impl-log T-AY-002); ASCII-only comments | ✅ met (parent re-confirms full gate at T-AY-018) |
+| NFR-AY-006 | build (registered + in both outputs) | TEST-AY-002; import-order contract; parent T-AY-018 confirms both built outputs | ✅ met (registration); ⏳ both-output presence confirmed at T-AY-018 |
+| NFR-AY-007 | quality (coverage 80/70/80/80) | parent T-AY-018 `npm run test:coverage` | ⏳ confirmed at T-AY-018 gate |
+| NFR-AY-008 | release (`manifest.json` untouched) | `git diff next -- manifest.json` empty (reviewer-confirmed) | ✅ met |
+| NFR-AY-009 | reliability (no surface breaks under a11y media) | RG-1..RG-4 inert until media query; forced-colors borders + focus ring perceivable | ✅ met (automatable); visual leg = human |
+| NFR-AY-010 | gate (verify + test:all green) | parent T-AY-018 full chain | ⏳ confirmed at T-AY-018 gate |
+
+## Edge-case coverage (EC-AY)
+
+All 14 EC-AY map to a test or rule group: EC-AY-001→RG-2/TEST-AY-004; EC-AY-002→RG-1/TEST-AY-003;
+EC-AY-003→RG-4/TEST-AY-006; EC-AY-004→RG-3+RG-5/TEST-AY-005/007; EC-AY-005/006→RG-5/TEST-AY-007;
+EC-AY-007→RG-6/TEST-AY-009; EC-AY-008/009→modal/TEST-AY-012/013; EC-AY-010→additivity/TEST-AY-014;
+EC-AY-011/012→live region/TEST-AY-010; EC-AY-013→lightningcss/T-AY-018; EC-AY-014→RG-5 token consume/TEST-AY-007.
+
+## Source-diff scope (additivity evidence — REQ-AY-014)
+
+`git diff next..HEAD` touches under `src/` exactly four files:
+
+- `src/ui/styles/accessibility.css` (new — RG-1..RG-6)
+- `src/plugin/main.ts` (+1 line — 3rd CSS import)
+- `src/ui/main.ts` (import + NoticeLiveRegion render wiring)
+- `src/ui/components/NoticeLiveRegion.vue` (new — `.sr-only` live region)
+
+Plus a test-only `tests/__fakes__/obsidian.stub.ts` `Modal` export (additive). No swept component
+template, no locale file, no `manifest.json` changed. Confirmed at review.
+
+## Orphan / dangling check
+
+- **Orphan tests:** none. Every TEST-AY-001..016 traces up to a REQ-AY and down to code/artifact.
+  TEST-AY-017 is the human gate (intentionally has no automatable downstream).
+- **Orphan tasks:** none. Every T-AY-001..018 names ≥ 1 SPEC-AY / TEST-AY / REQ-AY / NFR-AY.
+  T-AY-017 (human) + T-AY-018 (parent gate) remain open by design.
+- **Orphan ADRs:** none. P12 introduces no new ADR (DESIGN-AY-001 §C.6) and references no dangling ADR.
+- **Requirements without a downstream chain:** none. All 17 REQ-AY have a SPEC + task + test cell;
+  REQ-AY-017's downstream is the human sign-off (pending), which is correct for a final epic gate.
+
+## Pending downstream cells (by design)
+
+| Cell | Owner | Why pending |
+|---|---|---|
+| REQ-AY-017 / TEST-AY-017 / T-AY-017 | human | Final cross-surface parity screenshot sign-off + accumulated P5–P11 manual-Obsidian legs — the single final epic gate; never agent-self-claimed (constitution Art. VII). |
+| T-AY-018 (verify + build:web + draft `next` PR) | dev/orchestrator (parent) | The closing automatable gate; runs the full verify chain + confirms both built outputs + coverage. Out of this reviewer's scope (parent runs the suite/builds). |

--- a/specs/accessibility/workflow-state.md
+++ b/specs/accessibility/workflow-state.md
@@ -4,7 +4,7 @@ area: AY
 current_stage: tasks
 status: active
 last_updated: 2026-05-27
-last_agent: planner (tasks complete; hand-off → /spec:implement)
+last_agent: dev (Chunk 1 T-AY-001..005 complete; hand-off → qa/dev for Chunk 2)
 epic: claudian-reboot
 phase: P12
 integration_branch: next
@@ -16,8 +16,8 @@ artifacts:
   design.md: complete (DESIGN-AY-001, Parts A/B/C; no new port, no new ADR)
   spec.md: complete (SPEC-AY-001..011 + TEST-AY-001..017; coverage table)
   tasks.md: complete (TASKS-AY-001, 18 tasks T-AY-001..018; 3 chunks + GATE; coverage sanity-check)
-  implementation-log.md: pending
-  test-plan.md: pending
+  implementation-log.md: in-progress (Chunk 1 T-AY-001..005 logged; Chunk 2/3 + gate remain)
+  test-plan.md: in-progress (T-AY-001 baseline + guard-verify note; parity-screenshots.md scaffolded)
   test-report.md: pending
   review.md: pending
   traceability.md: pending
@@ -37,8 +37,8 @@ artifacts:
 | 4. Design | `design.md` | complete |
 | 5. Specification | `spec.md` | complete |
 | 6. Tasks | `tasks.md` | complete |
-| 7. Implementation | `implementation-log.md` + code | pending |
-| 8. Testing | `test-plan.md`, `test-report.md` | pending |
+| 7. Implementation | `implementation-log.md` + code | in-progress (Chunk 1 done) |
+| 8. Testing | `test-plan.md`, `test-report.md` | in-progress (baseline + Chunk-1 tests) |
 | 9. Review | `review.md`, `traceability.md` | pending |
 | 10. Release | `release-notes.md` | pending |
 | 11. Learning | `retrospective.md` | pending |
@@ -167,4 +167,27 @@ OUR `src/ui/styles/{tokens,animations}.css` + the P1-P11 components/modals for t
                           (T-AY-003/004 RED → T-AY-002/005). Suggested dispatch: C1 accessibility.css;
                           C2 Chunk-2 RED scaffold; C3 the three fills (parallel); C4 gate tests; C5
                           T-AY-018 gate then T-AY-017 human sign-off.
+2026-05-27 (dev): Chunk 1 (T-AY-001..005) COMPLETE on feature/accessibility (off next). Commits:
+                          T-AY-001 6b9bf920 (docs(ay): test-plan baseline + guard-verify note +
+                          parity-screenshots.md all-surfaces matrix scaffold + implementation-log);
+                          T-AY-003/004 46dc3896 (test(ay): RED RG-1..6 file-read + both-site
+                          registration tests, confirmed RED — file/imports absent);
+                          T-AY-002 19144399 (feat(ay): src/ui/styles/accessibility.css RG-1..RG-6,
+                          .specorator-root scoped, ASCII-only lightningcss-safe comments, no hex /
+                          no raw non --sp-* var outside forced-colors; registered as 3rd CSS import
+                          after tokens+animations at src/plugin/main.ts:3 + src/ui/main.ts:15;
+                          RG-5 reuses --sp-focus-ring / --sp-shadow-focus-ring, NO new token);
+                          T-AY-005 e2a1c53d (feat(ay): RG-4 forced-colors-border enumeration —
+                          .sp-toggle-switch / [data-state] / .sp-chip / .sp-tab /
+                          [role=option][aria-selected=true]). GREEN: 15 accessibility-css tests
+                          (TEST-AY-001/002/003/004/005/006-file/007-file/009-file/015-css). vue-tsc 0,
+                          whole-project lint 0 errors (22 pre-existing warnings), build:web lightningcss
+                          GREEN (RG rules present in the standalone bundle; styles.css not hand-edited).
+                          DEVIATION: RED test-helper bugs (mediaBlock all-blocks; RG-N section-marker
+                          order scan; scoped-selector tokeniser) corrected when greening T-AY-002 —
+                          assertions NOT weakened; folded into the T-AY-002 commit + logged.
+                          REMAINING (out of this chunk; parent dispatches): Chunk 2 (T-AY-006..013
+                          behaviour-fix sweep), Chunk 3 (T-AY-014..016 additivity/discipline/screenshot
+                          completeness), GATE (T-AY-018 verify + draft next PR), T-AY-017 (HUMAN final
+                          parity sign-off). Next agent: qa (Chunk 2 RED mount tests, dispatch C2).
 ```

--- a/specs/accessibility/workflow-state.md
+++ b/specs/accessibility/workflow-state.md
@@ -1,10 +1,10 @@
 ---
 feature: accessibility
 area: AY
-current_stage: requirements
+current_stage: design
 status: active
 last_updated: 2026-05-27
-last_agent: orchestrator (bootstrap)
+last_agent: pm (requirements accepted; hand-off → /spec:design)
 epic: claudian-reboot
 phase: P12
 integration_branch: next
@@ -12,7 +12,7 @@ reference: D:\Projects\claudian-main
 artifacts:
   idea.md: skipped (parity-charter §3.9/§3.10/§4 P12 + audits + claudian-main accessibility.css stand in)
   research.md: skipped
-  requirements.md: pending
+  requirements.md: accepted (PRD-AY-001, 17 REQ-AY + 10 NFR-AY; autonomous accept)
   design.md: pending
   spec.md: pending
   tasks.md: pending
@@ -33,7 +33,7 @@ artifacts:
 |---|---|---|
 | 1. Idea | `idea.md` | skipped |
 | 2. Research | `research.md` | skipped |
-| 3. Requirements | `requirements.md` | pending |
+| 3. Requirements | `requirements.md` | accepted |
 | 4. Design | `design.md` | pending |
 | 5. Specification | `spec.md` | pending |
 | 6. Tasks | `tasks.md` | pending |
@@ -99,4 +99,19 @@ OUR `src/ui/styles/{tokens,animations}.css` + the P1-P11 components/modals for t
                           (reduced-motion/forced-colors/focus-visible/sr-only), the behaviour-gap audit,
                           the WCAG 2.2 AA criteria, the human screenshot sign-off as the FINAL gate.
                           AFTER P12 MERGES: present the final review + open (don't merge) next→develop.
+2026-05-27 (pm): /spec:requirements done. PRD-AY-001 accepted (autonomous) — 17 functional REQ-AY
+                          (Group A accessibility.css+pipeline, B reduced-motion, C forced-colors+contrast,
+                          D focus-visible+keyboard, E ARIA+sr-only+live-regions, F modal focus trap/restore
+                          at P5/P7/P8/P10 seams, G additivity+no-raw-HTML, H final human sign-off) + 10
+                          NFR-AY (WCAG 2.2 AA, token-discipline w/ documented forced-colors exception, no
+                          v-html/innerHTML, additivity, coverage 80/70/80/80, manifest untouched,
+                          lightningcss-safe, verify+test:all green). Automatable = REQ-AY-001..016 (TEST-AY-*);
+                          REQ-AY-017 = HUMAN final parity screenshot sign-off (all surfaces, light+dark,
+                          320/520/720) — the single final epic gate, not self-claimed. Ref bar = audit
+                          line 358 (claudian accessibility.css minimal/focus-visible-only → meet+beat).
+                          Two CLAR resolved (CLAR-AY-001 ref-file-not-readable→use audit chars; CLAR-AY-002
+                          reduced-motion global-guard complements per-section token overrides). Hand-off →
+                          /spec:design (Part A UX + Part B UI): open the actual claudian accessibility.css,
+                          design the .specorator-root reduced-motion/forced-colors/focus-visible/sr-only
+                          rule groups + the per-surface ARIA/live-region/modal-focus fixes.
 ```

--- a/specs/accessibility/workflow-state.md
+++ b/specs/accessibility/workflow-state.md
@@ -1,10 +1,10 @@
 ---
 feature: accessibility
 area: AY
-current_stage: tasks
+current_stage: review
 status: active
 last_updated: 2026-05-27
-last_agent: dev (Chunk 2 T-AY-006..013 + Chunk 3 T-AY-014..016 complete; hand-off → parent for T-AY-018 gate + T-AY-017 human sign-off)
+last_agent: reviewer (REVIEW-AY-001 + TRACE-AY-001 complete; verdict approve-with-nits; hand-off → release-manager for T-AY-018 gate + the human REQ-AY-017 sign-off)
 epic: claudian-reboot
 phase: P12
 integration_branch: next
@@ -19,8 +19,8 @@ artifacts:
   implementation-log.md: in-progress (Chunk 1 T-AY-001..005 + Chunk 2 T-AY-006..013 + Chunk 3 T-AY-014..016 logged; T-AY-018 gate + T-AY-017 human sign-off remain)
   test-plan.md: in-progress (T-AY-001 baseline + guard-verify note; parity-screenshots.md complete — TEST-AY-016 green)
   test-report.md: pending
-  review.md: pending
-  traceability.md: pending
+  review.md: complete (REVIEW-AY-001 — verdict approve-with-nits; 0 P1/P2; 2 low nits R-AY-001/002)
+  traceability.md: complete (TRACE-AY-001 — full REQ↔SPEC↔TASK↔code↔TEST chain; no orphans; REQ-AY-017 pending = human gate)
   release-notes.md: pending
   retrospective.md: pending
 ---
@@ -39,7 +39,7 @@ artifacts:
 | 6. Tasks | `tasks.md` | complete |
 | 7. Implementation | `implementation-log.md` + code | in-progress (Chunk 1+2+3 done; T-AY-017/018 remain) |
 | 8. Testing | `test-plan.md`, `test-report.md` | in-progress (TEST-AY-001..016 green; TEST-AY-017 human) |
-| 9. Review | `review.md`, `traceability.md` | pending |
+| 9. Review | `review.md`, `traceability.md` | complete (approve-with-nits; 0 P1/P2; T-AY-018 gate + REQ-AY-017 human sign-off remain) |
 | 10. Release | `release-notes.md` | pending |
 | 11. Learning | `retrospective.md` | pending |
 
@@ -220,4 +220,27 @@ OUR `src/ui/styles/{tokens,animations}.css` + the P1-P11 components/modals for t
                           build:web + draft next PR) + T-AY-017 (HUMAN final parity sign-off, 👤). DID NOT
                           run verify/build/build:web/docs:api; DID NOT push. Next agent: parent (T-AY-018
                           gate, then present T-AY-017 to the human + open — do NOT merge — next→develop).
+2026-05-27 (reviewer): /spec:review done. REVIEW-AY-001 + TRACE-AY-001 complete. VERDICT:
+                          APPROVE-WITH-NITS — 0 critical/high/medium findings; 2 low doc-sync nits.
+                          VERIFIED read-only: all 6 rule groups RG-1..RG-6 present + ordered in
+                          src/ui/styles/accessibility.css (.specorator-root-scoped, ASCII comments,
+                          system colours only inside forced-colors, RG-5 reuses --sp-focus-ring/
+                          --sp-shadow-focus-ring — no new token); registered as 3rd CSS import at BOTH
+                          sites (plugin/main.ts:3 + ui/main.ts:15). Ran the 2 CSS suites (15 green) +
+                          tests/ui/a11y/ (40 green / 8 files). ADDITIVITY CONFIRMED: git diff next..HEAD
+                          under src/ = EXACTLY accessibility.css + plugin/main.ts + ui/main.ts +
+                          NoticeLiveRegion.vue (+ a test-only obsidian Modal stub); manifest.json +
+                          all locales byte-identical (empty diff). WCAG 2.2 AA met at the automatable
+                          level (focus-visible SC2.4.7, modal trap/restore SC2.1.2/2.4.3, forced-colors
+                          SC1.4.x, reduced-motion SC2.3.3, status messages SC4.1.3, name/role/value);
+                          visual conformance = the human leg. ARCH: no new port/InjectionKey/ADR;
+                          NoticeLiveRegion is pure Vue on the sp:notice channel (no obsidian import);
+                          no v-html/innerHTML; token discipline holds. Brand review: not-applicable.
+                          NITS (non-blocking): R-AY-001 (stage frontmatter in impl-log/test-plan/
+                          workflow-state lagged actual progress — partly fixed here), R-AY-002
+                          (test-plan §4 RG-4 selector table still lists the corrected placeholders).
+                          REQ-AY-017 (human final parity sign-off) recorded PENDING as the single final
+                          epic gate. Hand-off → release-manager: run T-AY-018 (full verify + build:web
+                          lightningcss + both-output presence + coverage 80/70/80/80), fold R-AY-001/002,
+                          then PRESENT (do NOT merge) the next→develop PR + surface REQ-AY-017 to the human.
 ```

--- a/specs/accessibility/workflow-state.md
+++ b/specs/accessibility/workflow-state.md
@@ -4,7 +4,7 @@ area: AY
 current_stage: tasks
 status: active
 last_updated: 2026-05-27
-last_agent: dev (Chunk 1 T-AY-001..005 complete; hand-off → qa/dev for Chunk 2)
+last_agent: dev (Chunk 2 T-AY-006..013 + Chunk 3 T-AY-014..016 complete; hand-off → parent for T-AY-018 gate + T-AY-017 human sign-off)
 epic: claudian-reboot
 phase: P12
 integration_branch: next
@@ -16,8 +16,8 @@ artifacts:
   design.md: complete (DESIGN-AY-001, Parts A/B/C; no new port, no new ADR)
   spec.md: complete (SPEC-AY-001..011 + TEST-AY-001..017; coverage table)
   tasks.md: complete (TASKS-AY-001, 18 tasks T-AY-001..018; 3 chunks + GATE; coverage sanity-check)
-  implementation-log.md: in-progress (Chunk 1 T-AY-001..005 logged; Chunk 2/3 + gate remain)
-  test-plan.md: in-progress (T-AY-001 baseline + guard-verify note; parity-screenshots.md scaffolded)
+  implementation-log.md: in-progress (Chunk 1 T-AY-001..005 + Chunk 2 T-AY-006..013 + Chunk 3 T-AY-014..016 logged; T-AY-018 gate + T-AY-017 human sign-off remain)
+  test-plan.md: in-progress (T-AY-001 baseline + guard-verify note; parity-screenshots.md complete — TEST-AY-016 green)
   test-report.md: pending
   review.md: pending
   traceability.md: pending
@@ -37,8 +37,8 @@ artifacts:
 | 4. Design | `design.md` | complete |
 | 5. Specification | `spec.md` | complete |
 | 6. Tasks | `tasks.md` | complete |
-| 7. Implementation | `implementation-log.md` + code | in-progress (Chunk 1 done) |
-| 8. Testing | `test-plan.md`, `test-report.md` | in-progress (baseline + Chunk-1 tests) |
+| 7. Implementation | `implementation-log.md` + code | in-progress (Chunk 1+2+3 done; T-AY-017/018 remain) |
+| 8. Testing | `test-plan.md`, `test-report.md` | in-progress (TEST-AY-001..016 green; TEST-AY-017 human) |
 | 9. Review | `review.md`, `traceability.md` | pending |
 | 10. Release | `release-notes.md` | pending |
 | 11. Learning | `retrospective.md` | pending |
@@ -190,4 +190,34 @@ OUR `src/ui/styles/{tokens,animations}.css` + the P1-P11 components/modals for t
                           behaviour-fix sweep), Chunk 3 (T-AY-014..016 additivity/discipline/screenshot
                           completeness), GATE (T-AY-018 verify + draft next PR), T-AY-017 (HUMAN final
                           parity sign-off). Next agent: qa (Chunk 2 RED mount tests, dispatch C2).
+2026-05-27 (dev): Chunk 2 (T-AY-006..013) + Chunk 3 (T-AY-014..016) COMPLETE on feature/accessibility.
+                          Commits: T-AY-006 46869990 (forced-colors RG-4 controls mount leg + corrected
+                          the RG-4 enumeration to the REAL swept selectors [role=switch] /
+                          .sp-file-chips__chip / .sp-image-thumb / [data-state] / .sp-tab /
+                          [role=option][aria-selected] — the T-AY-005 .sp-toggle-switch/.sp-chip were
+                          dead; the mount leg surfaced it); T-AY-007 8eb7c8da (focus-visible reachability
+                          + keyboard + accessible names — VERIFY-ONLY, all controls already labelled);
+                          T-AY-008 2b59482c (RED live-region: busy verify + notice-host RED); T-AY-009
+                          7603abf2 (collapsible aria-expanded flips + icon-only labels — VERIFY-ONLY, all
+                          via SpCollapsible / already labelled); T-AY-011 5fcc472e (FILL: NoticeLiveRegion.vue
+                          — the .sr-only standalone notice live region on the existing sp:notice channel,
+                          no new port; wired into ui/main.ts); T-AY-013 39121ad5 (modal trap/restore
+                          structural verify — all 8 seams extend Obsidian Modal; added a minimal Modal to
+                          the obsidian test stub); T-AY-014 7ead8bb6 (additivity invariant — locale +
+                          manifest byte-identical, src/ diff = ONLY the P12 allow-list, swept renders
+                          intact); T-AY-015 07c1fb7f (discipline scan — no added innerHTML/v-html sink);
+                          T-AY-016 3f103ef2 (parity-screenshots.md completeness + matrix marked complete).
+                          T-AY-010 + T-AY-012 = VERIFY-ONLY no-op (no gap found; logged, no code change).
+                          VERIFICATION: vue-tsc 0; whole-project lint 0 errors (22 pre-existing warnings);
+                          a11y + styles suite 80 green; P5-P11 regression (TabBar/ChatComposer/FileChips/
+                          ImageThumb/SpCollapsible/ToolCallBlock/ChatSurface/ServiceTierToggle/
+                          PermissionToggle/ui/main/modalSeam) 102 green. ADDITIVITY CONFIRMED: src/ diff
+                          vs next = accessibility.css + plugin/main.ts + ui/main.ts + NoticeLiveRegion.vue
+                          ONLY; no swept template, no locale, no manifest changed. GENUINE FILLS =
+                          NoticeLiveRegion (SPEC-AY-004 gap) + the RG-4 real-selector correction; all else
+                          verify-only (the per-phase a11y sweep was thorough, as designed). REMAINING
+                          (PARENT-OWNED, not executed): T-AY-018 (the gate — full verify + lightningcss
+                          build:web + draft next PR) + T-AY-017 (HUMAN final parity sign-off, 👤). DID NOT
+                          run verify/build/build:web/docs:api; DID NOT push. Next agent: parent (T-AY-018
+                          gate, then present T-AY-017 to the human + open — do NOT merge — next→develop).
 ```

--- a/specs/accessibility/workflow-state.md
+++ b/specs/accessibility/workflow-state.md
@@ -4,7 +4,7 @@ area: AY
 current_stage: tasks
 status: active
 last_updated: 2026-05-27
-last_agent: architect (design + spec complete; hand-off → /spec:tasks)
+last_agent: planner (tasks complete; hand-off → /spec:implement)
 epic: claudian-reboot
 phase: P12
 integration_branch: next
@@ -15,7 +15,7 @@ artifacts:
   requirements.md: accepted (PRD-AY-001, 17 REQ-AY + 10 NFR-AY; autonomous accept)
   design.md: complete (DESIGN-AY-001, Parts A/B/C; no new port, no new ADR)
   spec.md: complete (SPEC-AY-001..011 + TEST-AY-001..017; coverage table)
-  tasks.md: pending
+  tasks.md: complete (TASKS-AY-001, 18 tasks T-AY-001..018; 3 chunks + GATE; coverage sanity-check)
   implementation-log.md: pending
   test-plan.md: pending
   test-report.md: pending
@@ -36,7 +36,7 @@ artifacts:
 | 3. Requirements | `requirements.md` | accepted |
 | 4. Design | `design.md` | complete |
 | 5. Specification | `spec.md` | complete |
-| 6. Tasks | `tasks.md` | pending |
+| 6. Tasks | `tasks.md` | complete |
 | 7. Implementation | `implementation-log.md` + code | pending |
 | 8. Testing | `test-plan.md`, `test-report.md` | pending |
 | 9. Review | `review.md`, `traceability.md` | pending |
@@ -140,4 +140,31 @@ OUR `src/ui/styles/{tokens,animations}.css` + the P1-P11 components/modals for t
                           edits; (2) behaviour-fix sweep; (3) tests + parity-screenshots.md artifact.
                           OPEN CLARIFICATIONS: none blocking. AFTER P12 MERGES: present final review +
                           open (DO NOT merge) next→develop PR — the human's call.
+2026-05-27 (planner): /spec:tasks done. TASKS-AY-001 complete — 18 tasks (T-AY-001..018) decomposing
+                          SPEC-AY-001..011 across 3 chunks + a GATE. CHUNK 1 (accessibility.css +
+                          registration): T-AY-001 (baseline + guard verdict + parity-screenshots.md
+                          scaffold), T-AY-002 (the new src/ui/styles/accessibility.css RG-1..6 +
+                          register at BOTH import sites src/plugin/main.ts:2 + src/ui/main.ts:14),
+                          T-AY-003/004 (RED RG file-read + registration, land first), T-AY-005 (RG-4
+                          forced-colors-border selector enumeration). CHUNK 2 (behaviour-fix sweep,
+                          additive + mostly verify-only): T-AY-006..009/013 RED component/PageObject
+                          tests (forced-colors controls mounted, focus-visible+keyboard/labels,
+                          live-region, aria-expanded+sr-only, modal trap/restore verify-only across the
+                          8 seams); T-AY-010 (icon-only labels fill), T-AY-011 (notice-host live region),
+                          T-AY-012 (collapsible aria-expanded fill). CHUNK 3 (tests + additivity gate):
+                          T-AY-014 (additivity diff), T-AY-015 (no raw-HTML discipline scan), T-AY-016
+                          (parity-screenshots.md completeness). GATE: T-AY-018 (full verify + lightningcss
+                          build:web green + all-auto suites + parity self-review + draft PR into next),
+                          then T-AY-017 = the HUMAN final cross-surface parity screenshot sign-off (all
+                          P1-P11 surfaces, light+dark, 320/520/720 + the accumulated P5-P11 manual legs)
+                          — the SINGLE FINAL EPIC GATE, owner: human, NEVER agent-self-claimed. GUARD
+                          VERDICT: NO new InjectionKey/port/composable/component/ADR, NO guard-relax (CSS
+                          layer + additive ARIA; manifest/locales byte-identical). lightningcss-safe ASCII
+                          comments + RG-5 reuses --sp-focus-ring (no new token) + whole-project lint 0
+                          notes carried per task. AFTER P12 MERGES: present final review + open (DO NOT
+                          merge) next→develop PR — the human's call. Hand-off → /spec:implement (dev/qa):
+                          first ready task = T-AY-001 (dev, baseline + scaffold), then dispatch chunk C1
+                          (T-AY-003/004 RED → T-AY-002/005). Suggested dispatch: C1 accessibility.css;
+                          C2 Chunk-2 RED scaffold; C3 the three fills (parallel); C4 gate tests; C5
+                          T-AY-018 gate then T-AY-017 human sign-off.
 ```

--- a/specs/accessibility/workflow-state.md
+++ b/specs/accessibility/workflow-state.md
@@ -1,0 +1,102 @@
+---
+feature: accessibility
+area: AY
+current_stage: requirements
+status: active
+last_updated: 2026-05-27
+last_agent: orchestrator (bootstrap)
+epic: claudian-reboot
+phase: P12
+integration_branch: next
+reference: D:\Projects\claudian-main
+artifacts:
+  idea.md: skipped (parity-charter §3.9/§3.10/§4 P12 + audits + claudian-main accessibility.css stand in)
+  research.md: skipped
+  requirements.md: pending
+  design.md: pending
+  spec.md: pending
+  tasks.md: pending
+  implementation-log.md: pending
+  test-plan.md: pending
+  test-report.md: pending
+  review.md: pending
+  traceability.md: pending
+  release-notes.md: pending
+  retrospective.md: pending
+---
+
+# Workflow state — accessibility (P12, FINAL phase)
+
+## Stage progress
+
+| Stage | Artifact | Status |
+|---|---|---|
+| 1. Idea | `idea.md` | skipped |
+| 2. Research | `research.md` | skipped |
+| 3. Requirements | `requirements.md` | pending |
+| 4. Design | `design.md` | pending |
+| 5. Specification | `spec.md` | pending |
+| 6. Tasks | `tasks.md` | pending |
+| 7. Implementation | `implementation-log.md` + code | pending |
+| 8. Testing | `test-plan.md`, `test-report.md` | pending |
+| 9. Review | `review.md`, `traceability.md` | pending |
+| 10. Release | `release-notes.md` | pending |
+| 11. Learning | `retrospective.md` | pending |
+
+## Epic context — claudian-reboot P12 (a11y + final parity sign-off) — THE LAST PHASE
+
+P0-P11 merged to `next` (P11 i18n-locales #452 / d4733464). P12 closes the epic: the accessibility
+stylesheet + behaviour polish + the WCAG 2.2 AA sweep across all P1-P11 surfaces, then the **final parity
+screenshot sign-off** (human).
+
+**Scope (charter §4 P12 row line 195 + §3.9/§3.10):**
+- **`src/ui/styles/accessibility.css`** — the global a11y layer matching/beating claudian's
+  `accessibility.css`: `prefers-reduced-motion` (disable/soften the P-various animations in
+  `animations.css`), `forced-colors`/high-contrast (system-color mapping, `forced-color-adjust`),
+  `:focus-visible` ring (keyboard focus across all `--sp-*` surfaces), `.sr-only` screen-reader-only
+  utility, any reduced-transparency. Registered in the build's CSS pipeline (like tokens.css/animations.css).
+- **a11y behaviour polish** across the P1-P11 surfaces — ARIA roles/labels gaps, focus management
+  (modals trap+restore — verify the P5/P7/P8 modal seams, the toolbar/settings keyboard order), live
+  regions for streaming/notices where missing, alt/label text. Audit + fill gaps (much WCAG was built
+  per-phase: data-testid, keyboard nav, ARIA — P12 sweeps for the remainder).
+- **WCAG 2.2 AA** as the bar (charter §1 line 50-51: keyboard nav, focus management, forced-colors,
+  reduced-motion).
+- **The FINAL parity screenshot sign-off (ALL surfaces) — HUMAN-owned.** The accumulated manual-Obsidian
+  + parity-screenshot legs from P5-P11 (TEST-*-M* across the phases) converge here as the single final
+  human review gate (charter §6 / line 219). P12's automatable part = accessibility.css + the behaviour
+  fixes + a11y tests; the screenshot sign-off itself is the human leg.
+
+**Epic completion (after P12 merges — charter line 219, the original /goal end-state):** the whole reboot
+(P0-P12) is on `next`, full verify gate green → **present the final review + open (DO NOT merge) the
+`next`→`develop` PR.** Per the charter, `next`→`develop` is the human's call at parity.
+
+**Epic constraints (every phase):** NO backwards compat; DDD inward imports; Vue never imports `obsidian`;
+no `innerHTML`/`v-html` (build DOM safe); the accessibility.css uses `--sp-*` tokens + standard a11y
+media queries (no new raw colors outside the token layer where avoidable — but forced-colors/system
+colors are the documented exception); `<script setup>`; tests mirror `src/` + `data-testid`; coverage
+80/70/80/80; perceptual `--sp-*` parity; identity stays Specorator; manifest untouched; CI SHA-pinned.
+VERIFY GATE (`npm run verify` + `npm run test:all` zero) + the lightningcss-safe CSS comment rule.
+
+**Operating mode (human directive, /goal 2026-05-26):** AUTONOMOUS DRIVE — P12 is the last phase; merge
+to `next` after a green gate + green CI; deploy to `D:/TestVault`. Then present the final review + open
+(don't merge) the `next`→`develop` PR. The single FINAL human review gate (screenshots + manual-Obsidian)
+is the human's; surface it, don't self-claim.
+
+**Mandatory inputs:** `specs/claudian-reboot/parity-charter.md` §3.9/§3.10/§4 P12 + §1 (WCAG line 50-51) +
+`claudian-audit-frontend.md` + `D:\Projects\claudian-main` (`accessibility.css` + the a11y behaviours) +
+OUR `src/ui/styles/{tokens,animations}.css` + the P1-P11 components/modals for the behaviour sweep.
+
+## Hand-off notes
+
+```
+2026-05-27 (orchestrator): P12 (LAST phase) bootstrapped on feature/accessibility (off next; P0-P11
+                          merged). Scope = charter §3.10 accessibility.css + a11y behaviour polish +
+                          WCAG 2.2 AA sweep across all surfaces; the final parity screenshot sign-off is
+                          HUMAN-owned (the accumulated P5-P11 manual legs converge). Autonomous; no new
+                          port/ADR expected (CSS layer + behaviour fixes). Next: /spec:requirements (pm)
+                          grounded in charter §3.9/§3.10/§1 + the claudian accessibility.css + our
+                          tokens/animations css + the P1-P11 surfaces. KEY: accessibility.css contents
+                          (reduced-motion/forced-colors/focus-visible/sr-only), the behaviour-gap audit,
+                          the WCAG 2.2 AA criteria, the human screenshot sign-off as the FINAL gate.
+                          AFTER P12 MERGES: present the final review + open (don't merge) next→develop.
+```

--- a/specs/accessibility/workflow-state.md
+++ b/specs/accessibility/workflow-state.md
@@ -1,10 +1,10 @@
 ---
 feature: accessibility
 area: AY
-current_stage: design
+current_stage: tasks
 status: active
 last_updated: 2026-05-27
-last_agent: pm (requirements accepted; hand-off → /spec:design)
+last_agent: architect (design + spec complete; hand-off → /spec:tasks)
 epic: claudian-reboot
 phase: P12
 integration_branch: next
@@ -13,8 +13,8 @@ artifacts:
   idea.md: skipped (parity-charter §3.9/§3.10/§4 P12 + audits + claudian-main accessibility.css stand in)
   research.md: skipped
   requirements.md: accepted (PRD-AY-001, 17 REQ-AY + 10 NFR-AY; autonomous accept)
-  design.md: pending
-  spec.md: pending
+  design.md: complete (DESIGN-AY-001, Parts A/B/C; no new port, no new ADR)
+  spec.md: complete (SPEC-AY-001..011 + TEST-AY-001..017; coverage table)
   tasks.md: pending
   implementation-log.md: pending
   test-plan.md: pending
@@ -34,8 +34,8 @@ artifacts:
 | 1. Idea | `idea.md` | skipped |
 | 2. Research | `research.md` | skipped |
 | 3. Requirements | `requirements.md` | accepted |
-| 4. Design | `design.md` | pending |
-| 5. Specification | `spec.md` | pending |
+| 4. Design | `design.md` | complete |
+| 5. Specification | `spec.md` | complete |
 | 6. Tasks | `tasks.md` | pending |
 | 7. Implementation | `implementation-log.md` + code | pending |
 | 8. Testing | `test-plan.md`, `test-report.md` | pending |
@@ -114,4 +114,30 @@ OUR `src/ui/styles/{tokens,animations}.css` + the P1-P11 components/modals for t
                           /spec:design (Part A UX + Part B UI): open the actual claudian accessibility.css,
                           design the .specorator-root reduced-motion/forced-colors/focus-visible/sr-only
                           rule groups + the per-surface ARIA/live-region/modal-focus fixes.
+2026-05-27 (architect): /spec:design + /spec:specify done. DESIGN-AY-001 (Parts A/B/C) + SPEC-AY-001
+                          (11 SPEC items + TEST-AY-001..017) complete. CLAR-AY-001 RESOLVED by reading
+                          the actual D:\Projects\claudian-main\src\style\accessibility.css — confirmed
+                          MINIMAL: focus-visible outline rings only (41 lines, 3 selector groups, NO
+                          reduced-motion / NO forced-colors / NO sr-only). So "meet" = the focus ring
+                          (REQ-AY-007); "beat" = the other five groups. CLAR-AY-002 RESOLVED: the global
+                          reduced-motion guard COMPLEMENTS (does not replace) the tokens.css per-section
+                          overrides + the CQ-AUX-14 spin halt. accessibility.css = 6 rule groups (RG-1
+                          reduced-motion guard, RG-2 spin halt, RG-3 forced-colors mapping, RG-4
+                          forced-colors borders, RG-5 :focus-visible ring, RG-6 .sr-only) scoped to
+                          .specorator-root, joins tokens.css+animations.css as the 3rd CSS layer at BOTH
+                          import sites (src/plugin/main.ts:2 + src/ui/main.ts:14). FOCUS TOKEN: reuse the
+                          EXISTING --sp-focus-ring (tokens.css:42) + --sp-shadow-focus-ring (:140) — NO
+                          new token. MODAL FOCUS: Obsidian Modal base natively traps+restores focus → the
+                          8 modal seams are VERIFY-ONLY, no hand-rolled trap. NO NEW PORT, NO NEW ADR
+                          (CSS layer + additive ARIA, all existing patterns). Behaviour sweep = mostly
+                          verify-only (busy region already aria-live polite+role=status, TabBar already
+                          full ARIA+roving tabindex) + targeted fills (collapsible aria-expanded,
+                          icon-only labels, RG-4 selector enumeration). SPLIT: TEST-AY-001..016 automatable
+                          (CSS-rule-read / registration / PageObject mounts / additivity diff / discipline
+                          scan); TEST-AY-017 = HUMAN final parity screenshot sign-off (all surfaces,
+                          light+dark, 320/520/720) — the single final epic gate, agent PRESENTS not claims.
+                          Hand-off → /spec:tasks (planner): 3 chunks — (1) accessibility.css + 2 import
+                          edits; (2) behaviour-fix sweep; (3) tests + parity-screenshots.md artifact.
+                          OPEN CLARIFICATIONS: none blocking. AFTER P12 MERGES: present final review +
+                          open (DO NOT merge) next→develop PR — the human's call.
 ```

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -1,5 +1,6 @@
 import '@/ui/styles/tokens.css';
 import '@/ui/styles/animations.css';
+import '@/ui/styles/accessibility.css';
 import { Plugin } from 'obsidian';
 import { AgentSidebarView, VIEW_TYPE_AGENT } from './AgentSidebarView';
 import { SpecoratorSettingTab, type SettingsTabDeps } from './settings';

--- a/src/ui/components/NoticeLiveRegion.vue
+++ b/src/ui/components/NoticeLiveRegion.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
+
+/**
+ * The standalone notice live region (SPEC-AY-004, REQ-AY-010). A visually-hidden
+ * (`.sr-only`) ARIA live region that announces non-blocking notices to screen
+ * readers in the standalone / GitHub Pages host, where the Obsidian native
+ * `Notice` (the plugin leg, announced by the host) is not present.
+ *
+ * It subscribes to the existing `sp:notice` window `CustomEvent` that
+ * `LocalStorageBridge` already dispatches (error/warning/success/info severity) —
+ * NO new port, NO new channel (the spec's Observability note). Error notices map
+ * to `aria-live="assertive"` + `role="alert"` (they interrupt); info/success/
+ * warning map to `aria-live="polite"` + `role="status"`. The notice text is bound
+ * DECLARATIVELY as `{{ }}` text — never `innerHTML`/`v-html` (REQ-AY-015,
+ * NFR-AY-003). The region is passive: it never calls `.focus()`, so an
+ * announcement never steals focus (EC-AY-011/012). The `.sr-only` clip (RG-6)
+ * gives it zero visible footprint, so the default render stays additive
+ * (REQ-AY-014).
+ */
+interface NoticeDetail {
+	severity: 'error' | 'warning' | 'success' | 'info';
+	message: string;
+}
+
+const message = ref('');
+const severity = ref<NoticeDetail['severity']>('info');
+
+const isAssertive = computed(() => severity.value === 'error');
+const ariaLive = computed(() => (isAssertive.value ? 'assertive' : 'polite'));
+const role = computed(() => (isAssertive.value ? 'alert' : 'status'));
+
+function onNotice(event: Event): void {
+	// A runtime event may carry a malformed detail; type it nullable so the guard
+	// is meaningful (the DOM `CustomEvent.detail` static type is non-nullable).
+	const detail = (event as CustomEvent).detail as Partial<NoticeDetail> | null | undefined;
+	if (detail === null || detail === undefined) return;
+	severity.value = detail.severity ?? 'info';
+	message.value = detail.message ?? '';
+}
+
+onMounted(() => {
+	window.addEventListener('sp:notice', onNotice);
+});
+
+onBeforeUnmount(() => {
+	window.removeEventListener('sp:notice', onNotice);
+});
+</script>
+
+<template>
+	<div
+		class="sr-only"
+		data-testid="notice-live-region"
+		:aria-live="ariaLive"
+		:role="role"
+		aria-atomic="true"
+	>
+		{{ message }}
+	</div>
+</template>

--- a/src/ui/main.ts
+++ b/src/ui/main.ts
@@ -12,6 +12,7 @@
 import './standalone.css';
 import './styles/tokens.css';
 import './styles/animations.css';
+import './styles/accessibility.css';
 import { createApp, h } from 'vue';
 import { createPinia } from 'pinia';
 import ChatSurface from './chat/ChatSurface.vue';

--- a/src/ui/main.ts
+++ b/src/ui/main.ts
@@ -17,6 +17,7 @@ import { createApp, h } from 'vue';
 import { createPinia } from 'pinia';
 import ChatSurface from './chat/ChatSurface.vue';
 import ErrorBoundary from './components/ErrorBoundary.vue';
+import NoticeLiveRegion from './components/NoticeLiveRegion.vue';
 import { i18n, setLocale, toSupportedLocale } from './i18n';
 import {
 	SETTINGS_PORT,
@@ -64,7 +65,14 @@ mountPoint?.classList.add('specorator-root');
 
 const app = createApp({
 	name: 'StandaloneRoot',
-	render: () => h(ErrorBoundary, null, { default: () => h(ChatSurface) }),
+	// The notice live region (SPEC-AY-004) rides alongside the chat surface so the
+	// standalone / GitHub Pages host announces non-blocking notices to screen
+	// readers. It is `.sr-only` (zero visible footprint), so the default render is
+	// byte-identical (REQ-AY-014).
+	render: () =>
+		h(ErrorBoundary, null, {
+			default: () => [h(ChatSurface), h(NoticeLiveRegion)],
+		}),
 });
 app.use(createPinia());
 app.use(i18n);

--- a/src/ui/styles/accessibility.css
+++ b/src/ui/styles/accessibility.css
@@ -1,0 +1,117 @@
+/*
+ * Specorator accessibility CSS layer (DESIGN-AY-001 Part B, SPEC-AY-001).
+ *
+ * The third global CSS layer, after tokens.css and animations.css. It adds the
+ * six accessibility rule groups RG-1 through RG-6. Every selector is prefixed
+ * with .specorator-root so the build scopeBuiltCss step leaves it as-is, and
+ * keyframes are never targeted (the guard targets animation consumers, not the
+ * keyframe definitions). The only colour keywords in this file are CSS system
+ * colours inside the forced-colors block (RG-3 and RG-4) - the single
+ * documented exception (NFR-AY-002). RG-5 reuses the existing --sp-focus-ring
+ * and --sp-shadow-focus-ring tokens; no new token is minted. Comments use
+ * ASCII-only markers so the standalone lightningcss minifier accepts them
+ * (NFR-AY-005, EC-AY-013).
+ *
+ * Every rule is gated behind a media query, focus-visible, .sr-only, or an
+ * additive ARIA attribute, so the default render is the next baseline for
+ * mouse users, unchanged (REQ-AY-014).
+ *
+ * REQ-AY-001, REQ-AY-003, REQ-AY-004, REQ-AY-005, REQ-AY-006, REQ-AY-007,
+ * REQ-AY-009, REQ-AY-015.
+ */
+
+/* RG-1 - reduced-motion global guard (REQ-AY-003).
+ * Safety-net that collapses any animation or transition the per-section
+ * tokens.css duration overrides did not reach. Complements, does not replace,
+ * those overrides (CLAR-AY-002, D-AY-1). important is required here so the
+ * universal guard wins over any per-component shorthand. */
+@media (prefers-reduced-motion: reduce) {
+	.specorator-root *,
+	.specorator-root *::before,
+	.specorator-root *::after {
+		animation-duration: 0.001ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.001ms !important;
+		scroll-behavior: auto !important;
+	}
+}
+
+/* RG-2 - reduced-motion spin halt (REQ-AY-004, EC-AY-001).
+ * Re-asserts the CQ-AUX-14 explicit spin halt. An indeterminate loop is not
+ * stopped by a near-zero duration alone, so this sets animation none. */
+@media (prefers-reduced-motion: reduce) {
+	.specorator-root [data-animation="spin"],
+	.specorator-root .sp-spin {
+		animation: none !important;
+	}
+}
+
+/* RG-3 - forced-colors surface mapping (REQ-AY-005, D-AY-5).
+ * When the OS replaces the palette, map text and surfaces to system colours,
+ * focus and selected states to Highlight, and button affordances to the button
+ * system colours. Colour mapping only - no layout shift. */
+@media (forced-colors: active) {
+	.specorator-root {
+		forced-color-adjust: auto;
+		color: CanvasText;
+		background-color: Canvas;
+	}
+
+	.specorator-root :where(button, [role="button"]) {
+		color: ButtonText;
+		background-color: ButtonFace;
+	}
+
+	.specorator-root :where([aria-selected="true"], [data-selected="true"]),
+	.specorator-root :where(button, [role="tab"], [role="option"], [role="switch"],
+		a[href], textarea, input, select, [tabindex]):focus-visible {
+		color: HighlightText;
+		background-color: Highlight;
+	}
+}
+
+/* RG-4 - forced-colors border guarantee (REQ-AY-006, EC-AY-003).
+ * Background-cue-only controls (those signalled by a fill or wash alone) gain a
+ * visible currentColor border under forced-colors so they stay distinguishable.
+ * The concrete selector enumeration is refined in T-AY-005 (SPEC-AY-006). */
+@media (forced-colors: active) {
+	.specorator-root .sp-toggle-switch {
+		border: 1px solid currentColor;
+	}
+}
+
+/* RG-5 - focus-visible ring (REQ-AY-007, EC-AY-005/006/014).
+ * The keyboard focus ring across every interactive control. Uses
+ * focus-visible so a mouse click shows no stray ring (the counter-metric).
+ * Consumes the existing --sp-focus-ring token (no new token, D-AY-2); the ring
+ * follows the user theme accent via --interactive-accent (EC-AY-014). */
+.specorator-root
+	:where(button, [role="tab"], [role="option"], [role="switch"], a[href], textarea, input, select, [tabindex]):focus-visible {
+	outline: 2px solid var(--sp-focus-ring);
+	outline-offset: 2px;
+}
+
+/* The box-shadow ring variant for controls whose outline is clipped by an
+ * ancestor overflow hidden. Consumes the existing --sp-shadow-focus-ring. */
+.specorator-root
+	:where(.sp-clip-ring, [data-focus-ring="shadow"]):focus-visible {
+	outline: none;
+	box-shadow: var(--sp-shadow-focus-ring);
+}
+
+/* RG-6 - sr-only utility (REQ-AY-009, EC-AY-007).
+ * Visually hides an element while keeping it in the accessibility tree (the
+ * standard clip technique). Never display none or visibility hidden, which
+ * would remove the element from the accessibility tree. */
+.specorator-root .sr-only {
+	position: absolute;
+	inline-size: 1px;
+	block-size: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0 0 0 0);
+	clip-path: inset(50%);
+	white-space: nowrap;
+	border: 0;
+}

--- a/src/ui/styles/accessibility.css
+++ b/src/ui/styles/accessibility.css
@@ -70,12 +70,17 @@
 	}
 }
 
-/* RG-4 - forced-colors border guarantee (REQ-AY-006, EC-AY-003).
+/* RG-4 - forced-colors border guarantee (REQ-AY-006, EC-AY-003, SPEC-AY-006).
  * Background-cue-only controls (those signalled by a fill or wash alone) gain a
  * visible currentColor border under forced-colors so they stay distinguishable.
- * The concrete selector enumeration is refined in T-AY-005 (SPEC-AY-006). */
+ * The enumerated controls per the audit: the toolbar toggle switch, state
+ * pills, file and image chips, tab badges, and the selected dropdown option. */
 @media (forced-colors: active) {
-	.specorator-root .sp-toggle-switch {
+	.specorator-root .sp-toggle-switch,
+	.specorator-root [data-state],
+	.specorator-root .sp-chip,
+	.specorator-root .sp-tab,
+	.specorator-root [role="option"][aria-selected="true"] {
 		border: 1px solid currentColor;
 	}
 }

--- a/src/ui/styles/accessibility.css
+++ b/src/ui/styles/accessibility.css
@@ -73,12 +73,17 @@
 /* RG-4 - forced-colors border guarantee (REQ-AY-006, EC-AY-003, SPEC-AY-006).
  * Background-cue-only controls (those signalled by a fill or wash alone) gain a
  * visible currentColor border under forced-colors so they stay distinguishable.
- * The enumerated controls per the audit: the toolbar toggle switch, state
- * pills, file and image chips, tab badges, and the selected dropdown option. */
+ * The enumerated controls per the swept-component audit (TEST-AY-006 mount leg):
+ * the toolbar toggle switches are role="switch" (ServiceTier/Mode/Permission);
+ * state pills carry data-state (the tab + subagent state machines); the file
+ * chips are .sp-file-chips__chip and the image thumbs .sp-image-thumb; the tab
+ * badges are .sp-tab; the selected dropdown option is
+ * [role="option"][aria-selected="true"]. */
 @media (forced-colors: active) {
-	.specorator-root .sp-toggle-switch,
+	.specorator-root [role="switch"],
 	.specorator-root [data-state],
-	.specorator-root .sp-chip,
+	.specorator-root .sp-file-chips__chip,
+	.specorator-root .sp-image-thumb,
 	.specorator-root .sp-tab,
 	.specorator-root [role="option"][aria-selected="true"] {
 		border: 1px solid currentColor;

--- a/styles.css
+++ b/styles.css
@@ -490,6 +490,132 @@
 		animation: none;
 	}
 }
+/*
+ * Specorator accessibility CSS layer (DESIGN-AY-001 Part B, SPEC-AY-001).
+ *
+ * The third global CSS layer, after tokens.css and animations.css. It adds the
+ * six accessibility rule groups RG-1 through RG-6. Every selector is prefixed
+ * with .specorator-root so the build scopeBuiltCss step leaves it as-is, and
+ * keyframes are never targeted (the guard targets animation consumers, not the
+ * keyframe definitions). The only colour keywords in this file are CSS system
+ * colours inside the forced-colors block (RG-3 and RG-4) - the single
+ * documented exception (NFR-AY-002). RG-5 reuses the existing --sp-focus-ring
+ * and --sp-shadow-focus-ring tokens; no new token is minted. Comments use
+ * ASCII-only markers so the standalone lightningcss minifier accepts them
+ * (NFR-AY-005, EC-AY-013).
+ *
+ * Every rule is gated behind a media query, focus-visible, .sr-only, or an
+ * additive ARIA attribute, so the default render is the next baseline for
+ * mouse users, unchanged (REQ-AY-014).
+ *
+ * REQ-AY-001, REQ-AY-003, REQ-AY-004, REQ-AY-005, REQ-AY-006, REQ-AY-007,
+ * REQ-AY-009, REQ-AY-015.
+ */
+
+/* RG-1 - reduced-motion global guard (REQ-AY-003).
+ * Safety-net that collapses any animation or transition the per-section
+ * tokens.css duration overrides did not reach. Complements, does not replace,
+ * those overrides (CLAR-AY-002, D-AY-1). important is required here so the
+ * universal guard wins over any per-component shorthand. */
+@media (prefers-reduced-motion: reduce) {
+	.specorator-root *,
+	.specorator-root *::before,
+	.specorator-root *::after {
+		animation-duration: 0.001ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.001ms !important;
+		scroll-behavior: auto !important;
+	}
+}
+
+/* RG-2 - reduced-motion spin halt (REQ-AY-004, EC-AY-001).
+ * Re-asserts the CQ-AUX-14 explicit spin halt. An indeterminate loop is not
+ * stopped by a near-zero duration alone, so this sets animation none. */
+@media (prefers-reduced-motion: reduce) {
+	.specorator-root [data-animation="spin"],
+	.specorator-root .sp-spin {
+		animation: none !important;
+	}
+}
+
+/* RG-3 - forced-colors surface mapping (REQ-AY-005, D-AY-5).
+ * When the OS replaces the palette, map text and surfaces to system colours,
+ * focus and selected states to Highlight, and button affordances to the button
+ * system colours. Colour mapping only - no layout shift. */
+@media (forced-colors: active) {
+	.specorator-root {
+		forced-color-adjust: auto;
+		color: CanvasText;
+		background-color: Canvas;
+	}
+
+	.specorator-root :where(button, [role="button"]) {
+		color: ButtonText;
+		background-color: ButtonFace;
+	}
+
+	.specorator-root :where([aria-selected="true"], [data-selected="true"]), .specorator-root :where(button, [role="tab"], [role="option"], [role="switch"],
+		a[href], textarea, input, select, [tabindex]):focus-visible {
+		color: HighlightText;
+		background-color: Highlight;
+	}
+}
+
+/* RG-4 - forced-colors border guarantee (REQ-AY-006, EC-AY-003, SPEC-AY-006).
+ * Background-cue-only controls (those signalled by a fill or wash alone) gain a
+ * visible currentColor border under forced-colors so they stay distinguishable.
+ * The enumerated controls per the swept-component audit (TEST-AY-006 mount leg):
+ * the toolbar toggle switches are role="switch" (ServiceTier/Mode/Permission);
+ * state pills carry data-state (the tab + subagent state machines); the file
+ * chips are .sp-file-chips__chip and the image thumbs .sp-image-thumb; the tab
+ * badges are .sp-tab; the selected dropdown option is
+ * [role="option"][aria-selected="true"]. */
+@media (forced-colors: active) {
+	.specorator-root [role="switch"],
+	.specorator-root [data-state],
+	.specorator-root .sp-file-chips__chip,
+	.specorator-root .sp-image-thumb,
+	.specorator-root .sp-tab,
+	.specorator-root [role="option"][aria-selected="true"] {
+		border: 1px solid currentColor;
+	}
+}
+
+/* RG-5 - focus-visible ring (REQ-AY-007, EC-AY-005/006/014).
+ * The keyboard focus ring across every interactive control. Uses
+ * focus-visible so a mouse click shows no stray ring (the counter-metric).
+ * Consumes the existing --sp-focus-ring token (no new token, D-AY-2); the ring
+ * follows the user theme accent via --interactive-accent (EC-AY-014). */
+.specorator-root
+	:where(button, [role="tab"], [role="option"], [role="switch"], a[href], textarea, input, select, [tabindex]):focus-visible {
+	outline: 2px solid var(--sp-focus-ring);
+	outline-offset: 2px;
+}
+
+/* The box-shadow ring variant for controls whose outline is clipped by an
+ * ancestor overflow hidden. Consumes the existing --sp-shadow-focus-ring. */
+.specorator-root
+	:where(.sp-clip-ring, [data-focus-ring="shadow"]):focus-visible {
+	outline: none;
+	box-shadow: var(--sp-shadow-focus-ring);
+}
+
+/* RG-6 - sr-only utility (REQ-AY-009, EC-AY-007).
+ * Visually hides an element while keeping it in the accessibility tree (the
+ * standard clip technique). Never display none or visibility hidden, which
+ * would remove the element from the accessibility tree. */
+.specorator-root .sr-only {
+	position: absolute;
+	inline-size: 1px;
+	block-size: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0 0 0 0);
+	clip-path: inset(50%);
+	white-space: nowrap;
+	border: 0;
+}
 
 .specorator-root :where(.sp-provider-option[data-v-7a6fdee7]) {
 	display: inline-flex;

--- a/tests/__fakes__/obsidian.stub.ts
+++ b/tests/__fakes__/obsidian.stub.ts
@@ -58,6 +58,27 @@ export function setIcon(_el: HTMLElement, _name: string): void {
 }
 
 /**
+ * Minimal stand-in for the desktop `Modal` base class. The real `Modal`
+ * natively saves `document.activeElement` on `open()` and restores it on
+ * `close()`, and traps Tab/Shift+Tab within `.modal` (SPEC-AY-009, D-AY-3). The
+ * Specorator modal hosts (`src/plugin/modals/**`) only `extends Modal`, so the
+ * stub needs just enough surface for the `extends` chain to form + the
+ * structural `instanceof Modal` verify (TEST-AY-012/013). No-op `open`/`close`.
+ */
+export class Modal {
+  app: unknown
+  contentEl: HTMLElement = document.createElement('div')
+  modalEl: HTMLElement = document.createElement('div')
+  constructor(app: unknown) {
+    this.app = app
+  }
+  open(): void {}
+  close(): void {}
+  onOpen(): void {}
+  onClose(): void {}
+}
+
+/**
  * Minimal lifecycle-owner stub for `MarkdownRenderer.render` post-processors.
  * The real `Component` manages child lifecycles; the bridge only needs an
  * instance to pass through, so the stub is empty.

--- a/tests/ui/a11y/NoticeLiveRegion.po.ts
+++ b/tests/ui/a11y/NoticeLiveRegion.po.ts
@@ -1,0 +1,37 @@
+import type { VueWrapper } from '@vue/test-utils';
+
+const TID = { region: 'notice-live-region' } as const;
+
+/**
+ * PageObject for `NoticeLiveRegion.vue` (SPEC-AY-004). Queries by `data-testid`
+ * only (ADR-009). Reads the live-region wiring (`aria-live` polite/assertive,
+ * `role` status/alert) + the mirrored notice text.
+ */
+export class NoticeLiveRegionPageObject {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	private byTid(tid: string): string {
+		return `[data-testid="${tid}"]`;
+	}
+
+	exists(): boolean {
+		return this.wrapper.find(this.byTid(TID.region)).exists();
+	}
+
+	ariaLive(): string {
+		return this.wrapper.get(this.byTid(TID.region)).attributes('aria-live') ?? '';
+	}
+
+	role(): string {
+		return this.wrapper.get(this.byTid(TID.region)).attributes('role') ?? '';
+	}
+
+	text(): string {
+		return this.wrapper.get(this.byTid(TID.region)).text().trim();
+	}
+
+	/** The serialized region markup — for the no-`v-html` verbatim-text assertion. */
+	html(): string {
+		return this.wrapper.get(this.byTid(TID.region)).html();
+	}
+}

--- a/tests/ui/a11y/additivity.test.ts
+++ b/tests/ui/a11y/additivity.test.ts
@@ -1,0 +1,131 @@
+/**
+ * T-AY-014 (RED -> green) — additivity invariant: no swept surface's default
+ * render or locale output regresses from the `next` baseline (TEST-AY-014).
+ * SPEC-AY-010, REQ-AY-014, NFR-AY-004, EC-AY-010 — the cardinal P12
+ * counter-metric.
+ *
+ * Three legs:
+ *  - Locale byte-identity: `git diff next -- src/ui/i18n/locales` is empty (en/de
+ *    + all ten locales unchanged, NFR-AY-004/008).
+ *  - Source allow-list: the entire `src/` diff vs `next` touches ONLY the P12
+ *    allow-list (the new CSS layer, the two CSS-import entry edits, and the new
+ *    `.sr-only` notice live region). No swept component template under
+ *    `src/ui/chat/**` / `src/ui/agent/**` / `src/plugin/modals/**` changed — the
+ *    P0-P11 default render is byte-identical at the source.
+ *  - Default-render structural check: representative swept components render their
+ *    existing visible structure; the added a11y attributes (`aria-*`) + the
+ *    `.sr-only` clip do not alter the visible default render.
+ *
+ * Traces: TEST-AY-014, SPEC-AY-010, REQ-AY-014, NFR-AY-004, EC-AY-010.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { mount } from '@vue/test-utils';
+import { setActivePinia, createPinia } from 'pinia';
+import TabBar from '@/ui/chat/TabBar.vue';
+import FileChips from '@/ui/chat/FileChips.vue';
+import ImageThumb from '@/ui/chat/ImageThumb.vue';
+import ChatComposer from '@/ui/chat/ChatComposer.vue';
+import { useTabsStore } from '@/ui/stores/tabsStore';
+import type { ChatTurnRunner } from '@/ui/stores/chatStore';
+import { i18n } from '@/ui/i18n';
+import { ok } from '@/domain/shared/Result';
+import { MockChatRuntime } from '@/infrastructure/mock/MockChatRuntime';
+import { MockHistoryStore } from '@/infrastructure/mock/MockHistoryStore';
+import type { AttachedFileRef, AttachedImage } from '@/domain/chat/attachments';
+
+const REPO_ROOT = resolve(__dirname, '../../..');
+
+/** Run a git command at the repo root and return trimmed stdout. */
+function git(args: string[]): string {
+	return execFileSync('git', args, { cwd: REPO_ROOT, encoding: 'utf8' }).trim();
+}
+
+/** The exact P12 allow-list of `src/` files (additive layer + entry edits + host). */
+const ALLOWED = new Set([
+	'src/plugin/main.ts',
+	'src/ui/main.ts',
+	'src/ui/styles/accessibility.css',
+	'src/ui/components/NoticeLiveRegion.vue',
+]);
+
+function bindStore(maxTabs = 3) {
+	const store = useTabsStore();
+	store.bindTabDeps({
+		createRuntime: () => new MockChatRuntime([]),
+		createRunner: (): ChatTurnRunner => ({
+			run: vi.fn().mockResolvedValue(ok(undefined)),
+			cancel: vi.fn(),
+		}),
+		notifyStartFailure: () => undefined,
+		notifyInfo: () => undefined,
+		history: new MockHistoryStore(),
+		generateTitle: () => Promise.resolve(ok('title')),
+		getMaxTabs: () => maxTabs,
+	});
+	return store;
+}
+
+const file: AttachedFileRef = { path: 'notes/a.md', displayName: 'a' };
+const image: AttachedImage = {
+	path: 'img/a.png',
+	mimeType: 'image/png',
+	byteSize: 4,
+	dataBase64: 'AAAA',
+};
+
+describe('additivity invariant (TEST-AY-014)', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+	});
+
+	it('the locale output is byte-identical to the next baseline (NFR-AY-004/008)', () => {
+		const diff = git(['diff', '--name-only', 'next', '--', 'src/ui/i18n/locales']);
+		expect(diff, `locale files changed vs next:\n${diff}`).toBe('');
+	});
+
+	it('manifest.json is byte-identical to the next baseline (NFR-AY-008)', () => {
+		const diff = git(['diff', '--name-only', 'next', '--', 'manifest.json']);
+		expect(diff, 'manifest.json changed vs next').toBe('');
+	});
+
+	it('the src/ diff vs next touches only the P12 additive allow-list (no swept surface)', () => {
+		const out = git(['diff', '--name-only', 'next', '--', 'src']);
+		const changed = out.length === 0 ? [] : out.split('\n').map((p) => p.replace(/\\/g, '/'));
+		const offenders = changed.filter((p) => !ALLOWED.has(p));
+		expect(offenders, `unexpected swept-surface changes vs next: ${JSON.stringify(offenders)}`).toEqual(
+			[],
+		);
+	});
+
+	it('TabBar default render keeps its visible badge structure (no a11y artifact)', () => {
+		bindStore();
+		const store = useTabsStore();
+		store.openTab();
+		const wrapper = mount(TabBar, { global: { plugins: [i18n] } });
+		// The visible non-colour numeric cue is intact (1-based numbers as text).
+		const numbers = wrapper.findAll('[data-testid="tab-number"]').map((n) => n.text().trim());
+		expect(numbers.length).toBeGreaterThan(0);
+		expect(numbers.every((n) => /^\d+$/.test(n))).toBe(true);
+	});
+
+	it('FileChips + ImageThumb default render keep their visible labels (no a11y artifact)', () => {
+		const chips = mount(FileChips, { props: { files: [file] }, global: { plugins: [i18n] } });
+		expect(chips.get('[data-testid="file-chip-link"]').text()).toContain('a');
+		const thumb = mount(ImageThumb, {
+			props: { image, resolveThumbSrc: () => 'blob:x' },
+			global: { plugins: [i18n] },
+		});
+		expect(thumb.find('[data-testid="image-thumb-img"]').exists()).toBe(true);
+	});
+
+	it('ChatComposer default render shows the textarea + send (P1 byte-identical seam)', () => {
+		const wrapper = mount(ChatComposer, {
+			props: { isStreaming: false },
+			global: { plugins: [i18n] },
+		});
+		expect(wrapper.find('[data-testid="composer-textarea"]').exists()).toBe(true);
+		expect(wrapper.find('[data-testid="composer-send"]').exists()).toBe(true);
+	});
+});

--- a/tests/ui/a11y/collapsibleAndSrOnly.po.ts
+++ b/tests/ui/a11y/collapsibleAndSrOnly.po.ts
@@ -1,0 +1,32 @@
+import type { VueWrapper } from '@vue/test-utils';
+
+/**
+ * Shared PageObject for the T-AY-009 icon-only-control leg (TEST-AY-009 mount).
+ * Locates an icon-only control by `data-testid` only (ADR-009), then reads its
+ * accessible name (`aria-label`) and confirms its decorative glyph carries
+ * `aria-hidden="true"` (the decorative glyph is excluded from the accessibility
+ * tree; the name comes from the label, not the glyph).
+ */
+export class IconOnlyControlPageObject {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	private byTid(tid: string): string {
+		return `[data-testid="${tid}"]`;
+	}
+
+	exists(tid: string): boolean {
+		return this.wrapper.find(this.byTid(tid)).exists();
+	}
+
+	/** A non-empty `aria-label` is the accessible name for an icon-only control. */
+	ariaLabel(tid: string): string {
+		return this.wrapper.get(this.byTid(tid)).attributes('aria-label') ?? '';
+	}
+
+	/** True iff the control's decorative glyph span is `aria-hidden="true"`. */
+	decorativeGlyphHidden(tid: string): boolean {
+		const el = this.wrapper.get(this.byTid(tid));
+		const hidden = el.findAll('[aria-hidden="true"]');
+		return hidden.length > 0;
+	}
+}

--- a/tests/ui/a11y/collapsibleAndSrOnly.test.ts
+++ b/tests/ui/a11y/collapsibleAndSrOnly.test.ts
@@ -1,0 +1,119 @@
+/**
+ * T-AY-009 (RED -> verify) — collapsible `aria-expanded` flips + accessible name
+ * (TEST-AY-011); icon-only controls expose an `.sr-only`/`aria-label` name with
+ * zero visible footprint (TEST-AY-009 mount leg). SPEC-AY-005, SPEC-AY-007,
+ * REQ-AY-009, REQ-AY-011, EC-AY-007.
+ *
+ * The RG-6 `.sr-only` clip technique file-read leg rides T-AY-003. This mount leg
+ * asserts: (a) a collapsible header (`SpCollapsible`, reused by every rich block:
+ * tool call / thinking / subagent / write-edit) exposes `aria-expanded` that
+ * FLIPS on Enter/Space/click and an accessible name; and (b) icon-only controls
+ * carry an accessible name via `aria-label` while their decorative glyph is
+ * `aria-hidden="true"` (excluded from the accessibility tree). Verify-only: every
+ * collapsible uses `SpCollapsible` (which already binds `aria-expanded` + a
+ * dynamic `aria-label`), and every icon-only control already labels itself.
+ * Queried by `data-testid` only (ADR-009).
+ *
+ * Traces: TEST-AY-011, TEST-AY-009, SPEC-AY-005, SPEC-AY-007, REQ-AY-009/011,
+ * EC-AY-007.
+ */
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { h } from 'vue';
+import SpCollapsible from '@/ui/chat/SpCollapsible.vue';
+import ToolCallBlock from '@/ui/chat/ToolCallBlock.vue';
+import FileChips from '@/ui/chat/FileChips.vue';
+import ImageThumb from '@/ui/chat/ImageThumb.vue';
+import { i18n } from '@/ui/i18n';
+import { ICON_PORT } from '@/infrastructure/bridge/ports';
+import { staticIconPort } from '@/infrastructure/icons/staticIconPort';
+import type { ToolCall } from '@/domain/chat/ToolCall';
+import type { AttachedFileRef, AttachedImage } from '@/domain/chat/attachments';
+import { SpCollapsiblePageObject } from '../chat/SpCollapsible.po';
+import { ToolCallBlockPageObject } from '../chat/ToolCallBlock.po';
+import { IconOnlyControlPageObject } from './collapsibleAndSrOnly.po';
+
+function mountCollapsible() {
+	const wrapper = mount(SpCollapsible, {
+		props: { label: 'Tool call' },
+		slots: { header: () => h('span', 'Header'), default: () => h('span', 'Body') },
+		global: { plugins: [i18n] },
+	});
+	return { wrapper, po: new SpCollapsiblePageObject(wrapper) };
+}
+
+const toolCall: ToolCall = {
+	id: 't1',
+	name: 'Read',
+	input: { file_path: 'src/a.ts' },
+	status: 'completed',
+	result: 'ok',
+};
+
+const file: AttachedFileRef = { path: 'notes/a.md', displayName: 'a' };
+const image: AttachedImage = {
+	path: 'img/a.png',
+	mimeType: 'image/png',
+	byteSize: 4,
+	dataBase64: 'AAAA',
+};
+
+describe('collapsible aria-expanded (TEST-AY-011)', () => {
+	it('starts collapsed with aria-expanded=false and an accessible name', () => {
+		const { po } = mountCollapsible();
+		expect(po.role()).toBe('button');
+		expect(po.tabindex()).toBe('0');
+		expect(po.ariaExpanded()).toBe('false');
+		expect(po.ariaLabel().length).toBeGreaterThan(0);
+	});
+
+	it('flips aria-expanded on click', async () => {
+		const { po } = mountCollapsible();
+		await po.clickHeader();
+		expect(po.ariaExpanded()).toBe('true');
+		await po.clickHeader();
+		expect(po.ariaExpanded()).toBe('false');
+	});
+
+	it('flips aria-expanded on Enter and Space', async () => {
+		const { po } = mountCollapsible();
+		await po.pressEnter();
+		expect(po.ariaExpanded()).toBe('true');
+		await po.pressSpace();
+		expect(po.ariaExpanded()).toBe('false');
+	});
+
+	it('a rich-render block (ToolCallBlock) exposes the collapsible aria-expanded + name', async () => {
+		const wrapper = mount(ToolCallBlock, {
+			props: { toolCall },
+			global: { plugins: [i18n], provide: { [ICON_PORT as symbol]: staticIconPort } },
+		});
+		const po = new ToolCallBlockPageObject(wrapper);
+		const collapsible = new SpCollapsiblePageObject(wrapper);
+		expect(po.collapsibleAriaLabel().length).toBeGreaterThan(0);
+		expect(collapsible.ariaExpanded()).toBe('false');
+		await collapsible.clickHeader();
+		expect(collapsible.ariaExpanded()).toBe('true');
+	});
+});
+
+describe('icon-only control accessible names (TEST-AY-009 mount leg)', () => {
+	it('file chip remove carries an aria-label + an aria-hidden decorative glyph', () => {
+		const wrapper = mount(FileChips, { props: { files: [file] }, global: { plugins: [i18n] } });
+		const po = new IconOnlyControlPageObject(wrapper);
+		expect(po.exists('file-chip-remove')).toBe(true);
+		expect(po.ariaLabel('file-chip-remove').length).toBeGreaterThan(0);
+		expect(po.decorativeGlyphHidden('file-chip-remove')).toBe(true);
+	});
+
+	it('image thumb remove carries an aria-label + an aria-hidden decorative glyph', () => {
+		const wrapper = mount(ImageThumb, {
+			props: { image, resolveThumbSrc: () => 'blob:x' },
+			global: { plugins: [i18n] },
+		});
+		const po = new IconOnlyControlPageObject(wrapper);
+		expect(po.exists('image-thumb-remove')).toBe(true);
+		expect(po.ariaLabel('image-thumb-remove').length).toBeGreaterThan(0);
+		expect(po.decorativeGlyphHidden('image-thumb-remove')).toBe(true);
+	});
+});

--- a/tests/ui/a11y/disciplineScan.test.ts
+++ b/tests/ui/a11y/disciplineScan.test.ts
@@ -1,0 +1,57 @@
+/**
+ * T-AY-015 (RED -> green) — discipline scan: no added raw-HTML sink in the P12
+ * diff (TEST-AY-015 diff leg). SPEC-AY-011, REQ-AY-015, NFR-AY-003 — the security
+ * leg. (The accessibility.css token/comment leg rides T-AY-003.)
+ *
+ * Asserts the P12 source diff vs `next` adds NO `innerHTML`/`outerHTML`/
+ * `insertAdjacentHTML` assignment and NO `v-html`, and no new suppression of the
+ * raw-HTML guards. The additive ARIA edits bind attributes declaratively and the
+ * `.sr-only` notice text is rendered as `{{ }}` text — never injected as markup.
+ *
+ * Traces: TEST-AY-015, SPEC-AY-011, REQ-AY-015, NFR-AY-003.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const REPO_ROOT = resolve(__dirname, '../../..');
+
+function git(args: string[]): string {
+	return execFileSync('git', args, { cwd: REPO_ROOT, encoding: 'utf8' });
+}
+
+/** The added (`+`) lines of the P12 src/ diff vs the next baseline. */
+function addedSrcLines(): string[] {
+	const diff = git(['diff', 'next', '--', 'src']);
+	return diff
+		.split('\n')
+		.filter((line) => line.startsWith('+') && !line.startsWith('+++'))
+		.map((line) => line.slice(1));
+}
+
+describe('discipline scan — no added raw-HTML sink (TEST-AY-015 diff leg)', () => {
+	const added = addedSrcLines();
+
+	it('the P12 diff adds no innerHTML / outerHTML / insertAdjacentHTML assignment', () => {
+		const offenders = added.filter((l) =>
+			/\b(innerHTML|outerHTML)\s*=|insertAdjacentHTML\s*\(/.test(l),
+		);
+		expect(offenders, `raw-HTML sink added: ${JSON.stringify(offenders)}`).toEqual([]);
+	});
+
+	it('the P12 diff adds no v-html directive', () => {
+		// Match the directive usage (`v-html=` / `:v-html=` / a bound v-html), not a
+		// prose mention of the banned directive in a comment.
+		const offenders = added.filter((l) => /\bv-html\s*=|:v-html\b/.test(l));
+		expect(offenders, `v-html added: ${JSON.stringify(offenders)}`).toEqual([]);
+	});
+
+	it('the P12 diff adds no new eslint-disable of the raw-HTML / v-html guards', () => {
+		const offenders = added.filter(
+			(l) =>
+				l.includes('eslint-disable') &&
+				/(no-restricted-properties|vue\/no-v-html|no-restricted-syntax)/.test(l),
+		);
+		expect(offenders, `new raw-HTML guard suppression: ${JSON.stringify(offenders)}`).toEqual([]);
+	});
+});

--- a/tests/ui/a11y/forcedColorsControls.po.ts
+++ b/tests/ui/a11y/forcedColorsControls.po.ts
@@ -1,0 +1,44 @@
+import type { VueWrapper } from '@vue/test-utils';
+
+/**
+ * Shared PageObject for the T-AY-006 forced-colors-control mount leg (TEST-AY-006).
+ * Locates the RG-4-listed background-cue-only controls in a mounted surface by
+ * `data-testid` only (ADR-009), then reads the role / class / `data-state` /
+ * `aria-selected` attributes the RG-4 selectors key off. No CSS-class `find`
+ * literal — every locator is a `data-testid` attribute selector.
+ */
+export class ForcedColorsControlsPageObject {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	private byTid(tid: string): string {
+		return `[data-testid="${tid}"]`;
+	}
+
+	exists(tid: string): boolean {
+		return this.wrapper.find(this.byTid(tid)).exists();
+	}
+
+	role(tid: string): string {
+		return this.wrapper.get(this.byTid(tid)).attributes('role') ?? '';
+	}
+
+	dataState(tid: string): string {
+		return this.wrapper.get(this.byTid(tid)).attributes('data-state') ?? '';
+	}
+
+	classOf(tid: string): string {
+		return this.wrapper.get(this.byTid(tid)).attributes('class') ?? '';
+	}
+
+	ariaSelectedAt(tid: string, index: number): string {
+		return this.wrapper.findAll(this.byTid(tid))[index].attributes('aria-selected') ?? '';
+	}
+
+	roleAt(tid: string, index: number): string {
+		return this.wrapper.findAll(this.byTid(tid))[index].attributes('role') ?? '';
+	}
+
+	count(tid: string): number {
+		return this.wrapper.findAll(this.byTid(tid)).length;
+	}
+}

--- a/tests/ui/a11y/forcedColorsControls.test.ts
+++ b/tests/ui/a11y/forcedColorsControls.test.ts
@@ -1,0 +1,161 @@
+/**
+ * T-AY-006 (RED -> verify) — forced-colors border controls exist in the mounted
+ * surfaces (TEST-AY-006 mount leg). SPEC-AY-006, REQ-AY-006, NFR-AY-009.
+ *
+ * RG-4 in `accessibility.css` adds a `currentColor` border under
+ * `forced-colors: active` to the background-cue-only controls (toggle switch,
+ * state pills, file/image chips, tab badges, selected dropdown option). The
+ * forced-colors *appearance* is the human TEST-AY-017 leg; this asserts the RG-4
+ * selectors target REAL mounted controls, not dead selectors — each listed
+ * control is present in the rendered DOM, and RG-4 enumerates a selector that
+ * matches it. Queried by `data-testid` only (ADR-009).
+ *
+ * Traces: TEST-AY-006, SPEC-AY-006, REQ-AY-006, NFR-AY-009.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { mount } from '@vue/test-utils';
+import { setActivePinia, createPinia } from 'pinia';
+import TabBar from '@/ui/chat/TabBar.vue';
+import ServiceTierToggle from '@/ui/chat/toolbar/ServiceTierToggle.vue';
+import FileChips from '@/ui/chat/FileChips.vue';
+import ImageThumb from '@/ui/chat/ImageThumb.vue';
+import PermissionToggle from '@/ui/chat/toolbar/PermissionToggle.vue';
+import { useTabsStore } from '@/ui/stores/tabsStore';
+import type { ChatTurnRunner } from '@/ui/stores/chatStore';
+import { i18n } from '@/ui/i18n';
+import { ok } from '@/domain/shared/Result';
+import { MockChatRuntime } from '@/infrastructure/mock/MockChatRuntime';
+import { MockHistoryStore } from '@/infrastructure/mock/MockHistoryStore';
+import type { AttachedFileRef, AttachedImage } from '@/domain/chat/attachments';
+import { ForcedColorsControlsPageObject } from './forcedColorsControls.po';
+
+const CSS_PATH = resolve(__dirname, '../../../src/ui/styles/accessibility.css');
+
+/** Collect the body of the RG-4 forced-colors-border `@media` block. */
+function rg4Block(): string {
+	const css = readFileSync(CSS_PATH, 'utf8');
+	const marker = css.indexOf('RG-4 - forced-colors border guarantee');
+	expect(marker, 'RG-4 section marker present in accessibility.css').toBeGreaterThan(-1);
+	const open = css.indexOf('@media', marker);
+	// Walk balanced braces from the first `{` after the at-rule.
+	const firstBrace = css.indexOf('{', open);
+	let depth = 0;
+	let end = firstBrace;
+	for (let i = firstBrace; i < css.length; i++) {
+		if (css[i] === '{') depth++;
+		else if (css[i] === '}') {
+			depth--;
+			if (depth === 0) {
+				end = i;
+				break;
+			}
+		}
+	}
+	return css.slice(firstBrace, end + 1);
+}
+
+function bindStore(maxTabs = 3) {
+	const store = useTabsStore();
+	store.bindTabDeps({
+		createRuntime: () => new MockChatRuntime([]),
+		createRunner: (): ChatTurnRunner => ({
+			run: vi.fn().mockResolvedValue(ok(undefined)),
+			cancel: vi.fn(),
+		}),
+		notifyStartFailure: () => undefined,
+		notifyInfo: () => undefined,
+		history: new MockHistoryStore(),
+		generateTitle: () => Promise.resolve(ok('title')),
+		getMaxTabs: () => maxTabs,
+	});
+	return store;
+}
+
+const file: AttachedFileRef = { path: 'notes/a.md', displayName: 'a' };
+const image: AttachedImage = {
+	path: 'img/a.png',
+	mimeType: 'image/png',
+	byteSize: 4,
+	dataBase64: 'AAAA',
+};
+
+describe('forced-colors RG-4 controls (TEST-AY-006 mount leg)', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+	});
+
+	it('tab badges carry .sp-tab + a data-state state pill (RG-4 .sp-tab / [data-state])', () => {
+		bindStore();
+		const wrapper = mount(TabBar, { global: { plugins: [i18n] } });
+		const po = new ForcedColorsControlsPageObject(wrapper);
+		expect(po.exists('tab-badge')).toBe(true);
+		expect(po.classOf('tab-badge')).toContain('sp-tab');
+		expect(po.dataState('tab-badge').length).toBeGreaterThan(0);
+	});
+
+	it('the service-tier toggle switch is a role=switch control (RG-4 toggle switch)', () => {
+		const wrapper = mount(ServiceTierToggle, {
+			props: {
+				vm: {
+					visibility: { kind: 'visible', enabled: true },
+					descriptor: { activeValue: 'fast', inactiveValue: 'standard', label: 'Priority' },
+					active: false,
+				},
+			},
+			global: { plugins: [i18n] },
+		});
+		const po = new ForcedColorsControlsPageObject(wrapper);
+		expect(po.exists('toolbar-service-tier')).toBe(true);
+		expect(po.role('toolbar-service-tier')).toBe('switch');
+	});
+
+	it('file chips render as RG-4 chip controls', () => {
+		const wrapper = mount(FileChips, { props: { files: [file] }, global: { plugins: [i18n] } });
+		const po = new ForcedColorsControlsPageObject(wrapper);
+		expect(po.exists('file-chip')).toBe(true);
+	});
+
+	it('image thumbs render as RG-4 chip controls', () => {
+		const wrapper = mount(ImageThumb, {
+			props: { image, resolveThumbSrc: () => 'blob:x' },
+			global: { plugins: [i18n] },
+		});
+		const po = new ForcedColorsControlsPageObject(wrapper);
+		expect(po.exists('image-thumb')).toBe(true);
+	});
+
+	it('the permission toggle exposes a selected role=option (RG-4 selected dropdown option)', () => {
+		const wrapper = mount(PermissionToggle, {
+			props: {
+				vm: { visibility: { kind: 'visible', enabled: true }, plan: false, deferred: true },
+				mode: 'normal',
+			},
+			global: { plugins: [i18n] },
+		});
+		const po = new ForcedColorsControlsPageObject(wrapper);
+		expect(po.exists('toolbar-permission-option')).toBe(true);
+		// At least one option is the selected option RG-4 targets.
+		const count = po.count('toolbar-permission-option');
+		const selected = Array.from({ length: count }).some(
+			(_, i) =>
+				po.roleAt('toolbar-permission-option', i) === 'option' &&
+				po.ariaSelectedAt('toolbar-permission-option', i) === 'true',
+		);
+		expect(selected).toBe(true);
+	});
+
+	it('RG-4 enumerates a selector matching every mounted background-cue-only control', () => {
+		const block = rg4Block();
+		// state pills + tab badges + selected dropdown option already match real DOM.
+		expect(block).toContain('[data-state]');
+		expect(block).toContain('.sp-tab');
+		expect(block).toContain('[role="option"][aria-selected="true"]');
+		// the toggle switch is a role=switch in the real DOM (ServiceTier/Mode/Permission).
+		expect(block).toContain('[role="switch"]');
+		// the file/image chips carry these real classes in the real DOM.
+		expect(block).toContain('.sp-file-chips__chip');
+		expect(block).toContain('.sp-image-thumb');
+	});
+});

--- a/tests/ui/a11y/keyboardAndLabels.po.ts
+++ b/tests/ui/a11y/keyboardAndLabels.po.ts
@@ -1,0 +1,54 @@
+import type { VueWrapper } from '@vue/test-utils';
+
+/**
+ * The RG-5 focus-visible target selector (SPEC-AY-001 / SPEC-AY-008): the set of
+ * elements the focus ring reaches. A control is focus-reachable iff its element
+ * matches this selector (a custom control carries `tabindex` so it matches
+ * `[tabindex]`). Kept in one place so the keyboard/label tests assert it
+ * uniformly.
+ */
+export const RG5_FOCUS_TARGET =
+	'button, [role="tab"], [role="option"], [role="switch"], a[href], textarea, input, select, [tabindex]';
+
+/**
+ * Shared PageObject for the T-AY-007 keyboard-operability + accessible-name leg
+ * (TEST-AY-007 mount / TEST-AY-008). Locates a control by `data-testid` only
+ * (ADR-009), then reads its accessible name (visible text, `aria-label`, or an
+ * associated `.sr-only` label) and asserts it matches the RG-5 focus target.
+ */
+export class KeyboardAndLabelsPageObject {
+	constructor(private readonly wrapper: VueWrapper) {}
+
+	private byTid(tid: string): string {
+		return `[data-testid="${tid}"]`;
+	}
+
+	exists(tid: string): boolean {
+		return this.wrapper.find(this.byTid(tid)).exists();
+	}
+
+	/** The accessible name: a non-empty `aria-label`, else the trimmed visible text. */
+	accessibleName(tid: string): string {
+		const el = this.wrapper.get(this.byTid(tid));
+		const label = el.attributes('aria-label');
+		if (label !== undefined && label.trim().length > 0) return label.trim();
+		return el.text().trim();
+	}
+
+	/** True iff the control's element matches the RG-5 focus-visible target selector. */
+	isFocusReachable(tid: string): boolean {
+		return this.wrapper.get(this.byTid(tid)).element.matches(RG5_FOCUS_TARGET);
+	}
+
+	/** The accessible name of the Nth control sharing a `data-testid`. */
+	accessibleNameAt(tid: string, index: number): string {
+		const el = this.wrapper.findAll(this.byTid(tid))[index];
+		const label = el.attributes('aria-label');
+		if (label !== undefined && label.trim().length > 0) return label.trim();
+		return el.text().trim();
+	}
+
+	count(tid: string): number {
+		return this.wrapper.findAll(this.byTid(tid)).length;
+	}
+}

--- a/tests/ui/a11y/keyboardAndLabels.test.ts
+++ b/tests/ui/a11y/keyboardAndLabels.test.ts
@@ -1,0 +1,145 @@
+/**
+ * T-AY-007 (RED -> verify) — focus-visible ring reachability + keyboard
+ * operability + accessible names across the toolbar / composer / chat controls
+ * (TEST-AY-007 mount leg + TEST-AY-008). SPEC-AY-007, SPEC-AY-008, REQ-AY-007/008.
+ *
+ * The RG-5 file-read leg (`:focus-visible` + `--sp-focus-ring`, no bare `:focus`)
+ * rides T-AY-003. This mount leg asserts (a) each audited interactive control
+ * matches the RG-5 focus-visible target selector (so the keyboard ring reaches
+ * it — a custom control carries `tabindex`/`role`), and (b) every audited control
+ * exposes a non-empty accessible name (visible label, `aria-label`, or `.sr-only`)
+ * — REQ-AY-008. The mouse-`:focus`-shows-no-stray-ring counter-metric (EC-AY-006)
+ * is the RG-5 `:focus-visible` discipline, asserted structurally in T-AY-003 (the
+ * rule never uses bare `:focus`). Queried by `data-testid` only (ADR-009).
+ *
+ * Traces: TEST-AY-007, TEST-AY-008, SPEC-AY-007, SPEC-AY-008, REQ-AY-007/008,
+ * NFR-AY-001, EC-AY-005, EC-AY-006.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { setActivePinia, createPinia } from 'pinia';
+import TabBar from '@/ui/chat/TabBar.vue';
+import ChatComposer from '@/ui/chat/ChatComposer.vue';
+import FileChips from '@/ui/chat/FileChips.vue';
+import ImageThumb from '@/ui/chat/ImageThumb.vue';
+import ServiceTierToggle from '@/ui/chat/toolbar/ServiceTierToggle.vue';
+import PermissionToggle from '@/ui/chat/toolbar/PermissionToggle.vue';
+import { useTabsStore } from '@/ui/stores/tabsStore';
+import type { ChatTurnRunner } from '@/ui/stores/chatStore';
+import { i18n } from '@/ui/i18n';
+import { ok } from '@/domain/shared/Result';
+import { MockChatRuntime } from '@/infrastructure/mock/MockChatRuntime';
+import { MockHistoryStore } from '@/infrastructure/mock/MockHistoryStore';
+import type { AttachedFileRef, AttachedImage } from '@/domain/chat/attachments';
+import { KeyboardAndLabelsPageObject } from './keyboardAndLabels.po';
+
+function bindStore(maxTabs = 3) {
+	const store = useTabsStore();
+	store.bindTabDeps({
+		createRuntime: () => new MockChatRuntime([]),
+		createRunner: (): ChatTurnRunner => ({
+			run: vi.fn().mockResolvedValue(ok(undefined)),
+			cancel: vi.fn(),
+		}),
+		notifyStartFailure: () => undefined,
+		notifyInfo: () => undefined,
+		history: new MockHistoryStore(),
+		generateTitle: () => Promise.resolve(ok('title')),
+		getMaxTabs: () => maxTabs,
+	});
+	return store;
+}
+
+const file: AttachedFileRef = { path: 'notes/a.md', displayName: 'a' };
+const image: AttachedImage = {
+	path: 'img/a.png',
+	mimeType: 'image/png',
+	byteSize: 4,
+	dataBase64: 'AAAA',
+};
+
+describe('keyboard operability + accessible names (TEST-AY-007/008)', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+	});
+
+	it('TabBar controls (badge, close, new) are focus-reachable with accessible names', () => {
+		bindStore();
+		const wrapper = mount(TabBar, { global: { plugins: [i18n] } });
+		const po = new KeyboardAndLabelsPageObject(wrapper);
+		// The badge is a role=tab carrying tabindex (roving) -> matches RG-5.
+		expect(po.isFocusReachable('tab-badge')).toBe(true);
+		expect(po.accessibleName('tab-badge').length).toBeGreaterThan(0);
+		// Close + new are native buttons -> match RG-5; both carry aria-label.
+		expect(po.isFocusReachable('tab-close')).toBe(true);
+		expect(po.accessibleName('tab-close').length).toBeGreaterThan(0);
+		expect(po.isFocusReachable('tab-new')).toBe(true);
+		expect(po.accessibleName('tab-new').length).toBeGreaterThan(0);
+	});
+
+	it('composer textarea, attach, and send are focus-reachable with accessible names', () => {
+		const wrapper = mount(ChatComposer, {
+			props: { isStreaming: false },
+			global: { plugins: [i18n] },
+		});
+		const po = new KeyboardAndLabelsPageObject(wrapper);
+		// The textarea is a native textarea -> matches RG-5; placeholder is set.
+		expect(po.isFocusReachable('composer-textarea')).toBe(true);
+		// The paperclip + send are icon-only buttons -> need a non-empty aria-label.
+		expect(po.isFocusReachable('composer-attach')).toBe(true);
+		expect(po.accessibleName('composer-attach').length).toBeGreaterThan(0);
+		expect(po.isFocusReachable('composer-send')).toBe(true);
+		expect(po.accessibleName('composer-send').length).toBeGreaterThan(0);
+	});
+
+	it('file chip link + remove are focus-reachable with accessible names', () => {
+		const wrapper = mount(FileChips, { props: { files: [file] }, global: { plugins: [i18n] } });
+		const po = new KeyboardAndLabelsPageObject(wrapper);
+		expect(po.isFocusReachable('file-chip-link')).toBe(true);
+		expect(po.accessibleName('file-chip-link').length).toBeGreaterThan(0);
+		expect(po.isFocusReachable('file-chip-remove')).toBe(true);
+		expect(po.accessibleName('file-chip-remove').length).toBeGreaterThan(0);
+	});
+
+	it('image thumb preview + remove are focus-reachable with accessible names', () => {
+		const wrapper = mount(ImageThumb, {
+			props: { image, resolveThumbSrc: () => 'blob:x' },
+			global: { plugins: [i18n] },
+		});
+		const po = new KeyboardAndLabelsPageObject(wrapper);
+		expect(po.isFocusReachable('image-thumb-preview')).toBe(true);
+		expect(po.accessibleName('image-thumb-preview').length).toBeGreaterThan(0);
+		expect(po.isFocusReachable('image-thumb-remove')).toBe(true);
+		expect(po.accessibleName('image-thumb-remove').length).toBeGreaterThan(0);
+	});
+
+	it('toolbar switches expose role + accessible name and are focus-reachable', () => {
+		const tier = mount(ServiceTierToggle, {
+			props: {
+				vm: {
+					visibility: { kind: 'visible', enabled: true },
+					descriptor: { activeValue: 'fast', inactiveValue: 'standard', label: 'Priority' },
+					active: false,
+				},
+			},
+			global: { plugins: [i18n] },
+		});
+		const tierPo = new KeyboardAndLabelsPageObject(tier);
+		expect(tierPo.isFocusReachable('toolbar-service-tier')).toBe(true);
+		expect(tierPo.accessibleName('toolbar-service-tier').length).toBeGreaterThan(0);
+
+		const perm = mount(PermissionToggle, {
+			props: {
+				vm: { visibility: { kind: 'visible', enabled: true }, plan: false, deferred: true },
+				mode: 'normal',
+			},
+			global: { plugins: [i18n] },
+		});
+		const permPo = new KeyboardAndLabelsPageObject(perm);
+		// The live listbox is tabindex=0 -> matches RG-5; options are role=option.
+		expect(permPo.isFocusReachable('toolbar-permission')).toBe(true);
+		expect(permPo.accessibleName('toolbar-permission').length).toBeGreaterThan(0);
+		expect(permPo.isFocusReachable('toolbar-permission-option')).toBe(true);
+		expect(permPo.accessibleNameAt('toolbar-permission-option', 0).length).toBeGreaterThan(0);
+	});
+});

--- a/tests/ui/a11y/liveRegions.test.ts
+++ b/tests/ui/a11y/liveRegions.test.ts
@@ -1,0 +1,165 @@
+/**
+ * T-AY-008 (RED -> verify+fill) — live-region presence + severity (TEST-AY-010).
+ * SPEC-AY-004, REQ-AY-010, NFR-AY-001, EC-AY-011/012.
+ *
+ * Two legs:
+ *  - Busy region (verify-only): the `ChatSurface` streaming busy region carries
+ *    `aria-live="polite"` + `role="status"` (already present, lines 856-857).
+ *  - Notice host (fill, T-AY-011): the standalone notice host announces error
+ *    notices ASSERTIVE (`role="alert"`) and info/success POLITE (`role="status"`)
+ *    via an `aria-live` region that mirrors the notice text DECLARATIVELY (no
+ *    `innerHTML`/`v-html`) and NEVER steals focus.
+ *
+ * The notice host is `NoticeLiveRegion.vue` (created in T-AY-011), driven by the
+ * existing `sp:notice` CustomEvent channel `LocalStorageBridge` already dispatches
+ * — no new port, no new channel. Queried by `data-testid` only (ADR-009).
+ *
+ * Traces: TEST-AY-010, SPEC-AY-004, REQ-AY-010, NFR-AY-001, EC-AY-011, EC-AY-012.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { setActivePinia, createPinia } from 'pinia';
+import ChatSurface from '@/ui/chat/ChatSurface.vue';
+import NoticeLiveRegion from '@/ui/components/NoticeLiveRegion.vue';
+import { i18n } from '@/ui/i18n';
+import {
+	MARKDOWN_RENDER_PORT,
+	NOTIFICATION_PORT,
+	LOGGER_PORT,
+	PROVIDER_HISTORY_PORT,
+	ICON_PORT,
+} from '@/infrastructure/bridge/ports';
+import { CHAT_RUNTIME_FACTORY } from '@/ui/chat/modalSeam';
+import { ok } from '@/domain/shared/Result';
+import { safeMarkdownRenderPort } from '@/application/chat/safeMarkdownRenderPort';
+import { MockChatRuntime } from '@/infrastructure/mock/MockChatRuntime';
+import { MockHistoryStore } from '@/infrastructure/mock/MockHistoryStore';
+import { MockBridge } from '@/infrastructure/mock/MockBridge';
+import type { ChatRuntimePort, StreamChunk, NotificationPort, LoggerPort } from '@/domain/ports';
+import { ChatSurfacePageObject } from '../chat/ChatSurface.po';
+import { NoticeLiveRegionPageObject } from './NoticeLiveRegion.po';
+
+const iconBridge = new MockBridge();
+const logger: LoggerPort = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+function notifySpy(): NotificationPort {
+	return { showError: vi.fn(), showWarning: vi.fn(), showSuccess: vi.fn(), showInfo: vi.fn() };
+}
+
+/** A streaming runtime that keeps the busy region open until done. */
+class StreamingRuntime extends MockChatRuntime {
+	private gate: (() => void) | null = null;
+	private readonly queued: StreamChunk[] = [];
+	constructor() {
+		super([]);
+	}
+	override ensureReady(): Promise<boolean> {
+		return Promise.resolve(true);
+	}
+	override async *query(): AsyncGenerator<StreamChunk> {
+		for (;;) {
+			if (this.queued.length === 0) {
+				await new Promise<void>((resolve) => (this.gate = resolve));
+			}
+			const chunk = this.queued.shift();
+			if (chunk === undefined) continue;
+			yield chunk;
+			if (chunk.type === 'done') return;
+		}
+	}
+	emit(chunk: StreamChunk): void {
+		this.queued.push(chunk);
+		this.gate?.();
+		this.gate = null;
+	}
+}
+
+function mountSurface(runtime: ChatRuntimePort) {
+	const wrapper = mount(ChatSurface, {
+		global: {
+			plugins: [i18n],
+			provide: {
+				[CHAT_RUNTIME_FACTORY as symbol]: () => ok(runtime),
+				[MARKDOWN_RENDER_PORT as symbol]: safeMarkdownRenderPort,
+				[NOTIFICATION_PORT as symbol]: notifySpy(),
+				[LOGGER_PORT as symbol]: logger,
+				[PROVIDER_HISTORY_PORT as symbol]: new MockHistoryStore(),
+				[ICON_PORT as symbol]: iconBridge.createIconPort(),
+			},
+		},
+	});
+	return { wrapper, po: new ChatSurfacePageObject(wrapper) };
+}
+
+/** Dispatch the `sp:notice` channel the standalone notice host listens to. */
+function emitNotice(severity: string, message: string): void {
+	window.dispatchEvent(new CustomEvent('sp:notice', { detail: { severity, message, durationMs: 0 } }));
+}
+
+describe('live regions (TEST-AY-010)', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+	});
+
+	it('busy region carries aria-live=polite + role=status while streaming (verify-only)', async () => {
+		const runtime = new StreamingRuntime();
+		const { po } = mountSurface(runtime);
+		await po.typeAndSend('Hi');
+		await flushPromises();
+		expect(po.showsBusy()).toBe(true);
+		expect(po.busyAriaLive()).toBe('polite');
+		expect(po.busyRole()).toBe('status');
+	});
+});
+
+describe('NoticeLiveRegion notice host (SPEC-AY-004)', () => {
+	it('renders a polite live region by default', () => {
+		const wrapper = mount(NoticeLiveRegion, { global: { plugins: [i18n] } });
+		const po = new NoticeLiveRegionPageObject(wrapper);
+		expect(po.exists()).toBe(true);
+		expect(po.ariaLive()).toBe('polite');
+		expect(po.role()).toBe('status');
+	});
+
+	it('announces an info notice POLITE, mirroring the text (EC-AY-011)', async () => {
+		const wrapper = mount(NoticeLiveRegion, { global: { plugins: [i18n] } });
+		const po = new NoticeLiveRegionPageObject(wrapper);
+		emitNotice('info', 'Saved');
+		await flushPromises();
+		expect(po.ariaLive()).toBe('polite');
+		expect(po.role()).toBe('status');
+		expect(po.text()).toContain('Saved');
+	});
+
+	it('announces an error notice ASSERTIVE (EC-AY-012)', async () => {
+		const wrapper = mount(NoticeLiveRegion, { global: { plugins: [i18n] } });
+		const po = new NoticeLiveRegionPageObject(wrapper);
+		emitNotice('error', 'Boom');
+		await flushPromises();
+		expect(po.ariaLive()).toBe('assertive');
+		expect(po.role()).toBe('alert');
+		expect(po.text()).toContain('Boom');
+	});
+
+	it('does not steal focus when a notice fires', async () => {
+		const probe = document.createElement('input');
+		document.body.appendChild(probe);
+		probe.focus();
+		const wrapper = mount(NoticeLiveRegion, { attachTo: document.body, global: { plugins: [i18n] } });
+		emitNotice('error', 'Boom');
+		await flushPromises();
+		expect(document.activeElement).toBe(probe);
+		wrapper.unmount();
+		probe.remove();
+	});
+
+	it('mirrors the notice text declaratively (no raw-HTML sink)', async () => {
+		const wrapper = mount(NoticeLiveRegion, { global: { plugins: [i18n] } });
+		const po = new NoticeLiveRegionPageObject(wrapper);
+		emitNotice('info', '<b>x</b>');
+		await flushPromises();
+		// The angle brackets are escaped as text, never injected as markup.
+		expect(po.html()).not.toContain('<b>x</b>');
+		expect(po.text()).toContain('<b>x</b>');
+	});
+});

--- a/tests/ui/a11y/modalFocusTrap.test.ts
+++ b/tests/ui/a11y/modalFocusTrap.test.ts
@@ -1,0 +1,64 @@
+/**
+ * T-AY-013 (verify-only) — modal focus trap + restore via the platform (the 8
+ * Specorator modal seams). SPEC-AY-009, REQ-AY-012/013, NFR-AY-001,
+ * EC-AY-008/009.
+ *
+ * Every Specorator modal extends Obsidian `Modal`, which NATIVELY traps
+ * Tab/Shift+Tab within `.modal` and restores `document.activeElement` on close
+ * (D-AY-3). The spec requires each launcher to open a `Modal` subclass; this is
+ * the structural assertion that property holds (the live Tab-cycle + focus
+ * restore are the human TEST-AY-017 leg / the Obsidian runtime, which the JSDOM
+ * harness cannot exercise). Do NOT hand-roll a trap.
+ *
+ * DEFECT-ESCALATION NOTE: a modal found NOT to extend `Modal` is a defect — file
+ * ADR-AY-001 + a new hand-rolled-trap task (the P5-P11 way), never a silent
+ * default. As verified below, all 8 extend `Modal`, so that does not arise.
+ *
+ * Traces: TEST-AY-012, TEST-AY-013, SPEC-AY-009, REQ-AY-012/013, EC-AY-008/009.
+ */
+import { describe, it, expect } from 'vitest';
+import { Modal } from 'obsidian';
+import { ProviderConsentModal } from '@/plugin/modals/ProviderConsentModal';
+import { DeleteConfirmModal } from '@/plugin/modals/DeleteConfirmModal';
+import { ForkTargetModal } from '@/plugin/modals/ForkTargetModal';
+import { InstructionConfirmModal } from '@/plugin/modals/InstructionConfirmModal';
+import { InlineEditModal } from '@/plugin/modals/InlineEditModal';
+import { ImagePreviewModal } from '@/plugin/modals/ImagePreviewModal';
+import { McpServerModalHost } from '@/plugin/modals/McpServerModalHost';
+import { McpTestModalHost } from '@/plugin/modals/McpTestModalHost';
+
+/** The 8 Specorator modal seams (DESIGN-AY-001 B.2). */
+const MODALS = [
+	['ProviderConsentModal', ProviderConsentModal],
+	['DeleteConfirmModal', DeleteConfirmModal],
+	['ForkTargetModal', ForkTargetModal],
+	['InstructionConfirmModal', InstructionConfirmModal],
+	['InlineEditModal', InlineEditModal],
+	['ImagePreviewModal', ImagePreviewModal],
+	['McpServerModalHost', McpServerModalHost],
+	['McpTestModalHost', McpTestModalHost],
+] as const;
+
+describe('modal focus trap + restore (TEST-AY-012/013, verify-only)', () => {
+	it('all 8 modal seams extend Obsidian Modal (native trap + restore, EC-AY-008/009)', () => {
+		for (const [name, ctor] of MODALS) {
+			expect(ctor.prototype instanceof Modal, `${name} must extend Obsidian Modal`).toBe(true);
+		}
+	});
+
+	it('each modal class is in the Modal prototype chain (no hand-rolled trap)', () => {
+		for (const [name, ctor] of MODALS) {
+			// Walk the prototype chain to Modal — the native trap/restore source.
+			let proto: unknown = Object.getPrototypeOf(ctor.prototype);
+			let found = false;
+			while (proto !== null) {
+				if (proto === Modal.prototype) {
+					found = true;
+					break;
+				}
+				proto = Object.getPrototypeOf(proto);
+			}
+			expect(found, `${name} must inherit Modal.prototype`).toBe(true);
+		}
+	});
+});

--- a/tests/ui/a11y/parityScreenshots.test.ts
+++ b/tests/ui/a11y/parityScreenshots.test.ts
@@ -1,0 +1,78 @@
+/**
+ * T-AY-016 (RED -> green) — `parity-screenshots.md` completeness (TEST-AY-016).
+ * REQ-AY-016. Artifact-completeness ONLY — it checks the matrix has every
+ * required row/cell slot (every charter §3 surface at 320/520/720 px in light +
+ * dark, each with a claudian-baseline + Specorator cell); the VISUAL judgment is
+ * the human TEST-AY-017 leg.
+ *
+ * Traces: TEST-AY-016, REQ-AY-016.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const DOC_PATH = resolve(__dirname, '../../../specs/accessibility/parity-screenshots.md');
+
+function loadDoc(): string {
+	return readFileSync(DOC_PATH, 'utf8');
+}
+
+/** Every charter §3 surface group that must be represented in the matrix. */
+const SECTIONS = ['§3.1', '§3.2', '§3.3', '§3.4', '§3.5', '§3.6', '§3.7', '§3.8', '§3.9'];
+
+describe('parity-screenshots.md completeness (TEST-AY-016)', () => {
+	it('the artifact exists and is non-trivial', () => {
+		const doc = loadDoc();
+		expect(doc.length).toBeGreaterThan(200);
+		expect(doc).toContain('parity');
+	});
+
+	it('declares the three charter widths in both themes (320/520/720 x L/D)', () => {
+		const doc = loadDoc();
+		for (const width of ['320', '520', '720']) {
+			expect(doc, `width ${width} present`).toContain(width);
+		}
+		// The default-render matrix header carries the per-width light/dark columns.
+		for (const header of ['320 L', '320 D', '520 L', '520 D', '720 L', '720 D']) {
+			expect(doc, `column ${header} present`).toContain(header);
+		}
+	});
+
+	it('represents every charter §3 surface group', () => {
+		const doc = loadDoc();
+		for (const section of SECTIONS) {
+			expect(doc, `charter surface ${section} present`).toContain(section);
+		}
+	});
+
+	it('carries a claudian baseline column + a Specorator side-by-side leg', () => {
+		const doc = loadDoc();
+		expect(doc).toContain('Baseline (claudian)');
+		// Each surface row pairs the claudian baseline with the Specorator capture columns.
+		expect(doc.toLowerCase()).toContain('specorator');
+	});
+
+	it('carries the a11y-condition columns (reduced-motion + forced-colors)', () => {
+		const doc = loadDoc();
+		expect(doc).toContain('reduced-motion');
+		expect(doc).toContain('forced-colors');
+	});
+
+	it('the matrix is structurally complete (no surface row left without its baseline cell)', () => {
+		const doc = loadDoc();
+		// Every default-render surface row is a table row that names a charter section
+		// and carries a non-empty Baseline (claudian) reference cell.
+		const rows = doc
+			.split('\n')
+			.filter((l) => l.trim().startsWith('|') && /§3\.\d/.test(l));
+		expect(rows.length, 'at least one surface row per charter §3 section').toBeGreaterThanOrEqual(
+			SECTIONS.length,
+		);
+		for (const row of rows) {
+			const cells = row.split('|').map((c) => c.trim());
+			// cells[1] = surface name, cells[2] = baseline reference; both non-empty.
+			expect(cells[1]?.length ?? 0, `surface name in row: ${row}`).toBeGreaterThan(0);
+			expect(cells[2]?.length ?? 0, `baseline cell in row: ${row}`).toBeGreaterThan(0);
+		}
+	});
+});

--- a/tests/ui/chat/ChatSurface.po.ts
+++ b/tests/ui/chat/ChatSurface.po.ts
@@ -36,6 +36,10 @@ export class ChatSurfacePageObject {
 		return this.wrapper.get('[data-testid="chat-busy"]').attributes('aria-live');
 	}
 
+	busyRole(): string | undefined {
+		return this.wrapper.get('[data-testid="chat-busy"]').attributes('role');
+	}
+
 	assistantText(): string {
 		return this.wrapper.get('[data-testid="message-assistant"]').text();
 	}

--- a/tests/ui/styles/accessibility-registration.test.ts
+++ b/tests/ui/styles/accessibility-registration.test.ts
@@ -1,0 +1,47 @@
+/**
+ * CSS-pipeline registration contract for the P12 accessibility layer
+ * (SPEC-AY-002, SPEC-AY-003, NFR-AY-006). Reads the two entry files as text and
+ * asserts each imports `accessibility.css` as the 3rd CSS import — positioned
+ * AFTER the tokens + animations imports (the ordering contract).
+ *
+ * TEST-AY-002. RED until T-AY-002 adds the two import lines; GREEN once both land.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+const PLUGIN_MAIN = resolve(__dirname, '../../../src/plugin/main.ts');
+const UI_MAIN = resolve(__dirname, '../../../src/ui/main.ts');
+
+function lineIndexMatching(source: string, re: RegExp): number {
+	const lines = source.split(/\r?\n/);
+	return lines.findIndex((l) => re.test(l));
+}
+
+describe('accessibility.css registration (SPEC-AY-002/003, NFR-AY-006)', () => {
+	it('TEST-AY-002: src/plugin/main.ts imports accessibility.css after tokens + animations', () => {
+		const src = readFileSync(PLUGIN_MAIN, 'utf8');
+		const tokens = lineIndexMatching(src, /import\s+['"]@\/ui\/styles\/tokens\.css['"]/);
+		const animations = lineIndexMatching(src, /import\s+['"]@\/ui\/styles\/animations\.css['"]/);
+		const a11y = lineIndexMatching(src, /import\s+['"]@\/ui\/styles\/accessibility\.css['"]/);
+
+		expect(tokens, 'tokens.css import present').toBeGreaterThanOrEqual(0);
+		expect(animations, 'animations.css import present').toBeGreaterThanOrEqual(0);
+		expect(a11y, 'accessibility.css import present in plugin entry').toBeGreaterThanOrEqual(0);
+		expect(a11y, 'accessibility.css must come after animations.css').toBeGreaterThan(animations);
+		expect(animations, 'animations.css must come after tokens.css').toBeGreaterThan(tokens);
+	});
+
+	it('TEST-AY-002: src/ui/main.ts imports accessibility.css after tokens + animations', () => {
+		const src = readFileSync(UI_MAIN, 'utf8');
+		const tokens = lineIndexMatching(src, /import\s+['"]\.\/styles\/tokens\.css['"]/);
+		const animations = lineIndexMatching(src, /import\s+['"]\.\/styles\/animations\.css['"]/);
+		const a11y = lineIndexMatching(src, /import\s+['"]\.\/styles\/accessibility\.css['"]/);
+
+		expect(tokens, 'tokens.css import present').toBeGreaterThanOrEqual(0);
+		expect(animations, 'animations.css import present').toBeGreaterThanOrEqual(0);
+		expect(a11y, 'accessibility.css import present in standalone entry').toBeGreaterThanOrEqual(0);
+		expect(a11y, 'accessibility.css must come after animations.css').toBeGreaterThan(animations);
+		expect(animations, 'animations.css must come after tokens.css').toBeGreaterThan(tokens);
+	});
+});

--- a/tests/ui/styles/accessibility.test.ts
+++ b/tests/ui/styles/accessibility.test.ts
@@ -138,11 +138,16 @@ describe('src/ui/styles/accessibility.css — RG-4 forced-colors borders (SPEC-A
 	it('TEST-AY-006 (file leg): RG-4 enumerates the background-cue-only controls with a currentColor border', () => {
 		const block = mediaBlock(loadA11y(), 'forced-colors:\\s*active');
 		expect(block, 'expected a `forced-colors: active` @media block').not.toBe('');
-		// Each enumerated control whose normal affordance is a background fill/wash.
+		// Each enumerated control whose normal affordance is a background fill/wash,
+		// keyed to the real swept-component selectors (TEST-AY-006 mount leg):
+		// the toggle switches are role="switch"; the chips are .sp-file-chips__chip
+		// / .sp-image-thumb; state pills carry data-state; tab badges are .sp-tab;
+		// the selected dropdown option is [role="option"][aria-selected="true"].
 		const controls = [
-			'.sp-toggle-switch',
+			'[role="switch"]',
 			'[data-state]',
-			'.sp-chip',
+			'.sp-file-chips__chip',
+			'.sp-image-thumb',
 			'.sp-tab',
 			'[role="option"][aria-selected="true"]',
 		];

--- a/tests/ui/styles/accessibility.test.ts
+++ b/tests/ui/styles/accessibility.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Rule-group presence + CSS-discipline contract for the P12 accessibility layer
+ * (SPEC-AY-001, SPEC-AY-011). Reads `src/ui/styles/accessibility.css` as text
+ * (jsdom does not compute media queries / `:focus-visible`, so behaviour is
+ * verified at the source level — the established `tokens.test.ts` /
+ * `animations.test.ts` pattern, ADR-009).
+ *
+ * Covers:
+ *   - TEST-AY-001  file exists + declares RG-1..RG-6; every selector `.specorator-root`-scoped.
+ *   - TEST-AY-003  RG-1 reduced-motion guard (collapses animation/transition duration).
+ *   - TEST-AY-004  RG-2 sets `animation: none` (not a duration) for spin under reduced-motion.
+ *   - TEST-AY-005  RG-3 forced-colors mapping with `forced-color-adjust` + system colours.
+ *   - TEST-AY-007  (file leg) RG-5 uses `:focus-visible` (no bare-`:focus` ring) + `--sp-focus-ring`.
+ *   - TEST-AY-009  (file leg) RG-6 `.sr-only` clip technique (not `display:none`/`visibility:hidden`).
+ *   - TEST-AY-015  (css leg) no hex / no raw Obsidian var outside `forced-colors`; ASCII-only comments.
+ *
+ * RED until T-AY-002 lands the file; GREEN once it does.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+const A11Y_PATH = resolve(__dirname, '../../../src/ui/styles/accessibility.css');
+
+function loadA11y(): string {
+	return readFileSync(A11Y_PATH, 'utf8');
+}
+
+/** Strip `/* ... *\/` comment blocks so selector / property scans ignore prose. */
+function stripComments(css: string): string {
+	return css.replace(/\/\*[^]*?\*\//g, '');
+}
+
+/** Extract the body of the first `@media (<query>) { ... }` block whose header matches. */
+function mediaBlock(css: string, queryFragment: string): string {
+	const stripped = stripComments(css);
+	const headerRe = new RegExp(`@media[^{]*${queryFragment}[^{]*\\{`, 'i');
+	const m = headerRe.exec(stripped);
+	if (!m) return '';
+	// Walk braces from the header's opening `{` to its matching close.
+	let depth = 0;
+	let start = -1;
+	for (let i = m.index; i < stripped.length; i++) {
+		const ch = stripped[i];
+		if (ch === '{') {
+			if (depth === 0) start = i + 1;
+			depth++;
+		} else if (ch === '}') {
+			depth--;
+			if (depth === 0) return stripped.slice(start, i);
+		}
+	}
+	return '';
+}
+
+describe('src/ui/styles/accessibility.css — rule-group contract (SPEC-AY-001)', () => {
+	it('TEST-AY-001: the file exists', () => {
+		expect(() => loadA11y(), 'expected src/ui/styles/accessibility.css to exist').not.toThrow();
+	});
+
+	it('TEST-AY-001: declares all six rule groups RG-1..RG-6 in order', () => {
+		const css = loadA11y();
+		const groups = ['RG-1', 'RG-2', 'RG-3', 'RG-4', 'RG-5', 'RG-6'];
+		let lastIdx = -1;
+		for (const g of groups) {
+			const idx = css.indexOf(g);
+			expect(idx, `expected rule-group marker ${g} present`).toBeGreaterThanOrEqual(0);
+			expect(idx, `expected ${g} to appear after the previous group (in order)`).toBeGreaterThan(
+				lastIdx,
+			);
+			lastIdx = idx;
+		}
+	});
+
+	it('TEST-AY-001: every selector is `.specorator-root`-scoped (no rule escapes the subtree)', () => {
+		const stripped = stripComments(loadA11y());
+		// Collect the selector text preceding each declaration block `{`, excluding
+		// at-rule headers (`@media`, `@keyframes`, …). Every concrete selector group
+		// must reference `.specorator-root`.
+		const blockRe = /([^{}@]+)\{/g;
+		let m: RegExpExecArray | null;
+		const offenders: string[] = [];
+		while ((m = blockRe.exec(stripped)) !== null) {
+			const sel = m[1].trim();
+			if (sel === '' || sel.startsWith('@')) continue;
+			// The bare `.specorator-root { forced-color-adjust: auto; }` rule in RG-3 is fine.
+			if (!sel.includes('.specorator-root')) offenders.push(sel);
+		}
+		expect(offenders, `unscoped selectors: ${JSON.stringify(offenders)}`).toHaveLength(0);
+	});
+});
+
+describe('src/ui/styles/accessibility.css — RG-1/RG-2 reduced motion (SPEC-AY-001, EC-AY-001/002)', () => {
+	it('TEST-AY-003: RG-1 reduced-motion guard collapses animation + transition duration', () => {
+		const block = mediaBlock(loadA11y(), 'prefers-reduced-motion:\\s*reduce');
+		expect(block, 'expected a `prefers-reduced-motion: reduce` @media block').not.toBe('');
+		expect(block).toMatch(/animation-duration:/);
+		expect(block).toMatch(/transition-duration:/);
+		expect(block, 'RG-1 guard uses !important').toMatch(/!important/);
+	});
+
+	it('TEST-AY-004: RG-2 sets `animation: none` (not a duration) for spin under reduced-motion', () => {
+		const block = mediaBlock(loadA11y(), 'prefers-reduced-motion:\\s*reduce');
+		// The spin halt must use `animation: none` — a near-zero duration alone does
+		// not stop an indeterminate loop (CQ-AUX-14 / EC-AY-001).
+		expect(block).toMatch(/\[data-animation="spin"\]|\.sp-spin/);
+		expect(block, 'RG-2 must set `animation: none` for the spin halt').toMatch(
+			/animation:\s*none\s*!important/,
+		);
+	});
+});
+
+describe('src/ui/styles/accessibility.css — RG-3 forced-colors mapping (SPEC-AY-001, REQ-AY-005)', () => {
+	it('TEST-AY-005: RG-3 forced-colors block present with forced-color-adjust + system colours', () => {
+		const block = mediaBlock(loadA11y(), 'forced-colors:\\s*active');
+		expect(block, 'expected a `forced-colors: active` @media block').not.toBe('');
+		expect(block).toMatch(/forced-color-adjust/);
+		// Maps surface/text/focus/button affordances to CSS system colours.
+		for (const kw of ['CanvasText', 'Canvas', 'Highlight', 'ButtonText', 'ButtonFace']) {
+			expect(block, `expected system colour ${kw} in the forced-colors block`).toMatch(
+				new RegExp(`\\b${kw}\\b`),
+			);
+		}
+	});
+});
+
+describe('src/ui/styles/accessibility.css — RG-5 focus-visible ring (SPEC-AY-001, EC-AY-005/006/014)', () => {
+	it('TEST-AY-007 (file leg): RG-5 uses `:focus-visible` and consumes var(--sp-focus-ring)', () => {
+		const css = loadA11y();
+		expect(css, 'RG-5 must key the ring off :focus-visible').toMatch(/:focus-visible/);
+		expect(css, 'RG-5 must consume the existing --sp-focus-ring token').toMatch(
+			/var\(--sp-focus-ring\)/,
+		);
+	});
+
+	it('TEST-AY-007 (file leg): no bare-`:focus` ring rule (the mouse counter-metric, EC-AY-006)', () => {
+		const stripped = stripComments(loadA11y());
+		// A `:focus` not immediately followed by `-visible` would ring mouse focus.
+		expect(stripped, 'a bare `:focus` ring would show on mouse click').not.toMatch(
+			/:focus(?!-visible)/,
+		);
+	});
+});
+
+describe('src/ui/styles/accessibility.css — RG-6 .sr-only utility (SPEC-AY-001, EC-AY-007)', () => {
+	it('TEST-AY-009 (file leg): `.sr-only` uses the clip technique, never display/visibility hiding', () => {
+		const css = loadA11y();
+		expect(css).toMatch(/\.sr-only/);
+		expect(css, 'expected the clip technique').toMatch(/clip-path:\s*inset\(50%\)|clip:\s*rect/);
+		expect(css).toMatch(/overflow:\s*hidden/);
+		// Must not hide via display/visibility (removes from the accessibility tree).
+		const block = (() => {
+			const stripped = stripComments(css);
+			const m = /\.sr-only[^{]*\{([^}]*)\}/.exec(stripped);
+			return m ? m[1] : '';
+		})();
+		expect(block, `.sr-only body: ${block}`).not.toMatch(/display:\s*none/);
+		expect(block).not.toMatch(/visibility:\s*hidden/);
+	});
+});
+
+describe('src/ui/styles/accessibility.css — CSS discipline (SPEC-AY-011, NFR-AY-002/005)', () => {
+	it('TEST-AY-015 (css leg): no hex literal outside the forced-colors block', () => {
+		const css = loadA11y();
+		const forcedBlock = mediaBlock(css, 'forced-colors:\\s*active');
+		const outside = stripComments(css).replace(forcedBlock, '');
+		expect(outside, 'no hex colour literal permitted outside forced-colors').not.toMatch(
+			/#[0-9a-fA-F]{3,8}\b/,
+		);
+	});
+
+	it('TEST-AY-015 (css leg): no raw Obsidian var outside the forced-colors block (only --sp-* / --interactive-accent via token)', () => {
+		const css = loadA11y();
+		const forcedBlock = mediaBlock(css, 'forced-colors:\\s*active');
+		const outside = stripComments(css).replace(forcedBlock, '');
+		const vars = outside.match(/var\(\s*(--[a-zA-Z0-9-]+)/g) ?? [];
+		const offenders = vars
+			.map((v) => v.replace(/var\(\s*/, ''))
+			.filter((name) => !name.startsWith('--sp-'));
+		expect(offenders, `raw non --sp-* vars outside forced-colors: ${JSON.stringify(offenders)}`).toHaveLength(
+			0,
+		);
+	});
+
+	it('TEST-AY-015 (css leg): comments are ASCII-only (lightningcss-safe, EC-AY-013)', () => {
+		const css = loadA11y();
+		// eslint-disable-next-line no-control-regex
+		const nonAscii = css.match(/[^\x00-\x7F]/g);
+		expect(nonAscii, `non-ASCII bytes found: ${JSON.stringify(nonAscii)}`).toBeNull();
+	});
+});

--- a/tests/ui/styles/accessibility.test.ts
+++ b/tests/ui/styles/accessibility.test.ts
@@ -31,26 +31,32 @@ function stripComments(css: string): string {
 	return css.replace(/\/\*[^]*?\*\//g, '');
 }
 
-/** Extract the body of the first `@media (<query>) { ... }` block whose header matches. */
+/** Concatenate the bodies of every `@media (<query>) { ... }` block whose header matches. */
 function mediaBlock(css: string, queryFragment: string): string {
 	const stripped = stripComments(css);
-	const headerRe = new RegExp(`@media[^{]*${queryFragment}[^{]*\\{`, 'i');
-	const m = headerRe.exec(stripped);
-	if (!m) return '';
-	// Walk braces from the header's opening `{` to its matching close.
-	let depth = 0;
-	let start = -1;
-	for (let i = m.index; i < stripped.length; i++) {
-		const ch = stripped[i];
-		if (ch === '{') {
-			if (depth === 0) start = i + 1;
-			depth++;
-		} else if (ch === '}') {
-			depth--;
-			if (depth === 0) return stripped.slice(start, i);
+	const headerRe = new RegExp(`@media[^{]*${queryFragment}[^{]*\\{`, 'gi');
+	const bodies: string[] = [];
+	let m: RegExpExecArray | null;
+	while ((m = headerRe.exec(stripped)) !== null) {
+		// Walk braces from the header's opening `{` to its matching close.
+		let depth = 0;
+		let start = -1;
+		for (let i = m.index; i < stripped.length; i++) {
+			const ch = stripped[i];
+			if (ch === '{') {
+				if (depth === 0) start = i + 1;
+				depth++;
+			} else if (ch === '}') {
+				depth--;
+				if (depth === 0) {
+					bodies.push(stripped.slice(start, i));
+					headerRe.lastIndex = i + 1;
+					break;
+				}
+			}
 		}
 	}
-	return '';
+	return bodies.join('\n');
 }
 
 describe('src/ui/styles/accessibility.css — rule-group contract (SPEC-AY-001)', () => {
@@ -60,30 +66,34 @@ describe('src/ui/styles/accessibility.css — rule-group contract (SPEC-AY-001)'
 
 	it('TEST-AY-001: declares all six rule groups RG-1..RG-6 in order', () => {
 		const css = loadA11y();
-		const groups = ['RG-1', 'RG-2', 'RG-3', 'RG-4', 'RG-5', 'RG-6'];
+		// Match each rule-group SECTION marker (`RG-N -` at the head of its comment),
+		// not bare `RG-N` prose mentions elsewhere (e.g. the file header naming the set).
 		let lastIdx = -1;
-		for (const g of groups) {
-			const idx = css.indexOf(g);
-			expect(idx, `expected rule-group marker ${g} present`).toBeGreaterThanOrEqual(0);
-			expect(idx, `expected ${g} to appear after the previous group (in order)`).toBeGreaterThan(
-				lastIdx,
-			);
+		for (let n = 1; n <= 6; n++) {
+			const re = new RegExp(`RG-${n}\\s*-`);
+			const idx = css.search(re);
+			expect(idx, `expected rule-group section marker RG-${n} present`).toBeGreaterThanOrEqual(0);
+			expect(
+				idx,
+				`expected RG-${n} section to appear after the previous group (in order)`,
+			).toBeGreaterThan(lastIdx);
 			lastIdx = idx;
 		}
 	});
 
 	it('TEST-AY-001: every selector is `.specorator-root`-scoped (no rule escapes the subtree)', () => {
 		const stripped = stripComments(loadA11y());
-		// Collect the selector text preceding each declaration block `{`, excluding
-		// at-rule headers (`@media`, `@keyframes`, …). Every concrete selector group
-		// must reference `.specorator-root`.
-		const blockRe = /([^{}@]+)\{/g;
-		let m: RegExpExecArray | null;
+		// Collect the selector text preceding each `{`. Tokenise on `{` and `}` so the
+		// segment after an opening brace (declarations) and at-rule headers (`@media`)
+		// are dropped; every concrete style-rule selector must reference
+		// `.specorator-root`.
 		const offenders: string[] = [];
-		while ((m = blockRe.exec(stripped)) !== null) {
-			const sel = m[1].trim();
-			if (sel === '' || sel.startsWith('@')) continue;
-			// The bare `.specorator-root { forced-color-adjust: auto; }` rule in RG-3 is fine.
+		const segments = stripped.split(/[{}]/);
+		for (const raw of segments) {
+			const sel = raw.trim();
+			if (sel === '') continue;
+			if (sel.startsWith('@')) continue; // at-rule header (@media …)
+			if (sel.includes(':')) continue; // a declaration body (prop: value) or empty between braces
 			if (!sel.includes('.specorator-root')) offenders.push(sel);
 		}
 		expect(offenders, `unscoped selectors: ${JSON.stringify(offenders)}`).toHaveLength(0);

--- a/tests/ui/styles/accessibility.test.ts
+++ b/tests/ui/styles/accessibility.test.ts
@@ -134,6 +134,27 @@ describe('src/ui/styles/accessibility.css — RG-3 forced-colors mapping (SPEC-A
 	});
 });
 
+describe('src/ui/styles/accessibility.css — RG-4 forced-colors borders (SPEC-AY-006, EC-AY-003)', () => {
+	it('TEST-AY-006 (file leg): RG-4 enumerates the background-cue-only controls with a currentColor border', () => {
+		const block = mediaBlock(loadA11y(), 'forced-colors:\\s*active');
+		expect(block, 'expected a `forced-colors: active` @media block').not.toBe('');
+		// Each enumerated control whose normal affordance is a background fill/wash.
+		const controls = [
+			'.sp-toggle-switch',
+			'[data-state]',
+			'.sp-chip',
+			'.sp-tab',
+			'[role="option"][aria-selected="true"]',
+		];
+		for (const sel of controls) {
+			expect(block, `expected RG-4 to list ${sel}`).toContain(sel);
+		}
+		expect(block, 'RG-4 gives a visible border under forced-colors').toMatch(
+			/border:\s*1px\s+solid\s+currentColor/,
+		);
+	});
+});
+
 describe('src/ui/styles/accessibility.css — RG-5 focus-visible ring (SPEC-AY-001, EC-AY-005/006/014)', () => {
 	it('TEST-AY-007 (file leg): RG-5 uses `:focus-visible` and consumes var(--sp-focus-ring)', () => {
 		const css = loadA11y();


### PR DESCRIPTION
## P12 — Accessibility (claudian-reboot, the FINAL phase)

The accessibility layer + WCAG 2.2 AA behaviour sweep closing the reboot (charter §3.9/§3.10/§4 P12). Spec: `specs/accessibility/` (PRD-AY-001, DESIGN-AY-001, SPEC-AY-001..011, no new ADR, TASKS-AY-001 = 18 tasks).

### Delivered (T-AY-001..016)
- **`src/ui/styles/accessibility.css`** — the 3rd global CSS layer (registered at both import sites), 6 `.specorator-root`-scoped rule groups: reduced-motion guard (softens/halts the 5 keyframes incl. an explicit `spin` stop), forced-colors system-color mapping + visible borders on background-cue-only controls, `:focus-visible` ring (reuses the existing `--sp-focus-ring`/`--sp-shadow-focus-ring` — no new token), `.sr-only`. lightningcss-safe; meets claudian's focus-ring layer + beats it on the other four.
- **Behaviour sweep** — mostly verify-only (the per-phase a11y was thorough: ChatSurface `aria-live`+`role=status`, TabBar `tablist`+roving tabindex, the 8 modal seams' native focus trap/restore, collapsible `aria-expanded`, icon-only labels) + 2 real fills: `NoticeLiveRegion.vue` (the standalone notice live-region gap, pure Vue on the `sp:notice` channel) + the RG-4 real-selector correction.
- **Fully additive** — the `src/` diff is ONLY `accessibility.css` + the 2 `main.ts` imports + `NoticeLiveRegion.vue`; no swept component template / locale / `manifest.json` changed; P0–P11 surfaces behaviourally + visually unchanged for existing users.

### Gate (local, green)
`vue-tsc` 0 · `eslint` 0 · **vitest 296 files / 2234 passed (0 errors)** · `build` + `build:web` (lightningcss) + `docs:api` clean · `npm audit --audit-level=high` clean.

### Parity self-review (Stage 9)
`review.md` **approve-with-nits** (0 P1/P2). 6 rule groups + both registrations confirmed; additivity proven; WCAG 2.2 AA met at the automatable level; no new port/ADR. Two low doc-sync nits (non-blocking).

### Deferred — the SINGLE FINAL epic gate (human)
**TEST-AY-017 / REQ-AY-017** — the human cross-surface **final parity screenshot sign-off** (all surfaces, light+dark, 320/520/720), into which the accumulated **P5–P11 manual-Obsidian + parity-screenshot legs** converge. Agent presents; never self-claims.

---
**This is the last implementation phase of the claudian-reboot epic (P0–P12).** After merge, the whole rebuilt plugin is on `next`; the `next`→`develop` PR is opened for the human's parity call (not auto-merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)