### PR TITLE
fix(agents): carry bound roster-agent persona through prepared-turn query path

### DIFF
--- a/src/providers/claude/runtime/claudeQueryTurnHelpers.ts
+++ b/src/providers/claude/runtime/claudeQueryTurnHelpers.ts
@@ -199,20 +199,25 @@ export function buildQueryOptionsFromTurnRequest(
     enabledMcpServers: request.enabledMcpServers ?? legacyQueryOptions?.enabledMcpServers,
     forceColdStart: legacyQueryOptions?.forceColdStart,
     externalContextPaths: request.externalContextPaths ?? legacyQueryOptions?.externalContextPaths,
+    // Bound roster-agent persona/model ride in on the explicit options; without
+    // carrying them through the prepared-turn rebuild the agent's identity never
+    // reaches the runtime and the chat answers with the generic assistant.
+    boundAgentPrompt: legacyQueryOptions?.boundAgentPrompt,
+    boundAgentModel: legacyQueryOptions?.boundAgentModel,
   };
 
-  if (
-    effectiveQueryOptions.allowedTools === undefined &&
-    effectiveQueryOptions.model === undefined &&
-    effectiveQueryOptions.enabledMcpServers === undefined &&
-    effectiveQueryOptions.forceColdStart === undefined &&
-    effectiveQueryOptions.externalContextPaths === undefined &&
-    (effectiveQueryOptions.mcpMentions?.size ?? 0) === 0
-  ) {
-    return undefined;
-  }
+  const hasScalarOption = [
+    effectiveQueryOptions.allowedTools,
+    effectiveQueryOptions.model,
+    effectiveQueryOptions.enabledMcpServers,
+    effectiveQueryOptions.forceColdStart,
+    effectiveQueryOptions.externalContextPaths,
+    effectiveQueryOptions.boundAgentPrompt,
+    effectiveQueryOptions.boundAgentModel,
+  ].some((value) => value !== undefined);
+  const hasMentions = (effectiveQueryOptions.mcpMentions?.size ?? 0) > 0;
 
-  return effectiveQueryOptions;
+  return hasScalarOption || hasMentions ? effectiveQueryOptions : undefined;
 }
 
 export function noteVisibleStreamContent(

--- a/tests/unit/providers/claude/runtime/claudeQueryTurnHelpers.test.ts
+++ b/tests/unit/providers/claude/runtime/claudeQueryTurnHelpers.test.ts
@@ -1,0 +1,52 @@
+import type { ChatRuntimeQueryOptions, ChatTurnRequest, PreparedChatTurn } from '@/core/runtime/types';
+import { buildQueryOptionsFromTurnRequest } from '@/providers/claude/runtime/claudeQueryTurnHelpers';
+
+function makeTurn(overrides?: Partial<ChatTurnRequest>): PreparedChatTurn {
+  const request: ChatTurnRequest = { text: 'hello', ...overrides };
+  return {
+    request,
+    persistedContent: 'hello',
+    prompt: 'hello',
+    isCompact: false,
+    mcpMentions: new Set(),
+  };
+}
+
+describe('buildQueryOptionsFromTurnRequest', () => {
+  it('returns undefined when nothing is set on the turn or the explicit options', () => {
+    const result = buildQueryOptionsFromTurnRequest(makeTurn().request, makeTurn());
+    expect(result).toBeUndefined();
+  });
+
+  // Regression: the bound roster-agent persona/model rode in on the explicit
+  // query options but were dropped when the prepared-turn path rebuilt the
+  // object field-by-field, so agent chats answered with the generic identity.
+  it('preserves boundAgentPrompt and boundAgentModel from the explicit options', () => {
+    const turn = makeTurn();
+    const explicit: ChatRuntimeQueryOptions = {
+      boundAgentPrompt: 'You are Ada, a Rust expert.',
+      boundAgentModel: 'opus',
+    };
+
+    const result = buildQueryOptionsFromTurnRequest(turn.request, turn, explicit);
+
+    expect(result).toBeDefined();
+    expect(result?.boundAgentPrompt).toBe('You are Ada, a Rust expert.');
+    expect(result?.boundAgentModel).toBe('opus');
+  });
+
+  it('keeps bound-agent fields alongside other preserved options', () => {
+    const turn = makeTurn();
+    const explicit: ChatRuntimeQueryOptions = {
+      model: 'opus',
+      boundAgentPrompt: 'You are Ada.',
+      boundAgentModel: 'opus',
+    };
+
+    const result = buildQueryOptionsFromTurnRequest(turn.request, turn, explicit);
+
+    expect(result?.model).toBe('opus');
+    expect(result?.boundAgentPrompt).toBe('You are Ada.');
+    expect(result?.boundAgentModel).toBe('opus');
+  });
+});


### PR DESCRIPTION
## Problem

Starting a new chat with an agent from the agent roster via the **Start Chat** button still answered with the generic Specorator assistant identity instead of the selected agent's persona.

## Root cause

The data flow was correct right up until the runtime hand-off:

1. `AgentRosterView.startChatWithAgent` creates a conversation with `boundAgentId` and opens it. ✅
2. `InputController.resolveTurnQueryOptions` resolves the agent into `boundAgentPrompt` + `boundAgentModel` and puts them on the per-turn `ChatRuntimeQueryOptions`. ✅
3. `InputController` always dispatches the turn with a `PreparedChatTurn` object (not a raw string), so `ClaudeChatRuntime.query` routes through `normalizeTurnInvocation` → **`buildQueryOptionsFromTurnRequest`**.
4. `buildQueryOptionsFromTurnRequest` rebuilt the options object field-by-field and **never copied `boundAgentPrompt` / `boundAgentModel`** — so the agent's identity was silently dropped before it reached the SDK.

The bound *model* often still looked correct because `resolveTurnQueryOptions` also folds the bound model into the plain `model` field (which *was* preserved), but the system-prompt persona had no such fallback and was lost on every turn.

## Fix

- Preserve `boundAgentPrompt` and `boundAgentModel` when `buildQueryOptionsFromTurnRequest` rebuilds the options.
- Include both fields in the all-undefined short-circuit guard so a turn carrying only a bound persona still returns options instead of `undefined`.

## Tests

- New `tests/unit/providers/claude/runtime/claudeQueryTurnHelpers.test.ts` — a focused regression test that fails before the fix and passes after, asserting the bound-agent fields survive the prepared-turn rebuild (alone and alongside other options).
- Full unit suite green (`8838 passed`), `typecheck`, `lint`, and `build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AE5KHrCBzHeqzHp5GVaTBu

---
_Generated by [Claude Code](https://claude.ai/code/session_01AE5KHrCBzHeqzHp5GVaTBu)_