### PR TITLE
docs: render preview images on GitHub (README + feature docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Plan the work, run it, review what came back, keep the record. All in your vault.
 
-![[Preview.png]]
+![Specorator preview](Preview.png)
 
 You're already using AI for serious work. Drafting emails. Planning trips. Comparing options. Reading the long report you don't want to read yourself. The conversations help, but the moment you close the tab, the work is gone. Tomorrow you start again from scratch.
 

--- a/docs/product/features/Agent Kanban Board.md
+++ b/docs/product/features/Agent Kanban Board.md
@@ -27,7 +27,7 @@ Use it when you want to hand work **to** the assistant instead of working throug
 
 Every card on the board is a regular note in your vault. You write what you want help with and attach the documents the helper will need. You pick an engine and move the card to ready. One click starts the run, the card slides to running, and the reply streams back into the card as it arrives. When the run finishes, the card moves to review. You read the result before accepting it, asking a follow-up, or sending it on.
 
-![[agent-board-overview.png]]
+![Agent Board overview](../../attachments/agent-board-overview.png)
 <!-- screenshot: board view with columns Inbox, Ready, Running, Review, Done, a running card mid-stream, and the card detail panel open on the right -->
 
 The board and the notes are the same thing seen two ways. You can edit a card from the board, or open it as a regular Markdown file and edit it there. Both update at once. The folder belongs to you, so you can sync it, back it up, or rename it.

--- a/docs/product/features/Co-Worker - Chat.md
+++ b/docs/product/features/Co-Worker - Chat.md
@@ -28,7 +28,7 @@ The sidebar opens on a hotkey. The path of the note you're on goes in automatica
 
 Conversations stick around. Every session saves under `.specorator/sessions/` so you can leave one open for weeks, jump back in tomorrow, or split it into two when one line of thinking deserves its own branch.
 
-![[chat-sidepanel-overview.png]]
+![Chat side panel overview](../../attachments/chat-sidepanel-overview.png)
 <!-- screenshot: chat sidebar open beside a note, with a selection highlighted and quoted in the chat composer -->
 
 When your co-worker rewrites a paragraph or fills in a draft section, you choose how the change lands. Preview, apply, and discard — accept or reject before anything touches the note. Flip on YOLO mode and they write directly while you watch.

--- a/docs/product/features/Multi Provider Support.md
+++ b/docs/product/features/Multi Provider Support.md
@@ -26,7 +26,7 @@ This is not a model picker that swaps engines behind a single chat. Each provide
 
 Point Specorator at the providers you have once, and each gets its own chat tab and its own settings page under **Settings → Specorator**. If you only have one subscription, use that one. If you have several, open them in parallel. The tabs run side by side; your work stays in your vault whichever provider runs it.
 
-![[multi-provider-overview.png]]
+![Multi-provider support overview](../../attachments/multi-provider-overview.png)
 <!-- screenshot: chat tab header showing the provider switcher with the four options, transcripts panel visible -->
 
 Specorator keeps its own record of every conversation under `.specorator/sessions/`. You can leave one open for weeks and pick it back up tomorrow without losing where you were. Sessions stay inside Specorator; the plugin does not read or write to other tools' chat histories on disk.

--- a/docs/product/features/Quick Actions.md
+++ b/docs/product/features/Quick Actions.md
@@ -28,7 +28,7 @@ You keep a folder of quick-action notes. Each one has a name, an optional descri
 
 The actions live in your vault as ordinary files. You can edit them in any text editor, sync them with the rest of your notes, back them up, and share them with someone else. Specorator does not own them.
 
-![[quick-actions-overview.png]]
+![Quick Actions overview](../../attachments/quick-actions-overview.png)
 <!-- screenshot: quick actions picker open in chat toolbar, showing 4-5 action rows with icons -->
 
 ---


### PR DESCRIPTION
## Why

Obsidian wikilink embeds (`[[image.png]]`) only render inside Obsidian — GitHub shows them as literal text. Several preview images were embedded that way, so they didn't appear on the repo page.

## What changed

- **README** — `[[Preview.png]]` → `[Specorator preview](Preview.png)`.
- **Feature docs** (the four linked from the README) — converted each overview screenshot from a wikilink to standard Markdown with a relative path into `docs/attachments/`:
  - `Co-Worker - Chat.md` → `chat-sidepanel-overview.png`
  - `Agent Kanban Board.md` → `agent-board-overview.png`
  - `Quick Actions.md` → `quick-actions-overview.png`
  - `Multi Provider Support.md` → `multi-provider-overview.png`

## Left untouched (intentionally)

- `Agent Roster.md` and `Agent Loops.md` reference `agent-roster-overview.png` / `agent-loops-overview.png`, which **don't exist in the repo**. Converting them would produce broken-image icons, so their embeds are left as-is until the images are added. (Also: neither doc is linked from the README.)
- `docs/superpowers/plans/2026-06-07-co-worker-chat.md` has the same wikilink but it's an internal plan doc, not product-facing — left alone.
- `docs/product/user-manuals/settings.md` mentions `[[image.jpg]]` as literal example text, not an embed.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTbzqE2G5Xdbe27wrP78it)_