### PR TITLE
docs: fix README preview image to render on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Plan the work, run it, review what came back, keep the record. All in your vault.
 
-![[Preview.png]]
+![Specorator preview](Preview.png)
 
 You're already using AI for serious work. Drafting emails. Planning trips. Comparing options. Reading the long report you don't want to read yourself. The conversations help, but the moment you close the tab, the work is gone. Tomorrow you start again from scratch.
 


### PR DESCRIPTION
The preview was embedded as an Obsidian wikilink (![[Preview.png]]), which GitHub does not resolve. Use standard Markdown image syntax so it renders on the repo page.


Claude-Session: https://claude.ai/code/session_01WTbzqE2G5Xdbe27wrP78it