### PR TITLE
fix(quick-actions): fold unsent composer draft into chat-header quick action sends

### DIFF
--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -48,6 +48,7 @@ import {
   applyPlanApprovalDecision,
   bakeResponseDurationFooter,
   beginStreamingTurnState,
+  clearConsumedComposerInput,
   completeApprovedNewSessionPlanToolCalls,
   type ComposerSendContext,
   type ComposerTurnOptions,
@@ -268,7 +269,7 @@ export class InputController {
     // Check for built-in commands first (e.g., /clear, /new, /add-dir)
     const builtInCmd = detectBuiltInCommand(send.content);
     if (builtInCmd) {
-      this.clearComposerInputIfUserSend(send);
+      clearConsumedComposerInput(send, () => this.deps.resetInputHeight());
       await this.executeBuiltInCommand(builtInCmd.command, builtInCmd.args);
       return;
     }
@@ -295,13 +296,6 @@ export class InputController {
     return state.isCreatingConversation
       || state.isSwitchingConversation
       || state.isHydrating;
-  }
-
-  private clearComposerInputIfUserSend(send: ComposerSendContext): void {
-    if (send.shouldUseInput || send.consumesComposerDraft) {
-      send.inputEl.value = '';
-      this.deps.resetInputHeight();
-    }
   }
 
   private async persistComposerImages(send: ComposerSendContext): Promise<void> {
@@ -341,7 +335,7 @@ export class InputController {
     // so they don't linger in the composer after the user hits send while streaming.
     send.fileContextManager?.clearAttachedPills();
 
-    this.clearComposerInputIfUserSend(send);
+    clearConsumedComposerInput(send, () => this.deps.resetInputHeight());
     if (send.shouldUseInput || send.consumesComposerDraft) {
       send.imageContextManager?.clearImages();
     }
@@ -356,7 +350,7 @@ export class InputController {
     send: ComposerSendContext,
     options?: ComposerTurnOptions,
   ): Promise<ProgrammaticSendResult | void> {
-    this.clearComposerInputIfUserSend(send);
+    clearConsumedComposerInput(send, () => this.deps.resetInputHeight());
     // Bug — selected work-order model didn't reach the runtime: capture the
     // tab-pinned model BEFORE `ensureServiceInitialized` runs, since the tab
     // lifecycle clears `draftModel` during init. Plumbed into `query()` as

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -244,6 +244,8 @@ export class InputController {
     canvasContextOverride?: CanvasSelectionContext | null;
     content?: string;
     images?: ChatMessage['images'];
+    /** Fold the unsent composer draft into a content-override send and clear the composer. */
+    includeComposerDraft?: boolean;
     turnRequestOverride?: ChatTurnRequest;
   }): Promise<ProgrammaticSendResult | void> {
     const { state } = this.deps;
@@ -296,7 +298,7 @@ export class InputController {
   }
 
   private clearComposerInputIfUserSend(send: ComposerSendContext): void {
-    if (send.shouldUseInput) {
+    if (send.shouldUseInput || send.consumesComposerDraft) {
       send.inputEl.value = '';
       this.deps.resetInputHeight();
     }
@@ -340,7 +342,7 @@ export class InputController {
     send.fileContextManager?.clearAttachedPills();
 
     this.clearComposerInputIfUserSend(send);
-    if (send.shouldUseInput) {
+    if (send.shouldUseInput || send.consumesComposerDraft) {
       send.imageContextManager?.clearImages();
     }
     this.queuedMessages.updateQueueIndicator();
@@ -412,8 +414,9 @@ export class InputController {
     const imagesForMessage = images.length > 0 ? [...images] : undefined;
     const isCompact = /^\/compact(\s|$)/i.test(send.content);
 
-    // Only clear images if we consumed user input (not for programmatic content override)
-    if (send.shouldUseInput) {
+    // Only clear images if we consumed user input — either a plain user send or a
+    // content-override send that folded the composer draft in (quick actions).
+    if (send.shouldUseInput || send.consumesComposerDraft) {
       send.imageContextManager?.clearImages();
     }
 

--- a/src/features/chat/controllers/composerSendPhases.ts
+++ b/src/features/chat/controllers/composerSendPhases.ts
@@ -103,6 +103,20 @@ export function resolveComposerSend(args: {
   };
 }
 
+/**
+ * Clears the composer textarea when this send consumed it: a plain user send,
+ * or a content-override send that folded the draft in (quick actions).
+ */
+export function clearConsumedComposerInput(
+  send: ComposerSendContext,
+  resetInputHeight: () => void,
+): void {
+  if (send.shouldUseInput || send.consumesComposerDraft) {
+    send.inputEl.value = '';
+    resetInputHeight();
+  }
+}
+
 export function resolveComposerSourceImages(
   send: ComposerSendContext,
 ): NonNullable<ChatMessage['images']> {

--- a/src/features/chat/controllers/composerSendPhases.ts
+++ b/src/features/chat/controllers/composerSendPhases.ts
@@ -19,6 +19,12 @@ import type { ImageContextManager } from '../ui/ImageContext';
 export interface ComposerSendContext {
   content: string;
   shouldUseInput: boolean;
+  /**
+   * Content-override send that also consumed the composer (quick actions
+   * launched from the chat header): the unsent draft rode along as context,
+   * so the composer must be cleared like a user send.
+   */
+  consumesComposerDraft: boolean;
   hasImages: boolean;
   imageOverride?: ChatMessage['images'];
   inputEl: HTMLTextAreaElement;
@@ -72,12 +78,15 @@ export function resolveComposerSend(args: {
   inputEl: HTMLTextAreaElement;
   imageContextManager: ImageContextManager | null;
   fileContextManager: FileContextManager | null;
-  overrides?: { content?: string; images?: ChatMessage['images'] };
+  overrides?: { content?: string; images?: ChatMessage['images']; includeComposerDraft?: boolean };
 }): ComposerSendContext {
   const contentOverride = args.overrides?.content;
   const imageOverride = args.overrides?.images;
   const shouldUseInput = contentOverride === undefined;
-  const content = (contentOverride ?? args.inputEl.value).trim();
+  const consumesComposerDraft = !shouldUseInput && (args.overrides?.includeComposerDraft ?? false);
+  const baseContent = (contentOverride ?? args.inputEl.value).trim();
+  const draft = consumesComposerDraft ? args.inputEl.value.trim() : '';
+  const content = draft ? `${baseContent}\n\n${draft}` : baseContent;
   const hasImages = imageOverride !== undefined
     ? imageOverride.length > 0
     : (args.imageContextManager?.hasImages() ?? false);
@@ -85,6 +94,7 @@ export function resolveComposerSend(args: {
   return {
     content,
     shouldUseInput,
+    consumesComposerDraft,
     hasImages,
     imageOverride,
     inputEl: args.inputEl,

--- a/src/features/quickActions/CLAUDE.md
+++ b/src/features/quickActions/CLAUDE.md
@@ -9,7 +9,7 @@ All modal sites go through `openQuickActionsModal(plugin, { onRun, file? })`:
 | Site | File | `onRun` strategy | `file` |
 |------|------|------------------|--------|
 | File/folder context menu | `openContextMenuQuickAction.ts` | `runQuickAction` — resolves a tab and attaches the file as a pill | the right-clicked file |
-| Chat header toolbar | `SpecoratorView.ts` `quickActionsBtn` | Sends prompt into the currently active tab | `null` |
+| Chat header toolbar | `SpecoratorView.ts` `quickActionsBtn` | Sends prompt into the currently active tab; any unsent composer draft is folded in below the prompt as context (`includeComposerDraft` on `sendMessage`) and the composer is cleared | `null` |
 | WO card right-click | `src/features/tasks/ui/workOrderContextMenu.ts` | `runQuickActionForFile` (favorites) / `openContextMenuQuickAction` (picker) | the WO note `TFile` |
 
 `openQuickActionsModal` owns the shared wiring: `QuickActionStorage` (`plugin.storage.getAdapter()`) and the Skills-tab `onRunSkill` callback that routes to `runVaultSkill`. The Skills-tab `aggregator` parameter is read from `plugin.vaultSkillAggregator` (the plugin-lifetime singleton — see [Skills Tab Caching](#skills-tab-caching)); a transient fallback aggregator is built only when the modal is opened before `completeDeferredOnload()` has run. Adding a third modal entry point means calling the helper — never reassembling the wiring inline.

--- a/src/features/quickActions/runQuickActionForFile.ts
+++ b/src/features/quickActions/runQuickActionForFile.ts
@@ -32,7 +32,7 @@ export interface QuickActionRunOverride {
 export interface QuickActionDispatchTarget {
   controllers: {
     inputController?: {
-      sendMessage(options: { content: string }): Promise<unknown>;
+      sendMessage(options: { content: string; includeComposerDraft?: boolean }): Promise<unknown>;
     } | null;
   };
 }
@@ -54,7 +54,11 @@ export async function dispatchQuickActionToTab(
 ): Promise<void> {
   const inputController = tab.controllers.inputController;
   if (!inputController) return;
-  await inputController.sendMessage({ content: action.prompt });
+  // Fold any unsent composer draft into the send: the chat-header entry point
+  // targets the active tab, where the user may have typed context they expect
+  // the action to receive. Context-menu / favorites entry points resolve
+  // draft-free tabs (blankTabHasPendingDraft guard), so this is a no-op there.
+  await inputController.sendMessage({ content: action.prompt, includeComposerDraft: true });
   plugin.events.emit('usage.recorded', {
     kind: 'quickAction',
     name: quickActionStemFromPath(action.filePath),

--- a/tests/integration/features/quickActions/launchFromContextMenu.test.ts
+++ b/tests/integration/features/quickActions/launchFromContextMenu.test.ts
@@ -157,7 +157,7 @@ it('end-to-end: launch modal → confirm Codex → tab created with codex + pinn
   expect(tabManager.switchToTab).toHaveBeenCalledWith('new-tab');
   expect(createdTab.ui.fileContextManager.attachFileAsPill).toHaveBeenCalledWith('note.md');
   expect(createdTab.controllers.inputController.sendMessage)
-    .toHaveBeenCalledWith({ content: 'Summarize this.' });
+    .toHaveBeenCalledWith({ content: 'Summarize this.', includeComposerDraft: true });
   expect(eventsEmit).toHaveBeenCalledWith('usage.recorded', expect.objectContaining({
     kind: 'quickAction',
     name: 'summarize',

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -328,6 +328,27 @@ describe('InputController - Message Queue', () => {
 
       expect(deps.state.queuedMessage).toBeNull();
     });
+
+    it('folds the composer draft into a quick-action send when includeComposerDraft is set', async () => {
+      deps.state.isStreaming = true;
+      inputEl.value = 'my chat context';
+
+      await controller.sendMessage({ content: 'Summarize this.', includeComposerDraft: true });
+
+      expect(deps.state.queuedMessage!.content).toBe('Summarize this.\n\nmy chat context');
+      expect(deps.state.queuedMessage?.turnRequest?.text).toBe('Summarize this.\n\nmy chat context');
+      expect(inputEl.value).toBe('');
+    });
+
+    it('preserves the composer draft on a content-override send without includeComposerDraft', async () => {
+      deps.state.isStreaming = true;
+      inputEl.value = 'my chat context';
+
+      await controller.sendMessage({ content: 'Implement the plan.' });
+
+      expect(deps.state.queuedMessage!.content).toBe('Implement the plan.');
+      expect(inputEl.value).toBe('my chat context');
+    });
   });
 
   describe('Queued message processing', () => {

--- a/tests/unit/features/chat/controllers/composerSendPhases.test.ts
+++ b/tests/unit/features/chat/controllers/composerSendPhases.test.ts
@@ -1,0 +1,70 @@
+import { resolveComposerSend } from '@/features/chat/controllers/composerSendPhases';
+
+function makeInputEl(value: string): HTMLTextAreaElement {
+  return { value } as HTMLTextAreaElement;
+}
+
+describe('resolveComposerSend', () => {
+  it('uses the composer input when no content override is given', () => {
+    const send = resolveComposerSend({
+      inputEl: makeInputEl('  typed draft  '),
+      imageContextManager: null,
+      fileContextManager: null,
+    });
+
+    expect(send.content).toBe('typed draft');
+    expect(send.shouldUseInput).toBe(true);
+    expect(send.consumesComposerDraft).toBe(false);
+  });
+
+  it('ignores the composer draft on a plain content-override send', () => {
+    const send = resolveComposerSend({
+      inputEl: makeInputEl('typed draft'),
+      imageContextManager: null,
+      fileContextManager: null,
+      overrides: { content: 'Implement the plan.' },
+    });
+
+    expect(send.content).toBe('Implement the plan.');
+    expect(send.shouldUseInput).toBe(false);
+    expect(send.consumesComposerDraft).toBe(false);
+  });
+
+  it('folds the composer draft below the override when includeComposerDraft is set', () => {
+    const send = resolveComposerSend({
+      inputEl: makeInputEl('  my chat context  '),
+      imageContextManager: null,
+      fileContextManager: null,
+      overrides: { content: 'Summarize this.', includeComposerDraft: true },
+    });
+
+    expect(send.content).toBe('Summarize this.\n\nmy chat context');
+    expect(send.shouldUseInput).toBe(false);
+    expect(send.consumesComposerDraft).toBe(true);
+  });
+
+  it('sends the override alone when includeComposerDraft is set but the draft is blank', () => {
+    const send = resolveComposerSend({
+      inputEl: makeInputEl('   '),
+      imageContextManager: null,
+      fileContextManager: null,
+      overrides: { content: 'Summarize this.', includeComposerDraft: true },
+    });
+
+    expect(send.content).toBe('Summarize this.');
+    expect(send.consumesComposerDraft).toBe(true);
+  });
+
+  it('ignores includeComposerDraft when there is no content override', () => {
+    const send = resolveComposerSend({
+      inputEl: makeInputEl('typed draft'),
+      imageContextManager: null,
+      fileContextManager: null,
+      overrides: { includeComposerDraft: true },
+    });
+
+    expect(send.content).toBe('typed draft');
+    expect(send.shouldUseInput).toBe(true);
+    expect(send.consumesComposerDraft).toBe(false);
+  });
+});

--- a/tests/unit/features/quickActions/runQuickActionForFile.test.ts
+++ b/tests/unit/features/quickActions/runQuickActionForFile.test.ts
@@ -84,7 +84,10 @@ describe('runQuickActionForFile', () => {
 
     expect(tm.switchToTab).toHaveBeenCalledWith('tab-1');
     expect(tab.ui.fileContextManager.attachFileAsPill).toHaveBeenCalledWith('note.md');
-    expect(tab.controllers.inputController.sendMessage).toHaveBeenCalledWith({ content: 'Summarize this.' });
+    expect(tab.controllers.inputController.sendMessage).toHaveBeenCalledWith({
+      content: 'Summarize this.',
+      includeComposerDraft: true,
+    });
 
     const switchOrder = (tm.switchToTab as jest.Mock).mock.invocationCallOrder[0];
     const attachOrder = (tab.ui.fileContextManager.attachFileAsPill as jest.Mock).mock.invocationCallOrder[0];
@@ -210,7 +213,7 @@ describe('dispatchQuickActionToTab (shared seam)', () => {
       filePath: 'Quick Actions/idea-to-design.md',
     });
 
-    expect(sendMessage).toHaveBeenCalledWith({ content: 'p' });
+    expect(sendMessage).toHaveBeenCalledWith({ content: 'p', includeComposerDraft: true });
     expect(recorded).toEqual([{ kind: 'quickAction', name: 'idea-to-design' }]);
   });
 


### PR DESCRIPTION
## Bug

Launching a quick action from the chat-header toolbar (zap button) sent only the action prompt. Any text the user had already typed into the composer was silently ignored — it stayed in the input box and never reached the prompt. Attached file/folder pills were already folded in via the mention suffix, and composer images were sent, but the written draft was dropped.

Expected: when a quick action is launched from the chat panel, everything the user staged in the composer rides along as context. (The right-click file/folder entry point is unaffected by design — it always resolves a draft-free tab.)

## Root cause

`dispatchQuickActionToTab` calls `sendMessage({ content: action.prompt })`, and `resolveComposerSend` treats any content override as fully programmatic: `shouldUseInput = false`, composer text ignored and left in place.

## Fix

- `resolveComposerSend` accepts a new `includeComposerDraft` override. On a content-override send it appends the trimmed composer draft below the prompt (`prompt\n\ndraft`) and marks the send context `consumesComposerDraft`.
- When the composer is consumed this way, `InputController` clears the input and attached images exactly like a user send (covers both the immediate-dispatch and queued-while-streaming paths).
- `dispatchQuickActionToTab` — the shared seam all quick-action entry points funnel through — opts in. Context-menu / favorites / WO-card paths resolve draft-free tabs via the `blankTabHasPendingDraft` guard, so this is a no-op there; only the header path changes behavior.
- Other programmatic senders (Agent Board follow-ups, plan approval "Implement the plan.", retry, feedback prompts) don't pass the flag and keep their draft-preserving semantics.

## Tests

- New `tests/unit/features/chat/controllers/composerSendPhases.test.ts` covering `resolveComposerSend` draft-folding semantics (with/without flag, blank draft, no override).
- New `InputController` tests: draft folded + composer cleared with the flag; draft preserved without it.
- Updated `runQuickActionForFile` unit + `launchFromContextMenu` integration expectations for the new send option.

`npm run typecheck && npm run lint && npm run test && npm run build` all pass (9283 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015C6DDEHkz4X8iMDcxP4Sn3

---
_Generated by [Claude Code](https://claude.ai/code/session_015C6DDEHkz4X8iMDcxP4Sn3)_