### PR TITLE
docs: update install instructions for official marketplace listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Specorator is available in the official Obsidian community plugin directory:
 2. Search for **Specorator** and click **Install**.
 3. Enable Specorator under **Settings → Community plugins**.
 
-Or open it directly in the directory: [Specorator on obsidian.md/plugins](https://obsidian.md/plugins?id=specorator).
+Or open it directly in the directory: [Specorator on the Obsidian plugin directory](https://community.obsidian.md/plugins/specorator).
 
 Prefer pre-release builds? The [Beta Reviewers Auto-update Tool (BRAT)](https://github.com/TfTHacker/obsidian42-brat) still works: **Add Beta Plugin** → `Luis85/specorator`. If you previously installed via BRAT, switching to the community-plugin install keeps your settings — they live in your vault, not in the plugin folder.
 

--- a/README.md
+++ b/README.md
@@ -53,13 +53,15 @@ Everyday surfaces:
 
 ## Install
 
-Install via the [Beta Reviewers Auto-update Tool (BRAT)](https://github.com/TfTHacker/obsidian42-brat):
+Specorator is available in the official Obsidian community plugin directory:
 
-1. Install BRAT from the Obsidian community-plugin directory.
-2. In BRAT, **Add Beta Plugin** → `Luis85/specorator`.
-3. Enable Specorator in Obsidian → Settings → Community plugins.
+1. In Obsidian, open **Settings → Community plugins → Browse**.
+2. Search for **Specorator** and click **Install**.
+3. Enable Specorator under **Settings → Community plugins**.
 
-Submission to the official Obsidian community-plugin registry is planned once v1.0.x stabilises.
+Or open it directly in the directory: [Specorator on obsidian.md/plugins](https://obsidian.md/plugins?id=specorator).
+
+Prefer pre-release builds? The [Beta Reviewers Auto-update Tool (BRAT)](https://github.com/TfTHacker/obsidian42-brat) still works: **Add Beta Plugin** → `Luis85/specorator`. If you previously installed via BRAT, switching to the community-plugin install keeps your settings — they live in your vault, not in the plugin folder.
 
 Already installed? Open **Settings → Specorator** to point it at the providers you have, then open the chat sidebar from the ribbon or the command palette.
 

--- a/docs/product/Specorator - Product Vision.md
+++ b/docs/product/Specorator - Product Vision.md
@@ -89,7 +89,7 @@ The goal behind all of it: bring the power of frontier AI coding tools to anyone
 
 ## Get Specorator
 
-Install via BRAT or the Obsidian community plugins directory.
+Install from the official Obsidian community plugin directory: in Obsidian, open **Settings → Community plugins → Browse** and search for **Specorator**.
 
 **→ [GitHub — Luis85/specorator](https://github.com/Luis85/specorator)**
 

--- a/docs/product/features/Agent Kanban Board.md
+++ b/docs/product/features/Agent Kanban Board.md
@@ -72,7 +72,7 @@ A card might be "draft a thank-you letter to Aunt Maria", "summarize this twelve
 
 ## Get Specorator
 
-Install via BRAT or the Obsidian community plugins directory.
+Install from the official Obsidian community plugin directory: in Obsidian, open **Settings → Community plugins → Browse** and search for **Specorator**.
 
 **→ [GitHub — Luis85/specorator](https://github.com/Luis85/specorator)**
 

--- a/docs/product/features/Agent Loops.md
+++ b/docs/product/features/Agent Loops.md
@@ -71,7 +71,7 @@ A loop might be "reproduce, then fix, then verify", "characterize with a test, t
 
 ## Get Specorator
 
-Install via BRAT or the Obsidian community plugins directory.
+Install from the official Obsidian community plugin directory: in Obsidian, open **Settings → Community plugins → Browse** and search for **Specorator**.
 
 **→ [GitHub — Luis85/specorator](https://github.com/Luis85/specorator)**
 

--- a/docs/product/features/Agent Roster.md
+++ b/docs/product/features/Agent Roster.md
@@ -77,7 +77,7 @@ Your agents are plain JSON files under `.specorator/agents/`, one per agent. The
 
 ## Get Specorator
 
-Install via BRAT or the Obsidian community plugins directory.
+Install from the official Obsidian community plugin directory: in Obsidian, open **Settings → Community plugins → Browse** and search for **Specorator**.
 
 **→ [GitHub — Luis85/specorator](https://github.com/Luis85/specorator)**
 

--- a/docs/product/features/Co-Worker - Chat.md
+++ b/docs/product/features/Co-Worker - Chat.md
@@ -71,7 +71,7 @@ When your co-worker rewrites a paragraph or fills in a draft section, you choose
 
 ## Get Specorator
 
-Install via BRAT or the Obsidian community plugins directory.
+Install from the official Obsidian community plugin directory: in Obsidian, open **Settings → Community plugins → Browse** and search for **Specorator**.
 
 **→ [GitHub — Luis85/specorator](https://github.com/Luis85/specorator)**
 

--- a/docs/product/features/Multi Provider Support.md
+++ b/docs/product/features/Multi Provider Support.md
@@ -75,7 +75,7 @@ Claude is wired up the most fully today. Codex covers most of the same ground. O
 
 ## Get Specorator
 
-Install via BRAT or the Obsidian community plugins directory.
+Install from the official Obsidian community plugin directory: in Obsidian, open **Settings → Community plugins → Browse** and search for **Specorator**.
 
 **→ [GitHub — Luis85/specorator](https://github.com/Luis85/specorator)**
 

--- a/docs/product/features/Quick Actions.md
+++ b/docs/product/features/Quick Actions.md
@@ -57,7 +57,7 @@ The actions live in your vault as ordinary files. You can edit them in any text 
 
 ## Get Specorator
 
-Install via BRAT or the Obsidian community plugins directory.
+Install from the official Obsidian community plugin directory: in Obsidian, open **Settings → Community plugins → Browse** and search for **Specorator**.
 
 **→ [GitHub — Luis85/specorator](https://github.com/Luis85/specorator)**
 

--- a/docs/product/features/Workspace Isolation.md
+++ b/docs/product/features/Workspace Isolation.md
@@ -59,7 +59,7 @@ The important part is that this is one feature. Copy workspaces and git worktree
 
 ## Get Specorator
 
-Install via BRAT or the Obsidian community plugins directory.
+Install from the official Obsidian community plugin directory: in Obsidian, open **Settings → Community plugins → Browse** and search for **Specorator**.
 
 **→ [GitHub — Luis85/specorator](https://github.com/Luis85/specorator)**
 


### PR DESCRIPTION
Specorator is now published in the official Obsidian community plugin directory, so the user-facing docs no longer describe BRAT as the primary install path.

## Changes

- **README.md** — The Install section now leads with the community plugin directory (Settings → Community plugins → Browse), links the listing at `https://obsidian.md/plugins?id=specorator`, and drops the "submission to the official registry is planned" note. BRAT remains documented as the pre-release channel, with a note that switching install methods keeps vault-stored settings.
- **docs/product/features/*.md** (7 feature docs) and **docs/product/Specorator - Product Vision.md** — The shared "Get Specorator" line now points to the official directory instead of "BRAT or the community plugins directory".

Historical specs, plans, migration runbooks, and release notes that mention the BRAT-first launch are intentionally untouched — they document past decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMmK3hSykq8Cof3KpLD44K

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMmK3hSykq8Cof3KpLD44K)_