### PR TITLE
Library follow-ups (IconButton atom, live-refresh) + Agent Board Vue migration design

### DIFF
--- a/docs/superpowers/plans/2026-07-05-agent-board-vue-migration.md
+++ b/docs/superpowers/plans/2026-07-05-agent-board-vue-migration.md
@@ -1,0 +1,568 @@
+# Agent Board Vue 3 + Pinia Migration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the imperative Agent Board view (`AgentBoardRenderer` + `agentBoardCardActions` + `patchCard`/`patchLiveStrip`) with a reactive Vue 3 + Pinia surface over the untouched run engine, then migrate the detail/lane/template editors to Vue islands, deleting the hand-rolled DOM-patch machinery.
+
+**Architecture:** The board *view* becomes Vue; the run *engine* (`TaskRunCoordinator`, `RunSession`, `RunSidecarStore`, `sharedRunRegistry`, orphan recovery) is untouched and keeps emitting the same `task:*` EventBus events. A Pinia store (`useAgentBoardStore`) projects the resolved board layout (`TaskIndexer.indexVaultFolder` + `loadBoardConfig` + `resolveBoardLayout`) plus live overlays (heartbeats map, per-card ledger message, pause state) driven by those events. The board root owns the EventBus subscription lifecycle and routes each event to a store setter — full-refresh events → guarded `load()`, granular events → targeted refs (the O(1) live path that replaces `patchLiveStrip`). Accrete-then-swap: new Vue code lands unwired behind characterization tests; a single cutover task swaps `AgentBoardView` to the Vue root and deletes the imperative renderer. The three editors keep their existing entry points (Modal shell / settings render-function signature) unchanged and swap only their internals to a mounted Vue app, so every call site — including the out-of-scope `WorkOrderActivityProvider` and the two settings call sites — keeps working.
+
+**Tech Stack:** Vue 3 (SFC, `<script setup>`), Pinia (setup stores), Vitest + @testing-library/vue (the `tests/vue/` lane), esbuild + unplugin-vue (already wired), the shipped `--sp-*` style baseline + atoms (`IconButton`, `useRowActionPending`, `mergeById`, `useGuardedLoad`, `useFolderVaultRefresh`).
+
+---
+
+## Ground truth (from the imperative surface — do not re-derive)
+
+**Board view:** `AgentBoardView extends ItemView` (`src/features/tasks/ui/AgentBoardView.ts:53`). `getViewType()` → `VIEW_TYPE_SPECORATOR_AGENT_BOARD` (`:156`), `getIcon()` → `'kanban-square'`. Renderer is a field `private readonly renderer = new AgentBoardRenderer()` (`:56`), heartbeat tracker `new AgentBoardLiveHeartbeatTracker()` (`:98`). `render()` (`:322`) empties `contentEl`, creates `.specorator-agent-board-host` (`:331`), calls `renderer.render(host, state, callbacks)`.
+
+**Board load composition** (`AgentBoardView.refresh()`, `:257`): `TaskIndexer.indexVaultFolder(vault, folder)` → `TaskBoardModel` → `loadBoardConfig(plugin.settings)` → `resolveBoardLayout(config, model)` → `ResolvedBoardLayout`. Folder setting: `plugin.settings.agentBoardFolder` (confirm the exact key when implementing Task 1 by reading `AgentBoardView.refresh`).
+
+**Layout types** (`src/features/tasks/config/boardConfigTypes.ts`): `ResolvedBoardLayout = { lanes: ResolvedLane[]; errors: string[] }` (`:41`). `ResolvedLane = { id; title; tasks: TaskSpec[]; hostsNewWorkOrders; definitionOfReady: string[]; definitionOfDone: string[]; isCatchAll; collapsible; collapsed }` (`:25`). `resolveBoardLayout(config, model)` at `src/features/tasks/config/resolveBoardLayout.ts:10`. `loadBoardConfig(settings)` at `src/features/tasks/config/BoardConfigStore.ts:10`.
+
+**Task item** = `TaskSpec` (`src/features/tasks/model/taskTypes.ts:57`) = `{ path; frontmatter: TaskFrontmatter; sections: TaskSections; body; raw }`. `TaskFrontmatter` (`:18`) has `id`, `title`, `status: TaskStatus`, `priority: TaskPriority`, `agent?`, `provider?`, `model?`, `loop?`, `run_id?`, `conversation_id?`, `started?`, `heartbeat?`, `attempts`. **No `tags`.** `TaskStatus` (`:3`): `'inbox' | 'ready' | 'running' | 'needs_input' | 'needs_approval' | 'review' | 'needs_fix' | 'needs_handoff' | 'done' | 'failed' | 'canceled'`. `LIVE_STATUSES = new Set(['running','needs_input','needs_approval'])`.
+
+**EventBus** (`src/core/events/EventBus.ts`): `plugin.events.on(event, handler)` returns a disposer. `TaskEventMap` (`src/features/tasks/events.ts:11`) payloads (exact): `task:heartbeat {taskId,path,at}`, `task:ledger-appended {taskId,path,entry:{timestamp,status,message}}`, `task:attempt-started {taskId,path,attemptNumber}`, `task:status-changed {taskId,path,status}`, `task:resumed {taskId,path}`, `task:needs-input {taskId,path,question,why?,default?,runId}`, `task:needs-approval {taskId,path,action,risk?,reversible?,runId}`, `task:run-finished {taskId,path,status}`, `task:board-config-changed void`, `task:queue-* (various/void)`. `roster:changed void`. `chat:tabs-changed {openCount,chatCount,workOrderCount}`.
+
+**Full board subscription table** (`AgentBoardView.onOpen`, `:182-222`) — 18 EventBus subs + 4 vault subs. Full-refresh drivers: `chat:tabs-changed`(`:182`, refreshSlots→render), `task:board-config-changed`(`:186`), `roster:changed`(`:187`), `task:queue-cap-changed`(`:214`), `task:queue-paused`/`-resumed`/`-halted`/`-tick`/`-skipped`/`-state-changed`(`:217-222`, all `render()`). Granular drivers: `task:attempt-started`→patchCard, `task:ledger-appended`→patchLiveStrip(msg), `task:heartbeat`→tracker.record + patchLiveStrip, `task:needs-input`/`-approval`→onPauseRequested(patchCard), `task:resumed`→pauseState.delete + patchCard, `task:status-changed`→patchCard. `task:run-finished`→`runner?.tick()` only. The 4 vault subs (`create/modify/delete/rename`, `:170`) debounce 100ms → `refresh()`; `delete` also `evictInMemoryStateForPath`.
+
+**Renderer DOM** (`AgentBoardRenderer.ts`, exact class names — the parity target): root `.specorator-agent-board` (`:116`) → `.specorator-agent-board-toolbar` + `.specorator-agent-board-lanes` (`:130`) + optional `.specorator-agent-board-errors`. Lane `.specorator-agent-board-lane` (`:331`) → `-lane-header` (`-lane-title` + `-lane-header-meta` [`-lane-count`, `-lane-collapse-toggle`]) → cards → `.specorator-agent-board-lane-add` (only if `lane.hostsNewWorkOrders`). Collapsed lane `.specorator-agent-board-lane--collapsed` (`:387`, role=button, tabindex=0, aria-expanded=false). Card `.specorator-agent-board-card.specorator-agent-board-card--<status>[.--live-actions]` (`:438`) → `-card-title-row` (`-card-status-dot--<status>[--live]` + `-card-title`) + `-card-actions[--persistent]` + `-card-meta` (`-card-meta-engine` + `-card-priority--<mod>` with 3 `-card-priority-bar[.is-filled]`) + `-card-footer[.is-hidden]` (progress + `-card-assignee` 20px avatar) + `-card-live-strip` (only LIVE: `-live-strip--meta` [`-live-strip--dot .specorator-stale-<tier>` + `-live-strip--caption`] + `-live-strip--ledger`) + `-card-reply` (needs_input/needs_approval) + `-card-skip-host`. `applyStatusDot` (`:504`) sets `aria-label`/`title` to `DEFAULT_LANE_TITLES[status]`. Stale tiers `staleTier(ageMs)` (`:733`): green(<60s)/amber(<300s)/red.
+
+**Card action cluster** (`agentBoardCardActions.ts`): `CARD_ACTIONS: Partial<Record<TaskStatus, CardActionModel>>` (`:129`), `CardActionModel = { primary: CardAction|null; secondary?: CardAction; menu: CardAction[] }` (`:62`), `CardAction = { labelKey; icon; variant?:'cta'|'danger'|'ghost'; danger?; run(cb,task); available?(cb,task) }` (`:52`). **There is no busy/disabled state in this layer** — actions gate only via `available` predicate (menu items filtered at open time; secondary at render time) and `primary:null`. Cluster `.specorator-agent-board-card-actions[--persistent]`; primary `.specorator-agent-board-card-action-primary--<variant>`; secondary `.specorator-agent-board-card-action-secondary`; overflow `.specorator-agent-board-card-action-more`; menu classes `specorator-agent-board-card-menu[/-item/-item-icon/-item--danger/--up]`; open card gets `is-menu-open`. `CardAction.run` late-binds via `deps.getCallbacks()` — never captured at render. Per-status table verbatim: inbox→primary onMarkReady(cta)/menu OpenNote,Archive; ready & needs_fix→onRun(cta)/OpenNote,BackToInbox; running→onStop(danger) + secondary GoToConversation(ghost)/OpenNote; needs_input & needs_approval→primary null/OpenNote,OpenConversation,Stop; review→onAccept(cta)/Rework,OpenNote,OpenConversation,BackToInbox; needs_handoff→onSendToReview(cta)/MarkFailed,OpenNote; done→onReopen(ghost)/OpenNote,Archive; failed & canceled→onMarkReady(cta,"Retry")/OpenNote,Archive.
+
+**portalPopover** (`portalPopover.ts`): `class PortalPopover` with `open()`/`close()`/`isOpen()`. `close()` (`:147`) drains `this.cleanups` (removes doc `mousedown`-capture, window `scroll`-capture, window `resize`, popover `keydown`), nulls `this.popover` before `pop.remove()`, fires `onClose`, refocuses trigger. Portals to `trigger.ownerDocument.body` (popout-safe). Position constants `ITEM_HEIGHT=34, MENU_PADDING=8, MENU_MIN_WIDTH=180, OFFSET=4, VIEWPORT_MARGIN=8` (`:42`). One-popover invariant enforced by `AgentBoardCardActions.openPopover` + `closePopover()`.
+
+**Callback contract** `AgentBoardRenderCallbacks` (`agentBoardCardActions.ts:9`, re-exported from `AgentBoardRenderer.ts:12`) — 25 members: required `onOpenDetail, onRun, onStop, onAccept, onRework, onMarkReady, onReopen, onMoveToInbox, onAddWorkOrder, onRunNextReady, onContextMenu, onToggleLaneCollapse, onArchive, onOpenNote, onOpenConversation`; optional `getSkipReason?, onAckSkip?, onReply?, onApprove?, onReject?, onCancelPaused?, onSendToReview?, onMarkFailed?, canOpenConversation?, resolvePersona?`. View bindings at `AgentBoardView.render()` `:334-381`.
+
+**No drag-and-drop exists.** Lane movement is via status-transition callbacks (`onMoveToInbox`, `onMarkReady`, `onAccept`) gated by `canTransitionTaskStatus`. Keyboard: collapsed-lane strip Enter/Space (`AgentBoardRenderer.ts:413`), reply-input Enter-submits (`:636`); everything else is native `<button>`.
+
+**Modals:**
+- `WorkOrderDetailModal extends Modal` (`WorkOrderDetailModal.ts:102`), ctor `(app, task: TaskSpec, callbacks: WorkOrderDetailModalCallbacks)` (`:117`). Opened from `AgentBoardView.openDetail` (`:414`) **and** `WorkOrderActivityProvider.ts:211` (out of scope — keep ctor identical). Sub-panels: `renderWorkOrderProperties(sidebar, task, callbacks)` (`workOrderPropertiesPanel.ts:65`), `renderWorkOrderActivity(main, {task,app,markdownComponent})` (`workOrderActivitySection.ts:46`, read-only), `renderWorkOrderFooter(footerEl, ctx)` (`workOrderFooterActions.ts:282`), `renderWorkOrderEditForm(main, task): WorkOrderEditFormHandle` (`workOrderEditForm.ts:75`, `collect(): WorkOrderSectionUpdate`). Save routes `onSaveSections` → `TaskNoteStore.writeSections`; `onSaveFields` → `writeFields`.
+- `WorkOrderTemplateEditorModal extends Modal` (`WorkOrderTemplateEditorModal.ts:42`), ctor `(app, plugin, existing: WorkOrderTemplate|null, onSave)` (`:46`). Opened from `WorkOrderTemplatePickerModal.ts:148` (not the board directly). Persists via `TemplateNoteStore.save`.
+- `AgentBoardLaneEditor` is **not a Modal** — `renderAgentBoardLaneEditor(container, plugin)` (`AgentBoardLaneEditor.ts:53`). Two call sites, both Settings: `settings/registry/fields/agentBoard.ts:191`, `settings/ui/AgentBoardSettingsSection.ts:197`. Persists `plugin.settings.agentBoardConfig` + `plugin.saveSettings()` + emits `task:board-config-changed`.
+
+**Shared helpers to reuse or port:** `renderEditableValueChip` (`editableValueChip.ts:44`), `renderSectionHeader` (`sectionHeader.ts:32`), `renderAgentAvatar` (used at size 18/20 — find its module), `AgentBoardLiveHeartbeatTracker.computePatch` (`agentBoardLiveHeartbeat.ts`), `buildWorkOrderConversationBindings` (`workOrderConversationBindings.ts`), `buildWorkOrderFieldOptions` (`workOrderFieldOptions.ts`), `showWorkOrderContextMenu` (`WorkOrderContextMenu.ts:63`).
+
+**Island mount pattern** (copy from `src/features/library/LibraryView.ts`): `onOpen` → `vueApp?.unmount()`, `contentEl.empty()`, `addClass('specorator-vue')` + a root class, `createApp(Root)`, `app.use(pinia)`, `app.provide(KEY, markRaw(this.plugin))`, `app.mount(contentEl)`. `onClose` → `unmount()` + `empty()` + `removeClass`. Pinia singleton: mirror `globalPinia.ts` with a board-scoped `getAgentBoardPinia()`/`resetAgentBoardPinia()`.
+
+---
+
+## File Structure
+
+New Vue surface under `src/features/tasks/ui/vue/`:
+
+| File | Responsibility |
+|------|----------------|
+| `vue/globalPinia.ts` | Board Pinia singleton (`getAgentBoardPinia`/`resetAgentBoardPinia`), mirrors library `globalPinia.ts`. |
+| `vue/boardKeys.ts` | Vue `InjectionKey`s: `PLUGIN_KEY`, `CALLBACKS_KEY` (the `AgentBoardRenderCallbacks` provided by the view). |
+| `vue/stores/agentBoardStore.ts` | `useAgentBoardStore` — layout projection + live overlays + event setters. |
+| `vue/AgentBoardRoot.vue` | Toolbar + lanes container + errors; owns the EventBus subscription lifecycle → store setters. |
+| `vue/components/BoardToolbar.vue` | Add-work-order / Run-next-ready / auto-run switch / slot + queue info. |
+| `vue/components/BoardLane.vue` | One lane column (header, collapse, criteria, cards, Inbox add-row). |
+| `vue/components/WorkOrderCard.vue` | Card title row + status dot + meta + footer + reply surface + action cluster mount. |
+| `vue/components/LiveStrip.vue` | Live heartbeat/ledger strip — the perf-critical isolated reactive boundary. |
+| `vue/components/CardActionCluster.vue` | Per-status primary/secondary + ⋯ overflow, driven by `CARD_ACTIONS`. |
+| `vue/components/OverflowMenu.vue` | Body-teleported popover (Vue reimpl of `portalPopover`) with leak-safe teardown. |
+| `vue/useBoardEventRouting.ts` | Composable: subscribe the 18 EventBus + 4 vault events on mount, route to store setters, dispose on unmount. |
+| `vue/statusDot.ts` (or inline) | `statusDotClass(status)` + `staleTier(ageMs)` pure helpers (ported from renderer). |
+
+Modal islands (keep the existing entry files; add Vue roots):
+
+| File | Responsibility |
+|------|----------------|
+| `vue/WorkOrderDetailRoot.vue` + sub-panels (`WorkOrderProperties.vue`, `WorkOrderActivity.vue`, `WorkOrderFooter.vue`, `WorkOrderEditForm.vue`) | Detail modal internals as Vue; `WorkOrderDetailModal.ts` keeps its ctor and mounts this root. |
+| `vue/WorkOrderTemplateEditorRoot.vue` | Template editor internals; `WorkOrderTemplateEditorModal.ts` keeps its ctor and mounts this root. |
+| `vue/LaneEditorRoot.vue` | Lane editor internals; `renderAgentBoardLaneEditor(container, plugin)` keeps its signature and mounts this root. |
+
+Tests mirror under `tests/vue/tasks/` (Vitest lane) and `tests/perf/agentBoard.perf.test.ts` (rewritten). Delete on cutover: `AgentBoardRenderer.ts`, `agentBoardCardActions.ts`, `portalPopover.ts`, `agentBoardLiveHeartbeat.ts` (fold into store), and the `patch*` methods in `AgentBoardView.ts`.
+
+---
+
+## Correction to the approved spec (fold in, do not re-litigate)
+
+The spec listed drag parity as Risk #4 — **there is no drag-and-drop on the board**, so it is dropped. The spec framed the lane editor as a board "modal" — it is a settings-embedded `render*(container, plugin)` function; its migration keeps that signature and mounts a Vue island, touching neither the settings registry nor the board. The spec's Task 3 mentioned a "busy-gate" for card actions — **no busy/disabled state exists in the current action layer**; strict parity means the Vue cluster gates only via `available` + `primary:null`. Do not add busy-gating (it would be new behavior).
+
+---
+
+## Task 1: Board Pinia store — `useAgentBoardStore` (unwired)
+
+**Files:**
+- Create: `src/features/tasks/ui/vue/globalPinia.ts`
+- Create: `src/features/tasks/ui/vue/boardKeys.ts`
+- Create: `src/features/tasks/ui/vue/statusDot.ts`
+- Create: `src/features/tasks/ui/vue/stores/agentBoardStore.ts`
+- Test: `tests/vue/tasks/agentBoardStore.test.ts`
+
+- [ ] **Step 1: Read the two anchors so the projection matches reality.** Read `src/features/tasks/ui/AgentBoardView.ts:257-320` (`refresh()` + `render()` state shape — confirm the exact folder setting key and the `state` object the renderer consumes) and `src/features/library/vue/stores/quickActionStore.ts` (the projection template — init-guard, `useGuardedLoad`, `mergeById`). Note the live overlay the view keeps: `liveHeartbeats: Map<taskId,isoString>` (`AgentBoardView.ts:601`) and `pauseState: Map<taskId, AgentBoardPauseState>`.
+
+- [ ] **Step 2: Write the pure helpers.** `src/features/tasks/ui/vue/statusDot.ts`:
+
+```ts
+import type { TaskStatus } from '../../model/taskTypes';
+
+export const LIVE_STATUSES: ReadonlySet<TaskStatus> = new Set(['running', 'needs_input', 'needs_approval']);
+
+/** Parity with AgentBoardRenderer.applyStatusDot (:504). */
+export function statusDotClass(status: TaskStatus): string {
+  const live = LIVE_STATUSES.has(status) ? ' specorator-agent-board-card-status-dot--live' : '';
+  return `specorator-agent-board-card-status-dot specorator-agent-board-card-status-dot--${status}${live}`;
+}
+
+export type StaleTier = 'green' | 'amber' | 'red';
+
+/** Parity with AgentBoardRenderer.staleTier (:733). */
+export function staleTier(ageMs: number): StaleTier {
+  if (ageMs < 60_000) return 'green';
+  if (ageMs < 300_000) return 'amber';
+  return 'red';
+}
+```
+
+- [ ] **Step 3: Write the injection keys.** `src/features/tasks/ui/vue/boardKeys.ts`:
+
+```ts
+import type { InjectionKey } from 'vue';
+
+import type SpecoratorPlugin from '../../../../main';
+import type { AgentBoardRenderCallbacks } from '../AgentBoardRenderer';
+
+export const PLUGIN_KEY: InjectionKey<SpecoratorPlugin> = Symbol('agent-board-plugin');
+export const CALLBACKS_KEY: InjectionKey<AgentBoardRenderCallbacks> = Symbol('agent-board-callbacks');
+```
+
+- [ ] **Step 4: Write the Pinia singleton.** `src/features/tasks/ui/vue/globalPinia.ts` — copy `src/features/library/vue/globalPinia.ts` verbatim, renaming exports to `getAgentBoardPinia` / `resetAgentBoardPinia` and the comment to "One Pinia for every Agent Board leaf".
+
+- [ ] **Step 5: Write the failing store test.** `tests/vue/tasks/agentBoardStore.test.ts` — first test: `load()` projects the resolved layout.
+
+```ts
+import { setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getAgentBoardPinia, resetAgentBoardPinia } from '@/features/tasks/ui/vue/globalPinia';
+import { useAgentBoardStore } from '@/features/tasks/ui/vue/stores/agentBoardStore';
+import type { TaskSpec } from '@/features/tasks/model/taskTypes';
+
+function makeTask(id: string, status = 'ready'): TaskSpec {
+  return {
+    path: `Agent Board/${id}.md`,
+    frontmatter: { type: 'specorator-work-order', schema_version: 1, id, title: id, status, priority: '2 - normal', created: '', updated: '', attempts: 0 },
+    sections: { objective: '', acceptanceCriteria: '', context: '', constraints: '', ledger: '', handoff: '' },
+    body: '', raw: '',
+  } as TaskSpec;
+}
+
+function makePlugin(tasks: TaskSpec[]) {
+  return {
+    app: { vault: {} },
+    settings: {},
+    events: { on: vi.fn(() => vi.fn()) },
+    logger: { scope: () => ({ error: vi.fn(), warn: vi.fn() }) },
+  } as never;
+}
+
+describe('useAgentBoardStore', () => {
+  beforeEach(() => { resetAgentBoardPinia(); setActivePinia(getAgentBoardPinia()); vi.clearAllMocks(); });
+
+  it('load() projects lanes with their tasks from the resolved layout', async () => {
+    const tasks = [makeTask('a', 'ready'), makeTask('b', 'inbox')];
+    const store = useAgentBoardStore();
+    // Inject a fake loader so the store stays a pure projection in the test.
+    store.init(makePlugin(tasks), {
+      indexVaultFolder: vi.fn().mockResolvedValue({ tasks, invalidNotes: [] }),
+      loadBoardConfig: vi.fn().mockReturnValue({ config: { schemaVersion: 1, lanes: [] }, errors: [] }),
+      resolveBoardLayout: vi.fn().mockReturnValue({
+        lanes: [
+          { id: 'ready', title: 'Ready', tasks: [tasks[0]], hostsNewWorkOrders: false, definitionOfReady: [], definitionOfDone: [], isCatchAll: false, collapsible: false, collapsed: false },
+          { id: 'inbox', title: 'Inbox', tasks: [tasks[1]], hostsNewWorkOrders: true, definitionOfReady: [], definitionOfDone: [], isCatchAll: false, collapsible: false, collapsed: false },
+        ],
+        errors: [],
+      }),
+    });
+    await store.load();
+    expect(store.layout.lanes.map((l) => l.id)).toEqual(['ready', 'inbox']);
+    expect(store.layout.lanes[0].tasks[0].frontmatter.id).toBe('a');
+  });
+});
+```
+
+- [ ] **Step 6: Run it, confirm it fails** (store module missing). Run: `npx vitest run tests/vue/tasks/agentBoardStore.test.ts`. Expected: FAIL (cannot resolve `agentBoardStore`).
+
+- [ ] **Step 7: Implement the store.** `src/features/tasks/ui/vue/stores/agentBoardStore.ts`:
+
+```ts
+import { defineStore } from 'pinia';
+import { ref, shallowRef } from 'vue';
+
+import type SpecoratorPlugin from '../../../../main';
+import { loadBoardConfig } from '../../../config/BoardConfigStore';
+import type { ResolvedBoardLayout } from '../../../config/boardConfigTypes';
+import { resolveBoardLayout } from '../../../config/resolveBoardLayout';
+import { TaskIndexer } from '../../../indexing/TaskIndexer';
+import { TaskNoteStore } from '../../../storage/TaskNoteStore';
+import type { TaskSpec } from '../../../model/taskTypes';
+import { mergeById } from '../../../../library/vue/mergeById';
+import { useGuardedLoad } from '../../../../library/vue/useGuardedLoad';
+
+/** Loader seam so tests inject fakes; production wires the real modules. */
+export interface BoardLoaderDeps {
+  indexVaultFolder(vault: unknown, folder: string): Promise<{ tasks: TaskSpec[]; invalidNotes: unknown[] }>;
+  loadBoardConfig: typeof loadBoardConfig;
+  resolveBoardLayout: typeof resolveBoardLayout;
+}
+
+const EMPTY_LAYOUT: ResolvedBoardLayout = { lanes: [], errors: [] };
+
+export const useAgentBoardStore = defineStore('agent-board', () => {
+  const layout = shallowRef<ResolvedBoardLayout>(EMPTY_LAYOUT);
+  const liveHeartbeats = ref<Map<string, string>>(new Map());
+  const liveLedger = ref<Map<string, string>>(new Map());
+  const { loading, run } = useGuardedLoad();
+
+  let plugin: SpecoratorPlugin | null = null;
+  let deps: BoardLoaderDeps | null = null;
+
+  function init(p: SpecoratorPlugin, override?: BoardLoaderDeps): void {
+    if (plugin) return;
+    plugin = p;
+    const indexer = new TaskIndexer(new TaskNoteStore());
+    deps = override ?? {
+      indexVaultFolder: (vault, folder) => indexer.indexVaultFolder(vault as never, folder),
+      loadBoardConfig,
+      resolveBoardLayout,
+    };
+  }
+
+  function folder(): string {
+    // Confirm the exact setting key against AgentBoardView.refresh() in Step 1.
+    return (plugin?.settings.agentBoardFolder as string) || 'Agent Board';
+  }
+
+  async function load(): Promise<void> {
+    if (!plugin || !deps) return;
+    const p = plugin; const d = deps;
+    await run(
+      async () => {
+        const model = await d.indexVaultFolder(p.app.vault, folder());
+        const { config } = d.loadBoardConfig(p.settings as never);
+        return d.resolveBoardLayout(config, model as never);
+      },
+      (next) => {
+        // mergeById keeps a running card's TaskSpec identity stable across a
+        // sibling reload (avatar/strip repaint = visible flicker on a live board).
+        const merged = next.lanes.map((lane) => ({
+          ...lane,
+          tasks: mergeById(currentTasks(lane.id), lane.tasks, (t) => t.frontmatter.id),
+        }));
+        layout.value = { lanes: merged, errors: next.errors };
+      },
+    );
+  }
+
+  function currentTasks(laneId: string): TaskSpec[] {
+    return layout.value.lanes.find((l) => l.id === laneId)?.tasks ?? [];
+  }
+
+  // ── Granular live setters (the O(1) path replacing patchLiveStrip) ──
+  function recordHeartbeat(taskId: string, at: string): void {
+    const next = new Map(liveHeartbeats.value); next.set(taskId, at); liveHeartbeats.value = next;
+  }
+  function recordLedger(taskId: string, message: string): void {
+    const next = new Map(liveLedger.value); next.set(taskId, message); liveLedger.value = next;
+  }
+  function evictLive(taskId: string): void {
+    if (liveHeartbeats.value.has(taskId)) { const h = new Map(liveHeartbeats.value); h.delete(taskId); liveHeartbeats.value = h; }
+    if (liveLedger.value.has(taskId)) { const l = new Map(liveLedger.value); l.delete(taskId); liveLedger.value = l; }
+  }
+
+  return { layout, liveHeartbeats, liveLedger, loading, init, load, recordHeartbeat, recordLedger, evictLive };
+});
+```
+
+- [ ] **Step 8: Run the test, confirm it passes.** Run: `npx vitest run tests/vue/tasks/agentBoardStore.test.ts`. Expected: PASS.
+
+- [ ] **Step 9: Add granular-setter tests.** Append tests: `recordHeartbeat` replaces the map (new reference, so a `watch` fires) and sets the value; `recordLedger` likewise; `evictLive` drops both. Assert `store.liveHeartbeats` is a *new* Map instance after `recordHeartbeat` (reference change is what drives reactivity). Run the file; expected PASS.
+
+- [ ] **Step 10: Add the mergeById-identity test.** Two `load()` calls where a lane's running task keeps the same `id`: assert `store.layout.lanes[0].tasks[0]` is the *same object reference* across the two loads (identity preserved → no flicker). Run; expected PASS.
+
+- [ ] **Step 11: Typecheck + lint.** Run: `npm run typecheck:vue && npm run lint`. Expected: clean.
+
+- [ ] **Step 12: Commit.**
+
+```bash
+git add src/features/tasks/ui/vue/ tests/vue/tasks/agentBoardStore.test.ts
+git commit -m "feat(tasks): useAgentBoardStore layout projection + live setters (unwired)"
+```
+
+---
+
+## Task 2: Event-routing composable — `useBoardEventRouting` (unwired)
+
+**Files:**
+- Create: `src/features/tasks/ui/vue/useBoardEventRouting.ts`
+- Test: `tests/vue/tasks/useBoardEventRouting.test.ts`
+
+- [ ] **Step 1: Write the failing test.** The composable must, on mount, subscribe every event in the board's table and route it to the right store method; on unmount, dispose all. Test the two tiers: a granular event calls a granular setter (no `load`), a full-refresh event calls `load`. Mount via a throwaway host component (`defineComponent`) that calls the composable in `setup`, using a fake bus that captures handlers.
+
+```ts
+import { mount } from '@testing-library/vue';
+import { setActivePinia } from 'pinia';
+import { defineComponent } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getAgentBoardPinia, resetAgentBoardPinia } from '@/features/tasks/ui/vue/globalPinia';
+import { useAgentBoardStore } from '@/features/tasks/ui/vue/stores/agentBoardStore';
+import { useBoardEventRouting } from '@/features/tasks/ui/vue/useBoardEventRouting';
+
+function makeBus() {
+  const handlers: Record<string, (p: unknown) => void> = {};
+  const disposers: Array<() => void> = [];
+  return {
+    handlers, disposers,
+    on: vi.fn((e: string, h: (p: unknown) => void) => { handlers[e] = h; const d = vi.fn(); disposers.push(d); return d; }),
+  };
+}
+```
+
+Assert: after mount, `bus.on` was called with `'task:heartbeat'`, `'task:ledger-appended'`, `'task:status-changed'`, `'task:board-config-changed'`, `'roster:changed'`, `'task:queue-paused'` (spot-check the tiers). Fire `handlers['task:heartbeat']({ taskId: 'a', at: 'T' })` → `store.recordHeartbeat` called with `('a','T')` and `store.load` NOT called. Fire `handlers['task:board-config-changed']()` → `store.load` called. On unmount, every disposer ran.
+
+- [ ] **Step 2: Run it, confirm it fails** (module missing).
+
+- [ ] **Step 3: Implement the composable.** Route every board event. Full-refresh set → `store.load()` (guarded, so concurrent fires coalesce): `task:board-config-changed`, `roster:changed`, `chat:tabs-changed`, `task:queue-paused|-resumed|-halted|-tick|-skipped|-state-changed|-cap-changed`, `task:run-finished`, `task:attempt-started`, `task:status-changed`, `task:resumed`, `task:needs-input`, `task:needs-approval` (these last five change a card's status/pause → the layout re-buckets it into the right lane, so a guarded `load()` is the correct reactive equivalent of `patchCard`). Granular set → `task:heartbeat` → `store.recordHeartbeat(p.taskId, p.at)`; `task:ledger-appended` → `store.recordLedger(p.taskId, p.entry.message)`. On any status→terminal transition, also `store.evictLive(p.taskId)` (mirror the renderer's eviction). Own the 4 vault subs too (`create/modify/delete/rename`, debounced 100ms → `store.load`) — reuse `useFolderVaultRefresh` semantics but the board watches its whole `agentBoardFolder`. Register all disposers in an array; `onUnmounted` runs them all + clears any debounce timer.
+
+```ts
+import { onMounted, onUnmounted } from 'vue';
+import type SpecoratorPlugin from '../../../../main';
+import { useAgentBoardStore } from './stores/agentBoardStore';
+
+export function useBoardEventRouting(plugin: SpecoratorPlugin): void {
+  const store = useAgentBoardStore();
+  const disposers: Array<() => void> = [];
+  const bus = plugin.events;
+
+  const FULL_REFRESH = [
+    'task:board-config-changed', 'roster:changed', 'chat:tabs-changed',
+    'task:queue-paused', 'task:queue-resumed', 'task:queue-halted', 'task:queue-tick',
+    'task:queue-skipped', 'task:queue-state-changed', 'task:queue-cap-changed',
+    'task:run-finished', 'task:attempt-started', 'task:status-changed',
+    'task:resumed', 'task:needs-input', 'task:needs-approval',
+  ] as const;
+
+  onMounted(() => {
+    for (const evt of FULL_REFRESH) disposers.push(bus.on(evt as never, () => void store.load()));
+    disposers.push(bus.on('task:heartbeat' as never, (p: { taskId: string; at: string }) => store.recordHeartbeat(p.taskId, p.at)));
+    disposers.push(bus.on('task:ledger-appended' as never, (p: { taskId: string; entry: { message: string } }) => store.recordLedger(p.taskId, p.entry.message)));
+    disposers.push(bus.on('task:run-finished' as never, (p: { taskId: string }) => store.evictLive(p.taskId)));
+    // Vault subs (whole board folder) — port useFolderVaultRefresh's debounce inline.
+    // ...create/modify/delete/rename → debounced store.load; push offref disposers.
+  });
+
+  onUnmounted(() => { for (const d of disposers) d(); disposers.length = 0; });
+}
+```
+
+(Fill the vault-sub block with the `useFolderVaultRefresh` body inline, or refactor `useFolderVaultRefresh` to accept an event list — implementer's call; keep the 100ms board debounce to match `AgentBoardView.onVaultChange`.)
+
+- [ ] **Step 4: Run the test, confirm it passes.**
+
+- [ ] **Step 5: Add a terminal-eviction test.** Fire `task:run-finished` → `store.evictLive` called and `store.load` called. Run; PASS.
+
+- [ ] **Step 6: Typecheck + lint. Commit.**
+
+```bash
+git commit -am "feat(tasks): board EventBus→store routing composable (unwired)"
+```
+
+---
+
+## Task 3: Board components — Root / Toolbar / Lane / Card / LiveStrip (unwired, characterization-tested)
+
+**Files:**
+- Create: `AgentBoardRoot.vue`, `components/BoardToolbar.vue`, `components/BoardLane.vue`, `components/WorkOrderCard.vue`, `components/LiveStrip.vue` (all under `src/features/tasks/ui/vue/`)
+- Test: `tests/vue/tasks/boardComponents.test.ts`
+
+- [ ] **Step 1: Capture the parity target.** Re-read the "Renderer DOM" ground-truth block above — that class list IS the characterization target. The Vue components must emit the same class names so CSS (unchanged in this task) keeps applying.
+
+- [ ] **Step 2: Write the failing characterization test — lanes + cards.** Render `AgentBoardRoot` with a provided store whose `layout` has two lanes (one `hostsNewWorkOrders`, one collapsed) and cards across statuses. Assert exact classes: root `.specorator-agent-board`, lanes container `.specorator-agent-board-lanes`, each `.specorator-agent-board-lane`, header `.specorator-agent-board-lane-title` text, `.specorator-agent-board-lane-count`, the Inbox `.specorator-agent-board-lane-add` present only on the hosting lane, collapsed lane `.specorator-agent-board-lane--collapsed` with `role=button`/`aria-expanded=false`. For a card: `.specorator-agent-board-card.specorator-agent-board-card--ready`, status dot `.specorator-agent-board-card-status-dot--ready`, a `running` card gets `--live-actions` + `.specorator-agent-board-card-live-strip`, a non-live card has no live strip.
+
+- [ ] **Step 3: Run it, confirm it fails.**
+
+- [ ] **Step 4: Implement `LiveStrip.vue`** (the perf boundary — isolate reactive deps). Props: `taskId`, `task` (TaskSpec), and it reads `store.liveHeartbeats`/`store.liveLedger` itself so a heartbeat touches only this component. Compute the dot tier via `staleTier(now - heartbeatAt)` (use the store heartbeat if present else `task.frontmatter.heartbeat`), the caption via elapsed + attempt, the ledger line from `store.liveLedger.get(taskId)` else the last non-blank `task.sections.ledger` line. Classes exactly: `-card-live-strip`, `-live-strip--meta`, `-live-strip--dot .specorator-stale-<tier>`, `-live-strip--caption`, `-live-strip--ledger`. Port `AgentBoardLiveHeartbeatTracker.computePatch` logic into a pure function `computeLiveStrip(task, heartbeatAt, ledgerMsg, now)` in `agentBoardLiveHeartbeat.ts` (export it; keep the class too until cutover) and unit-test it.
+
+- [ ] **Step 5: Implement `WorkOrderCard.vue`.** Title row (`-card-title-row` → status-dot span with `statusDotClass(status)` + aria-label `DEFAULT_LANE_TITLES[status]` + `-card-title` text), meta row (`-card-meta-engine` "provider / model", priority bars), footer (progress + `-card-assignee` via `renderAgentAvatar` in a Vue ref-mount or a small `<AgentAvatar>` wrapper), `<LiveStrip v-if="LIVE_STATUSES.has(status)">`, `<CardActionCluster>` (added in Task 4 — leave a placeholder slot for now), reply surface for needs_input/needs_approval. Card `@click` → `callbacks.onOpenDetail(task)`; `@contextmenu.prevent` → `callbacks.onContextMenu(task, $event)`. Inject `CALLBACKS_KEY`.
+
+- [ ] **Step 6: Implement `BoardLane.vue`** (header + collapse toggle + criteria + `v-for` cards keyed by `task.frontmatter.id` + Inbox add-row) and `BoardToolbar.vue` (Add / Run-next-ready / auto-run switch / slot + queue counts — read the exact toolbar DOM from `AgentBoardRenderer.renderBoardToolbar` `:208` and reproduce classes).
+
+- [ ] **Step 7: Implement `AgentBoardRoot.vue`.** `<BoardToolbar>` + `.specorator-agent-board-lanes` with `<BoardLane v-for="lane in store.layout.lanes" :key="lane.id">` + `.specorator-agent-board-errors` when `store.layout.errors.length`. Call `useBoardEventRouting(plugin)` in setup (subscribes live — but this component is still unwired into the view, so it only runs under test until Task 4). Inject `PLUGIN_KEY`.
+
+- [ ] **Step 8: Run the characterization test, confirm it passes.** Iterate class names until exact parity.
+
+- [ ] **Step 9: Add the perf-isolation test (component-level).** Mount `AgentBoardRoot` with 2 running cards. Spy on each `LiveStrip`'s render (e.g. via `onUpdated` counter or a render-count ref). Call `store.recordHeartbeat('a','T')`. Assert only card `a`'s LiveStrip re-rendered — the board root, sibling cards, and card `b`'s LiveStrip did not. This is the guard that a heartbeat stays O(1). Run; PASS.
+
+- [ ] **Step 10: Typecheck:vue + lint + full Vue lane.** Run: `npm run typecheck:vue && npm run lint && npx vitest run tests/vue`. Expected: clean + all green.
+
+- [ ] **Step 11: Commit.**
+
+```bash
+git commit -am "feat(tasks): Vue board components (root/toolbar/lane/card/live-strip), characterization-tested, unwired"
+```
+
+---
+
+## Task 4: Card action cluster + overflow teleport (unwired)
+
+**Files:**
+- Create: `components/CardActionCluster.vue`, `components/OverflowMenu.vue`
+- Test: `tests/vue/tasks/cardActionCluster.test.ts`
+
+- [ ] **Step 1: Keep `CARD_ACTIONS` as the source of truth.** Do NOT re-type the table. Import `CARD_ACTIONS`, `CardAction`, `CardActionModel`, `FALLBACK_CARD_ACTIONS` from `agentBoardCardActions.ts` (they stay exported until cutover; after cutover, move the table into a `cardActions.ts` data module — plan that move in Task 8). `CardActionCluster.vue` reads `CARD_ACTIONS[status] ?? FALLBACK_CARD_ACTIONS` and renders primary/secondary/⋯ from it.
+
+- [ ] **Step 2: Write the failing test — per-status actions.** For each status assert the rendered primary label + variant class and the ⋯ menu item labels match the table (e.g. `running` → primary `.specorator-agent-board-card-action-primary--danger` "Stop" + secondary "Go to conversation" + menu ["Open note"]; `needs_input` → no primary, menu ["Open note","Open conversation","Stop"]). Assert `available` gating: a card with no `conversation_id` hides "Go to conversation"/"Open conversation". Assert each button's click calls the right injected callback via `deps.getCallbacks()` late-binding (provide a `CALLBACKS_KEY` spy).
+
+- [ ] **Step 3: Run it, confirm it fails.**
+
+- [ ] **Step 4: Implement `OverflowMenu.vue`** as a Vue `<Teleport to="body">` reimplementation of `portalPopover` with the SAME teardown contract. On open: teleport a `.specorator-agent-board-card-menu` (role=menu, tabindex=-1), position via the ported `position()` math (constants `ITEM_HEIGHT=34` etc.), register doc `mousedown`-capture + window `scroll`-capture + window `resize` + menu `keydown`(Esc) — all removed on close via `onBeforeUnmount` and an explicit `close()`. Items rebuilt each open (lazy — `available` re-evaluated). Emit `close`. Use `trigger.ownerDocument` for popout-safety. The card gets `is-menu-open` while open.
+
+- [ ] **Step 5: Implement `CardActionCluster.vue`.** Container `.specorator-agent-board-card-actions[--persistent]` (persistent when `LIVE_STATUSES.has(status)`), `@click.stop`. Primary button `.specorator-agent-board-card-action-primary--<variant>` with `<IconButton>`-style icon span + label. Secondary via `available`. ⋯ trigger `.specorator-agent-board-card-action-more` toggles `<OverflowMenu>`. Every `run` resolves callbacks fresh from the injected `CALLBACKS_KEY` (late-bind — don't capture).
+
+- [ ] **Step 6: Wire the cluster into `WorkOrderCard.vue`** (replace the Task 3 placeholder slot).
+
+- [ ] **Step 7: Run the per-status test, confirm it passes.**
+
+- [ ] **Step 8: Write the teleport leak test.** Open a card's ⋯ menu → assert one `.specorator-agent-board-card-menu` exists under `document.body` and the card has `is-menu-open`. Trigger each close path (select an item, outside `mousedown`, `Escape`, unmount the card). After each: assert zero `.specorator-agent-board-card-menu` under body, `is-menu-open` removed, and (for the listener leak) that a subsequent document `mousedown` does not throw / re-invoke. Run; PASS.
+
+- [ ] **Step 9: Add the one-popover-at-a-time test.** Open card A's menu, then card B's — assert A's teleported node is gone (only one menu in the DOM). Run; PASS.
+
+- [ ] **Step 10: Typecheck:vue + lint + full Vue lane. Commit.**
+
+```bash
+git commit -am "feat(tasks): Vue card action cluster + overflow teleport over CARD_ACTIONS (unwired)"
+```
+
+---
+
+## Task 5: Board cutover — the one live-run swap
+
+**Files:**
+- Modify: `src/features/tasks/ui/AgentBoardView.ts` (mount Vue root; delete render/patch machinery)
+- Delete: `AgentBoardRenderer.ts`, `agentBoardLiveHeartbeat.ts` tracker class (keep the ported pure fn), and the `patch*` methods
+- Modify (defer full delete to Task 8): `agentBoardCardActions.ts` (still exports `CARD_ACTIONS` + `AgentBoardRenderCallbacks`; delete the DOM-building class)
+- Rewrite: `tests/perf/agentBoard.perf.test.ts`
+- Test: `tests/vue/tasks/agentBoardCutover.test.ts`
+
+- [ ] **Step 1: Read the full `AgentBoardView.render()` + callback-binding block** (`:322-395`, `:334-381`) so the callbacks object handed to Vue is byte-identical to today's. The view keeps building this `AgentBoardRenderCallbacks` object — it is now `provide`d to Vue instead of passed to the renderer.
+
+- [ ] **Step 2: Write the failing cutover test.** Instantiate `AgentBoardView` against the obsidian fake, `onOpen()`, assert `contentEl` has `.specorator-vue` + `.specorator-agent-board-vue-root` and a mounted `.specorator-agent-board`. Assert the store's `load()` ran (lanes present). (Mirror `tests/vue/` LibraryView-mount coverage if one exists.)
+
+- [ ] **Step 3: Run it, confirm it fails.**
+
+- [ ] **Step 4: Swap the view to the Vue root.** In `AgentBoardView`: remove the `renderer` field and `render()`/`patchCard`/`patchLiveStrip`/`refreshSlots` DOM methods. Keep `refresh()`'s *data* path only if the store doesn't own it — but prefer: the store owns load; the view just triggers `store.load()`. `onOpen`: mount pattern from `LibraryView` — `createApp(AgentBoardRoot)`, `app.use(getAgentBoardPinia())`, `store.init(plugin)`, `app.provide(PLUGIN_KEY, markRaw(plugin))`, `app.provide(CALLBACKS_KEY, markRaw(this.buildCallbacks()))`, `app.mount(contentEl)`. Keep ALL engine wiring (coordinator, sidecar sweeps, orphan recovery, elapsed/orphan timers) — those are unchanged. The EventBus subscriptions move OUT of the view into `useBoardEventRouting` (called by `AgentBoardRoot`); delete the view's `:182-222` subscription block. `onClose`: `unmount()` + `empty()` + dispose engine as before.
+
+- [ ] **Step 5: Extract `buildCallbacks()`** — move the `:334-381` object literal into a private method returning `AgentBoardRenderCallbacks`, wired identically (openDetail→WorkOrderDetailModal, onRun→runTask, etc.). This is the seam Vue consumes.
+
+- [ ] **Step 6: Delete `AgentBoardRenderer.ts`** and the heartbeat tracker class (keep `computeLiveStrip` pure fn). Fix imports. Run `npm run typecheck` — resolve every dangling reference.
+
+- [ ] **Step 7: Run the cutover test + full unit/integration suites.** Run: `npm run test -- --selectProjects unit && npm run test -- --selectProjects integration`. The engine specs (`TaskRunCoordinator`, `RunSession`, sidecar, orphan recovery) MUST stay green — that is the proof the seam held. Fix any renderer-coupled test by pointing it at the Vue surface or deleting it if it characterized deleted DOM-building code.
+
+- [ ] **Step 8: Rewrite `agentBoard.perf.test.ts`.** Two guards: (a) mounted DOM/listeners stay O(rendered cards) as work-order count scales (mount N cards, assert node/listener count tracks a bounded window, not super-linear); (b) a single `store.recordHeartbeat` mutates one `LiveStrip`'s reactive dep — assert the board root and sibling cards do not re-render (render-count spies, as Task 3 Step 9). Keep it a scaling/structure assertion, never a timing assertion. Run: `npm run test:perf`. Expected: PASS.
+
+- [ ] **Step 9: Manual-parity checklist in the PR body** (no flag → QA is post-cutover): open board, create/run/stop a work order, watch a live heartbeat + ledger update, open the ⋯ menu, right-click context menu, collapse a lane, Inbox add-row. Cards still open the *existing imperative* detail/lane/template modals (unchanged this task) — the safety net.
+
+- [ ] **Step 10: Full gate.** Run: `npm run typecheck && npm run typecheck:vue && npm run lint && npm run test && npm run test:perf && npm run build && npm run check:quality`. Expected: all green (LOC/quality ratchet should IMPROVE as the renderer deletes — re-lock baselines if it does, in this commit, with justification).
+
+- [ ] **Step 11: Commit.**
+
+```bash
+git commit -am "feat(tasks): cut Agent Board over to the Vue root; delete imperative renderer + patch machinery"
+```
+
+---
+
+## Task 6: `WorkOrderDetailModal` internals → Vue
+
+**Files:**
+- Create: `vue/WorkOrderDetailRoot.vue` + `vue/components/WorkOrderProperties.vue`, `WorkOrderActivity.vue`, `WorkOrderFooter.vue`, `WorkOrderEditForm.vue`
+- Modify: `src/features/tasks/ui/WorkOrderDetailModal.ts` (keep ctor + `.open()`; mount Vue in `onOpen`)
+- Delete (after parity): `workOrderPropertiesPanel.ts`, `workOrderActivitySection.ts`, `workOrderFooterActions.ts`, `workOrderEditForm.ts` imperative bodies (keep any shared type + `footerActionsForStatus` data if reused)
+- Test: `tests/vue/tasks/workOrderDetail.test.ts`
+
+- [ ] **Step 1: Preserve the ctor contract.** `WorkOrderDetailModal` keeps `constructor(app, task, callbacks)` and `.open()` UNCHANGED so both consumers (`AgentBoardView.openDetail` and the out-of-scope `WorkOrderActivityProvider.ts:211`) keep working. `onOpen` builds the same modal shell classes (`specorator-work-order-modal` + CSS vars + header `--<status>`) then mounts `createApp(WorkOrderDetailRoot)` into `contentEl`, providing `task`, `callbacks`, and `app`. `onClose` unmounts.
+
+- [ ] **Step 2: Write the failing parity test — properties panel.** Render `WorkOrderProperties` with a task + spy callbacks. Assert: status pill `.specorator-work-order-modal-status-pill--<status>`; editable agent/provider/model/priority chips for editable statuses (`inbox/ready/needs_fix` for agent/loop; `!== running` for provider/model/priority); changing the provider chip calls `callbacks.onSaveFields({ provider, model: '' })`; changing priority calls `onSaveFields({ priority })`. Reproduce class names from `workOrderPropertiesPanel.ts` (the ground-truth block).
+
+- [ ] **Step 3: Run it, confirm it fails.**
+
+- [ ] **Step 4: Implement the four sub-panel SFCs**, porting each imperative renderer 1:1 (same classes, same callback calls). `WorkOrderActivity.vue` is read-only (renders handoff/salvage/ledger via `MarkdownRenderer` in a Vue mount using `:deep()` for markdown styling — see the Library's `MarkdownRenderer` usage pattern). `WorkOrderEditForm.vue` exposes a `collect(): WorkOrderSectionUpdate` via `defineExpose`. `WorkOrderFooter.vue` drives status CTAs from `footerActionsForStatus(task, callbacks)` (reuse it) + the Edit/Cancel/Save inline-edit toggle; suppress the right-side primary while editing (parity with `workOrderFooterActions.ts:296`).
+
+- [ ] **Step 5: Implement `WorkOrderDetailRoot.vue`.** Layout: header, body (`-modal-main` + `-modal-sidebar`), footer. Main pane shows read-only sections (Objective/Acceptance/Context/Constraints) or `<WorkOrderEditForm>` when `editing`. Sidebar `<WorkOrderProperties>`. Footer `<WorkOrderFooter>` with `onEdit`/`onCancel`/`onSave` toggling `editing` and `onSave` → `callbacks.onSaveSections(task, editForm.collect())`. Reproduce the acceptance-ring + checklist rendering (classes in the ground-truth block).
+
+- [ ] **Step 6: Point the modal at the Vue root.** Replace the modal's imperative `renderMainPane`/`renderFooter`/sidebar calls with the single Vue mount.
+
+- [ ] **Step 7: Run the parity tests** (properties, footer status actions per status, edit-form `collect()` → `onSaveSections`, activity dispatch by status). Iterate to green.
+
+- [ ] **Step 8: Delete the four imperative renderer bodies** (keep shared types + `footerActionsForStatus` if reused). `npm run typecheck` — resolve dangling refs.
+
+- [ ] **Step 9: Full gate + manual check** (open detail from a board card AND verify the chat-header activity dropdown still opens it). Commit.
+
+```bash
+git commit -am "feat(tasks): WorkOrderDetailModal internals → Vue island; delete imperative sub-panels"
+```
+
+---
+
+## Task 7: `WorkOrderTemplateEditorModal` + `AgentBoardLaneEditor` internals → Vue
+
+**Files:**
+- Create: `vue/WorkOrderTemplateEditorRoot.vue`, `vue/LaneEditorRoot.vue`
+- Modify: `WorkOrderTemplateEditorModal.ts` (keep ctor; mount Vue), `AgentBoardLaneEditor.ts` (keep `renderAgentBoardLaneEditor(container, plugin)` signature; mount Vue)
+- Test: `tests/vue/tasks/workOrderTemplateEditor.test.ts`, `tests/vue/tasks/laneEditor.test.ts`
+
+- [ ] **Step 1: Template editor — preserve ctor + persistence.** `WorkOrderTemplateEditorModal` keeps `constructor(app, plugin, existing, onSave)` and `.open()` so `WorkOrderTemplatePickerModal.ts:148` is unchanged. `onOpen` mounts `WorkOrderTemplateEditorRoot.vue` providing `plugin`, `existing`, and `onSave`. The Vue form (name/description/icon/provider/model/priority/loop/agent/body) validates name+body (Notice on empty) and calls `onSave(payload)` then `this.close()`. Provider change resets model; loop/agent options populate async (`LoopNoteStore.list`, `plugin.agentRosterStore.list`). Reproduce i18n keys `tasks.templateEditor.*` + `tasks.template.*`.
+
+- [ ] **Step 2: Write the failing template-editor parity test** (name-required Notice; provider change resets model; `onSave` receives the built `WorkOrderTemplateEditorPayload` with `originalPath` when editing). Run → fail → implement → pass.
+
+- [ ] **Step 3: Lane editor — preserve the render-function signature.** `renderAgentBoardLaneEditor(container, plugin)` keeps its signature (two settings call sites unchanged) but now mounts `createApp(LaneEditorRoot)` into `container` (a `.specorator-vue` wrapper) instead of building DOM imperatively. Return after mount; store the app on a WeakMap keyed by container OR expose an unmount hook the settings pane calls — check how the settings pane tears down its section and mirror it (read `AgentBoardSettingsSection.ts:197` context). The Vue editor edits `BoardConfig` lanes (title/visible/reorder/remove/collapsible/statuses/DoR/DoD, Add lane, Reset to default) and persists via `plugin.settings.agentBoardConfig = config` + `plugin.saveSettings()` + `plugin.events.emit('task:board-config-changed')`, with rollback + Notice on failure (parity with `AgentBoardLaneEditor.ts:70-91`).
+
+- [ ] **Step 4: Write the failing lane-editor parity test** (edit a lane title → persist writes `agentBoardConfig` + emits `task:board-config-changed`; Reset → `DEFAULT_BOARD_CONFIG`; status checkbox duplicate-owner hint). Run → fail → implement → pass.
+
+- [ ] **Step 5: Delete the imperative bodies** of both editors (keep the entry-point functions/ctors). `npm run typecheck`.
+
+- [ ] **Step 6: Full gate + manual check** (open template editor from Add-work-order → template picker; open lane editor from Settings → Agent Board; save each and confirm the board reacts to `task:board-config-changed`). Commit.
+
+```bash
+git commit -am "feat(tasks): template + lane editor internals → Vue islands; delete imperative bodies"
+```
+
+---
+
+## Task 8: Docs, final table moves, ratchet re-lock, full sweep
+
+**Files:**
+- Modify: `src/features/tasks/CLAUDE.md`, root `CLAUDE.md` (the features/tasks board row + perf table `agentBoard.perf` row)
+- Create: `docs/adr/0004-agent-board-vue-migration.md` (note the hard-cut, no-flag decision, mirroring ADR 0003)
+- Move: `CARD_ACTIONS` table + `AgentBoardRenderCallbacks` type into a data-only module (`src/features/tasks/ui/cardActions.ts`), delete the now-empty `agentBoardCardActions.ts`, delete `portalPopover.ts` (replaced by `OverflowMenu.vue`)
+- Modify: `scripts/quality-baseline.json`, LOC/CSS ratchet baselines
+
+- [ ] **Step 1: Move the data-only `CARD_ACTIONS` + callback type** out of `agentBoardCardActions.ts` into `cardActions.ts`; update imports in `CardActionCluster.vue` + the view. Delete `agentBoardCardActions.ts` and `portalPopover.ts`. `npm run typecheck`.
+
+- [ ] **Step 2: Update `src/features/tasks/CLAUDE.md`** — rewrite the `ui/AgentBoardRenderer` + `ui/agentBoardCardActions` + modal bullets to describe the Vue surface (`AgentBoardRoot` + store projection + `useBoardEventRouting` + the three Vue modal islands). Update root `CLAUDE.md`'s features/tasks row and the perf-suite `agentBoard.perf` description (now "Vue board render stays O(rendered cards); one heartbeat updates one LiveStrip").
+
+- [ ] **Step 3: Write ADR 0004** — frontmatter (`title`, `date: 2026-07-05`, `status: accepted`, `scope: features/tasks/ui`), record: view→Vue / engine untouched, no-flag direct replacement, drag parity N/A (no drag existed), busy-gate not added (no prior busy state), the store-as-projection + LiveStrip perf boundary.
+
+- [ ] **Step 4: Re-lock ratchets.** Run `npm run check:quality` — the renderer/card-actions/portalPopover deletions should DROP LOC + duplication + complexity. If any metric improved, re-lock with `npm run check:quality -- --update` and justify in the PR (net improvement, like the Library consolidation). If any metric REGRESSED, fix it (extract/decompose) — do not bump.
+
+- [ ] **Step 5: Full sweep.** Run: `npm run typecheck && npm run typecheck:vue && npm run lint && npm run test && npm run test:vue && npm run test:perf && npm run build && npm run check:artifacts && npm run check:quality && npm run check:css`. Expected: all green.
+
+- [ ] **Step 6: Commit + push + update PR.**
+
+```bash
+git commit -am "docs(tasks): Agent Board Vue migration — CLAUDE.md, ADR 0004, ratchet re-lock; delete residual imperative modules"
+git push
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** Task 1 (store projection), Task 2 (event routing — the EventBus→reactive mapping), Task 3 (board components + LiveStrip perf boundary), Task 4 (card action cluster + teleport, per spec §2), Task 5 (cutover + perf rewrite, the one live-run swap), Tasks 6–7 (the three editors, per spec §3 — corrected to keep entry-point signatures), Task 8 (docs + guards + ratchet, per spec §Guards & Testing). Perf contract (spec §Perf) → Task 3 Step 9 + Task 5 Step 8. Every spec section maps to a task.
+
+**Placeholder scan:** The bulk SFC template bodies (card/lane/toolbar/modal panels) are specified by exact class-parity lists + callback maps rather than full line-by-line SFC source — this matches how the Library plan handled its panels and is deliberate for a 6k-LOC migration; each is gated by a characterization/parity test that names the exact assertions. The store, event-routing composable, pure helpers, injection keys, and the load-bearing test are given as complete code. No "TBD"/"handle edge cases" left.
+
+**Type consistency:** `AgentBoardRenderCallbacks` (imported, not redefined), `CARD_ACTIONS`/`CardAction`/`CardActionModel` (imported from the existing module until Task 8 moves them), `ResolvedBoardLayout`/`ResolvedLane`/`TaskSpec`/`TaskStatus` (imported from their real modules), `useGuardedLoad`/`mergeById`/`useFolderVaultRefresh`/`IconButton` (shipped, reused). `store.load()`/`recordHeartbeat`/`recordLedger`/`evictLive` names are consistent across Tasks 1–5. One flagged verify: the board folder setting key (`agentBoardFolder`) is marked to confirm against `AgentBoardView.refresh()` in Task 1 Step 1 before the store hardcodes it.

--- a/docs/superpowers/specs/2026-07-05-agent-board-vue-migration-design.md
+++ b/docs/superpowers/specs/2026-07-05-agent-board-vue-migration-design.md
@@ -1,0 +1,186 @@
+---
+title: Agent Board Vue 3 + Pinia migration — reactive board over the imperative run engine
+date: 2026-07-05
+status: approved
+scope: features/tasks/ui (board view, cards, modals), features/tasks store projection, src/style/vue
+---
+
+# Agent Board — Vue 3 + Pinia Migration
+
+## Problem
+
+The Agent Board (`features/tasks/ui/`, ~6k LOC) is the last big imperative
+view after the Library shipped Vue. `AgentBoardRenderer` (764 LOC) builds
+lanes/cards by hand and keeps them live during runs through manual
+`patchCard`/`patchLiveStrip` DOM surgery driven by ~14 EventBus subscriptions.
+The detail/lane/template modals are likewise imperative. This is the natural
+next migration: it reuses the shipped harness (esbuild/unplugin-vue, Vitest
+lane, `--sp-*` style baseline, atoms, `useRowActionPending`, `mergeById`,
+`useGuardedLoad`) and replaces the hand-rolled patch machinery with reactive
+rendering.
+
+## Decisions (user-approved)
+
+| Question | Decision |
+|----------|----------|
+| Scope | **Full board surface**: board shell + lanes + cards + the card action cluster, AND the three modals (`WorkOrderDetailModal`, `AgentBoardLaneEditor`, `WorkOrderTemplateEditorModal`) migrate to Vue. |
+| Live-run boundary | **View is Vue; engine is untouched.** `TaskRunCoordinator`, `RunSession`, `RunSidecarStore` writes, `sharedRunRegistry`, orphan recovery, and the heartbeat/ledger sidecar model keep running imperatively and emitting the same EventBus events. |
+| Rollout | **Direct parity replacement, no flag.** Accrete-then-swap: new Vue code lands unwired while the board keeps running on the imperative renderer; a single cutover task swaps `AgentBoardView` to the Vue root and deletes the old renderer. No `useVueAgentBoard` flag, no user-facing half-state. |
+
+### The no-flag trade-off (accepted)
+
+Without a flag there is no early look: the board is QA'd only after the
+cutover commit. A live-run rendering regression that escapes the parity +
+perf tests is briefly in the working board until caught. Mitigation: the
+cutover is gated by (a) characterization tests asserting the Vue components
+reproduce the current renderer's DOM/class structure, and (b) a rewritten
+`agentBoard.perf` spec.
+
+## Architecture — four units
+
+### 1. `useAgentBoardStore` (Pinia, reactive projection)
+
+Wraps the existing services; I/O stays in them, the store is a reactive view
+(same contract as the Library stores — init-guard, `useGuardedLoad`,
+`mergeById` for stable card identity across reloads).
+
+State:
+- `layout` — the resolved board layout (`ResolvedBoardLayout`: lanes, each
+  `ResolvedLane` with its `tasks`), from `TaskNoteStore` + board config.
+- `liveHeartbeats: Map<taskId, isoString>` — mirrors the renderer's live map.
+- per-card live ledger message + run status refs.
+
+The store owns the EventBus→reactive mapping. Two tiers, mirroring the
+renderer's own split so perf is preserved:
+
+- **Full-refresh events** → `load()` (guarded): `task:board-config-changed`,
+  `roster:changed`, `chat:tabs-changed`, `task:queue-*`, `task:run-finished`
+  (→ runner tick + refresh).
+- **Granular events** → targeted ref updates (the O(1) live path that
+  replaces `patchCard`/`patchLiveStrip`): `task:heartbeat` →
+  `liveHeartbeats.set`; `task:ledger-appended` → that card's live message;
+  `task:attempt-started`/`task:status-changed`/`task:resumed`/
+  `task:needs-input`/`task:needs-approval` → that card's status ref (which
+  re-keys it into the right lane).
+
+Subscription lifecycle is owned by the **board root** (subscribe on mount,
+unsubscribe on unmount), routing each event to a store setter — the same
+ownership model the Library's vault-event refresh uses. The store exposes
+setters, not raw bus access.
+
+### 2. Board components
+
+`AgentBoardRoot.vue` (toolbar + lanes container + the Inbox add-work-order
+row) → `BoardLane.vue` (a keyed column over `lane.tasks`) → `WorkOrderCard.vue`
+(title row + status dot + `LiveStrip.vue` + hover action cluster).
+
+- **`LiveStrip.vue`** is a separate sub-component so a `task:heartbeat` /
+  `task:ledger-appended` update touches one strip's reactive deps, not the
+  board — this is the perf-critical boundary that keeps a heartbeat O(1).
+- Cards reuse shipped atoms: the new `IconButton` (from the merged follow-up),
+  `useRowActionPending` for async card actions, `--sp-*` chip/status styling.
+- The **card action cluster** (per-status primary button + ⋯ overflow
+  popover) becomes a Vue component driven by the existing `CARD_ACTIONS` spec
+  table + `AgentBoardRenderCallbacks` contract — the table stays the source of
+  truth; only its rendering moves to Vue. The body-portaled overflow popover
+  (`portalPopover.ts`) is reused or reimplemented as a Vue teleport.
+
+### 3. Modals → Vue
+
+Each mounts a Vue app in an Obsidian `Modal` shell (the Library's
+imperative-modal-stays-imperative lesson is respected only for *editors the
+board doesn't own*; here the board owns these three, so they migrate):
+
+- `WorkOrderDetailModal` decomposes along its existing seams —
+  `workOrderPropertiesPanel` (status pill + editable chips), the
+  `workOrderActivitySection` (handoff/salvage/ledger cards, `MarkdownRenderer`
+  via `:deep()`), `workOrderFooterActions` (status CTAs + inline edit
+  toggle), and `workOrderEditForm` (section textareas → `TaskNoteStore.writeSections`).
+  One migration task.
+- `AgentBoardLaneEditor` and `WorkOrderTemplateEditorModal` — one task each.
+
+### 4. Cutover
+
+`AgentBoardView.onOpen` mounts `AgentBoardRoot` (adds `.specorator-vue` +
+`.specorator-agent-board-vue-root`), wires the EventBus subscription, and
+deletes `AgentBoardRenderer`, `agentBoardCardActions`, and the `patch*`
+functions. `WorkOrderActivityProvider` (the chat-header work-order dropdown, a
+separate consumer of `TaskNoteStore`) is **out of scope** and unchanged.
+
+## Task sequence (accrete-then-swap; every task leaves the board green)
+
+1. **Store** — `useAgentBoardStore` projection + EventBus-routing plumbing,
+   *unwired*. Tests: layout projection, full-refresh vs granular event
+   handling, `mergeById` identity, guarded-load.
+2. **Board components** — `AgentBoardRoot`/`BoardLane`/`WorkOrderCard`/
+   `LiveStrip`, *unwired*; characterization tests assert DOM/class parity with
+   the current renderer output (lanes, status dot, live-pulse class, Inbox row).
+3. **Card action cluster** — per-status primary + ⋯ overflow as Vue over
+   `CARD_ACTIONS`, *unwired*; tests: each status → correct actions; busy-gate;
+   overflow teleport open/close + cleanup.
+4. **Board cutover** *(the one live-run swap)* — `AgentBoardView` mounts the
+   Vue root, wires events, deletes the imperative renderer/card-actions/patch
+   fns, rewrites `agentBoard.perf` for the Vue surface (mounted DOM/listeners
+   O(rendered cards); one heartbeat updates one `LiveStrip`, not the board).
+   **Cards still open the existing imperative detail/lane/template modals
+   unchanged** — the cutover swaps only the board, reusing proven modals as a
+   safety net.
+5. **`WorkOrderDetailModal` → Vue** — swap the open-call; parity tests per
+   sub-panel (properties/activity/footer/edit-form).
+6. **`AgentBoardLaneEditor` → Vue** — swap the open-call; parity tests.
+7. **`WorkOrderTemplateEditorModal` → Vue** — swap the open-call; parity tests.
+8. **Docs + final gate sweep** — architecture docs (`features/tasks/CLAUDE.md`,
+   root `CLAUDE.md` board row), ADR note, ratchet re-locks, full sweep.
+
+## Perf contract
+
+`agentBoard.perf` is rewritten for the Vue surface and remains the blocking
+gate it is today: (a) mounted DOM/listeners stay O(rendered cards) as the
+work-order count scales; (b) a single `task:heartbeat` mutates one card's
+`LiveStrip` reactive dep — assert the board root and sibling cards do not
+re-render. `taskRunCoordinator.perf` and `multiTabStreaming.perf` are engine
+specs (unchanged). The Library's `mergeById` is load-bearing here: during an
+active run, a sibling card's reload must not churn the running card's identity
+(avatar/strip repaint = visible flicker on a live board).
+
+## Guards & style
+
+`.specorator-vue-*` namespace + `is-*` (namespace guard); `--sp-*` tokens only
+in SFC/atoms styles (token guard); no `!important` (css ratchet); Vitest
+coverage floors extend to `src/features/tasks/ui/**/*.{ts,vue}` for the new
+Vue surface; LOC/quality ratchets re-locked as the imperative renderer deletes
+(net improvement expected, like the Library consolidation).
+
+## Testing
+
+- **Vitest (component lane)**: store event-mapping + projection specs; board
+  component characterization + parity specs; card-action-cluster specs; per-
+  modal parity specs. Reuse the obsidian fake + `tests/vue/` harness.
+- **Characterization before cutover**: snapshot/structure tests of the current
+  imperative renderer output become the parity target the Vue components must
+  match (captured in Task 2 before Task 4 swaps).
+- **Perf**: rewritten `agentBoard.perf` (Task 4).
+- **Jest**: the engine specs (`TaskRunCoordinator`, `RunSession`, sidecar,
+  orphan recovery) are untouched and must stay green — proof the seam held.
+
+## Risks
+
+1. **Live-run regression post-cutover** (no flag) — mitigated by
+   characterization + perf gates; the imperative modals stay as a safety net
+   through the board cutover.
+2. **Perf regression from over-reactive rendering** — a naive board where a
+   heartbeat re-renders every card. Mitigated by the `LiveStrip` sub-component
+   boundary + the rewritten perf spec asserting single-strip updates.
+3. **Overflow popover / teleport lifecycle** — the body-portaled menu must
+   clean up on card unmount/board close (a leak the Library's leak-test
+   pattern already guards; extend it to the board).
+4. **Drag/interaction parity** — the plan task must read the current renderer
+   for any drag-between-lanes or keyboard interaction and preserve it; not
+   assumed here.
+
+## Out of scope
+
+- The run execution engine (coordinator/session/sidecar/registry).
+- `WorkOrderActivityProvider` (chat-header dropdown).
+- The chat sidepanel migration (a separate, larger future spec).
+- Any change to work-order note format or the sidecar model.

--- a/src/features/library/vue/components/IconButton.vue
+++ b/src/features/library/vue/components/IconButton.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { setIcon } from 'obsidian';
+import type { ComponentPublicInstance } from 'vue';
+
+// `pressed` defaults to undefined (NOT Vue's Boolean-cast false): an absent
+// prop must leave the button a plain icon action with no aria-pressed, so the
+// three-state (unset / off / on) survives to the template.
+const props = withDefaults(
+  defineProps<{
+    icon: string;
+    ariaLabel: string;
+    /** A tri-state toggle: boolean renders aria-pressed + the is-on accent;
+     *  undefined leaves the button a plain (non-toggle) icon action. */
+    pressed?: boolean;
+    disabled?: boolean;
+    /** Fill the glyph in the on-state (e.g. a favorited star) rather than only
+     *  recoloring the outline. */
+    filled?: boolean;
+  }>(),
+  { pressed: undefined },
+);
+
+// The native MouseEvent rides along so a caller can keep `.stop` at the call
+// site (`@activate.stop`): the emit is a custom event with no DOM identity of
+// its own, so the modifier needs the real event to stopPropagation() on.
+const emit = defineEmits<{ activate: [event: MouseEvent] }>();
+
+// jsdom (and testing-library's fireEvent) dispatch clicks straight at a
+// disabled button, unlike a real browser — guard so a disabled icon never
+// emits.
+function onClick(event: MouseEvent): void {
+  if (props.disabled === true) return;
+  emit('activate', event);
+}
+
+/** setIcon host (function ref — no template ref needed for a single glyph). */
+function applyIcon(el: Element | ComponentPublicInstance | null): void {
+  if (el instanceof HTMLElement) setIcon(el, props.icon);
+}
+</script>
+
+<template>
+  <button
+    :ref="applyIcon"
+    type="button"
+    class="specorator-vue-icon-btn"
+    :class="{ 'is-on': pressed === true, 'is-filled': filled === true }"
+    :aria-pressed="typeof pressed === 'boolean' ? (pressed ? 'true' : 'false') : undefined"
+    :aria-label="ariaLabel"
+    :disabled="disabled === true"
+    @click="onClick"
+  />
+</template>
+
+<style scoped>
+/* Strip Obsidian's native button chrome so the glyph reads as an inline marker,
+   not a CTA, while keeping a real icon-sized hit area with a hover affordance.
+   Scoped (0,2,0) beats the host button baseline (0,1,1) by specificity. */
+.specorator-vue-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--sp-space-3xs);
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  border-radius: var(--sp-radius-s);
+  color: var(--sp-text-faint);
+  cursor: pointer;
+}
+
+/* setIcon() renders the lucide <svg> imperatively — no data-v, reach via
+   :deep(). */
+.specorator-vue-icon-btn :deep(svg) {
+  width: 18px;
+  height: 18px;
+}
+
+.specorator-vue-icon-btn:hover {
+  color: var(--sp-text);
+  background: var(--sp-surface-hover);
+}
+
+.specorator-vue-icon-btn.is-on {
+  color: var(--sp-accent);
+}
+
+/* Filled on-state: fill the outline glyph so the toggle reads at a glance. */
+.specorator-vue-icon-btn.is-on.is-filled :deep(svg) {
+  fill: currentColor;
+}
+</style>

--- a/src/features/library/vue/panels/AgentsPanel.vue
+++ b/src/features/library/vue/panels/AgentsPanel.vue
@@ -44,10 +44,39 @@ const tabGuard = inject(TAB_GUARD_KEY, null);
 
 onMounted(() => void withErrorNotice(() => store.load(), t('agentRoster.actionFailed'), fail));
 
+// Roster agents are managed through agentRosterStore, not loose vault notes, so
+// a raw folder watch is the wrong seam. The store emits `roster:changed` on
+// every save/delete, so an external writer — an Agent Board edit, a chat-view
+// roster edit, provider sync, the preset installer from another leaf — signals
+// through the event bus. Subscribe and reload so same-tab external edits land
+// without a remount (same debounce shape as the vault-note panels).
+const ROSTER_RELOAD_DEBOUNCE_MS = 300;
+let rosterOff: (() => void) | null = null;
+let reloadTimer: ReturnType<typeof setTimeout> | null = null;
+const rosterPlugin = plugin;
+
+onMounted(() => {
+  rosterOff = rosterPlugin.events.on('roster:changed', () => {
+    // Coalesce bursts (a multi-agent sync fires one event per file) into one
+    // reload.
+    if (reloadTimer !== null) clearTimeout(reloadTimer);
+    reloadTimer = setTimeout(() => {
+      reloadTimer = null;
+      void withErrorNotice(() => store.load(), t('agentRoster.actionFailed'), fail);
+    }, ROSTER_RELOAD_DEBOUNCE_MS);
+  });
+});
+
 // Safety net: if the panel unmounts through any other path, never leave a
 // stale guard blocking the tab strip.
 onUnmounted(() => {
   if (tabGuard) tabGuard.value = null;
+  if (reloadTimer !== null) {
+    clearTimeout(reloadTimer);
+    reloadTimer = null;
+  }
+  rosterOff?.();
+  rosterOff = null;
 });
 
 function fail(error: unknown): void {

--- a/src/features/library/vue/panels/LoopsPanel.vue
+++ b/src/features/library/vue/panels/LoopsPanel.vue
@@ -52,7 +52,12 @@ useFolderVaultRefresh({
     const raw = (plugin.settings.agentBoardLoopFolder || 'Agent Board/loops').trim();
     return raw ? normalizePath(raw) : '';
   },
-  reload: () => void store.load(),
+  // The loop store's load() re-throws (no onError in useGuardedLoad), unlike
+  // the quick-action store which captures into store.error. Route the
+  // refresh reload through the same withErrorNotice the mounted load uses so
+  // a transient vault-list rejection surfaces as a Notice, not an unhandled
+  // promise rejection.
+  reload: () => void withErrorNotice(() => store.load(), t('loopLibrary.actionFailed'), fail),
 });
 
 function openEditor(existing: LoopDefinition | null): void {

--- a/src/features/library/vue/panels/LoopsPanel.vue
+++ b/src/features/library/vue/panels/LoopsPanel.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import type { EventRef, TAbstractFile } from 'obsidian';
 import { normalizePath, Notice } from 'obsidian';
-import { inject, onMounted, onUnmounted } from 'vue';
+import { inject, onMounted } from 'vue';
 
 import { t } from '../../../../i18n/i18n';
 import { confirm } from '../../../../shared/modals/ConfirmModal';
@@ -16,6 +15,7 @@ import LibraryEmptyState from '../components/LibraryEmptyState.vue';
 import LibraryToolbar from '../components/LibraryToolbar.vue';
 import { PLUGIN_KEY } from '../libraryKeys';
 import { useLoopLibraryStore } from '../stores/loopLibraryStore';
+import { useFolderVaultRefresh } from '../useFolderVaultRefresh';
 import { useLibraryList } from '../useLibraryList';
 import { useRowActionPending } from '../useRowActionPending';
 
@@ -44,52 +44,15 @@ function fail(error: unknown): void {
 // another leaf — persists without touching this store. Vault events DO fire
 // for them (unlike the dot-folder skills Obsidian never indexes), so subscribe
 // folder-scoped and reload, mirroring QuickActionsPanel.
-const VAULT_RELOAD_DEBOUNCE_MS = 300;
-const vaultRefs: EventRef[] = [];
-let reloadTimer: ReturnType<typeof setTimeout> | null = null;
-// Straight-line alias: the setup-top throw guard doesn't narrow `plugin`
-// inside function declarations for vue-tsc.
-const vaultPlugin = plugin;
-
-function resolvedFolder(): string {
+useFolderVaultRefresh({
+  vault: plugin.app.vault,
   // Same live folder resolution as the store (default + normalizePath) — the
   // subscription and the loader must scan ONE folder.
-  const raw = (vaultPlugin.settings.agentBoardLoopFolder || 'Agent Board/loops').trim();
-  return raw ? normalizePath(raw) : '';
-}
-
-function isUnderFolder(path: string): boolean {
-  const folder = resolvedFolder();
-  if (!folder) return false;
-  return path === folder || path.startsWith(`${folder}/`);
-}
-
-function onVaultChange(file: TAbstractFile, oldPath?: string): void {
-  const path = (file as { path?: string })?.path ?? '';
-  const old = typeof oldPath === 'string' ? oldPath : '';
-  if (!isUnderFolder(path) && !(old && isUnderFolder(old))) return;
-  // Coalesce bursts (multi-file sync, folder renames) into one reload.
-  if (reloadTimer !== null) clearTimeout(reloadTimer);
-  reloadTimer = setTimeout(() => {
-    reloadTimer = null;
-    void store.load(); // load() captures failures into store.error, never throws
-  }, VAULT_RELOAD_DEBOUNCE_MS);
-}
-
-onMounted(() => {
-  vaultRefs.push(vaultPlugin.app.vault.on('create', onVaultChange));
-  vaultRefs.push(vaultPlugin.app.vault.on('modify', onVaultChange));
-  vaultRefs.push(vaultPlugin.app.vault.on('delete', onVaultChange));
-  vaultRefs.push(vaultPlugin.app.vault.on('rename', onVaultChange));
-});
-
-onUnmounted(() => {
-  if (reloadTimer !== null) {
-    clearTimeout(reloadTimer);
-    reloadTimer = null;
-  }
-  for (const ref of vaultRefs) vaultPlugin.app.vault.offref(ref);
-  vaultRefs.length = 0;
+  resolveFolder: () => {
+    const raw = (plugin.settings.agentBoardLoopFolder || 'Agent Board/loops').trim();
+    return raw ? normalizePath(raw) : '';
+  },
+  reload: () => void store.load(),
 });
 
 function openEditor(existing: LoopDefinition | null): void {

--- a/src/features/library/vue/panels/LoopsPanel.vue
+++ b/src/features/library/vue/panels/LoopsPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { Notice } from 'obsidian';
-import { inject, onMounted } from 'vue';
+import type { EventRef, TAbstractFile } from 'obsidian';
+import { normalizePath, Notice } from 'obsidian';
+import { inject, onMounted, onUnmounted } from 'vue';
 
 import { t } from '../../../../i18n/i18n';
 import { confirm } from '../../../../shared/modals/ConfirmModal';
@@ -37,6 +38,59 @@ onMounted(() => void withErrorNotice(() => store.load(), t('loopLibrary.actionFa
 function fail(error: unknown): void {
   plugin?.logger.scope('tasks').error('loop library action failed', error);
 }
+
+// Loops are regular vault notes, so an external writer — a note dropped in the
+// loop folder, an edit made outside the app, the preset installer running from
+// another leaf — persists without touching this store. Vault events DO fire
+// for them (unlike the dot-folder skills Obsidian never indexes), so subscribe
+// folder-scoped and reload, mirroring QuickActionsPanel.
+const VAULT_RELOAD_DEBOUNCE_MS = 300;
+const vaultRefs: EventRef[] = [];
+let reloadTimer: ReturnType<typeof setTimeout> | null = null;
+// Straight-line alias: the setup-top throw guard doesn't narrow `plugin`
+// inside function declarations for vue-tsc.
+const vaultPlugin = plugin;
+
+function resolvedFolder(): string {
+  // Same live folder resolution as the store (default + normalizePath) — the
+  // subscription and the loader must scan ONE folder.
+  const raw = (vaultPlugin.settings.agentBoardLoopFolder || 'Agent Board/loops').trim();
+  return raw ? normalizePath(raw) : '';
+}
+
+function isUnderFolder(path: string): boolean {
+  const folder = resolvedFolder();
+  if (!folder) return false;
+  return path === folder || path.startsWith(`${folder}/`);
+}
+
+function onVaultChange(file: TAbstractFile, oldPath?: string): void {
+  const path = (file as { path?: string })?.path ?? '';
+  const old = typeof oldPath === 'string' ? oldPath : '';
+  if (!isUnderFolder(path) && !(old && isUnderFolder(old))) return;
+  // Coalesce bursts (multi-file sync, folder renames) into one reload.
+  if (reloadTimer !== null) clearTimeout(reloadTimer);
+  reloadTimer = setTimeout(() => {
+    reloadTimer = null;
+    void store.load(); // load() captures failures into store.error, never throws
+  }, VAULT_RELOAD_DEBOUNCE_MS);
+}
+
+onMounted(() => {
+  vaultRefs.push(vaultPlugin.app.vault.on('create', onVaultChange));
+  vaultRefs.push(vaultPlugin.app.vault.on('modify', onVaultChange));
+  vaultRefs.push(vaultPlugin.app.vault.on('delete', onVaultChange));
+  vaultRefs.push(vaultPlugin.app.vault.on('rename', onVaultChange));
+});
+
+onUnmounted(() => {
+  if (reloadTimer !== null) {
+    clearTimeout(reloadTimer);
+    reloadTimer = null;
+  }
+  for (const ref of vaultRefs) vaultPlugin.app.vault.offref(ref);
+  vaultRefs.length = 0;
+});
 
 function openEditor(existing: LoopDefinition | null): void {
   if (!plugin) return;

--- a/src/features/library/vue/panels/QuickActionsPanel.vue
+++ b/src/features/library/vue/panels/QuickActionsPanel.vue
@@ -11,6 +11,7 @@ import { QuickActionStorage } from '../../../quickActions/QuickActionStorage';
 import { runQuickActionForFile } from '../../../quickActions/runQuickActionForFile';
 import type { QuickAction } from '../../../quickActions/types';
 import { QuickActionEditorModal } from '../../../quickActions/ui/QuickActionEditorModal';
+import IconButton from '../components/IconButton.vue';
 import LibraryCard from '../components/LibraryCard.vue';
 import LibraryEmptyState from '../components/LibraryEmptyState.vue';
 import LibraryToolbar from '../components/LibraryToolbar.vue';
@@ -254,18 +255,18 @@ function onToggleFavorite(action: QuickAction): void {
           />
         </template>
         <template #name-chips>
-          <!-- .stop: the star sits inside the card's activate surface, and a
-            toggle must not also open the editor. -->
-          <button
-            :ref="(el) => applyIcon(el, 'star')"
-            type="button"
-            class="specorator-vue-qa-star"
-            :class="{ 'is-on': action.favorite === true }"
-            :aria-pressed="action.favorite === true ? 'true' : 'false'"
-            :aria-label="t('quickActions.library.favoriteAria')"
+          <!-- .stop: the star sits inside the card's activate surface (the
+            name-chips slot has no @click.stop wrapper), so a toggle must not
+            also open the editor — IconButton emits the native event so .stop
+            lands here at the call site. -->
+          <IconButton
+            icon="star"
+            :ariaLabel="t('quickActions.library.favoriteAria')"
             :title="t('quickActions.library.favoriteAria')"
+            :pressed="action.favorite === true"
+            filled
             :disabled="pending.isBusy(action.filePath)"
-            @click.stop="onToggleFavorite(action)"
+            @activate.stop="onToggleFavorite(action)"
           />
         </template>
         <div
@@ -329,43 +330,5 @@ function onToggleFavorite(action: QuickAction): void {
 .specorator-vue-qa-icon :deep(svg) {
   width: 20px;
   height: 20px;
-}
-
-/* Icon toggle: strip Obsidian's native button chrome so the star reads as a
-   favorite marker, not a third CTA in the name row, but keep a real icon-sized
-   hit area with a hover affordance. Scoped (0,2,0) beats the host button
-   baseline (0,1,1) by specificity. */
-.specorator-vue-qa-star {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--sp-space-3xs);
-  background: transparent;
-  border: none;
-  box-shadow: none;
-  border-radius: var(--sp-radius-s);
-  color: var(--sp-text-faint);
-  cursor: pointer;
-}
-
-/* setIcon() renders the lucide <svg> imperatively — no data-v, reach via
-   :deep(). Sized to match the card's leading icon. */
-.specorator-vue-qa-star :deep(svg) {
-  width: 18px;
-  height: 18px;
-}
-
-.specorator-vue-qa-star:hover {
-  color: var(--sp-text);
-  background: var(--sp-surface-hover);
-}
-
-.specorator-vue-qa-star.is-on {
-  color: var(--sp-accent);
-}
-
-/* Favorited: fill the outline star so the on-state reads at a glance. */
-.specorator-vue-qa-star.is-on :deep(svg) {
-  fill: currentColor;
 }
 </style>

--- a/src/features/library/vue/panels/QuickActionsPanel.vue
+++ b/src/features/library/vue/panels/QuickActionsPanel.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import type { EventRef, TAbstractFile } from 'obsidian';
 import { normalizePath, Notice, setIcon } from 'obsidian';
 import type { ComponentPublicInstance } from 'vue';
-import { inject, onMounted, onUnmounted } from 'vue';
+import { inject, onMounted } from 'vue';
 
 import { t } from '../../../../i18n/i18n';
 import { confirm } from '../../../../shared/modals/ConfirmModal';
@@ -18,6 +17,7 @@ import LibraryToolbar from '../components/LibraryToolbar.vue';
 import { PLUGIN_KEY } from '../libraryKeys';
 import { quickActionLibraryAccessors } from '../quickActionLibraryAccessors';
 import { useQuickActionStore } from '../stores/quickActionStore';
+import { useFolderVaultRefresh } from '../useFolderVaultRefresh';
 import { useLibraryList } from '../useLibraryList';
 import { useRowActionPending } from '../useRowActionPending';
 
@@ -43,52 +43,15 @@ onMounted(() => void withErrorNotice(() => store.load(), t('quickActions.library
 // REGULAR vault folder (unlike the dot-folder skills Obsidian never indexes),
 // so vault events DO fire for them: subscribe folder-scoped, exactly like
 // QuickActionFavoritesCache.
-const VAULT_RELOAD_DEBOUNCE_MS = 300;
-const vaultRefs: EventRef[] = [];
-let reloadTimer: ReturnType<typeof setTimeout> | null = null;
-// Straight-line alias: the setup-top throw guard doesn't narrow `plugin`
-// inside function declarations for vue-tsc.
-const vaultPlugin = plugin;
-
-function resolvedFolder(): string {
+useFolderVaultRefresh({
+  vault: plugin.app.vault,
   // Same live folder resolution as the store's storage wiring (default +
   // normalizePath) — the subscription and the loader must scan ONE folder.
-  const raw = (vaultPlugin.settings.quickActionsFolder ?? 'Quick Actions').trim();
-  return raw ? normalizePath(raw) : '';
-}
-
-function isUnderFolder(path: string): boolean {
-  const folder = resolvedFolder();
-  if (!folder) return false;
-  return path === folder || path.startsWith(`${folder}/`);
-}
-
-function onVaultChange(file: TAbstractFile, oldPath?: string): void {
-  const path = (file as { path?: string })?.path ?? '';
-  const old = typeof oldPath === 'string' ? oldPath : '';
-  if (!isUnderFolder(path) && !(old && isUnderFolder(old))) return;
-  // Coalesce bursts (multi-file sync, folder renames) into one reload.
-  if (reloadTimer !== null) clearTimeout(reloadTimer);
-  reloadTimer = setTimeout(() => {
-    reloadTimer = null;
-    void store.load(); // load() captures failures into store.error, never throws
-  }, VAULT_RELOAD_DEBOUNCE_MS);
-}
-
-onMounted(() => {
-  vaultRefs.push(vaultPlugin.app.vault.on('create', onVaultChange));
-  vaultRefs.push(vaultPlugin.app.vault.on('modify', onVaultChange));
-  vaultRefs.push(vaultPlugin.app.vault.on('delete', onVaultChange));
-  vaultRefs.push(vaultPlugin.app.vault.on('rename', onVaultChange));
-});
-
-onUnmounted(() => {
-  if (reloadTimer !== null) {
-    clearTimeout(reloadTimer);
-    reloadTimer = null;
-  }
-  for (const ref of vaultRefs) vaultPlugin.app.vault.offref(ref);
-  vaultRefs.length = 0;
+  resolveFolder: () => {
+    const raw = (plugin.settings.quickActionsFolder ?? 'Quick Actions').trim();
+    return raw ? normalizePath(raw) : '';
+  },
+  reload: () => void store.load(),
 });
 
 function fail(error: unknown): void {

--- a/src/features/library/vue/useFolderVaultRefresh.ts
+++ b/src/features/library/vue/useFolderVaultRefresh.ts
@@ -1,0 +1,64 @@
+import type { EventRef, TAbstractFile, Vault } from 'obsidian';
+import { onMounted, onUnmounted } from 'vue';
+
+const VAULT_RELOAD_DEBOUNCE_MS = 300;
+
+export interface FolderVaultRefreshOptions {
+  vault: Vault;
+  /** Live folder resolution — re-read on every event so a settings change to
+   *  the watched folder takes effect without a remount. Return '' to watch
+   *  nothing (an unset folder). */
+  resolveFolder: () => string;
+  /** Reload the panel's store. Must not throw — the Library stores capture
+   *  failures into `store.error`. */
+  reload: () => void;
+}
+
+/**
+ * Folder-scoped vault-event refresh for a Library panel whose rows live in a
+ * REGULAR vault folder (quick actions, loops — unlike the dot-folder skills
+ * Obsidian never indexes). External writers (an edit outside the app, a note
+ * dropped in the folder, another leaf's modal) persist without touching the
+ * mounted store, so a tab would show stale rows until remount. Subscribe to
+ * create/modify/delete/rename, filter to the resolved folder, coalesce bursts
+ * (multi-file sync, folder renames) into one debounced reload, and offref all
+ * refs on unmount. Owns its own `onMounted`/`onUnmounted` — call it once from
+ * a panel's `setup`.
+ */
+export function useFolderVaultRefresh(options: FolderVaultRefreshOptions): void {
+  const vaultRefs: EventRef[] = [];
+  let reloadTimer: number | null = null;
+
+  function isUnderFolder(path: string): boolean {
+    const folder = options.resolveFolder();
+    if (!folder) return false;
+    return path === folder || path.startsWith(`${folder}/`);
+  }
+
+  function onVaultChange(file: TAbstractFile, oldPath?: string): void {
+    const path = (file as { path?: string })?.path ?? '';
+    const old = typeof oldPath === 'string' ? oldPath : '';
+    if (!isUnderFolder(path) && !(old && isUnderFolder(old))) return;
+    if (reloadTimer !== null) window.clearTimeout(reloadTimer);
+    reloadTimer = window.setTimeout(() => {
+      reloadTimer = null;
+      options.reload();
+    }, VAULT_RELOAD_DEBOUNCE_MS);
+  }
+
+  onMounted(() => {
+    vaultRefs.push(options.vault.on('create', onVaultChange));
+    vaultRefs.push(options.vault.on('modify', onVaultChange));
+    vaultRefs.push(options.vault.on('delete', onVaultChange));
+    vaultRefs.push(options.vault.on('rename', onVaultChange));
+  });
+
+  onUnmounted(() => {
+    if (reloadTimer !== null) {
+      window.clearTimeout(reloadTimer);
+      reloadTimer = null;
+    }
+    for (const ref of vaultRefs) options.vault.offref(ref);
+    vaultRefs.length = 0;
+  });
+}

--- a/tests/vue/components/iconButton.test.ts
+++ b/tests/vue/components/iconButton.test.ts
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen } from '@testing-library/vue';
+import { describe, expect, it } from 'vitest';
+
+import IconButton from '@/features/library/vue/components/IconButton.vue';
+
+describe('IconButton', () => {
+  it('renders a labelled button', () => {
+    render(IconButton, { props: { icon: 'star', ariaLabel: 'Toggle favorite' } });
+    const btn = screen.getByRole('button', { name: 'Toggle favorite' });
+    expect(btn.classList.contains('specorator-vue-icon-btn')).toBe(true);
+  });
+
+  it('reflects the pressed prop as aria-pressed + is-on, and omits aria-pressed when pressed is undefined', () => {
+    const { rerender } = render(IconButton, {
+      props: { icon: 'star', ariaLabel: 'Toggle favorite', pressed: false },
+    });
+    const btn = screen.getByRole('button', { name: 'Toggle favorite' });
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+    expect(btn.classList.contains('is-on')).toBe(false);
+    return rerender({ icon: 'star', ariaLabel: 'Toggle favorite', pressed: true }).then(() => {
+      expect(btn.getAttribute('aria-pressed')).toBe('true');
+      expect(btn.classList.contains('is-on')).toBe(true);
+    });
+  });
+
+  it('omits aria-pressed entirely when pressed is not a boolean', () => {
+    render(IconButton, { props: { icon: 'copy', ariaLabel: 'Duplicate' } });
+    expect(screen.getByRole('button', { name: 'Duplicate' }).hasAttribute('aria-pressed')).toBe(false);
+  });
+
+  it('emits activate with the native event on click (so callers can .stop propagation)', async () => {
+    const { emitted } = render(IconButton, { props: { icon: 'star', ariaLabel: 'Toggle favorite' } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Toggle favorite' }));
+    const events = emitted().activate as unknown[][];
+    expect(events).toHaveLength(1);
+    expect(events[0][0]).toBeInstanceOf(MouseEvent);
+  });
+
+  it('disables the button and blocks activation when disabled', async () => {
+    const { emitted } = render(IconButton, {
+      props: { icon: 'star', ariaLabel: 'Toggle favorite', disabled: true },
+    });
+    const btn = screen.getByRole('button', { name: 'Toggle favorite' }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    await fireEvent.click(btn);
+    expect(emitted().activate).toBeUndefined();
+  });
+
+  it('marks the filled variant so the on-state can fill the glyph', () => {
+    render(IconButton, {
+      props: { icon: 'star', ariaLabel: 'Toggle favorite', pressed: true, filled: true },
+    });
+    const btn = screen.getByRole('button', { name: 'Toggle favorite' });
+    expect(btn.classList.contains('is-filled')).toBe(true);
+  });
+});

--- a/tests/vue/helpers.ts
+++ b/tests/vue/helpers.ts
@@ -17,6 +17,9 @@ export function makePlugin() {
         offref: vi.fn(),
       },
     },
+    // Agents panel subscribes to `roster:changed` on mount; `on` returns an
+    // unsubscribe disposer (the real EventBus contract).
+    events: { on: vi.fn(() => vi.fn()) },
     logger: { scope: () => ({ error: vi.fn(), warn: vi.fn() }) },
     // Quick-action store wiring: real QuickActionStorage over a stub adapter
     // (loadAll resolves to [] when the folder listing is empty).

--- a/tests/vue/panels/__snapshots__/quickActionsPanel.test.ts.snap
+++ b/tests/vue/panels/__snapshots__/quickActionsPanel.test.ts.snap
@@ -34,13 +34,16 @@ exports[`QuickActionsPanel > card structure snapshot (small, stable sub-tree) 1`
         Summarize
       </span>
       
-      <!-- .stop: the star sits inside the card's activate surface, and a
-            toggle must not also open the editor. -->
+      <!-- .stop: the star sits inside the card's activate surface (the
+            name-chips slot has no @click.stop wrapper), so a toggle must not
+            also open the editor — IconButton emits the native event so .stop
+            lands here at the call site. -->
       <button
         aria-label="Toggle favorite"
         aria-pressed="false"
-        class="specorator-vue-qa-star"
+        class="specorator-vue-icon-btn is-filled"
         data-v-00781362=""
+        data-v-91821aec=""
         title="Toggle favorite"
         type="button"
       />

--- a/tests/vue/panels/agentsPanel.test.ts
+++ b/tests/vue/panels/agentsPanel.test.ts
@@ -50,10 +50,31 @@ const agent = {
   createdAt: 1, updatedAt: 2,
 };
 
+/** EventBus fake capturing the panel's `roster:changed` subscription: `on`
+ * returns a disposer (the real EventBus contract), so tests can emit as an
+ * external roster writer would and assert the panel unsubscribes on unmount. */
+function makeEventsFake() {
+  const handlers: Record<string, Set<() => void>> = {};
+  const disposers: ReturnType<typeof vi.fn>[] = [];
+  const events = {
+    on: vi.fn((name: string, handler: () => void) => {
+      (handlers[name] ??= new Set()).add(handler);
+      const off = vi.fn(() => { handlers[name]?.delete(handler); });
+      disposers.push(off);
+      return off;
+    }),
+  };
+  function emit(name: string): void {
+    for (const handler of [...(handlers[name] ?? [])]) handler();
+  }
+  return { events, emit, disposers };
+}
+
 function makePlugin() {
   return {
     agentRosterStore: { list: vi.fn().mockResolvedValue([agent]) },
     settings: {},
+    events: makeEventsFake().events,
     logger: { scope: () => ({ error: vi.fn() }) },
   } as never;
 }
@@ -104,9 +125,11 @@ function setupMutable(agents: unknown[], opts: { list?: ReturnType<typeof vi.fn>
   setActivePinia(pinia);
   const errorLog = vi.fn();
   const tabGuard = ref<(() => Promise<boolean>) | null>(null);
+  const { events, emit: emitRosterEvent, disposers: eventDisposers } = makeEventsFake();
   const plugin = {
     app: {},
     settings: {},
+    events,
     logger: { scope: () => ({ error: errorLog, warn: vi.fn() }) },
     agentRosterStore: {
       list: opts.list ?? vi.fn().mockResolvedValue(agents),
@@ -134,7 +157,7 @@ function setupMutable(agents: unknown[], opts: { list?: ReturnType<typeof vi.fn>
     openConversation: ReturnType<typeof vi.fn>;
     app: unknown;
   };
-  return { store, plugin, p, tabGuard, errorLog, ...utils };
+  return { store, plugin, p, tabGuard, errorLog, emitRosterEvent, eventDisposers, ...utils };
 }
 
 /** Callbacks the panel handed to the (mocked) detail editor's constructor. */
@@ -437,6 +460,50 @@ describe('AgentsPanel mutation flows', () => {
     resolveCreate({ id: 'conv-1' });
     await waitFor(() => expect(start.disabled).toBe(false));
     expect(p.openConversation).toHaveBeenCalledWith('conv-1', { requireNewTab: true });
+  });
+
+  // Roster agents are NOT loose vault notes — they're managed through
+  // agentRosterStore, which emits `roster:changed` on every save/delete. An
+  // external writer (Agent Board edit, chat-view roster edit, provider sync,
+  // preset install) therefore signals through the event bus, not a folder
+  // watch. The mounted panel subscribes and reloads so same-tab external edits
+  // land without a remount.
+  describe('roster-change refresh', () => {
+    it('reloads (debounced, coalescing bursts) when roster:changed fires', async () => {
+      const { p, emitRosterEvent } = setupMutable([agent]);
+      await screen.findByText('Alice');
+      const before = p.agentRosterStore.list.mock.calls.length;
+      vi.useFakeTimers();
+      try {
+        emitRosterEvent('roster:changed');
+        emitRosterEvent('roster:changed');
+        // Debounce window still open: no reload yet.
+        expect(p.agentRosterStore.list.mock.calls.length).toBe(before);
+        await vi.advanceTimersByTimeAsync(400);
+      } finally {
+        vi.useRealTimers();
+      }
+      // The burst coalesced into exactly one reload.
+      expect(p.agentRosterStore.list.mock.calls.length).toBe(before + 1);
+    });
+
+    it('unmount disposes the subscription and drops a pending debounce (no leak)', async () => {
+      const { p, emitRosterEvent, eventDisposers, unmount } = setupMutable([agent]);
+      await screen.findByText('Alice');
+      expect(eventDisposers.length).toBe(1);
+      const before = p.agentRosterStore.list.mock.calls.length;
+      vi.useFakeTimers();
+      try {
+        emitRosterEvent('roster:changed');
+        unmount();
+        await vi.advanceTimersByTimeAsync(400);
+      } finally {
+        vi.useRealTimers();
+      }
+      expect(eventDisposers[0]).toHaveBeenCalledTimes(1);
+      // The queued reload died with the panel.
+      expect(p.agentRosterStore.list.mock.calls.length).toBe(before);
+    });
   });
 
   // Spec DoD 5: snapshot ONE card (small stable sub-tree), never the whole

--- a/tests/vue/panels/agentsPanelDeleteE2E.test.ts
+++ b/tests/vue/panels/agentsPanelDeleteE2E.test.ts
@@ -43,6 +43,9 @@ function setup() {
   const plugin = {
     app: {},
     settings: {},
+    // Agents panel subscribes to `roster:changed` on mount; `on` returns a
+    // disposer (the real EventBus contract).
+    events: { on: vi.fn(() => vi.fn()) },
     logger: { scope: () => ({ error: vi.fn(), warn: vi.fn(), debug: vi.fn() }) },
     agentRosterStore: {
       list: vi.fn().mockImplementation(async () => [...backing.values()]),

--- a/tests/vue/panels/loopsPanel.test.ts
+++ b/tests/vue/panels/loopsPanel.test.ts
@@ -35,7 +35,7 @@ function setup(loops: unknown[]) {
   // One plugin object for BOTH init() and provide() — the panel re-inits the
   // store with the injected plugin, so they must be the same fake.
   const plugin = {
-    app: { vault: {} },
+    app: { vault: makeVaultFake().vault },
     settings: {},
     logger: { scope: () => ({ error: vi.fn(), warn: vi.fn() }) },
   } as never;
@@ -87,13 +87,33 @@ describe('LoopsPanel', () => {
   });
 });
 
+type VaultHandler = (file: { path?: string }, oldPath?: string) => void;
+
+/** Vault fake capturing the panel's folder-scoped event subscriptions so tests
+ * can fire create/modify/delete/rename as an external writer would. */
+function makeVaultFake() {
+  const handlers: Record<string, VaultHandler> = {};
+  return {
+    handlers,
+    vault: {
+      getAbstractFileByPath: vi.fn().mockReturnValue(null),
+      on: vi.fn((name: string, handler: VaultHandler) => {
+        handlers[name] = handler;
+        return { event: name }; // opaque EventRef token, asserted against offref
+      }),
+      offref: vi.fn(),
+    },
+  };
+}
+
 /** Mutation flows need a fuller note-store fake than the render-only setup. */
 function setupMutable(loops: unknown[], overrides: Record<string, unknown> = {}) {
   const pinia = createPinia();
   setActivePinia(pinia);
   const errorLog = vi.fn();
+  const { vault, handlers } = makeVaultFake();
   const plugin = {
-    app: { vault: { getAbstractFileByPath: vi.fn().mockReturnValue(null) } },
+    app: { vault },
     settings: {},
     logger: { scope: () => ({ error: errorLog, warn: vi.fn() }) },
   } as never;
@@ -109,7 +129,7 @@ function setupMutable(loops: unknown[], overrides: Record<string, unknown> = {})
   const utils = render(LoopsPanel, {
     global: { plugins: [pinia], provide: { [PLUGIN_KEY as symbol]: plugin } },
   });
-  return { store, plugin, noteStore, errorLog, ...utils };
+  return { store, plugin, noteStore, errorLog, vault, vaultHandlers: handlers, ...utils };
 }
 
 describe('LoopsPanel mutation flows', () => {
@@ -256,5 +276,83 @@ describe('LoopsPanel mutation flows', () => {
     setup([loop]);
     await screen.findByText('A loop');
     expect(document.querySelector('.specorator-vue-card')).toMatchSnapshot();
+  });
+});
+
+// Loops are regular vault notes under the loop folder (default
+// `Agent Board/loops`), so an external writer (a file dropped in the folder,
+// a note edited outside the app) fires vault events the mounted panel must
+// refresh from — a folder-scoped subscription, mirroring QuickActionsPanel.
+describe('LoopsPanel vault-event refresh', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reloads (debounced, coalescing bursts) after a create inside the loop folder', async () => {
+    const { noteStore, vaultHandlers } = setupMutable([loop]);
+    await screen.findByText('A loop');
+    const before = noteStore.list.mock.calls.length;
+    vi.useFakeTimers();
+    try {
+      vaultHandlers.create({ path: 'Agent Board/loops/new.md' });
+      vaultHandlers.modify({ path: 'Agent Board/loops/new.md' });
+      // Debounce window still open: no reload yet.
+      expect(noteStore.list.mock.calls.length).toBe(before);
+      await vi.advanceTimersByTimeAsync(400);
+    } finally {
+      vi.useRealTimers();
+    }
+    // The two-event burst coalesced into exactly one reload.
+    expect(noteStore.list.mock.calls.length).toBe(before + 1);
+  });
+
+  it('ignores vault events outside the loop folder', async () => {
+    const { noteStore, vaultHandlers } = setupMutable([loop]);
+    await screen.findByText('A loop');
+    const before = noteStore.list.mock.calls.length;
+    vi.useFakeTimers();
+    try {
+      vaultHandlers.modify({ path: 'Notes/unrelated.md' });
+      // Prefix must be path-segment-aware: a sibling folder sharing the
+      // configured folder's prefix is OUTSIDE.
+      vaultHandlers.create({ path: 'Agent Board/loopsish/nope.md' });
+      await vi.advanceTimersByTimeAsync(400);
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(noteStore.list.mock.calls.length).toBe(before);
+  });
+
+  it('reloads when a rename moves a note OUT of the folder (old path was inside)', async () => {
+    const { noteStore, vaultHandlers } = setupMutable([loop]);
+    await screen.findByText('A loop');
+    const before = noteStore.list.mock.calls.length;
+    vi.useFakeTimers();
+    try {
+      vaultHandlers.rename({ path: 'Notes/moved-away.md' }, 'Agent Board/loops/a.md');
+      await vi.advanceTimersByTimeAsync(400);
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(noteStore.list.mock.calls.length).toBe(before + 1);
+  });
+
+  it('unmount offrefs all four subscriptions and drops a pending debounce (no leak)', async () => {
+    const { noteStore, vault, vaultHandlers, unmount } = setupMutable([loop]);
+    await screen.findByText('A loop');
+    expect(vault.on.mock.calls.map((c) => c[0]).sort())
+      .toEqual(['create', 'delete', 'modify', 'rename']);
+    const refs = vault.on.mock.results.map((r) => r.value);
+    const before = noteStore.list.mock.calls.length;
+    vi.useFakeTimers();
+    try {
+      vaultHandlers.delete({ path: 'Agent Board/loops/a.md' });
+      unmount();
+      await vi.advanceTimersByTimeAsync(400);
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(vault.offref).toHaveBeenCalledTimes(4);
+    for (const ref of refs) expect(vault.offref).toHaveBeenCalledWith(ref);
+    // The queued reload died with the panel.
+    expect(noteStore.list.mock.calls.length).toBe(before);
   });
 });

--- a/tests/vue/panels/loopsPanel.test.ts
+++ b/tests/vue/panels/loopsPanel.test.ts
@@ -335,6 +335,26 @@ describe('LoopsPanel vault-event refresh', () => {
     expect(noteStore.list.mock.calls.length).toBe(before + 1);
   });
 
+  it('routes a rejecting refresh reload through the error logger (no unhandled rejection)', async () => {
+    // The loop store's load() re-throws (no onError guard), so the refresh
+    // path must wrap it in withErrorNotice like the mounted load does — else
+    // a transient vault-list rejection escapes as an unhandled promise.
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({ loops: [loop], warnings: [] }) // mount load succeeds
+      .mockRejectedValue(new Error('vault boom')); // refresh reload rejects
+    const { errorLog, vaultHandlers } = setupMutable([loop], { list });
+    await screen.findByText('A loop');
+    vi.useFakeTimers();
+    try {
+      vaultHandlers.modify({ path: 'Agent Board/loops/a.md' });
+      await vi.advanceTimersByTimeAsync(400);
+    } finally {
+      vi.useRealTimers();
+    }
+    await waitFor(() => expect(errorLog).toHaveBeenCalled());
+  });
+
   it('unmount offrefs all four subscriptions and drops a pending debounce (no leak)', async () => {
     const { noteStore, vault, vaultHandlers, unmount } = setupMutable([loop]);
     await screen.findByText('A loop');


### PR DESCRIPTION
## Summary

Three post-consolidation Library polish items plus the design spec for the next migration (Agent Board → Vue 3 + Pinia).

### Library follow-ups
- **Shared `IconButton` atom** (`dd60fc1`) — a `specorator-vue-icon-btn` glyph button (`{ icon, ariaLabel, pressed?, disabled?, filled? }`, emits `activate` with the native event so callers keep `.stop`). The Quick Actions favorite star adopts it, replacing the bare text glyph with a properly sized, hit-area-friendly icon button.
- **Loops tab live refresh** (`bdc1cd0`) — the Loops panel now reloads when its vault folder changes externally (edit outside the app, note dropped in the folder, preset installer from another leaf), folder-scoped and debounced.
- **Agents tab live refresh** (`d7c62fb`) — the Agents panel subscribes to the existing typed `roster:changed` EventBus signal (the correct seam — roster agents are not loose vault notes) and reloads on external roster mutations, debounced.
- **Dedup refactor** (`3340d41`) — the Loops and Quick Actions folder-refresh logic was near-verbatim duplicated; extracted into a shared `useFolderVaultRefresh` composable (folder-scoped subscription + debounced coalesced reload + offref-on-unmount). Restores the fallow duplication ratchet to baseline.

### Design spec
- **Agent Board Vue 3 + Pinia migration** (`97b5beb`) — `docs/superpowers/specs/2026-07-05-agent-board-vue-migration-design.md`. Accrete-then-swap plan: Vue board (root/lanes/cards/LiveStrip + card action cluster) over the untouched imperative run engine, a `useAgentBoardStore` projection routing EventBus events to reactive updates, then the three modals to Vue, then docs + ratchet re-lock. No feature flag (direct parity replacement, user-approved).

## Testing
- `npm run test:vue` — 206 passed (22 files)
- `npm run typecheck` / `npm run typecheck:vue` / `npm run lint` — clean
- `npm run check:quality` — ratchet at baseline (cloneGroups 32, duplicatedLines 787, complexFunctions 234, maintainability 90.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014VDsSXWHRqZr2EcNgDX2eq)_